### PR TITLE
Handle graceful shutdown of LdapServer.

### DIFF
--- a/src/FreeDSx/Ldap/Server/ChildProcess.php
+++ b/src/FreeDSx/Ldap/Server/ChildProcess.php
@@ -42,4 +42,9 @@ class ChildProcess
     {
         return $this->socket;
     }
+
+    public function closeSocket(): void
+    {
+        $this->socket->close();
+    }
 }

--- a/tests/spec/FreeDSx/Ldap/Server/ChildProcessSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Server/ChildProcessSpec.php
@@ -36,4 +36,11 @@ class ChildProcessSpec extends ObjectBehavior
     {
         $this->getSocket()->shouldBeAnInstanceOf(Socket::class);
     }
+
+    public function it_should_close_the_socket(Socket $socket)
+    {
+        $socket->close()->shouldBeCalled();
+
+        $this->closeSocket();
+    }
 }


### PR DESCRIPTION
If the server is stopped using a signal we can handle, then it should make an attempt to close / end any connected clients, clean up child processes, and end the server socket gracefully. This enables that by enabling async signal handling and installing signal handlers for either the parent server process or a child process handling a connected socket.

It will wait a max time of 15 seconds for all clients to end before attempting to force kill any that remain and exiting.