### PR TITLE
Only run integration tests on PHP 7.4+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ jobs:
   run:
     runs-on: ${{ matrix.operating-system }}
     strategy:
+      fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest]
         php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
@@ -19,10 +20,10 @@ jobs:
           coverage: xdebug
 
       - name: Install OpenLDAP
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.php-versions >= '7.4'
         run: sudo ./tests/resources/openldap/setup.sh
 
-    # Cannot get the reboot to work properly for this...
+    # Github Actions runner does not support reboots to work properly for this...
     #- name: Install Active Directory
     #  if: runner.os == 'Windows'
     #  run: powershell .\tests\resources\activedirectory\Install-AD-Step1.ps1
@@ -56,5 +57,5 @@ jobs:
       # Not ideal, but we run as root here because the LDAP server needs access to certs / keys system directories.
       # For tests this seems fine, but in a real scenario this would be bad...
       - name: Run Integration Tests
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && matrix.php-versions >= '7.4'
         run: sudo composer run-script test-integration


### PR DESCRIPTION
This fixes the integration build process that started failing this week. There are a couple of longer term solutions to this:

* Instead of attempting to install and configure OpenLDAP on the runner, use an OpenLDAP container in integration tests. This would require me to rework the setup of integration tests.
* Start to actually bump the required PHP version in this library. Everything up to PHP 7.4 is now EOL as far as PHP is concerned. So people should really be upgrading.

I think the best course of action is to start to require PHP 7.4 as a minimum. There are earlier versions of this library available that those with older PHP versions can use if they really need to. I will open a separate issue for this. I think ideally this would be a good candidate for a "1.0.0" release and getting out of these 0.x.0 updates.

