### PR TITLE
[1.0.0] Use strict types in all library classes.

### DIFF
--- a/src/FreeDSx/Ldap/Control/Ad/DirSyncRequestControl.php
+++ b/src/FreeDSx/Ldap/Control/Ad/DirSyncRequestControl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/Ad/DirSyncResponseControl.php
+++ b/src/FreeDSx/Ldap/Control/Ad/DirSyncResponseControl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/Ad/ExpectedEntryCountControl.php
+++ b/src/FreeDSx/Ldap/Control/Ad/ExpectedEntryCountControl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/Ad/ExtendedDnControl.php
+++ b/src/FreeDSx/Ldap/Control/Ad/ExtendedDnControl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/Ad/PolicyHintsControl.php
+++ b/src/FreeDSx/Ldap/Control/Ad/PolicyHintsControl.php
@@ -82,7 +82,7 @@ class PolicyHintsControl extends Control
         if (!$isEnabled instanceof IntegerType) {
             throw new ProtocolException('A PolicyHints control value sequence 0 must be an integer type.');
         }
-        $control = new static($isEnabled->getValue());
+        $control = new static((bool) $isEnabled->getValue());
 
         return self::mergeControlData(
             $control,

--- a/src/FreeDSx/Ldap/Control/Ad/PolicyHintsControl.php
+++ b/src/FreeDSx/Ldap/Control/Ad/PolicyHintsControl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/Ad/SdFlagsControl.php
+++ b/src/FreeDSx/Ldap/Control/Ad/SdFlagsControl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/Ad/SetOwnerControl.php
+++ b/src/FreeDSx/Ldap/Control/Ad/SetOwnerControl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/Control.php
+++ b/src/FreeDSx/Ldap/Control/Control.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/ControlBag.php
+++ b/src/FreeDSx/Ldap/Control/ControlBag.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/PagingControl.php
+++ b/src/FreeDSx/Ldap/Control/PagingControl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/PwdPolicyError.php
+++ b/src/FreeDSx/Ldap/Control/PwdPolicyError.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/PwdPolicyResponseControl.php
+++ b/src/FreeDSx/Ldap/Control/PwdPolicyResponseControl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/Sorting/SortKey.php
+++ b/src/FreeDSx/Ldap/Control/Sorting/SortKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/Sorting/SortingControl.php
+++ b/src/FreeDSx/Ldap/Control/Sorting/SortingControl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/Sorting/SortingResponseControl.php
+++ b/src/FreeDSx/Ldap/Control/Sorting/SortingResponseControl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/Vlv/VlvControl.php
+++ b/src/FreeDSx/Ldap/Control/Vlv/VlvControl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/Vlv/VlvResponseControl.php
+++ b/src/FreeDSx/Ldap/Control/Vlv/VlvResponseControl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Control/Vlv/VlvTrait.php
+++ b/src/FreeDSx/Ldap/Control/Vlv/VlvTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Controls.php
+++ b/src/FreeDSx/Ldap/Controls.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Entry/Attribute.php
+++ b/src/FreeDSx/Ldap/Entry/Attribute.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Entry/Change.php
+++ b/src/FreeDSx/Ldap/Entry/Change.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Entry/Changes.php
+++ b/src/FreeDSx/Ldap/Entry/Changes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Entry/Dn.php
+++ b/src/FreeDSx/Ldap/Entry/Dn.php
@@ -120,10 +120,10 @@ class Dn implements IteratorAggregate, Countable, Stringable
         return ($this->pieces === null) ? [] : $this->pieces;
     }
 
-    public static function isValid(string $dn): bool
+    public static function isValid(Stringable|string $dn): bool
     {
         try {
-            (new self($dn))->toArray();
+            (new self((string) $dn))->toArray();
 
             return true;
         } catch (UnexpectedValueException | InvalidArgumentException $e) {

--- a/src/FreeDSx/Ldap/Entry/Dn.php
+++ b/src/FreeDSx/Ldap/Entry/Dn.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Entry/Entries.php
+++ b/src/FreeDSx/Ldap/Entry/Entries.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Entry;
 use ArrayIterator;
 use Countable;
 use IteratorAggregate;
+use Stringable;
 use Traversable;
 use function array_merge;
 use function array_search;
@@ -84,10 +85,10 @@ class Entries implements Countable, IteratorAggregate
     /**
      * Get an entry from the collection by its DN.
      */
-    public function get(string $dn): ?Entry
+    public function get(Stringable|string $dn): ?Entry
     {
         foreach ($this->entries as $entry) {
-            if ($entry->getDn()->toString() === $dn) {
+            if ($entry->getDn()->toString() === (string) $dn) {
                 return $entry;
             }
         }

--- a/src/FreeDSx/Ldap/Entry/Entries.php
+++ b/src/FreeDSx/Ldap/Entry/Entries.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Entry/Entry.php
+++ b/src/FreeDSx/Ldap/Entry/Entry.php
@@ -20,6 +20,7 @@ use Stringable;
 use Traversable;
 use function count;
 use function is_array;
+use function array_map;
 
 /**
  * Represents an Entry in LDAP.
@@ -52,7 +53,13 @@ class Entry implements IteratorAggregate, Countable, Stringable
     ): static {
         $attribute = $attribute instanceof Attribute
             ? $attribute
-            : new Attribute($attribute, ...$values);
+            : new Attribute(
+                $attribute,
+                ...array_map(
+                    fn(Stringable|string $value) => $value instanceof Stringable ? (string) $value : $value,
+                    $values
+                )
+            );
 
         if (($exists = $this->get($attribute, true)) !== null) {
             $exists->add(...$attribute->getValues());
@@ -75,7 +82,10 @@ class Entry implements IteratorAggregate, Countable, Stringable
             ? $attribute
             : new Attribute(
                 $attribute,
-                ...$values
+                ...array_map(
+                    fn(Stringable|string $value) => $value instanceof Stringable ? (string) $value : $value,
+                    $values
+                )
             );
 
         if (count($attribute->getValues()) !== 0) {
@@ -118,7 +128,10 @@ class Entry implements IteratorAggregate, Countable, Stringable
             ? $attribute
             : new Attribute(
                 $attribute,
-                ...$values
+                ...array_map(
+                    fn(Stringable|string $value) => $value instanceof Stringable ? (string) $value : $value,
+                    $values
+                )
             );
 
         $exists = false;
@@ -265,11 +278,11 @@ class Entry implements IteratorAggregate, Countable, Stringable
      * @param array<string, string|array> $attributes
      */
     public static function create(
-        string $dn,
+        Stringable|string $dn,
         array $attributes = []
     ): Entry {
         return self::fromArray(
-            $dn,
+            (string) $dn,
             $attributes
         );
     }
@@ -280,8 +293,8 @@ class Entry implements IteratorAggregate, Countable, Stringable
      * @param array<string, string|string[]> $attributes
      */
     public static function fromArray(
-        string $dn,
-        array $attributes = []
+        Stringable|string $dn,
+        array             $attributes = []
     ): Entry {
         /** @var Attribute[] $entryAttr */
         $entryAttr = [];
@@ -294,7 +307,7 @@ class Entry implements IteratorAggregate, Countable, Stringable
         }
 
         return new self(
-            $dn,
+            (string) $dn,
             ...$entryAttr
         );
     }

--- a/src/FreeDSx/Ldap/Entry/Entry.php
+++ b/src/FreeDSx/Ldap/Entry/Entry.php
@@ -278,7 +278,7 @@ class Entry implements IteratorAggregate, Countable, Stringable
      * @param array<string, string|array> $attributes
      */
     public static function create(
-        Stringable|string $dn,
+        Dn|Stringable|string $dn,
         array $attributes = []
     ): Entry {
         return self::fromArray(
@@ -290,19 +290,25 @@ class Entry implements IteratorAggregate, Countable, Stringable
     /**
      * Construct an entry from an associative array.
      *
-     * @param array<string, string|string[]> $attributes
+     * @param array<string, string|array<string|Stringable>> $attributes
      */
     public static function fromArray(
-        Stringable|string $dn,
+        Dn|Stringable|string $dn,
         array             $attributes = []
     ): Entry {
         /** @var Attribute[] $entryAttr */
         $entryAttr = [];
 
-        foreach ($attributes as $attribute => $value) {
+        foreach ($attributes as $attribute => $attribute_values) {
             $entryAttr[] = new Attribute(
                 $attribute,
-                ...(is_array($value) ? $value : [$value])
+                ...(is_array($attribute_values)
+                    ? array_map(
+                          fn($value) => (string) $value,
+                          $attribute_values,
+                      )
+                    : [(string) $attribute_values]
+                )
             );
         }
 

--- a/src/FreeDSx/Ldap/Entry/Entry.php
+++ b/src/FreeDSx/Ldap/Entry/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Entry/EscapeTrait.php
+++ b/src/FreeDSx/Ldap/Entry/EscapeTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Entry/Option.php
+++ b/src/FreeDSx/Ldap/Entry/Option.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Entry/Options.php
+++ b/src/FreeDSx/Ldap/Entry/Options.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Entry/Rdn.php
+++ b/src/FreeDSx/Ldap/Entry/Rdn.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Exception/BindException.php
+++ b/src/FreeDSx/Ldap/Exception/BindException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Exception/ConnectionException.php
+++ b/src/FreeDSx/Ldap/Exception/ConnectionException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Exception/FilterParseException.php
+++ b/src/FreeDSx/Ldap/Exception/FilterParseException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Exception/InvalidArgumentException.php
+++ b/src/FreeDSx/Ldap/Exception/InvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Exception/OperationException.php
+++ b/src/FreeDSx/Ldap/Exception/OperationException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Exception/ProtocolException.php
+++ b/src/FreeDSx/Ldap/Exception/ProtocolException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Exception/ReferralException.php
+++ b/src/FreeDSx/Ldap/Exception/ReferralException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Exception/RuntimeException.php
+++ b/src/FreeDSx/Ldap/Exception/RuntimeException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Exception/SkipReferralException.php
+++ b/src/FreeDSx/Ldap/Exception/SkipReferralException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Exception/UnexpectedValueException.php
+++ b/src/FreeDSx/Ldap/Exception/UnexpectedValueException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Exception/UnsolicitedNotificationException.php
+++ b/src/FreeDSx/Ldap/Exception/UnsolicitedNotificationException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Exception/UrlParseException.php
+++ b/src/FreeDSx/Ldap/Exception/UrlParseException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/LdapClient.php
+++ b/src/FreeDSx/Ldap/LdapClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/LdapUrl.php
+++ b/src/FreeDSx/Ldap/LdapUrl.php
@@ -79,7 +79,7 @@ class LdapUrl implements Stringable
     {
         $this->dn = $dn === null
             ? $dn
-            : new Dn($dn);
+            : new Dn((string) $dn);
 
         return $this;
     }
@@ -209,7 +209,10 @@ class LdapUrl implements Stringable
             $url .= ':' . $this->port;
         }
 
-        return $url . '/' . self::encode($this->dn) . $this->getQueryString();
+        return $url
+            . '/'
+            . ($this->dn !== null ? self::encode($this->dn->toString()) : '')
+            . $this->getQueryString();
     }
 
     public function __toString(): string

--- a/src/FreeDSx/Ldap/LdapUrl.php
+++ b/src/FreeDSx/Ldap/LdapUrl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/LdapUrlExtension.php
+++ b/src/FreeDSx/Ldap/LdapUrlExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/LdapUrlTrait.php
+++ b/src/FreeDSx/Ldap/LdapUrlTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/LoggerTrait.php
+++ b/src/FreeDSx/Ldap/LoggerTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/LdapResult.php
+++ b/src/FreeDSx/Ldap/Operation/LdapResult.php
@@ -24,6 +24,7 @@ use FreeDSx\Ldap\Exception\UrlParseException;
 use FreeDSx\Ldap\LdapUrl;
 use FreeDSx\Ldap\Operation\Response\ResponseInterface;
 use FreeDSx\Ldap\Protocol\LdapEncoder;
+use Stringable;
 use function array_map;
 use function count;
 
@@ -102,12 +103,12 @@ class LdapResult implements ResponseInterface
 
     public function __construct(
         int $resultCode,
-        string $dn = '',
+        Stringable|string $dn = '',
         string $diagnosticMessage = '',
         LdapUrl ...$referrals
     ) {
         $this->resultCode = $resultCode;
-        $this->dn = new Dn($dn);
+        $this->dn = new Dn((string) $dn);
         $this->diagnosticMessage = $diagnosticMessage;
         $this->referrals = $referrals;
     }
@@ -142,7 +143,7 @@ class LdapResult implements ResponseInterface
     {
         $result = Asn1::sequence(
             Asn1::enumerated($this->resultCode),
-            Asn1::octetString($this->dn),
+            Asn1::octetString($this->dn->toString()),
             Asn1::octetString($this->diagnosticMessage)
         );
         if (count($this->referrals) !== 0) {

--- a/src/FreeDSx/Ldap/Operation/LdapResult.php
+++ b/src/FreeDSx/Ldap/Operation/LdapResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/AbandonRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/AbandonRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/AddRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/AddRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/AnonBindRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/AnonBindRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/BindRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/BindRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/CancelRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/CancelRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/CompareRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/CompareRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/DeleteRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/DeleteRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/DnRequestInterface.php
+++ b/src/FreeDSx/Ldap/Operation/Request/DnRequestInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/ExtendedRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/ExtendedRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/ModifyDnRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/ModifyDnRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/ModifyRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/ModifyRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/PasswordModifyRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/PasswordModifyRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/RequestInterface.php
+++ b/src/FreeDSx/Ldap/Operation/Request/RequestInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/SaslBindRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/SaslBindRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/SearchRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/SearchRequest.php
@@ -347,7 +347,7 @@ class SearchRequest implements RequestInterface
         }
 
         return Asn1::application(self::APP_TAG, Asn1::sequence(
-            Asn1::octetString($this->baseDn),
+            Asn1::octetString($this->baseDn->toString()),
             Asn1::enumerated($this->scope),
             Asn1::enumerated($this->derefAliases),
             Asn1::integer($this->sizeLimit),

--- a/src/FreeDSx/Ldap/Operation/Request/SearchRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/SearchRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/SimpleBindRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/SimpleBindRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Request/UnbindRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/UnbindRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Response/AddResponse.php
+++ b/src/FreeDSx/Ldap/Operation/Response/AddResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Response/BindResponse.php
+++ b/src/FreeDSx/Ldap/Operation/Response/BindResponse.php
@@ -42,7 +42,7 @@ class BindResponse extends LdapResult
         $this->saslCreds = $saslCreds;
         parent::__construct(
             $result->getResultCode(),
-            $result->getDn(),
+            $result->getDn()->toString(),
             $result->getDiagnosticMessage(),
             ...$result->getReferrals()
         );

--- a/src/FreeDSx/Ldap/Operation/Response/BindResponse.php
+++ b/src/FreeDSx/Ldap/Operation/Response/BindResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Response/CompareResponse.php
+++ b/src/FreeDSx/Ldap/Operation/Response/CompareResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Response/DeleteResponse.php
+++ b/src/FreeDSx/Ldap/Operation/Response/DeleteResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Response/ExtendedResponse.php
+++ b/src/FreeDSx/Ldap/Operation/Response/ExtendedResponse.php
@@ -124,15 +124,21 @@ class ExtendedResponse extends LdapResult
     /**
      * @return array{0: ?string, 1: ?string}
      */
-    protected static function parseExtendedResponse(AbstractType $type): array
+    private static function parseExtendedResponse(AbstractType $type): array
     {
         $info = [0 => null, 1 => null];
 
         foreach ($type->getChildren() as $child) {
             if ($child->getTagNumber() === 10) {
-                $info[0] = $child->getValue();
+                $value = $child->getValue();
+                $info[0] = $value !== null
+                    ? (string) $value
+                    : null;
             } elseif ($child->getTagNumber() === 11) {
-                $info[1] = $child->getValue();
+                $value = $child->getValue();
+                $info[1] = $value !== null
+                    ? (string) $value
+                    : null;
             }
         }
 

--- a/src/FreeDSx/Ldap/Operation/Response/ExtendedResponse.php
+++ b/src/FreeDSx/Ldap/Operation/Response/ExtendedResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Response/IntermediateResponse.php
+++ b/src/FreeDSx/Ldap/Operation/Response/IntermediateResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Response/ModifyDnResponse.php
+++ b/src/FreeDSx/Ldap/Operation/Response/ModifyDnResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Response/ModifyResponse.php
+++ b/src/FreeDSx/Ldap/Operation/Response/ModifyResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Response/PasswordModifyResponse.php
+++ b/src/FreeDSx/Ldap/Operation/Response/PasswordModifyResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Response/ResponseInterface.php
+++ b/src/FreeDSx/Ldap/Operation/Response/ResponseInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Response/SearchResponse.php
+++ b/src/FreeDSx/Ldap/Operation/Response/SearchResponse.php
@@ -32,7 +32,7 @@ class SearchResponse extends LdapResult
         $this->entries = $entries;
         parent::__construct(
             $result->resultCode,
-            $result->dn,
+            $result->dn->toString(),
             $result->diagnosticMessage,
             ...$result->referrals
         );

--- a/src/FreeDSx/Ldap/Operation/Response/SearchResponse.php
+++ b/src/FreeDSx/Ldap/Operation/Response/SearchResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Response/SearchResultDone.php
+++ b/src/FreeDSx/Ldap/Operation/Response/SearchResultDone.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Response/SearchResultEntry.php
+++ b/src/FreeDSx/Ldap/Operation/Response/SearchResultEntry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/Response/SearchResultReference.php
+++ b/src/FreeDSx/Ldap/Operation/Response/SearchResultReference.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operation/ResultCode.php
+++ b/src/FreeDSx/Ldap/Operation/ResultCode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Operations.php
+++ b/src/FreeDSx/Ldap/Operations.php
@@ -37,6 +37,7 @@ use FreeDSx\Ldap\Operation\Request\UnbindRequest;
 use FreeDSx\Ldap\Protocol\ProtocolElementInterface;
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
 use FreeDSx\Ldap\Search\Filters;
+use Stringable;
 
 /**
  * Provides a set of factory methods to help quickly construct different operations/requests.
@@ -111,12 +112,12 @@ class Operations
      * A comparison operation to check if an entry has an attribute with a certain value.
      */
     public static function compare(
-        string $dn,
+        Stringable|string $dn,
         string $attributeName,
         string $value
     ): CompareRequest {
         return new CompareRequest(
-            dn: $dn,
+            dn: (string) $dn,
             filter: Filters::equal(
                 attribute: $attributeName,
                 value: $value,
@@ -149,11 +150,11 @@ class Operations
      * Perform modification(s) on an LDAP entry.
      */
     public static function modify(
-        string $dn,
+        Stringable|string $dn,
         Change ...$changes,
     ): ModifyRequest {
         return new ModifyRequest(
-            $dn,
+            (string) $dn,
             ...$changes
         );
     }
@@ -164,16 +165,16 @@ class Operations
      * @throws UnexpectedValueException
      */
     public static function move(
-        string $dn,
-        string $newParentDn,
+        Stringable|string $dn,
+        Stringable|string $newParentDn,
     ): ModifyDnRequest {
-        $dnObj = new Dn($dn);
+        $dnObj = new Dn((string) $dn);
 
         return new ModifyDnRequest(
-            dn: $dn,
+            dn: (string) $dn,
             newRdn: $dnObj->getRdn()->toString(),
             deleteOldRdn: true,
-            newParentDn: $newParentDn,
+            newParentDn: (string) $newParentDn,
         );
     }
 
@@ -204,12 +205,12 @@ class Operations
      * Rename an LDAP entry by modifying its RDN.
      */
     public static function rename(
-        string|Dn $dn,
-        string|Rdn $rdn,
+        Stringable|string|Dn $dn,
+        Stringable|string|Rdn $rdn,
         bool $deleteOldRdn = true
     ): ModifyDnRequest {
         return new ModifyDnRequest(
-            dn: $dn,
+            dn: $dn ,
             newRdn: $rdn,
             deleteOldRdn: $deleteOldRdn,
         );

--- a/src/FreeDSx/Ldap/Operations.php
+++ b/src/FreeDSx/Ldap/Operations.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientBasicHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientBasicHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientExtendedOperationHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientExtendedOperationHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientProtocolContext.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientProtocolContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientReferralHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientReferralHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSaslBindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSaslBindHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSearchHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientStartTlsHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientStartTlsHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientUnbindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientUnbindHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/MessageCreationTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/MessageCreationTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/RequestHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/RequestHandlerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ResponseHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ResponseHandlerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/Factory/ClientProtocolHandlerFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ClientProtocolHandlerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/Factory/ExtendedResponseFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ExtendedResponseFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/Factory/FilterFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/FilterFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/Factory/ResponseFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ResponseFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/Factory/ServerBindHandlerFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ServerBindHandlerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/LdapEncoder.php
+++ b/src/FreeDSx/Ldap/Protocol/LdapEncoder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/LdapMessage.php
+++ b/src/FreeDSx/Ldap/Protocol/LdapMessage.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/LdapMessageRequest.php
+++ b/src/FreeDSx/Ldap/Protocol/LdapMessageRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/LdapMessageResponse.php
+++ b/src/FreeDSx/Ldap/Protocol/LdapMessageResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/LdapQueue.php
+++ b/src/FreeDSx/Ldap/Protocol/LdapQueue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ProtocolElementInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/ProtocolElementInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/Queue/ClientQueue.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/ClientQueue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/Queue/MessageWrapper/SaslMessageWrapper.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/MessageWrapper/SaslMessageWrapper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/Queue/MessageWrapperInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/MessageWrapperInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/Queue/ServerQueue.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/ServerQueue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ReferralContext.php
+++ b/src/FreeDSx/Ldap/Protocol/ReferralContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/BaseServerHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/BaseServerHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/BindHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/BindHandlerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAnonBindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAnonBindHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerBindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerBindHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerProtocolHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerProtocolHandlerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/ReferralChaserInterface.php
+++ b/src/FreeDSx/Ldap/ReferralChaserInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/DirSync.php
+++ b/src/FreeDSx/Ldap/Search/DirSync.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Filter/AndFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/AndFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Filter/ApproximateFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/ApproximateFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Filter/AttributeValueAssertionTrait.php
+++ b/src/FreeDSx/Ldap/Search/Filter/AttributeValueAssertionTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Filter/EqualityFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/EqualityFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Filter/FilterAttributeTrait.php
+++ b/src/FreeDSx/Ldap/Search/Filter/FilterAttributeTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Filter/FilterContainerInterface.php
+++ b/src/FreeDSx/Ldap/Search/Filter/FilterContainerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Filter/FilterContainerTrait.php
+++ b/src/FreeDSx/Ldap/Search/Filter/FilterContainerTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Filter/FilterInterface.php
+++ b/src/FreeDSx/Ldap/Search/Filter/FilterInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Filter/GreaterThanOrEqualFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/GreaterThanOrEqualFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Filter/LessThanOrEqualFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/LessThanOrEqualFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Filter/MatchingRuleFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/MatchingRuleFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Filter/NotFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/NotFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Filter/OrFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/OrFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Filter/PresentFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/PresentFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Filter/SubstringFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/SubstringFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/FilterParser.php
+++ b/src/FreeDSx/Ldap/Search/FilterParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Filters.php
+++ b/src/FreeDSx/Ldap/Search/Filters.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Paging.php
+++ b/src/FreeDSx/Ldap/Search/Paging.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/RangeRetrieval.php
+++ b/src/FreeDSx/Ldap/Search/RangeRetrieval.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Search/Vlv.php
+++ b/src/FreeDSx/Ldap/Search/Vlv.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/ChildProcess.php
+++ b/src/FreeDSx/Ldap/Server/ChildProcess.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/HandlerFactoryInterface.php
+++ b/src/FreeDSx/Ldap/Server/HandlerFactoryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/Paging/PagingRequest.php
+++ b/src/FreeDSx/Ldap/Server/Paging/PagingRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/Paging/PagingRequestComparator.php
+++ b/src/FreeDSx/Ldap/Server/Paging/PagingRequestComparator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/Paging/PagingRequests.php
+++ b/src/FreeDSx/Ldap/Server/Paging/PagingRequests.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/Paging/PagingResponse.php
+++ b/src/FreeDSx/Ldap/Server/Paging/PagingResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/RequestContext.php
+++ b/src/FreeDSx/Ldap/Server/RequestContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/RequestHandler/GenericRequestHandler.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/GenericRequestHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/RequestHandler/HandlerFactory.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/HandlerFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/RequestHandler/PagingHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/PagingHandlerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/RequestHandler/ProxyHandler.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/ProxyHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/RequestHandler/ProxyPagingHandler.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/ProxyPagingHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/RequestHandler/ProxyRequestHandler.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/ProxyRequestHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/RequestHandler/RequestHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/RequestHandlerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/RequestHandler/RootDseHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/RootDseHandlerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/RequestHistory.php
+++ b/src/FreeDSx/Ldap/Server/RequestHistory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/ServerRunner/ServerRunnerInterface.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/ServerRunnerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/Token/AnonToken.php
+++ b/src/FreeDSx/Ldap/Server/Token/AnonToken.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/Token/BindToken.php
+++ b/src/FreeDSx/Ldap/Server/Token/BindToken.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/src/FreeDSx/Ldap/Server/Token/TokenInterface.php
+++ b/src/FreeDSx/Ldap/Server/Token/TokenInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *

--- a/tests/bin/ldapserver.php
+++ b/tests/bin/ldapserver.php
@@ -33,8 +33,8 @@ class LdapServerPagingHandler implements PagingHandlerInterface
             $entries[] = Entry::fromArray(
                 "cn=foo$i,dc=foo,dc=bar",
                 [
-                    'foo' => $i,
-                    'bar' => $i,
+                    'foo' => (string) $i,
+                    'bar' => (string) $i,
                 ]
             );
         }
@@ -154,7 +154,7 @@ class LdapServerRequestHandler extends GenericRequestHandler
 
     public function modifyDn(RequestContext $context, ModifyDnRequest $modifyDn): void
     {
-        $dnLog = 'ParentDn => ' . $modifyDn->getNewParentDn()->toString();
+        $dnLog = 'ParentDn => ' . $modifyDn->getNewParentDn()?->toString();
         $dnLog .= ', ParentRdn => ' . $modifyDn->getNewRdn()->toString();
 
         $this->logRequest(
@@ -167,7 +167,7 @@ class LdapServerRequestHandler extends GenericRequestHandler
     {
         $this->logRequest(
             'search',
-            "base-dn => {$search->getBaseDn()->toString()}, filter => {$search->getFilter()->toString()}"
+            "base-dn => {$search->getBaseDn()?->toString()}, filter => {$search->getFilter()->toString()}"
         );
 
         return new Entries(

--- a/tests/integration/FreeDSx/Ldap/ServerTestCase.php
+++ b/tests/integration/FreeDSx/Ldap/ServerTestCase.php
@@ -55,7 +55,7 @@ class ServerTestCase extends LdapTestCase
             $output = $this->subject->getOutput();
             $this->subject->clearOutput();
 
-            if (strpos($output, $marker) !== false) {
+            if (str_contains($output, $marker)) {
                 return $output;
             }
 

--- a/tests/spec/FreeDSx/Ldap/Entry/EntrySpec.php
+++ b/tests/spec/FreeDSx/Ldap/Entry/EntrySpec.php
@@ -76,6 +76,24 @@ class EntrySpec extends ObjectBehavior
         ]);
     }
 
+    public function it_should_be_constructed_from_an_array_using_fromArray_when_not_all_data_are_strings(): void
+    {
+        $this->beConstructedThrough('fromArray', ['cn=foobar,dc=example,dc=local', [
+            'cn' => 'foobar',
+            'telephoneNumber' => [123, 456],
+            'is_bad_idea' => true,
+        ]]);
+
+        $this->getDn()
+            ->shouldBeLike(new Dn('cn=foobar,dc=example,dc=local'));
+        $this->getAttributes()
+            ->shouldBeLike([
+                new Attribute('cn', 'foobar'),
+                new Attribute('telephoneNumber', '123', '456'),
+                new Attribute('is_bad_idea', '1')
+            ]);
+    }
+
     public function it_should_get_the_entry_as_an_associative_array()
     {
         $this->toArray()->shouldBeEqualTo([


### PR DESCRIPTION
This is another clean-up task as part of a 1.0.0 release. It's best practice to enforce strict types. It leads to less ambiguous code and is easier to maintain and catch potential bugs. To that end, this caught many places in code that were implicitly doing type casts that were not very obvious.

https://github.com/FreeDSx/LDAP/issues/50