### PR TITLE
[1.0.0] Update PHPUnit tests for PHP 8.1 / best practices.

### DIFF
--- a/tests/integration/FreeDSx/Ldap/LdapClientTest.php
+++ b/tests/integration/FreeDSx/Ldap/LdapClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *
@@ -22,13 +24,11 @@ use FreeDSx\Ldap\Operation\Response\ModifyDnResponse;
 use FreeDSx\Ldap\Operation\Response\ModifyResponse;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Search\Filters;
+use Throwable;
 
 class LdapClientTest extends LdapTestCase
 {
-    /**
-     * @var LdapClient
-     */
-    protected $client;
+    private LdapClient $client;
 
     public function setUp(): void
     {
@@ -39,36 +39,58 @@ class LdapClientTest extends LdapTestCase
     {
         try {
             @$this->client->unbind();
-        } catch (\Exception|\Throwable $exception) {
+        } catch (Throwable) {
         }
     }
 
-    public function testUsernamePasswordBind()
+    public function testUsernamePasswordBind(): void
     {
-        $response = $this->client->bind($_ENV['LDAP_USERNAME'], $_ENV['LDAP_PASSWORD'])->getResponse();
+        $response = $this->client->bind(
+            $_ENV['LDAP_USERNAME'],
+            $_ENV['LDAP_PASSWORD']
+        )->getResponse();
 
-        $this->assertInstanceOf(BindResponse::class, $response);
-        $this->assertEquals(0, $response->getResultCode());
+        $this->assertInstanceOf(
+            BindResponse::class,
+            $response
+        );
+        $this->assertEquals(
+            0,
+            $response->getResultCode()
+        );
     }
 
-    public function testAnonymousBind()
+    public function testAnonymousBind(): void
     {
-        $response = $this->client->send(Operations::bindAnonymously())->getResponse();
+        $response = $this->client->send(Operations::bindAnonymously())
+            ?->getResponse();
 
-        $this->assertInstanceOf(BindResponse::class, $response);
-        $this->assertEquals(0, $response->getResultCode());
+        $this->assertInstanceOf(
+            BindResponse::class,
+            $response
+        );
+        $this->assertEquals(
+            0,
+            $response->getResultCode()
+        );
     }
 
-    public function testSaslBindWithAutoSelectingTheMechanism()
+    public function testSaslBindWithAutoSelectingTheMechanism(): void
     {
         $response = $this->client->bindSasl($this->getSaslOptions());
         $response = $response->getResponse();
 
-        $this->assertInstanceOf(BindResponse::class, $response);
-        $this->assertEquals(0, $response->getResultCode());
+        $this->assertInstanceOf(
+            BindResponse::class,
+            $response
+        );
+        $this->assertEquals(
+            0,
+            $response->getResultCode()
+        );
     }
 
-    public function testSaslBindWithCramMD5()
+    public function testSaslBindWithCramMD5(): void
     {
         if ($this->isActiveDirectory()) {
             $this->markTestSkipped('CRAM-MD5 not supported on AD.');
@@ -79,11 +101,17 @@ class LdapClientTest extends LdapTestCase
         );
         $response = $response->getResponse();
 
-        $this->assertInstanceOf(BindResponse::class, $response);
-        $this->assertEquals(0, $response->getResultCode());
+        $this->assertInstanceOf(
+            BindResponse::class,
+            $response
+        );
+        $this->assertEquals(
+            0,
+            $response->getResultCode()
+        );
     }
 
-    public function testSaslBindWithDigestMD5()
+    public function testSaslBindWithDigestMD5(): void
     {
         $response = $this->client->bindSasl(
             $this->getSaslOptions(),
@@ -91,11 +119,16 @@ class LdapClientTest extends LdapTestCase
         );
         $response = $response->getResponse();
 
-        $this->assertInstanceOf(BindResponse::class, $response);
-        $this->assertEquals(0, $response->getResultCode());
+        $this->assertInstanceOf(
+            BindResponse::class,
+            $response
+        );
+        $this->assertEquals(
+            0, $response->getResultCode()
+        );
     }
 
-    public function testSaslBindWithAnIntegritySecurityLayerIsFunctional()
+    public function testSaslBindWithAnIntegritySecurityLayerIsFunctional(): void
     {
         $this->client->bindSasl(
             array_merge($this->getSaslOptions(), ['use_integrity' => true]),
@@ -103,21 +136,32 @@ class LdapClientTest extends LdapTestCase
         );
         $entry = $this->client->read('', ['supportedSaslMechanisms']);
 
-        $this->assertInstanceOf(Entry::class, $entry);
+        $this->assertInstanceOf(
+            Entry::class,
+            $entry
+        );
     }
 
-    public function testCompareOperation()
+    public function testCompareOperation(): void
     {
         $this->bindClient($this->client);
 
-        $success = $this->client->compare('cn=Birgit Pankhurst,ou=Janitorial,ou=FreeDSx-Test,dc=example,dc=com', 'cn', 'Birgit Pankhurst');
-        $failure = $this->client->compare('cn=Birgit Pankhurst,ou=Janitorial,ou=FreeDSx-Test,dc=example,dc=com', 'cn', 'foo');
+        $success = $this->client->compare(
+            'cn=Birgit Pankhurst,ou=Janitorial,ou=FreeDSx-Test,dc=example,dc=com',
+            'cn',
+            'Birgit Pankhurst'
+        );
+        $failure = $this->client->compare(
+            'cn=Birgit Pankhurst,ou=Janitorial,ou=FreeDSx-Test,dc=example,dc=com',
+            'cn',
+            'foo'
+        );
 
         $this->assertTrue($success);
         $this->assertFalse($failure);
     }
 
-    public function testCreateOperation()
+    public function testCreateOperation(): void
     {
         $this->bindClient($this->client);
 
@@ -130,18 +174,35 @@ class LdapClientTest extends LdapTestCase
             'givenName' => ['Foo'],
         ];
 
-        $response = $this->client->create(Entry::fromArray('cn=Foo,ou=FreeDSx-Test,dc=example,dc=com', $attributes))->getResponse();
-        $this->assertInstanceOf(AddResponse::class, $response);
-        $this->assertEquals(0, $response->getResultCode());
+        $response = $this->client->create(Entry::fromArray(
+            'cn=Foo,ou=FreeDSx-Test,dc=example,dc=com',
+            $attributes
+        ))->getResponse();
+
+        $this->assertInstanceOf(
+            AddResponse::class,
+            $response
+        );
+        $this->assertEquals(
+            0,
+            $response->getResultCode()
+        );
 
         # Testing across AD / OpenLDAP. Ignore the ObjectClass differences...
         unset($attributes['objectClass']);
 
-        $entry = $this->client->read('cn=Foo,ou=FreeDSx-Test,dc=example,dc=com', array_keys($attributes));
-        $this->assertEquals($attributes, $entry->toArray());
+        $entry = $this->client->readOrFail(
+            'cn=Foo,ou=FreeDSx-Test,dc=example,dc=com',
+            array_keys($attributes)
+        );
+
+        $this->assertEquals(
+            $attributes,
+            $entry->toArray()
+        );
     }
 
-    public function testReadOperation()
+    public function testReadOperation(): void
     {
         $this->bindClient($this->client);
 
@@ -153,23 +214,43 @@ class LdapClientTest extends LdapTestCase
             'l' => ['San Jose'],
             'postalAddress' => ['Product Testing$San Jose'],
         ];
-        $entry = $this->client->read('cn=Carmelina Esposito,ou=Product Testing,ou=FreeDSx-Test,dc=example,dc=com', array_keys($attributes));
+        $entry = $this->client->read(
+            'cn=Carmelina Esposito,ou=Product Testing,ou=FreeDSx-Test,dc=example,dc=com',
+            array_keys($attributes)
+        );
 
-        $this->assertInstanceOf(Entry::class, $entry);
-        $this->assertEquals(strtolower($entry->getDn()->toString()), strtolower('cn=Carmelina Esposito,ou=Product Testing,ou=FreeDSx-Test,dc=example,dc=com'));
-        $this->assertEquals($entry->toArray(), $attributes);
+        $this->assertInstanceOf(
+            Entry::class,
+            $entry
+        );
+        $this->assertEquals(
+            strtolower($entry->getDn()->toString()),
+            strtolower('cn=Carmelina Esposito,ou=Product Testing,ou=FreeDSx-Test,dc=example,dc=com')
+        );
+        $this->assertEquals(
+            $entry->toArray(),
+            $attributes
+        );
     }
 
-    public function testDeleteOperation()
+    public function testDeleteOperation(): void
     {
         $this->bindClient($this->client);
 
-        $response = $this->client->delete('cn=Foo,ou=FreeDSx-Test,dc=example,dc=com')->getResponse();
-        $this->assertInstanceOf(DeleteResponse::class, $response);
-        $this->assertEquals(0, $response->getResultCode());
+        $response = $this->client->delete('cn=Foo,ou=FreeDSx-Test,dc=example,dc=com')
+            ->getResponse();
+
+        $this->assertInstanceOf(
+            DeleteResponse::class,
+            $response
+        );
+        $this->assertEquals(
+            0,
+            $response->getResultCode()
+        );
     }
 
-    public function testModifyOperation()
+    public function testModifyOperation(): void
     {
         $this->bindClient($this->client);
 
@@ -180,51 +261,98 @@ class LdapClientTest extends LdapTestCase
         $entry->remove('homePhone', '+1 510 991-4348');
         $entry->set('title', 'Head Payroll Dude');
 
-        $response = $this->client->update($entry)->getResponse();
+        $response = $this->client->update($entry)
+            ->getResponse();
+
         $this->assertInstanceOf(ModifyResponse::class, $response);
         $this->assertEquals(0, $response->getResultCode());
         $this->assertEmpty($entry->changes()->toArray());
 
-        $modified = $this->client->read('cn=Kathrine Erbach,ou=Payroll,ou=FreeDSx-Test,dc=example,dc=com', [
-            'facsimileTelephoneNumber',
-            'mobile',
-            'homePhone',
-            'title',
-        ]);
-        $this->assertEquals(['mobile' => ['+1 555 555-5555'], 'title' => ['Head Payroll Dude']], $modified->toArray());
+        $modified = $this->client->readOrFail(
+            'cn=Kathrine Erbach,ou=Payroll,ou=FreeDSx-Test,dc=example,dc=com',
+            [
+                'facsimileTelephoneNumber',
+                'mobile',
+                'homePhone',
+                'title',
+            ]
+        );
+        $this->assertEquals(
+            [
+                'mobile' => ['+1 555 555-5555'],
+                'title' => ['Head Payroll Dude']
+            ],
+            $modified->toArray()
+        );
     }
 
-    public function testRenameOperation()
+    public function testRenameOperation(): void
     {
         $this->bindClient($this->client);
 
-        $result = $this->client->rename('cn=Arleen Sevigny,ou=Janitorial,ou=FreeDSx-Test,dc=example,dc=com', 'cn=Arleen Sevigny-Foo');
-        $entry = $this->client->read('cn=Arleen Sevigny-Foo,ou=Janitorial,ou=FreeDSx-Test,dc=example,dc=com', ['cn']);
+        $result = $this->client->rename(
+            'cn=Arleen Sevigny,ou=Janitorial,ou=FreeDSx-Test,dc=example,dc=com',
+            'cn=Arleen Sevigny-Foo'
+        );
+        $entry = $this->client->readOrFail(
+            'cn=Arleen Sevigny-Foo,ou=Janitorial,ou=FreeDSx-Test,dc=example,dc=com',
+            ['cn']
+        );
 
-        $this->assertInstanceOf(ModifyDnResponse::class, $result->getResponse());
-        $this->assertInstanceOf(Entry::class, $entry);
-        $this->assertEquals(['Arleen Sevigny-Foo'], $entry->get('cn')->getValues());
+        $this->assertInstanceOf(
+            ModifyDnResponse::class,
+            $result->getResponse()
+        );
+        $this->assertInstanceOf(
+            Entry::class,
+            $entry
+        );
+        $this->assertEquals(
+            ['Arleen Sevigny-Foo'],
+            $entry->get('cn')?->getValues()
+        );
     }
 
-    public function testRenameWithoutDeleteOperation()
+    public function testRenameWithoutDeleteOperation(): void
     {
         if ($this->isActiveDirectory()) {
             $this->markTestSkipped('Rename without delete not supported in Active Directory.');
         }
         $this->bindClient($this->client);
 
-        $result = $this->client->rename('cn=Farouk Langdon,ou=Administrative,ou=FreeDSx-Test,dc=example,dc=com', 'cn=Farouk Langdon-Bar', false);
-        $entry = $this->client->read('cn=Farouk Langdon-Bar,ou=Administrative,ou=FreeDSx-Test,dc=example,dc=com', ['cn']);
+        $result = $this->client->rename(
+            'cn=Farouk Langdon,ou=Administrative,ou=FreeDSx-Test,dc=example,dc=com',
+            'cn=Farouk Langdon-Bar',
+            false
+        );
+        $entry = $this->client->read(
+            'cn=Farouk Langdon-Bar,ou=Administrative,ou=FreeDSx-Test,dc=example,dc=com',
+            ['cn']
+        );
 
-        $this->assertInstanceOf(ModifyDnResponse::class, $result->getResponse());
-        $this->assertInstanceOf(Entry::class, $entry);
-        $this->assertContains('Farouk Langdon', $entry->get('cn')->getValues());
-        $this->assertContains('Farouk Langdon-Bar', $entry->get('cn')->getValues());
+        $this->assertInstanceOf(
+            ModifyDnResponse::class,
+            $result->getResponse()
+        );
+        $this->assertInstanceOf(
+            Entry::class,
+            $entry
+        );
+        $this->assertContains(
+            'Farouk Langdon',
+            (array) $entry->get('cn')?->getValues()
+        );
+        $this->assertContains(
+            'Farouk Langdon-Bar',
+            (array) $entry->get('cn')?->getValues()
+        );
     }
 
-    public function testMoveOperation()
+    public function testMoveOperation(): void
     {
         $this->markTestSkipped('Rename without delete not supported in Active Directory.');
+
+        /*
         $this->bindClient($this->client);
 
         $result = $this->client->move('cn=Minne Schmelzel,ou=Janitorial,ou=FreeDSx-Test,dc=example,dc=com', 'ou=Administrative,ou=FreeDSx-Test,dc=example,dc=com');
@@ -232,55 +360,84 @@ class LdapClientTest extends LdapTestCase
 
         $this->assertInstanceOf(ModifyDnResponse::class, $result->getResponse());
         $this->assertInstanceOf(Entry::class, $entry);
+        */
     }
 
-    public function testSubSearchOperation()
+    public function testSubSearchOperation(): void
     {
         $this->bindClient($this->client);
 
-        $entries = $this->client->search(Operations::search(Filters::raw('(&(objectClass=inetOrgPerson)(cn=A*))')));
-        $this->assertInstanceOf(Entries::class, $entries);
-        $this->assertEquals(843, $entries->count());
+        $entries = $this->client->search(Operations::search(
+            Filters::raw('(&(objectClass=inetOrgPerson)(cn=A*))')
+        ));
+
+        $this->assertInstanceOf(
+            Entries::class,
+            $entries
+        );
+        $this->assertEquals(
+            843,
+            $entries->count()
+        );
     }
 
-    public function testListSearchOperation()
+    public function testListSearchOperation(): void
     {
         $this->bindClient($this->client);
 
-        $entries = $this->client->search(Operations::list(Filters::raw('(&(objectClass=inetOrgPerson)(cn=A*))'), 'ou=Payroll,ou=FreeDSx-Test,dc=example,dc=com'));
-        $this->assertInstanceOf(Entries::class, $entries);
-        $this->assertEquals(100, $entries->count());
+        $entries = $this->client->search(Operations::list(
+            Filters::raw('(&(objectClass=inetOrgPerson)(cn=A*))'),
+            'ou=Payroll,ou=FreeDSx-Test,dc=example,dc=com'
+        ));
 
-        /** @var Entry $entry */
-        foreach ($entries as $entry) {
-            $this->assertEquals(strtolower('ou=Payroll,ou=FreeDSx-Test,dc=example,dc=com'), strtolower($entry->getDn()->getParent()->toString()));
+        $this->assertInstanceOf(
+            Entries::class,
+            $entries
+        );
+        $this->assertEquals(
+            100,
+            $entries->count()
+        );
+
+        foreach ($entries->toArray() as $entry) {
+            $this->assertEquals(
+                strtolower('ou=Payroll,ou=FreeDSx-Test,dc=example,dc=com'),
+                strtolower((string) $entry->getDn()->getParent()?->toString())
+            );
         }
     }
 
-    public function testWhoAmI()
+    public function testWhoAmI(): void
     {
         $this->bindClient($this->client);
 
-        $this->assertMatchesRegularExpression('/^(dn|u):.*/', $this->client->whoami());
+        $this->assertMatchesRegularExpression(
+            '/^(dn|u):.*/',
+            (string) $this->client->whoami()
+        );
     }
 
-    public function testSetOptionsDisconnectsIfRequested()
+    public function testSetOptionsDisconnectsIfRequested(): void
     {
         $this->bindClient($this->client);
-        $this->client->setOptions([], true);
+
+        $this->client->setOptions(
+            options: [],
+            forceDisconnect: true,
+        );
 
         $this->assertFalse($this->client->isConnected());
     }
 
-    public function testStartTls()
+    public function testStartTls(): void
     {
         $this->client = $this->getClient();
         $this->client->startTls();
 
-        $this->assertTrue(true);
+        $this->assertTrue($this->client->isConnected());
     }
 
-    public function testStartTlsFailure()
+    public function testStartTlsFailure(): void
     {
         $this->client = $this->getClient(['servers' => 'foo.com']);
 
@@ -288,23 +445,29 @@ class LdapClientTest extends LdapTestCase
         @$this->client->startTls();
     }
 
-    public function testStartTlsIgnoreCertValidation()
+    public function testStartTlsIgnoreCertValidation(): void
     {
-        $this->client = $this->getClient(['servers' => 'foo.com', 'ssl_validate_cert' => false]);
+        $this->client = $this->getClient([
+            'servers' => 'foo.com',
+            'ssl_validate_cert' => false,
+        ]);
 
         $this->client->startTls();
-        $this->assertTrue(true);
+        $this->assertTrue($this->client->isConnected());
     }
 
-    public function testUseSsl()
+    public function testUseSsl(): void
     {
-        $this->client = $this->getClient(['use_ssl' => true, 'port' => 636]);
+        $this->client = $this->getClient([
+            'use_ssl' => true,
+            'port' => 636
+        ]);
         $this->client->read('');
 
-        $this->assertTrue(true);
+        $this->assertTrue($this->client->isConnected());
     }
 
-    public function testItCanWorkOverUnixSocket()
+    public function testItCanWorkOverUnixSocket(): void
     {
         if ($this->isActiveDirectory()) {
             $this->markTestSkipped('Connecting via a unix socket only tested on OpenLDAP.');
@@ -318,15 +481,20 @@ class LdapClientTest extends LdapTestCase
         $this->assertNotNull($entry);
     }
 
-    public function testUseSslFailure()
+    public function testUseSslFailure(): void
     {
-        $this->client = $this->getClient(['servers' => 'foo.com', 'use_ssl' => true, 'port' => 636]);
+        $this->client = $this->getClient([
+            'servers' => 'foo.com',
+            'use_ssl' => true,
+            'port' => 636
+        ]);
 
         $this->expectException(ConnectionException::class);
+
         $this->client->read('');
     }
 
-    public function testUseSslIgnoreCertValidation()
+    public function testUseSslIgnoreCertValidation(): void
     {
         $this->client = $this->getClient([
             'servers' => 'foo.com',
@@ -336,7 +504,8 @@ class LdapClientTest extends LdapTestCase
         ]);
 
         $this->client->read('');
-        $this->assertTrue(true);
+
+        $this->assertTrue($this->client->isConnected());
     }
 
     protected function getSaslOptions(): array

--- a/tests/integration/FreeDSx/Ldap/LdapServerTest.php
+++ b/tests/integration/FreeDSx/Ldap/LdapServerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *
@@ -20,10 +22,10 @@ use FreeDSx\Ldap\Search\Filters;
 
 class LdapServerTest extends ServerTestCase
 {
-    protected $serverExec = 'ldapserver';
-
     public function setUp(): void
     {
+        $this->setServerMode('ldapserver');
+
         parent::setUp();
 
         $this->createServerProcess('tcp');
@@ -31,7 +33,7 @@ class LdapServerTest extends ServerTestCase
 
     public function testItCanBind(): void
     {
-        $response = $this->client->bind(
+        $response = $this->ldapClient()->bind(
             'cn=user,dc=foo,dc=bar',
             '12345'
         );
@@ -48,13 +50,12 @@ class LdapServerTest extends ServerTestCase
         );
     }
 
-
     public function testItRejectsBindWithIncorrectCredentials(): void
     {
         $bindException = null;
 
         try {
-            $this->client->bind(
+            $this->ldapClient()->bind(
                 'cn=fake,dc=foo,dc=bar',
                 'also-fake'
             );
@@ -68,7 +69,7 @@ class LdapServerTest extends ServerTestCase
     public function testItPerformsAnAdd(): void
     {
         $this->authenticate();
-        $response = $this->client->create(Entry::fromArray(
+        $response = $this->ldapClient()->create(Entry::fromArray(
             'cn=meh,dc=foo,dc=bar',
             [
                 'foo' => 'bar',
@@ -90,7 +91,7 @@ class LdapServerTest extends ServerTestCase
     public function testItPerformsDelete(): void
     {
         $this->authenticate();
-        $response = $this->client->delete('cn=meh,dc=foo,dc=bar');
+        $response = $this->ldapClient()->delete('cn=meh,dc=foo,dc=bar');
         $output = $this->waitForServerOutput('---delete---');
 
         $this->assertNotNull($response);
@@ -118,7 +119,7 @@ class LdapServerTest extends ServerTestCase
         $entry->set('surname', 'LastName');
         $entry->reset('phone');
 
-        $response = $this->client->update($entry);
+        $response = $this->ldapClient()->update($entry);
         $output = $this->waitForServerOutput('---modify---');
 
         $this->assertNotNull($response);
@@ -136,7 +137,7 @@ class LdapServerTest extends ServerTestCase
     {
         $this->authenticate();
 
-        $response = $this->client->read('cn=meh,dc=foo,dc=bar');
+        $response = $this->ldapClient()->read('cn=meh,dc=foo,dc=bar');
         $output = $this->waitForServerOutput('---search---');
 
         $this->assertNotNull($response);
@@ -154,7 +155,7 @@ class LdapServerTest extends ServerTestCase
     {
         $this->authenticate();
 
-        $response = $this->client->compare(
+        $response = $this->ldapClient()->compare(
             'cn=meh,dc=foo,dc=bar',
             'foo',
             'bar'
@@ -180,7 +181,7 @@ class LdapServerTest extends ServerTestCase
     {
         $this->authenticate();
 
-        $response = $this->client->move(
+        $response = $this->ldapClient()->move(
             'cn=meh,dc=foo,dc=bar',
             'cn=bleh,dc=foo,dc=bar'
         );
@@ -201,9 +202,9 @@ class LdapServerTest extends ServerTestCase
         );
     }
 
-    public function testItCanRetrieveTheRootDSE()
+    public function testItCanRetrieveTheRootDSE(): void
     {
-        $rootDse = $this->client->read();
+        $rootDse = $this->ldapClient()->read();
 
         $this->assertNotNull($rootDse);
         $this->assertEquals(
@@ -226,39 +227,39 @@ class LdapServerTest extends ServerTestCase
         );
     }
 
-    public function testThatOperationCompareRequireAuthentication()
+    public function testThatOperationCompareRequireAuthentication(): void
     {
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
 
-        $this->client->compare('dc=foo,dc=bar', 'foo', 'bar');
+        $this->ldapClient()->compare('dc=foo,dc=bar', 'foo', 'bar');
     }
 
-    public function testThatOperationSearchRequireAuthentication()
+    public function testThatOperationSearchRequireAuthentication(): void
     {
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
 
-        $this->client->read('dc=foo,dc=bar');
+        $this->ldapClient()->read('dc=foo,dc=bar');
     }
 
-    public function testThatOperationAddRequireAuthentication()
+    public function testThatOperationAddRequireAuthentication(): void
     {
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
 
-        $this->client->create(Entry::fromArray('dc=foo,dc=bar', ['foo' => 'bar']));
+        $this->ldapClient()->create(Entry::fromArray('dc=foo,dc=bar', ['foo' => 'bar']));
     }
 
-    public function testThatOperationDeleteRequireAuthentication()
+    public function testThatOperationDeleteRequireAuthentication(): void
     {
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
 
-        $this->client->delete('dc=foo,dc=bar');
+        $this->ldapClient()->delete('dc=foo,dc=bar');
     }
 
-    public function testThatOperationModifyRequireAuthentication()
+    public function testThatOperationModifyRequireAuthentication(): void
     {
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
@@ -266,33 +267,33 @@ class LdapServerTest extends ServerTestCase
         $entry = Entry::fromArray('cn=foo,dc=foo,dc=bar');
         $entry->add('email', 'foo@bar.local');
 
-        $this->client->update($entry);
+        $this->ldapClient()->update($entry);
     }
 
-    public function testThatOperationModifyDnRequireAuthentication()
+    public function testThatOperationModifyDnRequireAuthentication(): void
     {
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
 
-        $this->client->move('dc=foo,dc=bar', 'cn=here, dc=foo, dc=bar');
+        $this->ldapClient()->move('dc=foo,dc=bar', 'cn=here, dc=foo, dc=bar');
     }
 
-    public function testWhoAmIWhenAuthenticated()
+    public function testWhoAmIWhenAuthenticated(): void
     {
         $this->authenticate();
-        $output = $this->client->whoami();
+        $output = $this->ldapClient()->whoami();
 
         $this->assertEquals('dn:cn=user,dc=foo,dc=bar', $output);
     }
 
-    public function testWhoAmIWhenNotAuthenticated()
+    public function testWhoAmIWhenNotAuthenticated(): void
     {
-        $output = $this->client->whoami();
+        $output = $this->ldapClient()->whoami();
 
         $this->assertNull($output);
     }
 
-    public function testItCanHandlingPaging()
+    public function testItCanHandlingPaging(): void
     {
         $this->stopServer();
         $this->createServerProcess('tcp', 'paging');
@@ -302,7 +303,7 @@ class LdapServerTest extends ServerTestCase
         $i = 0;
 
         $search = Operations::search(Filters::raw('(cn=foo)'));
-        $paging = $this->client->paging($search);
+        $paging = $this->ldapClient()->paging($search);
 
         while ($paging->hasEntries()) {
             $i++;
@@ -324,7 +325,7 @@ class LdapServerTest extends ServerTestCase
         $this->assertCount(300, $allEntries);
     }
 
-    public function testItThrowsAnExceptionForPagingWhenNotSupported()
+    public function testItThrowsAnExceptionForPagingWhenNotSupported(): void
     {
         $this->authenticate();
 
@@ -332,53 +333,53 @@ class LdapServerTest extends ServerTestCase
         $this->expectExceptionCode(ResultCode::UNAVAILABLE_CRITICAL_EXTENSION);
 
         $search = Operations::search(Filters::raw('(cn=foo)'));
-        $this->client->paging($search)
+        $this->ldapClient()->paging($search)
             ->isCritical()
             ->getEntries();
     }
 
-    public function testItDoesASearchWhenPagingIsNotMarkedAsCritical()
+    public function testItDoesASearchWhenPagingIsNotMarkedAsCritical(): void
     {
         $this->authenticate();
 
         $search = Operations::search(Filters::raw('(cn=foo)'));
-        $paging = $this->client->paging($search);
+        $paging = $this->ldapClient()->paging($search);
         $result = $paging->getEntries();
 
         $this->assertFalse($paging->hasEntries());
         $this->assertNotEmpty($result->toArray());
     }
 
-    public function testItCanStartTLSThenStillPerformOperations()
+    public function testItCanStartTLSThenStillPerformOperations(): void
     {
-        $this->client->startTls();
-        $result = $this->client->read();
+        $this->ldapClient()->startTls();
+        $result = $this->ldapClient()->read();
 
         $this->assertNotNull($result);
     }
 
-    public function testItCanRunOverSSLOnly()
+    public function testItCanRunOverSSLOnly(): void
     {
         $this->stopServer();
         $this->createServerProcess('ssl');
 
-        $result = $this->client->read('');
+        $result = $this->ldapClient()->read('');
         $this->assertNotNull($result);
     }
 
-    public function testItCanRunOverUnixSocket()
+    public function testItCanRunOverUnixSocket(): void
     {
         $this->stopServer();
         $this->createServerProcess('unix');
 
-        $result = $this->client->read('');
+        $result = $this->ldapClient()->read('');
         $this->assertNotNull($result);
     }
 
-    public function testItCanHandleMultipleClients()
+    public function testItCanHandleMultipleClients(): void
     {
-        $this->client->read();
-        $client2 = $this->getClient($this->client->getOptions());
+        $this->ldapClient()->read();
+        $client2 = $this->getClient($this->ldapClient()->getOptions());
 
         $result = $client2->read();
         $this->assertNotNull($result);

--- a/tests/integration/FreeDSx/Ldap/LdapTestCase.php
+++ b/tests/integration/FreeDSx/Ldap/LdapTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *
@@ -13,48 +15,47 @@ namespace integration\FreeDSx\Ldap;
 
 use FreeDSx\Ldap\LdapClient;
 use PHPUnit\Framework\TestCase;
+use Throwable;
 
 class LdapTestCase extends TestCase
 {
-    /**
-     * @var bool
-     */
-    protected static $isActiveDirectory;
+    protected static ?bool $isActiveDirectory = null;
 
     /**
-     * @param array $options
-     * @return LdapClient
+     * @param array<string, mixed> $options
      */
     protected function getClient(array $options = []): LdapClient
     {
-        $default = [
-            'servers' => $_ENV['LDAP_SERVER'],
-            'port' => $_ENV['LDAP_PORT'],
-            'ssl_ca_cert' => $_ENV['LDAP_CA_CERT'] === '' ? __DIR__ . '/../../../resources/cert/ca.crt' : $_ENV['LDAP_CA_CERT'],
-            'base_dn' => $_ENV['LDAP_BASE_DN'],
-        ];
-
-        return new LdapClient(array_merge($default, $options));
+        return new LdapClient(array_merge(
+            [
+                'servers' => $_ENV['LDAP_SERVER'],
+                'port' => $_ENV['LDAP_PORT'],
+                'ssl_ca_cert' => $_ENV['LDAP_CA_CERT'] === ''
+                    ? __DIR__ . '/../../../resources/cert/ca.crt'
+                    : $_ENV['LDAP_CA_CERT'],
+                'base_dn' => $_ENV['LDAP_BASE_DN'],
+            ],
+            $options,
+        ));
     }
 
-    /**
-     * @param LdapClient $client
-     */
     protected function bindClient(LdapClient $client): void
     {
-        $client->bind($_ENV['LDAP_USERNAME'], $_ENV['LDAP_PASSWORD']);
+        $client->bind(
+            $_ENV['LDAP_USERNAME'],
+            $_ENV['LDAP_PASSWORD'],
+        );
     }
 
-    /**
-     * @return bool
-     */
     protected function isActiveDirectory(): bool
     {
         if (self::$isActiveDirectory === null) {
             $client = $this->getClient();
+
             try {
-                self::$isActiveDirectory = $client->read('')->has('forestFunctionality');
-            } catch (\Exception|\Throwable $e) {
+                self::$isActiveDirectory = $client->readOrFail('')
+                    ->has('forestFunctionality');
+            } catch (Throwable $e) {
                 self::$isActiveDirectory = false;
             } finally {
                 $client->unbind();

--- a/tests/integration/FreeDSx/Ldap/Search/DirSyncTest.php
+++ b/tests/integration/FreeDSx/Ldap/Search/DirSyncTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *
@@ -19,20 +21,11 @@ use integration\FreeDSx\Ldap\LdapTestCase;
 
 class DirSyncTest extends LdapTestCase
 {
-    /**
-     * @var LdapClient
-     */
-    protected $client;
+    private LdapClient $client;
 
-    /**
-     * @var DirSync
-     */
-    protected $dirSync;
+    private DirSync $dirSync;
 
-    /**
-     * @var FilterInterface
-     */
-    protected $filter;
+    private FilterInterface $filter;
 
     public function setUp(): void
     {
@@ -43,13 +36,25 @@ class DirSyncTest extends LdapTestCase
         $this->bindClient($this->client);
 
         $this->filter = Filters::and(
-            Filters::equal('objectClass', 'inetOrgPerson'),
-            Filters::not(Filters::equal('isDeleted', 'TRUE'))
+            Filters::equal(
+                'objectClass',
+                'inetOrgPerson'
+            ),
+            Filters::not(Filters::equal(
+                'isDeleted',
+                'TRUE'
+            ))
         );
-        $this->dirSync = new DirSync($this->client, null, $this->filter, 'description');
+
+        $this->dirSync = new DirSync(
+            $this->client,
+            null,
+            $this->filter,
+            'description'
+        );
     }
 
-    public function testPagingSync()
+    public function testPagingSync(): void
     {
         $all = $this->dirSync->getChanges();
 
@@ -58,10 +63,16 @@ class DirSyncTest extends LdapTestCase
         }
         $this->assertCount(10001, $all);
 
-        $entry = $this->client->read('cn=Vivie Niebudek,ou=Administrative,ou=FreeDSx-Test,dc=example,dc=com');
-        $entry->set('description', 'foobar ' . rand());
+        $entry = $this->client->readOrFail('cn=Vivie Niebudek,ou=Administrative,ou=FreeDSx-Test,dc=example,dc=com');
+        $entry->set(
+            'description',
+            'foobar ' . rand()
+        );
         $this->client->update($entry);
 
-        $this->assertCount(1, $this->dirSync->getChanges());
+        $this->assertCount(
+            1,
+            $this->dirSync->getChanges()
+        );
     }
 }

--- a/tests/integration/FreeDSx/Ldap/Search/PagingTest.php
+++ b/tests/integration/FreeDSx/Ldap/Search/PagingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *
@@ -17,60 +19,75 @@ use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Search\Paging;
 use integration\FreeDSx\Ldap\LdapTestCase;
+use Throwable;
 
 class PagingTest extends LdapTestCase
 {
-    /**
-     * @var Paging
-     */
-    protected $paging;
+    private Paging $paging;
 
-    /**
-     * @var SearchRequest
-     */
-    protected $search;
+    private SearchRequest $search;
 
-    /**
-     * @var LdapClient
-     */
-    protected $client;
+    private LdapClient $client;
 
     protected function setUp(): void
     {
         $this->client = $this->getClient();
         $this->bindClient($this->client);
 
-        $this->search = Operations::search(Filters::equal('objectClass', 'inetOrgPerson'), 'cn');
-        $this->paging = new Paging($this->client, $this->search);
+        $this->search = Operations::search(
+            Filters::equal(
+                'objectClass',
+                'inetOrgPerson'
+            ),
+            'cn'
+        );
+
+        $this->paging = new Paging(
+            $this->client,
+            $this->search
+        );
     }
 
     protected function tearDown(): void
     {
         try {
             $this->client->unbind();
-        } catch (\Exception|\Throwable $e) {
+        } catch (Throwable) {
         }
     }
 
-    public function testPagingAll()
+    public function testPagingAll(): void
     {
         $entries = $this->paging->getEntries();
-        $this->assertEquals(1000, $entries->count());
+
+        $this->assertEquals(
+            1000,
+            $entries->count()
+        );
 
         while ($this->paging->hasEntries()) {
             $entries->add(...$this->paging->getEntries());
         }
 
-        $this->assertEquals(10001, $entries->count());
+        $this->assertEquals(
+            10001,
+            $entries->count()
+        );
     }
 
-    public function testPagingSpecificSize()
+    public function testPagingSpecificSize(): void
     {
         $entries = $this->paging->getEntries(100);
-        $this->assertEquals(100, $entries->count());
+
+        $this->assertEquals(
+            100,
+            $entries->count()
+        );
+
         $this->assertTrue($this->paging->hasEntries());
 
         $this->paging->end();
+
         $this->assertFalse($this->paging->hasEntries());
     }
 }

--- a/tests/integration/FreeDSx/Ldap/Search/RangeRetrievalTest.php
+++ b/tests/integration/FreeDSx/Ldap/Search/RangeRetrievalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *
@@ -18,15 +20,9 @@ use integration\FreeDSx\Ldap\LdapTestCase;
 
 class RangeRetrievalTest extends LdapTestCase
 {
-    /**
-     * @var LdapClient
-     */
-    protected $client;
+    private LdapClient $client;
 
-    /**
-     * @var RangeRetrieval
-     */
-    protected $range;
+    private RangeRetrieval $range;
 
     public function setUp(): void
     {
@@ -47,49 +43,93 @@ class RangeRetrievalTest extends LdapTestCase
         }
     }
     
-    public function testRetrieveAll()
+    public function testRetrieveAll(): void
     {
-        $result = $this->range->getAllValues('cn=All Employees,ou=FreeDSx-Test,dc=example,dc=com', 'member');
+        $result = $this->range->getAllValues(
+            'cn=All Employees,ou=FreeDSx-Test,dc=example,dc=com',
+            'member'
+        );
 
-        $this->assertEquals(10001, count($result->getValues()));
+        $this->assertEquals(
+            10001,
+            count($result->getValues())
+        );
     }
 
-    public function testHasRanged()
+    public function testHasRanged(): void
     {
-        $entry = $this->client->read('cn=All Employees,ou=FreeDSx-Test,dc=example,dc=com');
+        $entry = $this->client->readOrFail('cn=All Employees,ou=FreeDSx-Test,dc=example,dc=com');
 
-        $this->assertTrue($this->range->hasRanged($entry, 'member'));
-        $this->assertFalse($this->range->hasRanged($entry, 'description'));
+        $this->assertTrue($this->range->hasRanged(
+            $entry,
+            'member'
+        ));
+        $this->assertFalse($this->range->hasRanged(
+            $entry,
+            'description'
+        ));
     }
 
-    public function testGetRanged()
+    public function testGetRanged(): void
     {
-        $entry = $this->client->read('cn=All Employees,ou=FreeDSx-Test,dc=example,dc=com');
+        $entry = $this->client->readOrFail('cn=All Employees,ou=FreeDSx-Test,dc=example,dc=com');
 
-        $this->assertInstanceOf(Attribute::class, $this->range->getRanged($entry, 'member'));
-        $this->assertNull($this->range->getRanged($entry, 'description'));
+        $this->assertInstanceOf(
+            Attribute::class,
+            $this->range->getRanged(
+                $entry,
+                'member'
+            )
+        );
+        $this->assertNull($this->range->getRanged(
+            $entry,
+            'description'
+        ));
     }
 
-    public function testGetAllRanged()
+    public function testGetAllRanged(): void
     {
-        $allUsers = $this->client->read('cn=All Employees,ou=FreeDSx-Test,dc=example,dc=com');
-        $adminUsers = $this->client->read('cn=Administrative Users,ou=FreeDSx-Test,dc=example,dc=com');
+        $allUsers = $this->client->readOrFail('cn=All Employees,ou=FreeDSx-Test,dc=example,dc=com');
+        $adminUsers = $this->client->readOrFail('cn=Administrative Users,ou=FreeDSx-Test,dc=example,dc=com');
 
-        $this->assertCount(1, $this->range->getAllRanged($allUsers));
-        $this->assertCount(0, $this->range->getAllRanged($adminUsers));
+        $this->assertCount(
+            1,
+            $this->range->getAllRanged($allUsers)
+        );
+        $this->assertCount(
+            0,
+            $this->range->getAllRanged($adminUsers)
+        );
     }
 
-    public function testPagingRangedValues()
+    public function testPagingRangedValues(): void
     {
-        $members = $this->client->read('cn=All Employees,ou=FreeDSx-Test,dc=example,dc=com', ['member;range=0-*'])->get('member');
+        $members = $this->client->readOrFail(
+            'cn=All Employees,ou=FreeDSx-Test,dc=example,dc=com',
+            ['member;range=0-*']
+        )->get('member');
+
+        $this->assertInstanceOf(
+            Attribute::class,
+            $members,
+        );
         $this->assertTrue($this->range->hasMoreValues($members));
 
         $all = $members->getValues();
         while ($this->range->hasMoreValues($members)) {
-            $members = $this->range->getMoreValues('cn=All Employees,ou=FreeDSx-Test,dc=example,dc=com', $members);
-            $all = array_merge($all, $members->getValues());
+            $members = $this->range->getMoreValues(
+                'cn=All Employees,ou=FreeDSx-Test,dc=example,dc=com',
+                $members
+            );
+            $all = array_merge(
+                $all,
+                $members->getValues(),
+            );
         }
 
-        $this->assertCount(10001, $all);
+        $this->assertCount(
+            10001,
+            $all
+        );
     }
 }

--- a/tests/integration/FreeDSx/Ldap/Search/VlvTest.php
+++ b/tests/integration/FreeDSx/Ldap/Search/VlvTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *
@@ -17,23 +19,15 @@ use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Search\Vlv;
 use integration\FreeDSx\Ldap\LdapTestCase;
+use Throwable;
 
 class VlvTest extends LdapTestCase
 {
-    /**
-     * @var Vlv
-     */
-    protected $vlv;
+    private Vlv $vlv;
 
-    /**
-     * @var SearchRequest
-     */
-    protected $search;
+    private SearchRequest $search;
 
-    /**
-     * @var LdapClient
-     */
-    protected $client;
+    private LdapClient $client;
 
     protected function setUp(): void
     {
@@ -44,76 +38,155 @@ class VlvTest extends LdapTestCase
             Filters::equal('objectClass', 'inetOrgPerson'),
             Filters::startsWith('cn', 'B')
         ), 'sn', 'givenName');
-        $this->vlv = new Vlv($this->client, $this->search, 'sn');
+
+        $this->vlv = new Vlv(
+            $this->client,
+            $this->search,
+            'sn'
+        );
     }
 
     protected function tearDown(): void
     {
         try {
             $this->client->unbind();
-        } catch (\Exception|\Throwable $e) {
+        } catch (Throwable) {
         }
     }
 
-    public function testVlv()
+    public function testVlv(): void
     {
-        $this->assertEquals(101, $this->vlv->getEntries()->count());
-        $this->assertEquals(453, $this->vlv->listSize());
-        $this->assertEquals(1, $this->vlv->listOffset());
+        $this->assertEquals(
+            101,
+            $this->vlv->getEntries()->count()
+        );
+        $this->assertEquals(
+            453,
+            $this->vlv->listSize()
+        );
+        $this->assertEquals(
+            1,
+            $this->vlv->listOffset()
+        );
         $this->assertTrue($this->vlv->isAtStartOfList());
 
         $this->vlv->moveForward(100);
-        $this->assertEquals(101, $this->vlv->getEntries()->count());
-        $this->assertEquals(101, $this->vlv->listOffset());
+
+        $this->assertEquals(
+            101,
+            $this->vlv->getEntries()->count()
+        );
+        $this->assertEquals(
+            101,
+            $this->vlv->listOffset()
+        );
 
         $this->vlv->moveTo(300);
-        $this->assertEquals(101, $this->vlv->getEntries()->count());
-        $this->assertEquals(300, $this->vlv->listOffset());
+
+        $this->assertEquals(
+            101,
+            $this->vlv->getEntries()->count()
+        );
+        $this->assertEquals(
+            300,
+            $this->vlv->listOffset()
+        );
 
         $this->vlv->moveBackward(100);
-        $this->assertEquals(101, $this->vlv->getEntries()->count());
-        $this->assertEquals(200, $this->vlv->listOffset());
 
-        $this->vlv->moveTo($this->vlv->listSize());
-        $this->assertEquals(1, $this->vlv->getEntries()->count());
+        $this->assertEquals(
+            101,
+            $this->vlv->getEntries()->count()
+        );
+        $this->assertEquals(
+            200,
+            $this->vlv->listOffset()
+        );
+
+        $this->vlv->moveTo((int) $this->vlv->listSize());
+
+        $this->assertEquals(
+            1,
+            $this->vlv->getEntries()->count()
+        );
         $this->assertTrue($this->vlv->isAtEndOfList());
     }
 
-    public function testVlvAsPercentage()
+    public function testVlvAsPercentage(): void
     {
         $this->search = Operations::search(Filters::and(
             Filters::equal('objectClass', 'inetOrgPerson'),
             Filters::startsWith('cn', 'E')
         ), 'sn', 'givenName');
-        $this->vlv = new Vlv($this->client, $this->search, 'sn');
+        $this->vlv = new Vlv(
+            $this->client,
+            $this->search,
+            'sn'
+        );
 
-        $this->vlv->asPercentage(true);
+        $this->vlv->asPercentage();
         $this->vlv->beforePosition(100);
         $this->vlv->moveTo(50);
 
-        $this->assertEquals(201, $this->vlv->getEntries()->count());
-        $this->assertGreaterThan(215, $this->vlv->listOffset());
-        $this->assertLessThan(225, $this->vlv->listOffset());
+        $this->assertEquals(
+            201,
+            $this->vlv->getEntries()->count()
+        );
+        $this->assertGreaterThan(
+            215,
+            $this->vlv->listOffset()
+        );
+        $this->assertLessThan(
+            225,
+            $this->vlv->listOffset()
+        );
 
         $this->vlv->moveForward(25);
-        $this->assertEquals(201, $this->vlv->getEntries()->count());
-        $this->assertGreaterThan(325, $this->vlv->listOffset());
-        $this->assertLessThan(335, $this->vlv->listOffset());
+
+        $this->assertEquals(
+            201,
+            $this->vlv->getEntries()->count()
+        );
+        $this->assertGreaterThan(
+            325, $this->vlv->listOffset()
+        );
+        $this->assertLessThan(
+            335,
+            $this->vlv->listOffset()
+        );
 
         $this->vlv->moveBackward(50);
-        $this->assertEquals(201, $this->vlv->getEntries()->count());
-        $this->assertGreaterThan(105, $this->vlv->listOffset());
-        $this->assertLessThan(115, $this->vlv->listOffset());
 
-        $this->assertEquals(25, $this->vlv->position());
-        $this->assertEquals(440, $this->vlv->listSize());
+        $this->assertEquals(
+            201,
+            $this->vlv->getEntries()->count()
+        );
+        $this->assertGreaterThan(
+            105,
+            $this->vlv->listOffset()
+        );
+        $this->assertLessThan(
+            115,
+            $this->vlv->listOffset()
+        );
+
+        $this->assertEquals(
+            25,
+            $this->vlv->position()
+        );
+        $this->assertEquals(
+            440,
+            $this->vlv->listSize()
+        );
 
         $this->vlv->moveTo(100);
         $this->vlv->getEntries()->count();
+
         $this->assertTrue($this->vlv->isAtEndOfList());
 
         $this->vlv->moveTo(1);
         $this->vlv->getEntries();
+
         $this->assertTrue($this->vlv->isAtStartOfList());
     }
 }

--- a/tests/integration/FreeDSx/Ldap/ServerTestCase.php
+++ b/tests/integration/FreeDSx/Ldap/ServerTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * This file is part of the FreeDSx LDAP package.
  *
@@ -17,20 +19,11 @@ use Symfony\Component\Process\Process;
 
 class ServerTestCase extends LdapTestCase
 {
-    /**
-     * @var Process
-     */
-    protected $subject;
+    private Process $subject;
 
-    /**
-     * @var LdapClient
-     */
-    protected $client;
+    private ?LdapClient $client;
 
-    /**
-     * @var string
-     */
-    protected $serverExec = 'ldapserver';
+    private string $serverMode = 'ldapserver';
 
     public function tearDown(): void
     {
@@ -40,7 +33,7 @@ class ServerTestCase extends LdapTestCase
 
     protected function authenticate(): void
     {
-        $this->client->bind(
+        $this->ldapClient()->bind(
             'cn=user,dc=foo,dc=bar',
             '12345'
         );
@@ -80,7 +73,7 @@ class ServerTestCase extends LdapTestCase
     ): void {
         $processArgs = [
             'php',
-            __DIR__ . '/../../../bin/' . $this->serverExec . '.php',
+            __DIR__ . '/../../../bin/' . $this->serverMode . '.php',
             $transport,
         ];
 
@@ -114,8 +107,18 @@ class ServerTestCase extends LdapTestCase
 
     protected function stopServer(): void
     {
-        $this->client->unbind();
+        $this->ldapClient()->unbind();
         $this->client = null;
         $this->subject->stop();
+    }
+
+    protected function setServerMode(string $mode): void
+    {
+        $this->serverMode = $mode;
+    }
+
+    protected function ldapClient(): LdapClient
+    {
+        return $this->client ?? throw new \RuntimeException('The test LDAP client is not set.');
     }
 }


### PR DESCRIPTION
This updates the PHPUnit tests now that the PHP version is bumped. It adds types where possible, declares strict types, and does a little clean-up.

https://github.com/FreeDSx/LDAP/issues/50