### PR TITLE
Send 32 instead of 2 for empty SearchResultDone

### DIFF
--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
@@ -49,7 +49,7 @@ trait ServerSearchTrait
 
         $messages[] = new LdapMessageResponse(
             $message->getMessageId(),
-            new SearchResultDone(ResultCode::SUCCESS),
+            new SearchResultDone( $entries->count() ? ResultCode::SUCCESS : ResultCode::NO_SUCH_OBJECT ),
             ...$controls
         );
 


### PR DESCRIPTION
Send NO_SUCH_OBJECT (32) instead of SUCCESS (2) as code of SearchResultDone message when no entries where returned. This matches the ldap spec, and behavior of other ldap server implementations.