### PR TITLE
[1.0.0] More code clean-up since PHP update.

### DIFF
--- a/src/FreeDSx/Ldap/Control/Control.php
+++ b/src/FreeDSx/Ldap/Control/Control.php
@@ -167,12 +167,12 @@ class Control implements ProtocolElementInterface, Stringable
 
     /**
      * @template T of Control
-     * @param T $control
-     * @return T
+     * @phpstan-param T $control
+     * @phpstan-return T
      * @throws ProtocolException
      */
     protected static function mergeControlData(
-        $control,
+        Control $control,
         AbstractType $type
     ): Control {
         if (!($type instanceof SequenceType && count($type->getChildren()) <= 3)) {

--- a/src/FreeDSx/Ldap/Entry/Attribute.php
+++ b/src/FreeDSx/Ldap/Entry/Attribute.php
@@ -173,7 +173,7 @@ class Attribute implements IteratorAggregate, Countable, Stringable
     }
 
     /**
-     * Gets the options within the AttributeDescription (semi-colon separated list of options).
+     * Gets the options within the AttributeDescription (semicolon separated list of options).
      */
     public function getOptions(): Options
     {

--- a/src/FreeDSx/Ldap/Entry/Dn.php
+++ b/src/FreeDSx/Ldap/Entry/Dn.php
@@ -126,7 +126,7 @@ class Dn implements IteratorAggregate, Countable, Stringable
             (new self((string) $dn))->toArray();
 
             return true;
-        } catch (UnexpectedValueException | InvalidArgumentException $e) {
+        } catch (UnexpectedValueException | InvalidArgumentException) {
             return false;
         }
     }

--- a/src/FreeDSx/Ldap/Entry/Options.php
+++ b/src/FreeDSx/Ldap/Entry/Options.php
@@ -50,7 +50,7 @@ class Options implements Countable, IteratorAggregate, Stringable
     public function set(string|Option ...$options): self
     {
         $this->options = [];
-        foreach ($options as $i => $option) {
+        foreach ($options as $option) {
             if ($option instanceof Option) {
                 $this->options[] = $option;
             } else {

--- a/src/FreeDSx/Ldap/LdapClient.php
+++ b/src/FreeDSx/Ldap/LdapClient.php
@@ -21,7 +21,6 @@ use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entries;
 use FreeDSx\Ldap\Entry\Entry;
-use FreeDSx\Ldap\Entry\Rdn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -161,7 +161,7 @@ class LdapServer
      * @param array<string, mixed> $serverOptions Any additional server options for the LDAP server.
      */
     public static function makeProxy(
-        $servers,
+        array|string $servers,
         array $clientOptions = [],
         array $serverOptions = []
     ): LdapServer {

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -37,7 +37,7 @@ class LdapServer
     /**
      * @var array<string, mixed>
      */
-    protected array $options = [
+    private array $options = [
         'ip' => '0.0.0.0',
         'port' => 389,
         'unix_socket' => '/var/run/ldap.socket',

--- a/src/FreeDSx/Ldap/Operation/Request/PasswordModifyRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/PasswordModifyRequest.php
@@ -146,9 +146,9 @@ class PasswordModifyRequest extends ExtendedRequest
         }
 
         return new static(
-            $userIdentity !== null ? $userIdentity->getValue() : null,
-            $oldPasswd !== null ? $oldPasswd->getValue() : null,
-            $newPasswd !== null ? $newPasswd->getValue() : null
+            $userIdentity?->getValue(),
+            $oldPasswd?->getValue(),
+            $newPasswd?->getValue()
         );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientReferralHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientReferralHandler.php
@@ -134,7 +134,7 @@ class ClientReferralHandler implements ResponseHandlerInterface
                     referral: $referral,
                     bind: null,
                 );
-            } catch (SkipReferralException $e) {
+            } catch (SkipReferralException) {
                 continue;
             }
             $options = $this->options;
@@ -167,7 +167,7 @@ class ClientReferralHandler implements ResponseHandlerInterface
                     ...$messageTo->controls()->toArray()
                 );
                 # Skip referrals that fail due to connection issues and not other issues
-            } catch (ConnectionException $e) {
+            } catch (ConnectionException) {
                 continue;
                 # If the referral encountered other referrals but exhausted them, continue to the next one.
             } catch (OperationException $e) {

--- a/src/FreeDSx/Ldap/Protocol/LdapMessage.php
+++ b/src/FreeDSx/Ldap/Protocol/LdapMessage.php
@@ -149,7 +149,6 @@ abstract class LdapMessage implements ProtocolElementInterface, PduInterface
                     if (!$child instanceof IncompleteType) {
                         throw new ProtocolException('The ASN1 structure for the controls is malformed.');
                     }
-                    /** @var SequenceOfType $child */
                     $child = (new LdapEncoder())->complete(
                         $child,
                         AbstractType::TAG_TYPE_SEQUENCE

--- a/src/FreeDSx/Ldap/Protocol/ReferralContext.php
+++ b/src/FreeDSx/Ldap/Protocol/ReferralContext.php
@@ -28,7 +28,7 @@ class ReferralContext implements Countable
     /**
      * @var LdapUrl[]
      */
-    private array $referrals = [];
+    private array $referrals;
 
     public function __construct(LdapUrl ...$referrals)
     {

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -129,7 +129,7 @@ class ServerProtocolHandler
                     $defaultContext
                 )
             );
-        } catch (EncoderException | ProtocolException $e) {
+        } catch (EncoderException | ProtocolException) {
             # Per RFC 4511, 4.1.1 if the PDU cannot be parsed or is otherwise malformed a disconnect should be sent with a
             # result code of protocol error.
             $this->sendNoticeOfDisconnect('The message encoding is malformed.');

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -164,7 +164,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
     {
         try {
             return random_bytes(16);
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             throw new OperationException(
                 'Internal server error.',
                 ResultCode::OPERATIONS_ERROR

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
@@ -49,7 +49,7 @@ class ServerWhoAmIHandler implements ServerProtocolHandlerInterface
             try {
                 (new Dn($userId))->toArray();
                 $userId = 'dn:' . $userId;
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $userId = 'u:' . $userId;
             }
         }

--- a/src/FreeDSx/Ldap/Search/FilterParser.php
+++ b/src/FreeDSx/Ldap/Search/FilterParser.php
@@ -29,9 +29,9 @@ class FilterParser
 {
     private const MATCHING_RULE = '/^([a-zA-Z0-9\.]+)?(\:dn)?(\:([a-zA-Z0-9\.]+))?$/';
 
-    private string $filter = '';
+    private string $filter;
 
-    private int $length = 0;
+    private int $length;
 
     private int $depth = 0;
 
@@ -206,7 +206,7 @@ class FilterParser
             $pos = false;
             try {
                 $pos = $this->nextClosingParenthesis($startAt);
-            } catch (FilterParseException $e) {
+            } catch (FilterParseException) {
             }
             if ($pos !== false) {
                 throw new FilterParseException(sprintf('The ")" at char %s has no matching parenthesis', $pos));

--- a/src/FreeDSx/Ldap/Search/RangeRetrieval.php
+++ b/src/FreeDSx/Ldap/Search/RangeRetrieval.php
@@ -137,7 +137,7 @@ class RangeRetrieval
                 $attribute->getName()
             ));
         }
-        if (($range = $this->getRangeOption($attrResult)) === null) {
+        if ($this->getRangeOption($attrResult) === null) {
             throw new RuntimeException(sprintf(
                 'No ranged option received for attribute "%s" on "%s".',
                 $attribute->getName(),

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -342,7 +342,7 @@ class PcntlServerRunner implements ServerRunnerInterface
     private function runChildProcessThenExit(
         Socket $socket,
         int $pid
-    ): void {
+    ): never {
         $context = ['pid' => $pid];
         $this->isMainProcess = false;
         $serverProtocolHandler = new ServerProtocolHandler(

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -47,7 +47,7 @@ class PcntlServerRunner implements ServerRunnerInterface
     /**
      * @var array<string, mixed>
      */
-    protected array $options;
+    private array $options;
 
     /**
      * @var ChildProcess[]

--- a/src/FreeDSx/Ldap/Server/Token/AnonToken.php
+++ b/src/FreeDSx/Ldap/Server/Token/AnonToken.php
@@ -32,9 +32,6 @@ class AnonToken implements TokenInterface
         $this->version = $version;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getUsername(): ?string
     {
         return $this->username;
@@ -45,9 +42,6 @@ class AnonToken implements TokenInterface
         return null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getVersion(): int
     {
         return $this->version;

--- a/src/FreeDSx/Ldap/Server/Token/BindToken.php
+++ b/src/FreeDSx/Ldap/Server/Token/BindToken.php
@@ -46,9 +46,6 @@ class BindToken implements TokenInterface
         return $this->password;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getVersion(): int
     {
         return $this->version;


### PR DESCRIPTION
This is a set of miscellaneous code clean-up items:

* Redundant phpdoc.
* Unused variables.
* Unnecessary property initialization.
* Missed types in params.
* Usage of null-safe operator.
* Typos.

https://github.com/FreeDSx/LDAP/issues/50