### PR TITLE
[LdapServer] Fix the SearchResultDone result code if an operation exception occurs.

### DIFF
--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/SearchResult.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/SearchResult.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+
+use FreeDSx\Ldap\Entry\Entries;
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Operation\ResultCode;
+
+final class SearchResult
+{
+    /**
+     * @var Entries
+     */
+    private $entries;
+
+    /**
+     * @var string
+     */
+    private $baseDn;
+
+    /**
+     * @var int
+     */
+    private $resultCode;
+
+    /**
+     * @var string
+     */
+    private $diagnosticMessage;
+
+    private function __construct(
+        Entries $entries,
+        string $baseDn = '',
+        int $resultCode = ResultCode::SUCCESS,
+        string $diagnosticMessage = ''
+    ) {
+        $this->entries = $entries;
+        $this->baseDn = $baseDn;
+        $this->resultCode = $resultCode;
+        $this->diagnosticMessage = $diagnosticMessage;
+    }
+
+    /**
+     * Make a successful server search result representation.
+     */
+    public static function makeSuccessResult(
+        Entries $entries,
+        string $baseDn = '',
+        string $diagnosticMessage = ''
+    ): self {
+        return new self(
+            $entries,
+            $baseDn,
+            ResultCode::SUCCESS,
+            $diagnosticMessage
+        );
+    }
+
+    /**
+     * Make an error result for server search result representation. This could occur for any reason, such as a base DN
+     * not existing. This result MUST not return a success result code.
+     */
+    public static function makeErrorResult(
+        int $resultCode,
+        string $baseDn = '',
+        string $diagnosticMessage = '',
+        ?Entries $entries = null
+    ): self {
+        if ($resultCode === ResultCode::SUCCESS) {
+            throw new InvalidArgumentException('You must not return a success result code on a search error.');
+        }
+
+        return new self(
+            $entries ?? new Entries(),
+            $baseDn,
+            $resultCode,
+            $diagnosticMessage
+        );
+    }
+
+    public function getEntries(): Entries
+    {
+        return $this->entries;
+    }
+
+    public function getResultCode(): int
+    {
+        return $this->resultCode;
+    }
+
+    public function getDiagnosticMessage(): string
+    {
+        return $this->diagnosticMessage;
+    }
+
+    public function getBaseDn(): string
+    {
+        return $this->baseDn;
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandler.php
@@ -60,13 +60,24 @@ class ServerPagingUnsupportedHandler implements ServerProtocolHandlerInterface
             );
         }
 
-        $entries = $dispatcher->search(
-            $context,
-            $request
-        );
+        try {
+            $searchResult = SearchResult::makeSuccessResult(
+                $dispatcher->search(
+                    $context,
+                    $request
+                ),
+                (string) $request->getBaseDn()
+            );
+        } catch (OperationException $e) {
+            $searchResult = SearchResult::makeErrorResult(
+                $e->getCode(),
+                (string) $request->getBaseDn(),
+                $e->getMessage()
+            );
+        }
 
         $this->sendEntriesToClient(
-            $entries,
+            $searchResult,
             $message,
             $queue
         );

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
@@ -27,18 +27,19 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 trait ServerSearchTrait
 {
     /**
-     * @param Entries $entries
+     * @param SearchResult $searchResult
      * @param LdapMessageRequest $message
      * @param ServerQueue $queue
      * @return void
      */
     private function sendEntriesToClient(
-        Entries $entries,
+        SearchResult $searchResult,
         LdapMessageRequest $message,
         ServerQueue $queue,
         Control ...$controls
     ): void {
         $messages = [];
+        $entries = $searchResult->getEntries();
 
         foreach ($entries->toArray() as $entry) {
             $messages[] = new LdapMessageResponse(
@@ -49,7 +50,11 @@ trait ServerSearchTrait
 
         $messages[] = new LdapMessageResponse(
             $message->getMessageId(),
-            new SearchResultDone(ResultCode::SUCCESS),
+            new SearchResultDone(
+                $searchResult->getResultCode(),
+                $searchResult->getBaseDn(),
+                $searchResult->getDiagnosticMessage()
+            ),
             ...$controls
         );
 


### PR DESCRIPTION
This resolves the issues brought up in this PR / bug report: https://github.com/FreeDSx/LDAP/pull/58

The issue is that we are sending the OperationException result code, during server search handler implementations, as an out of order message after the SearchResultDone is already sent. This corrects the logic so that the result code and any diagnostic message is now sent properly in the SearchResultDone message.

I will likely change the interface for handler implementations as part of the `1.0.0` release so that the new `ServerSearchResult` object needs to be returned by handler implementations instead of just the entries object. 