### PR TITLE
Add the ability to connect over a unix socket.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": ">=7.1",
     "freedsx/asn1": "^0.4.0",
-    "freedsx/socket": "^0.4.0",
+    "freedsx/socket": "^0.5.0",
     "freedsx/sasl": "^0.1.0"
   },
   "require-dev": {

--- a/docs/Client/Configuration.md
+++ b/docs/Client/Configuration.md
@@ -4,6 +4,7 @@ LDAP Client Configuration
 * [General Options](#general-options)
     * [base_dn](#base_dn)
     * [page_size](#page_size)
+    * [transport] (#transport)
     * [port](#port)
     * [servers](#servers)
     * [timeout_connect](#timeout_connect)
@@ -48,6 +49,18 @@ A default page size to use for paging operations. This will be used if a page si
 client's paging method.
 
 **Default**: `1000`
+
+------------------
+#### transport
+
+The transport mechanism to connect to LDAP with. Use either:
+
+* `tcp`
+* `unix`
+
+If using `unix` for the transport you should set the `servers` to a file representing the unix socket to connect to. ie: `/var/run/slapd/ldapi` (for OpenLDAP)
+
+**Default**: `tcp`
 
 ------------------
 #### port

--- a/src/FreeDSx/Ldap/LdapClient.php
+++ b/src/FreeDSx/Ldap/LdapClient.php
@@ -50,6 +50,7 @@ class LdapClient
         'version' => 3,
         'servers' => [],
         'port' => 389,
+        'transport' => 'tcp',
         'base_dn' => null,
         'page_size' => 1000,
         'use_ssl' => false,

--- a/tests/spec/FreeDSx/Ldap/LdapClientSpec.php
+++ b/tests/spec/FreeDSx/Ldap/LdapClientSpec.php
@@ -254,6 +254,7 @@ class LdapClientSpec extends ObjectBehavior
             'version' => 3,
             'servers' => [],
             'port' => 389,
+            'transport' => 'tcp',
             'base_dn' => null,
             'page_size' => 1000,
             'use_ssl' => false,

--- a/tests/unit/FreeDSx/Ldap/LdapClientTest.php
+++ b/tests/unit/FreeDSx/Ldap/LdapClientTest.php
@@ -297,6 +297,9 @@ class LdapClientTest extends LdapTestCase
 
     public function testItCanWorkOverUnixSocket()
     {
+        if ($this->isActiveDirectory()) {
+            $this->markTestSkipped('Connecting via a unix socket only tested on OpenLDAP.');
+        }
         $this->client = $this->getClient([
             'transport' => 'unix',
             'servers' => '/var/run/slapd/ldapi',

--- a/tests/unit/FreeDSx/Ldap/LdapClientTest.php
+++ b/tests/unit/FreeDSx/Ldap/LdapClientTest.php
@@ -295,6 +295,17 @@ class LdapClientTest extends LdapTestCase
         $this->assertTrue(true);
     }
 
+    public function testItCanWorkOverUnixSocket()
+    {
+        $this->client = $this->getClient([
+            'transport' => 'unix',
+            'servers' => '/var/run/slapd/ldapi',
+        ]);
+        $entry = $this->client->read('');
+
+        $this->assertNotNull($entry);
+    }
+
     public function testUseSslFailure()
     {
         $this->client = $this->getClient(['servers' => 'foo.com', 'use_ssl' => true, 'port' => 636]);


### PR DESCRIPTION
This addresses issue #45 and allows connecting over a unix based socket. Well it is not defined in any LDAP standard, it seems fine to allow it as a general option if the LDAP server supports it. I suspect trying to issue a `startTLS()` would fail miserably if not using the tcp transport. Though I suppose if you're changing the transport to unix you are probably aware of that.