### PR TITLE
Proxy integration tests and fixes.

### DIFF
--- a/src/FreeDSx/Ldap/Server/Paging/PagingRequest.php
+++ b/src/FreeDSx/Ldap/Server/Paging/PagingRequest.php
@@ -60,6 +60,11 @@ final class PagingRequest
     private $created;
 
     /**
+     * @var string
+     */
+    private $uniqueId;
+
+    /**
      * @var bool
      */
     private $hasProcessed = false;
@@ -69,13 +74,35 @@ final class PagingRequest
         SearchRequest $request,
         ControlBag $controls,
         string $nextCookie,
-        ?DateTimeInterface $created = null
+        ?DateTimeInterface $created = null,
+        ?string $uniqueId = null
     ) {
         $this->control = $control;
         $this->request = $request;
         $this->controls = $controls;
         $this->nextCookie = $nextCookie;
         $this->created = $created ?? new DateTime();
+        $this->uniqueId = $uniqueId ?? random_bytes(16);
+    }
+
+    /**
+     * An opaque value that uniquely identifies this paging request across its lifecycle.
+     *
+     * @return string
+     */
+    public function getUniqueId(): string
+    {
+        return $this->uniqueId;
+    }
+
+    /**
+     * Whether the paging control is considered critical or not.
+     *
+     * @return bool
+     */
+    public function isCritical(): bool
+    {
+        return $this->control->getCriticality();
     }
 
     /**

--- a/tests/bin/ldapproxy.php
+++ b/tests/bin/ldapproxy.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use FreeDSx\Ldap\LdapServer;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$server = LdapServer::makeProxy(
+    'localhost',
+    [],
+    ['port' => 3389]
+);
+
+echo "server starting..." . PHP_EOL;
+
+$server->run();

--- a/tests/integration/FreeDSx/Ldap/LdapClientTest.php
+++ b/tests/integration/FreeDSx/Ldap/LdapClientTest.php
@@ -261,7 +261,7 @@ class LdapClientTest extends LdapTestCase
     {
         $this->bindClient($this->client);
 
-        $this->assertRegExp('/^(dn|u):.*/', $this->client->whoami());
+        $this->assertMatchesRegularExpression('/^(dn|u):.*/', $this->client->whoami());
     }
 
     public function testSetOptionsDisconnectsIfRequested()

--- a/tests/integration/FreeDSx/Ldap/LdapProxyTest.php
+++ b/tests/integration/FreeDSx/Ldap/LdapProxyTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace integration\FreeDSx\Ldap;
+
+use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\Search\Filters;
+
+class LdapProxyTest extends ServerTestCase
+{
+    protected $serverExec = 'ldapproxy';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createServerProcess('tcp');
+    }
+
+    public function testItBindsToTheProxy()
+    {
+        $this->authenticate();
+
+        $this->assertNotEmpty($this->client->whoami());
+    }
+
+    public function testItRetrievesTheRootDse()
+    {
+        $this->authenticate();
+        $rootDse = $this->client->read();
+
+        $this->assertNotEmpty($rootDse->toArray());
+    }
+
+    public function testItCanHandlePaging()
+    {
+        $this->authenticate();
+
+        $search = Operations::search(Filters::equal('objectClass', 'inetOrgPerson'), 'cn');
+        $paging = $this->client->paging($search);
+
+        $entries = $paging->getEntries();
+        $this->assertEquals(1000, $entries->count());
+
+        while ($paging->hasEntries()) {
+            $entries->add(...$paging->getEntries());
+        }
+
+        $this->assertEquals(10001, $entries->count());
+    }
+
+    protected function authenticate(): void
+    {
+        $this->client->bind(
+            $_ENV['LDAP_USERNAME'],
+            $_ENV['LDAP_PASSWORD']
+        );
+    }
+}

--- a/tests/integration/FreeDSx/Ldap/ServerTestCase.php
+++ b/tests/integration/FreeDSx/Ldap/ServerTestCase.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace integration\FreeDSx\Ldap;
+
+use Exception;
+use FreeDSx\Ldap\LdapClient;
+use Symfony\Component\Process\Process;
+
+class ServerTestCase extends LdapTestCase
+{
+    /**
+     * @var Process
+     */
+    protected $subject;
+
+    /**
+     * @var LdapClient
+     */
+    protected $client;
+
+    /**
+     * @var string
+     */
+    protected $serverExec = 'ldapserver';
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        $this->stopServer();
+    }
+
+    protected function authenticate(): void
+    {
+        $this->client->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345'
+        );
+    }
+
+    protected function waitForServerOutput(string $marker): string
+    {
+        $maxWait = 10;
+        $i = 0;
+
+        while ($this->subject->isRunning()) {
+            $output = $this->subject->getOutput();
+            $this->subject->clearOutput();
+
+            if (strpos($output, $marker) !== false) {
+                return $output;
+            }
+
+            $i++;
+            if ($i === $maxWait) {
+                break;
+            }
+
+            sleep(1);
+        }
+
+        throw new Exception(sprintf(
+            'The expected output (%s) was not received after %d seconds.',
+            $marker,
+            $i
+        ));
+    }
+
+    protected function createServerProcess(
+        string $transport,
+        ?string $handler = null
+    ): void {
+        $processArgs = [
+            'php',
+            __DIR__ . '/../../../bin/' . $this->serverExec . '.php',
+            $transport,
+        ];
+
+        if ($handler) {
+            $processArgs[] = $handler;
+        }
+
+        $this->subject = new Process($processArgs);
+        $this->subject->start();
+        $this->waitForServerOutput('server starting...');
+
+        $useSsl = false;
+        $servers = '127.0.0.1';
+
+        if ($transport === 'ssl') {
+            $transport = 'tcp';
+            $useSsl = true;
+        }
+        if ($transport === 'unix') {
+            $servers = '/var/run/ldap.socket';
+        }
+
+        $this->client = $this->getClient([
+            'port' => 3389,
+            'transport' => $transport,
+            'servers' => $servers,
+            'ssl_validate_cert' => false,
+            'use_ssl' => $useSsl,
+        ]);
+    }
+
+    protected function stopServer(): void
+    {
+        $this->client->unbind();
+        $this->client = null;
+        $this->subject->stop();
+    }
+}

--- a/tests/spec/FreeDSx/Ldap/Server/Paging/PagingRequestSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Server/Paging/PagingRequestSpec.php
@@ -129,4 +129,14 @@ class PagingRequestSpec extends ObjectBehavior
     {
         $this->lastProcessedAt()->shouldBeNull();
     }
+
+    public function it_should_get_a_unique_id()
+    {
+        $this->getUniqueId()->shouldBeString();
+    }
+
+    public function it_should_get_the_criticality_of_the_control()
+    {
+        $this->isCritical()->shouldBeEqualTo(false);
+    }
 }


### PR DESCRIPTION
Writing the proxy integration test revealed that a unique ID was needed in paging requests so you can track it properly in the server. The cookie changes between requests, so would not work. This adjusts the proxy paging handler so it works as expected. It also adds integration tests for proxy behavior in general.