### PR TITLE
[1.0.0] Use Options objects instead of arrays.

### DIFF
--- a/src/FreeDSx/Ldap/ClientOptions.php
+++ b/src/FreeDSx/Ldap/ClientOptions.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap;
+
+final class ClientOptions
+{
+    private int $version = 3;
+    
+    private array $servers = [];
+    
+    private int $port = 389;
+    
+    private string $transport = 'tcp';
+    
+    private ?string $baseDn = null;
+    
+    private int $pageSize = 1000;
+    
+    private bool $useSsl = false;
+    
+    private bool $sslValidateCert = true;
+    
+    private ?bool $sslAllowSelfSigned = null;
+    
+    private ?string $sslCaCert = null;
+    
+    private ?string $sslPeerName = null;
+    
+    private int $timeoutConnect = 3;
+    
+    private int $timeoutRead = 10;
+    
+    private string $referral = 'throw';
+    
+    private ?ReferralChaserInterface $referralChaser = null;
+    
+    private int $referralLimit = 10;
+
+    /**
+     * A helper method designed to ease migration from array options to the new options object.
+     *
+     * @param array<string, mixed> $options
+     */
+    public static function fromArray(array $options): self
+    {
+        $instance = new self();
+        
+        return $instance;
+    }
+
+    public function getVersion(): int
+    {
+        return $this->version;
+    }
+
+    public function setVersion(int $version): self
+    {
+        $this->version = $version;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getServers(): array
+    {
+        return $this->servers;
+    }
+
+    /**
+     * @param string[] $servers
+     */
+    public function setServers(array $servers): self
+    {
+        $this->servers = $servers;
+
+        return $this;
+    }
+
+    public function getPort(): int
+    {
+        return $this->port;
+    }
+
+    public function setPort(int $port): self
+    {
+        $this->port = $port;
+
+        return $this;
+    }
+
+    public function getTransport(): string
+    {
+        return $this->transport;
+    }
+
+    public function setTransport(string $transport): self
+    {
+        $this->transport = $transport;
+
+        return $this;
+    }
+
+    public function getBaseDn(): ?string
+    {
+        return $this->baseDn;
+    }
+
+    public function setBaseDn(?string $baseDn): self
+    {
+        $this->baseDn = $baseDn;
+
+        return $this;
+    }
+
+    public function getPageSize(): int
+    {
+        return $this->pageSize;
+    }
+
+    public function setPageSize(int $pageSize): self
+    {
+        $this->pageSize = $pageSize;
+
+        return $this;
+    }
+
+    public function isUseSsl(): bool
+    {
+        return $this->useSsl;
+    }
+
+    public function setUseSsl(bool $useSsl): self
+    {
+        $this->useSsl = $useSsl;
+
+        return $this;
+    }
+
+    public function isSslValidateCert(): bool
+    {
+        return $this->sslValidateCert;
+    }
+
+    public function setSslValidateCert(bool $sslValidateCert): self
+    {
+        $this->sslValidateCert = $sslValidateCert;
+
+        return $this;
+    }
+
+    public function getSslAllowSelfSigned(): ?bool
+    {
+        return $this->sslAllowSelfSigned;
+    }
+
+    public function setSslAllowSelfSigned(?bool $sslAllowSelfSigned): self
+    {
+        $this->sslAllowSelfSigned = $sslAllowSelfSigned;
+
+        return $this;
+    }
+
+    public function getSslCaCert(): ?string
+    {
+        return $this->sslCaCert;
+    }
+
+
+    public function setSslCaCert(?string $sslCaCert): self
+    {
+        $this->sslCaCert = $sslCaCert;
+
+        return $this;
+    }
+
+    public function getSslPeerName(): ?string
+    {
+        return $this->sslPeerName;
+    }
+
+    public function setSslPeerName(?string $sslPeerName): self
+    {
+        $this->sslPeerName = $sslPeerName;
+
+        return $this;
+    }
+
+    public function getTimeoutConnect(): int
+    {
+        return $this->timeoutConnect;
+    }
+
+    public function setTimeoutConnect(int $timeoutConnect): self
+    {
+        $this->timeoutConnect = $timeoutConnect;
+
+        return $this;
+    }
+
+    public function getTimeoutRead(): int
+    {
+        return $this->timeoutRead;
+    }
+
+    public function setTimeoutRead(int $timeoutRead): self
+    {
+        $this->timeoutRead = $timeoutRead;
+
+        return $this;
+    }
+
+    public function getReferral(): string
+    {
+        return $this->referral;
+    }
+
+    public function setReferral(string $referral): self
+    {
+        $this->referral = $referral;
+
+        return $this;
+    }
+
+    public function getReferralChaser(): ?ReferralChaserInterface
+    {
+        return $this->referralChaser;
+    }
+
+    public function setReferralChaser(?ReferralChaserInterface $referralChaser): self
+    {
+        $this->referralChaser = $referralChaser;
+
+        return $this;
+    }
+
+    public function getReferralLimit(): int
+    {
+        return $this->referralLimit;
+    }
+
+    public function setReferralLimit(int $referralLimit): self
+    {
+        $this->referralLimit = $referralLimit;
+
+        return $this;
+    }
+    
+    
+}

--- a/src/FreeDSx/Ldap/ClientOptions.php
+++ b/src/FreeDSx/Ldap/ClientOptions.php
@@ -31,7 +31,7 @@ final class ClientOptions
     
     private bool $sslValidateCert = true;
     
-    private ?bool $sslAllowSelfSigned = null;
+    private bool $sslAllowSelfSigned = false;
     
     private ?string $sslCaCert = null;
     
@@ -161,12 +161,12 @@ final class ClientOptions
         return $this;
     }
 
-    public function getSslAllowSelfSigned(): ?bool
+    public function isSslAllowSelfSigned(): bool
     {
         return $this->sslAllowSelfSigned;
     }
 
-    public function setSslAllowSelfSigned(?bool $sslAllowSelfSigned): self
+    public function setSslAllowSelfSigned(bool $sslAllowSelfSigned): self
     {
         $this->sslAllowSelfSigned = $sslAllowSelfSigned;
 
@@ -257,6 +257,29 @@ final class ClientOptions
 
         return $this;
     }
-    
-    
+
+    /**
+     * @return array{version: int, servers: string[], port: int, base_dn: ?string, page_size: int, use_ssl: bool, ssl_validate_cert: bool, ssl_allow_self_signed: bool, ssl_ca_cert: ?string, ssl_peer_name: ?string, timeout_connect: int, timeout_read: int, referral: string, referral_chaser: ?ReferralChaserInterface, referral_limit: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'version' => $this->getVersion(),
+            'servers' => $this->getServers(),
+            'port' => $this->getPort(),
+            'transport' => $this->getTransport(),
+            'base_dn' => $this->getBaseDn(),
+            'page_size' => $this->getPageSize(),
+            'use_ssl' => $this->isUseSsl(),
+            'ssl_validate_cert' => $this->isSslValidateCert(),
+            'ssl_allow_self_signed' => $this->isSslAllowSelfSigned(),
+            'ssl_ca_cert' => $this->getSslCaCert(),
+            'ssl_peer_name' => $this->getSslPeerName(),
+            'timeout_connect' => $this->getTimeoutConnect(),
+            'timeout_read' => $this->getTimeoutRead(),
+            'referral' => $this->getReferral(),
+            'referral_chaser' => $this->getReferralChaser(),
+            'referral_limit' => $this->getReferralLimit(),
+        ];
+    }
 }

--- a/src/FreeDSx/Ldap/Control/ControlBag.php
+++ b/src/FreeDSx/Ldap/Control/ControlBag.php
@@ -18,6 +18,7 @@ use Countable;
 use IteratorAggregate;
 use Traversable;
 use function array_search;
+use function in_array;
 use function count;
 use function in_array;
 use function is_string;

--- a/src/FreeDSx/Ldap/Control/ControlBag.php
+++ b/src/FreeDSx/Ldap/Control/ControlBag.php
@@ -17,8 +17,8 @@ use ArrayIterator;
 use Countable;
 use IteratorAggregate;
 use Traversable;
-use function count;
 use function array_search;
+use function count;
 use function in_array;
 use function is_string;
 

--- a/src/FreeDSx/Ldap/Control/ControlBag.php
+++ b/src/FreeDSx/Ldap/Control/ControlBag.php
@@ -17,9 +17,8 @@ use ArrayIterator;
 use Countable;
 use IteratorAggregate;
 use Traversable;
-use function array_search;
-use function in_array;
 use function count;
+use function array_search;
 use function in_array;
 use function is_string;
 

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap;
 
-use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Server\LoggerTrait;
 use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\ProxyHandler;
 use FreeDSx\Ldap\Server\RequestHandler\ProxyPagingHandler;
@@ -34,45 +34,13 @@ class LdapServer
 {
     use LoggerTrait;
 
-    /**
-     * @var array<string, mixed>
-     */
-    private array $options = [
-        'ip' => '0.0.0.0',
-        'port' => 389,
-        'unix_socket' => '/var/run/ldap.socket',
-        'transport' => 'tcp',
-        'idle_timeout' => 600,
-        'require_authentication' => true,
-        'allow_anonymous' => false,
-        'request_handler' => null,
-        'rootdse_handler' => null,
-        'paging_handler' => null,
-        'logger' => null,
-        'use_ssl' => false,
-        'ssl_cert' => null,
-        'ssl_cert_passphrase' => null,
-        'dse_alt_server' => null,
-        'dse_naming_contexts' => 'dc=FreeDSx,dc=local',
-        'dse_vendor_name' => 'FreeDSx',
-        'dse_vendor_version' => null,
-    ];
-
     private ?ServerRunnerInterface $runner;
 
-    /**
-     * @param array<string, mixed> $options
-     *
-     * @throws RuntimeException
-     */
     public function __construct(
-        array $options = [],
+        ServerOptions $options = new ServerOptions(),
         ?ServerRunnerInterface $serverRunner = null
     ) {
-        $this->options = array_merge(
-            $this->options,
-            $options
-        );
+        $this->options = $options;
         $this->runner = $serverRunner;
     }
 
@@ -83,10 +51,10 @@ class LdapServer
      */
     public function run(): void
     {
-        $isUnixSocket = $this->options['transport'] === 'unix';
+        $isUnixSocket = $this->options->getTransport() === 'unix';
         $resource = $isUnixSocket
-            ? $this->options['unix_socket']
-            : $this->options['ip'];
+            ? $this->options->getUnixSocket()
+            : $this->options->getIp();
 
         if ($isUnixSocket) {
             $this->removeExistingSocketIfNeeded($resource);
@@ -94,8 +62,8 @@ class LdapServer
 
         $socketServer = SocketServer::bind(
             $resource,
-            $this->options['port'],
-            $this->options
+            $this->options->getPort(),
+            $this->options->toArray(),
         );
 
         $this->runner()->run($socketServer);
@@ -103,10 +71,8 @@ class LdapServer
 
     /**
      * Get the options currently set for the LDAP server.
-     *
-     * @return array<string, mixed>
      */
-    public function getOptions(): array
+    public function getOptions(): ServerOptions
     {
         return $this->options;
     }
@@ -116,7 +82,7 @@ class LdapServer
      */
     public function useRequestHandler(RequestHandlerInterface $requestHandler): self
     {
-        $this->options['request_handler'] = $requestHandler;
+        $this->options->setRequestHandler($requestHandler);
 
         return $this;
     }
@@ -126,7 +92,7 @@ class LdapServer
      */
     public function useRootDseHandler(RootDseHandlerInterface $rootDseHandler): self
     {
-        $this->options['rootdse_handler'] = $rootDseHandler;
+        $this->options->setRootDseHandler($rootDseHandler);
 
         return $this;
     }
@@ -136,7 +102,7 @@ class LdapServer
      */
     public function usePagingHandler(PagingHandlerInterface $pagingHandler): self
     {
-        $this->options['paging_handler'] = $pagingHandler;
+        $this->options->setPagingHandler($pagingHandler);
 
         return $this;
     }
@@ -146,7 +112,7 @@ class LdapServer
      */
     public function useLogger(LoggerInterface $logger): self
     {
-        $this->options['logger'] = $logger;
+        $this->options->setLogger($logger);
 
         return $this;
     }
@@ -157,17 +123,17 @@ class LdapServer
      * Note: This is only intended to work with the PCNTL server runner.
      *
      * @param string|string[] $servers The LDAP server(s) to proxy the request to.
-     * @param array<string, mixed> $clientOptions Any additional client options for the proxy connection.
-     * @param array<string, mixed> $serverOptions Any additional server options for the LDAP server.
+     * @param ClientOptions $clientOptions Any additional client options for the proxy connection.
+     * @param ServerOptions $serverOptions Any additional server options for the LDAP server.
      */
     public static function makeProxy(
         array|string $servers,
-        array $clientOptions = [],
-        array $serverOptions = []
+        ClientOptions $clientOptions = new ClientOptions(),
+        ServerOptions $serverOptions = new ServerOptions(),
     ): LdapServer {
-        $client = new LdapClient(array_merge([
-            'servers' => $servers,
-        ], $clientOptions));
+        $client = new LdapClient(
+            $clientOptions->setServers((array) $servers)
+        );
 
         $proxyRequestHandler = new ProxyHandler($client);
         $server = new LdapServer($serverOptions);

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol;
 
 use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Entry\Entry;
@@ -51,7 +52,7 @@ class ClientProtocolHandler
 
     private ?ClientQueue $queue;
 
-    private array $options;
+    private ClientOptions $options;
 
     private ControlBag $controls;
 
@@ -60,13 +61,13 @@ class ClientProtocolHandler
     private ?Entry $rootDse = null;
 
     public function __construct(
-        array $options,
+        ClientOptions $options,
         ClientQueue $queue = null,
         SocketPool $pool = null,
         ClientProtocolHandlerFactory $clientProtocolHandlerFactory = null
     ) {
         $this->options = $options;
-        $this->pool = $pool ?? new SocketPool($options);
+        $this->pool = $pool ?? new SocketPool($this->options->toArray());
         $this->protocolHandlerFactory = $clientProtocolHandlerFactory ?? new ClientProtocolHandlerFactory();
         $this->controls = new ControlBag();
         $this->queue = $queue;

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientBasicHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientBasicHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 
 use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\ProtocolException;
@@ -68,7 +69,7 @@ class ClientBasicHandler implements RequestHandlerInterface, ResponseHandlerInte
         LdapMessageRequest $messageTo,
         LdapMessageResponse $messageFrom,
         ClientQueue $queue,
-        array $options
+        ClientOptions $options
     ): ?LdapMessageResponse {
         $result = $messageFrom->getResponse();
 

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientProtocolContext.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientProtocolContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 
 use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\BindException;
@@ -36,14 +37,11 @@ use FreeDSx\Sasl\Exception\SaslException;
 class ClientProtocolContext
 {
     /**
-     * @var array<string, mixed>
-     */
-    private array $options;
-
-    /**
      * @var Control[]
      */
     private array $controls;
+
+    private ClientOptions $options;
 
     private ClientProtocolHandler $protocolHandler;
 
@@ -58,7 +56,7 @@ class ClientProtocolContext
         array $controls,
         ClientProtocolHandler $protocolHandler,
         ClientQueue $queue,
-        array $options
+        ClientOptions $options
     ) {
         $this->request = $request;
         $this->controls = $controls;
@@ -90,7 +88,7 @@ class ClientProtocolContext
         return $this->clientQueue;
     }
 
-    public function getOptions(): array
+    public function getOptions(): ClientOptions
     {
         return $this->options;
     }

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSearchHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 
 use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Entry\Entries;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -47,7 +48,7 @@ class ClientSearchHandler extends ClientBasicHandler
         /** @var SearchRequest $request */
         $request = $context->getRequest();
         if ($request->getBaseDn() === null) {
-            $request->setBaseDn($context->getOptions()['base_dn'] ?? null);
+            $request->setBaseDn($context->getOptions()->getBaseDn() ?? null);
         }
 
         return parent::handleRequest($context);
@@ -62,10 +63,10 @@ class ClientSearchHandler extends ClientBasicHandler
      * @throws ConnectionException
      */
     public function handleResponse(
-        LdapMessageRequest $messageTo,
+        LdapMessageRequest  $messageTo,
         LdapMessageResponse $messageFrom,
         ClientQueue $queue,
-        array $options,
+        ClientOptions $options,
     ): ?LdapMessageResponse {
         $entries = [];
 

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientStartTlsHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientStartTlsHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Exception\ConnectionException;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
@@ -36,7 +37,7 @@ class ClientStartTlsHandler implements ResponseHandlerInterface
         LdapMessageRequest $messageTo,
         LdapMessageResponse $messageFrom,
         ClientQueue $queue,
-        array $options
+        ClientOptions $options
     ): ?LdapMessageResponse {
         /** @var ExtendedResponse $response */
         $response = $messageFrom->getResponse();

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ResponseHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ResponseHandlerInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ClientQueue;
@@ -28,12 +29,12 @@ interface ResponseHandlerInterface
     /**
      * Pass the message response to the handler specific to it.
      *
-     * @param array<string, mixed> $options
+     * @param ClientOptions $options
      */
     public function handleResponse(
         LdapMessageRequest $messageTo,
         LdapMessageResponse $messageFrom,
         ClientQueue $queue,
-        array $options
+        ClientOptions $options
     ): ?LdapMessageResponse;
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
@@ -37,11 +37,14 @@ class ServerAuthorization
 
     private TokenInterface $token;
 
-    public function __construct(TokenInterface $token = null, array $options = [])
-    {
-        $this->token = $token ?? new AnonToken();
-        $this->isAuthRequired = !isset($options['require_authentication']) || $options['require_authentication'];
-        $this->isAnonymousAllowed = isset($options['allow_anonymous']) && $options['allow_anonymous'];
+    public function __construct(
+        TokenInterface $token = new AnonToken(),
+        bool $isAnonymousAllowed = false,
+        bool $isAuthRequired = true,
+    ) {
+        $this->token = $token;
+        $this->isAuthRequired = $isAuthRequired;
+        $this->isAnonymousAllowed = $isAnonymousAllowed;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/BindHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/BindHandlerInterface.php
@@ -29,13 +29,11 @@ interface BindHandlerInterface
     /**
      * Returns a token indicating the outcome of a bind request.
      *
-     * @param array<string, mixed> $options
      * @throws OperationException
      */
     public function handleBind(
         LdapMessageRequest $message,
         RequestHandlerInterface $dispatcher,
-        ServerQueue $queue,
-        array $options
+        ServerQueue $queue
     ): TokenInterface;
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAnonBindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAnonBindHandler.php
@@ -22,6 +22,7 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 
 /**
  * Handles anonymous bind requests.
@@ -39,8 +40,7 @@ class ServerAnonBindHandler extends ServerBindHandler
     public function handleBind(
         LdapMessageRequest $message,
         RequestHandlerInterface $dispatcher,
-        ServerQueue $queue,
-        array $options
+        ServerQueue $queue
     ): TokenInterface {
         $request = $message->getRequest();
         if (!$request instanceof AnonBindRequest) {

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerBindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerBindHandler.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 
 /**
  * Handles a simple bind request.
@@ -39,8 +40,7 @@ class ServerBindHandler extends BaseServerHandler implements BindHandlerInterfac
     public function handleBind(
         LdapMessageRequest $message,
         RequestHandlerInterface $dispatcher,
-        ServerQueue $queue,
-        array $options
+        ServerQueue $queue
     ): TokenInterface {
         /** @var BindRequest $request */
         $request = $message->getRequest();

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -22,6 +22,7 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestContext;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 
 /**
  * Handles generic requests that can be sent to the user supplied dispatcher / handler.
@@ -40,7 +41,7 @@ class ServerDispatchHandler extends BaseServerHandler implements ServerProtocolH
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
         ServerQueue $queue,
-        array $options
+        ServerOptions $options
     ): void {
         $context = new RequestContext($message->controls(), $token);
         $request = $message->getRequest();

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -30,6 +30,7 @@ use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHistory;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 use Throwable;
 
 /**
@@ -66,7 +67,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
         ServerQueue $queue,
-        array $options
+        ServerOptions $options
     ): void {
         $context = new RequestContext(
             $message->controls(),

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandler.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestContext;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 
 /**
  * Determines whether we can page results if no paging handler is defined.
@@ -38,7 +39,7 @@ class ServerPagingUnsupportedHandler implements ServerProtocolHandlerInterface
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
         ServerQueue $queue,
-        array $options
+        ServerOptions $options
     ): void {
         $context = new RequestContext(
             $message->controls(),

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerProtocolHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerProtocolHandlerInterface.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\Exception\ConnectionException;
 
 /**
@@ -31,7 +32,7 @@ interface ServerProtocolHandlerInterface
     /**
      * Handle protocol actions specific to the request received.
      *
-     * @param array<string, mixed> $options
+     * @param ServerOptions $options
      * @throws OperationException
      * @throws ConnectionException
      */
@@ -40,6 +41,6 @@ interface ServerProtocolHandlerInterface
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
         ServerQueue $queue,
-        array $options
+        ServerOptions $options
     ): void;
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
@@ -28,6 +28,7 @@ use FreeDSx\Ldap\Server\RequestContext;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 use function count;
 
 /**
@@ -53,33 +54,33 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
         ServerQueue $queue,
-        array $options
+        ServerOptions $options
     ): void {
         $entry = Entry::fromArray('', [
-            'namingContexts' => $options['dse_naming_contexts'] ?? '',
+            'namingContexts' => $options->getDseNamingContexts(),
             'supportedExtension' => [
                 ExtendedRequest::OID_WHOAMI,
             ],
             'supportedLDAPVersion' => ['3'],
-            'vendorName' => $options['dse_vendor_name'] ?? '',
+            'vendorName' => $options->getDseVendorName(),
         ]);
-        if (isset($options['ssl_cert'])) {
+        if ($options->getSslCert()) {
             $entry->add(
                 'supportedExtension',
                 ExtendedRequest::OID_START_TLS
             );
         }
-        if (isset($options['paging_handler'])) {
+        if ($options->getPagingHandler()) {
             $entry->add(
                 'supportedControl',
                 Control::OID_PAGING
             );
         }
-        if (isset($options['vendor_version'])) {
-            $entry->set('vendorVersion', $options['vendor_version']);
+        if ($options->getDseVendorVersion()) {
+            $entry->set('vendorVersion', (string) $options->getDseVendorVersion());
         }
-        if (isset($options['alt_server'])) {
-            $entry->set('altServer', $options['alt_server']);
+        if ($options->getDseAlServer()) {
+            $entry->set('altServer', (string) $options->getDseAlServer());
         }
 
         /** @var SearchRequest $request */

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestContext;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 
 /**
  * Handles search request logic.
@@ -37,7 +38,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
         ServerQueue $queue,
-        array $options
+        ServerOptions $options
     ): void {
         $context = new RequestContext(
             $message->controls(),

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\Exception\ConnectionException;
 use function extension_loaded;
 
@@ -52,10 +53,10 @@ class ServerStartTlsHandler implements ServerProtocolHandlerInterface
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
         ServerQueue $queue,
-        array $options
+        ServerOptions $options
     ): void {
         # If we don't have a SSL cert or the OpenSSL extension is not available, then we can do nothing...
-        if (!isset($options['ssl_cert']) || !self::$hasOpenssl) {
+        if ($options->getSslCert() === null || !self::$hasOpenssl) {
             $queue->sendMessage(new LdapMessageResponse($message->getMessageId(), new ExtendedResponse(
                 new LdapResult(ResultCode::PROTOCOL_ERROR),
                 ExtendedRequest::OID_START_TLS

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandler.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 
 /**
  * Handles an un-bind. Which just closes the connection.
@@ -33,7 +34,7 @@ class ServerUnbindHandler implements ServerProtocolHandlerInterface
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
         ServerQueue $queue,
-        array $options
+        ServerOptions $options
     ): void {
         $queue->close();
     }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
@@ -24,6 +24,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 
 /**
  * Handles a whoami request.
@@ -41,7 +42,7 @@ class ServerWhoAmIHandler implements ServerProtocolHandlerInterface
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
         ServerQueue $queue,
-        array $options
+        ServerOptions $options
     ): void {
         $userId = $token->getUsername();
 

--- a/src/FreeDSx/Ldap/ReferralChaserInterface.php
+++ b/src/FreeDSx/Ldap/ReferralChaserInterface.php
@@ -39,9 +39,7 @@ interface ReferralChaserInterface
     ): ?BindRequest;
 
     /**
-     * Construct the LdapClient with the options you want, and perform other tasks (such as StartTLS)
-     *
-     * @param array<string, mixed> $options
+     * Construct the LdapClient with the options you want, and perform other tasks (such as StartTLS).
      */
-    public function client(array $options): LdapClient;
+    public function client(ClientOptions $options): LdapClient;
 }

--- a/src/FreeDSx/Ldap/Server/LoggerTrait.php
+++ b/src/FreeDSx/Ldap/Server/LoggerTrait.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap;
+namespace FreeDSx\Ldap\Server;
 
 use FreeDSx\Ldap\Exception\RuntimeException;
-use Psr\Log\LoggerInterface;
+use FreeDSx\Ldap\ServerOptions;
 use Psr\Log\LogLevel;
 
 /**
@@ -24,6 +24,8 @@ use Psr\Log\LogLevel;
  */
 trait LoggerTrait
 {
+    private ServerOptions $options;
+
     /**
      * Logs a message and then throws a runtime exception.
      *
@@ -80,12 +82,10 @@ trait LoggerTrait
         string $message,
         array $context = []
     ): void {
-        if (isset($this->options['logger']) && $this->options['logger'] instanceof LoggerInterface) {
-            $this->options['logger']->log(
-                level: $level,
-                message: $message,
-                context: $context,
-            );
-        }
+        $this->options->getLogger()?->log(
+            level: $level,
+            message: $message,
+            context: $context,
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/RequestHandler/ProxyRequestHandler.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/ProxyRequestHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\RequestHandler;
 
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Entry\Entries;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -38,10 +39,12 @@ class ProxyRequestHandler implements RequestHandlerInterface
 {
     protected ?LdapClient $ldap = null;
 
-    /**
-     * @var array<string, mixed>
-     */
-    protected array $options = [];
+    protected ClientOptions $options;
+
+    public function __construct(ClientOptions $options = new ClientOptions())
+    {
+        $this->options = $options;
+    }
 
     /**
      * @inheritDoc

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -15,11 +15,12 @@ namespace FreeDSx\Ldap\Server\ServerRunner;
 
 use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Exception\RuntimeException;
-use FreeDSx\Ldap\LoggerTrait;
+use FreeDSx\Ldap\Server\LoggerTrait;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Server\ChildProcess;
 use FreeDSx\Ldap\Server\RequestHandler\HandlerFactory;
+use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\Socket;
 use FreeDSx\Socket\SocketServer;
 
@@ -44,10 +45,7 @@ class PcntlServerRunner implements ServerRunnerInterface
 
     private SocketServer $server;
 
-    /**
-     * @var array<string, mixed>
-     */
-    private array $options;
+    private ServerOptions $options;
 
     /**
      * @var ChildProcess[]
@@ -73,10 +71,9 @@ class PcntlServerRunner implements ServerRunnerInterface
     private array $defaultContext = [];
 
     /**
-     * @param array<string, mixed> $options
      * @throws RuntimeException
      */
-    public function __construct(array $options = [])
+    public function __construct(ServerOptions $options)
     {
         if (!extension_loaded('pcntl')) {
             throw new RuntimeException('The PCNTL extension is needed to fork incoming requests, which is only available on Linux.');

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap;
+
+use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
+use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
+use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
+use Psr\Log\LoggerInterface;
+
+final class ServerOptions
+{
+    private string $ip = '0.0.0.0';
+    
+    private int $port = 389;
+    
+    private string $unixSocket = '/var/run/ldap.socket';
+    
+    private string $transport = 'tcp';
+    
+    private int $idleTimeout = 600;
+    
+    private bool $requireAuthentication = true;
+    
+    private bool $allowAnonymous = false;
+    
+    private bool $useSsl = false;
+    
+    private ?string $sslCert = null;
+
+    private ?string $sslCertKey = null;
+
+    private ?string $sslCertPassphrase = null;
+    
+    private ?string $dseAlServer = null;
+
+    /**
+     * @var string[]
+     */
+    private array $dseNamingContexts = ['dc=FreeDSx,dc=local'];
+
+    private string $dseVendorName = 'FreeDSx';
+    
+    private ?string $dseVendorVersion = null;
+
+    private ?RequestHandlerInterface $requestHandler = null;
+    
+    private ?RootDseHandlerInterface $rootDseHandler = null;
+    
+    private ?PagingHandlerInterface $pagingHandler = null;
+    
+    private ?LoggerInterface $logger = null;
+
+    /**
+     * A helper method designed to ease migration from array options to the new options object.
+     *
+     * @param array<string, mixed> $options
+     */
+    public static function fromArray(array $options): self
+    {
+        $instance = new self();
+
+        return $instance;
+    }
+
+    public function getIp(): string
+    {
+        return $this->ip;
+    }
+
+    public function setIp(string $ip): self
+    {
+        $this->ip = $ip;
+
+        return $this;
+    }
+
+    public function getPort(): int
+    {
+        return $this->port;
+    }
+
+    public function setPort(int $port): self
+    {
+        $this->port = $port;
+
+        return $this;
+    }
+
+    public function getUnixSocket(): string
+    {
+        return $this->unixSocket;
+    }
+
+    public function setUnixSocket(string $unixSocket): self
+    {
+        $this->unixSocket = $unixSocket;
+
+        return $this;
+    }
+
+    public function getTransport(): string
+    {
+        return $this->transport;
+    }
+
+    public function setTransport(string $transport): self
+    {
+        $this->transport = $transport;
+
+        return $this;
+    }
+
+    public function getIdleTimeout(): int
+    {
+        return $this->idleTimeout;
+    }
+
+    public function setIdleTimeout(int $idleTimeout): self
+    {
+        $this->idleTimeout = $idleTimeout;
+
+        return $this;
+    }
+
+    public function isRequireAuthentication(): bool
+    {
+        return $this->requireAuthentication;
+    }
+
+    public function setRequireAuthentication(bool $requireAuthentication): self
+    {
+        $this->requireAuthentication = $requireAuthentication;
+
+        return $this;
+    }
+
+    public function isAllowAnonymous(): bool
+    {
+        return $this->allowAnonymous;
+    }
+
+    public function setAllowAnonymous(bool $allowAnonymous): self
+    {
+        $this->allowAnonymous = $allowAnonymous;
+
+        return $this;
+    }
+
+    public function isUseSsl(): bool
+    {
+        return $this->useSsl;
+    }
+
+    public function setUseSsl(bool $useSsl): self
+    {
+        $this->useSsl = $useSsl;
+
+        return $this;
+    }
+
+    public function getSslCertKey(): ?string
+    {
+        return $this->sslCertKey;
+    }
+
+    public function setSslCertKey(?string $sslCertKey): self
+    {
+        $this->sslCertKey = $sslCertKey;
+
+        return $this;
+    }
+
+    public function getSslCert(): ?string
+    {
+        return $this->sslCert;
+    }
+
+    public function setSslCert(?string $sslCert): self
+    {
+        $this->sslCert = $sslCert;
+
+        return $this;
+    }
+
+    public function getSslCertPassphrase(): ?string
+    {
+        return $this->sslCertPassphrase;
+    }
+
+    public function setSslCertPassphrase(?string $sslCertPassphrase): self
+    {
+        $this->sslCertPassphrase = $sslCertPassphrase;
+
+        return $this;
+    }
+
+    public function getDseAlServer(): ?string
+    {
+        return $this->dseAlServer;
+    }
+
+    public function setDseAlServer(?string $dseAlServer): self
+    {
+        $this->dseAlServer = $dseAlServer;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getDseNamingContexts(): array
+    {
+        return $this->dseNamingContexts;
+    }
+
+    public function setDseNamingContexts(string ...$dseNamingContexts): self
+    {
+        $this->dseNamingContexts = $dseNamingContexts;
+
+        return $this;
+    }
+
+    public function getDseVendorName(): string
+    {
+        return $this->dseVendorName;
+    }
+
+    public function setDseVendorName(string $dseVendorName): self
+    {
+        $this->dseVendorName = $dseVendorName;
+
+        return $this;
+    }
+
+    public function getDseVendorVersion(): ?string
+    {
+        return $this->dseVendorVersion;
+    }
+
+    public function setDseVendorVersion(?string $dseVendorVersion): self
+    {
+        $this->dseVendorVersion = $dseVendorVersion;
+
+        return $this;
+    }
+
+    public function getRequestHandler(): ?RequestHandlerInterface
+    {
+        return $this->requestHandler;
+    }
+
+    public function setRequestHandler(?RequestHandlerInterface $requestHandler): self
+    {
+        $this->requestHandler = $requestHandler;
+
+        return $this;
+    }
+
+    public function getRootDseHandler(): ?RootDseHandlerInterface
+    {
+        return $this->rootDseHandler;
+    }
+
+    public function setRootDseHandler(?RootDseHandlerInterface $rootDseHandler): self
+    {
+        $this->rootDseHandler = $rootDseHandler;
+        
+        return $this;
+    }
+
+    public function getPagingHandler(): ?PagingHandlerInterface
+    {
+        return $this->pagingHandler;
+    }
+
+    public function setPagingHandler(?PagingHandlerInterface $pagingHandler): self
+    {
+        $this->pagingHandler = $pagingHandler;
+        
+        return $this;
+    }
+
+    public function getLogger(): ?LoggerInterface
+    {
+        return $this->logger;
+    }
+
+    public function setLogger(?LoggerInterface $logger): self
+    {
+        $this->logger = $logger;
+        
+        return $this;
+    }
+
+    /**
+     * @return array{ip: string, port: int, unix_socket: string, transport: string, idle_timeout: int, require_authentication: bool, allow_anonymous: bool, request_handler: ?RequestHandlerInterface, rootdse_handler: ?RootDseHandlerInterface, paging_handler: ?PagingHandlerInterface, logger: ?LoggerInterface, use_ssl: bool, ssl_cert: ?string, ssl_cert_key: ?string, ssl_cert_passphrase: ?string, dse_alt_server: ?string, dse_naming_contexts: string[], dse_vendor_name: string, dse_vendor_version: ?string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'ip' => $this->getIp(),
+            'port' => $this->getPort(),
+            'unix_socket' => $this->getUnixSocket(),
+            'transport' => $this->getTransport(),
+            'idle_timeout' => $this->getIdleTimeout(),
+            'require_authentication' => $this->isRequireAuthentication(),
+            'allow_anonymous' => $this->isAllowAnonymous(),
+            'request_handler' => $this->getRequestHandler(),
+            'rootdse_handler' => $this->getRootDseHandler(),
+            'paging_handler' => $this->getPagingHandler(),
+            'logger' => $this->getLogger(),
+            'use_ssl' => $this->isUseSsl(),
+            'ssl_cert' => $this->getSslCert(),
+            'ssl_cert_key' => $this->getSslCertKey(),
+            'ssl_cert_passphrase' => $this->getSslCertPassphrase(),
+            'dse_alt_server' => $this->getDseAlServer(),
+            'dse_naming_contexts' => $this->getDseNamingContexts(),
+            'dse_vendor_name' => $this->getDseVendorName(),
+            'dse_vendor_version' => $this->getDseVendorVersion(),
+        ];
+    }
+}

--- a/tests/bin/ldapproxy.php
+++ b/tests/bin/ldapproxy.php
@@ -3,13 +3,13 @@
 declare(strict_types=1);
 
 use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\ServerOptions;
 
 require __DIR__ . '/../../vendor/autoload.php';
 
 $server = LdapServer::makeProxy(
-    'localhost',
-    [],
-    ['port' => 3389]
+    servers: 'localhost',
+    serverOptions: (new ServerOptions())->setPort(3389)
 );
 
 echo "server starting..." . PHP_EOL;

--- a/tests/bin/ldapserver.php
+++ b/tests/bin/ldapserver.php
@@ -16,6 +16,7 @@ use FreeDSx\Ldap\Server\Paging\PagingResponse;
 use FreeDSx\Ldap\Server\RequestContext;
 use FreeDSx\Ldap\Server\RequestHandler\GenericRequestHandler;
 use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
+use FreeDSx\Ldap\ServerOptions;
 
 require __DIR__ . '/../../vendor/autoload.php';
 
@@ -200,18 +201,20 @@ if ($transport === 'ssl') {
     $useSsl = true;
 }
 
-$server = new LdapServer([
-    'request_handler' => LdapServerRequestHandler::class,
-    'port' => 3389,
-    'transport' => $transport,
-    'ssl_cert' => $sslCert,
-    'ssl_cert_key' => $sslKey,
-    'use_ssl' => $useSsl,
-]);
-
-if ($handler === 'paging') {
-    $server->usePagingHandler(new LdapServerPagingHandler());
-}
+$server = new LdapServer(
+    (new ServerOptions())
+        ->setRequestHandler(new LdapServerRequestHandler())
+        ->setPort(3389)
+        ->setTransport($transport)
+        ->setSslCert($sslCert)
+        ->setSslCertKey($sslKey)
+        ->setUseSsl($useSsl)
+        ->setPagingHandler(
+            $handler === 'paging'
+                ? new LdapServerPagingHandler()
+                : null
+        )
+);
 
 echo "server starting..." . PHP_EOL;
 

--- a/tests/integration/FreeDSx/Ldap/LdapClientTest.php
+++ b/tests/integration/FreeDSx/Ldap/LdapClientTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace integration\FreeDSx\Ldap;
 
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Entry\Entries;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\ConnectionException;
@@ -423,7 +424,7 @@ class LdapClientTest extends LdapTestCase
         $this->bindClient($this->client);
 
         $this->client->setOptions(
-            options: [],
+            options: new ClientOptions(),
             forceDisconnect: true,
         );
 
@@ -440,7 +441,10 @@ class LdapClientTest extends LdapTestCase
 
     public function testStartTlsFailure(): void
     {
-        $this->client = $this->getClient(['servers' => 'foo.com']);
+        $this->client = $this->getClient(
+            $this->makeOptions()
+                ->setServers(['foo.com'])
+        );
 
         $this->expectException(ConnectionException::class);
         @$this->client->startTls();
@@ -448,10 +452,11 @@ class LdapClientTest extends LdapTestCase
 
     public function testStartTlsIgnoreCertValidation(): void
     {
-        $this->client = $this->getClient([
-            'servers' => 'foo.com',
-            'ssl_validate_cert' => false,
-        ]);
+        $this->client = $this->getClient(
+            $this->makeOptions()
+                ->setServers(['foo.com'])
+                ->setSslValidateCert(false)
+        );
 
         $this->client->startTls();
         $this->assertTrue($this->client->isConnected());
@@ -459,10 +464,11 @@ class LdapClientTest extends LdapTestCase
 
     public function testUseSsl(): void
     {
-        $this->client = $this->getClient([
-            'use_ssl' => true,
-            'port' => 636
-        ]);
+        $this->client = $this->getClient(
+            $this->makeOptions()
+                ->setUseSsl(true)
+                ->setPort(636)
+        );
         $this->client->read('');
 
         $this->assertTrue($this->client->isConnected());
@@ -473,10 +479,11 @@ class LdapClientTest extends LdapTestCase
         if ($this->isActiveDirectory()) {
             $this->markTestSkipped('Connecting via a unix socket only tested on OpenLDAP.');
         }
-        $this->client = $this->getClient([
-            'transport' => 'unix',
-            'servers' => '/var/run/slapd/ldapi',
-        ]);
+        $this->client = $this->getClient(
+            $this->makeOptions()
+                ->setTransport('unix')
+                ->setServers(['/var/run/slapd/ldapi'])
+        );
         $entry = $this->client->read('');
 
         $this->assertNotNull($entry);
@@ -484,11 +491,12 @@ class LdapClientTest extends LdapTestCase
 
     public function testUseSslFailure(): void
     {
-        $this->client = $this->getClient([
-            'servers' => 'foo.com',
-            'use_ssl' => true,
-            'port' => 636
-        ]);
+        $this->client = $this->getClient(
+            $this->makeOptions()
+                ->setServers(['foo.com'])
+                ->setUseSsl(true)
+                ->setPort(636)
+        );
 
         $this->expectException(ConnectionException::class);
 
@@ -497,12 +505,13 @@ class LdapClientTest extends LdapTestCase
 
     public function testUseSslIgnoreCertValidation(): void
     {
-        $this->client = $this->getClient([
-            'servers' => 'foo.com',
-            'ssl_validate_cert' => false,
-            'use_ssl' => true,
-            'port' => 636,
-        ]);
+        $this->client = $this->getClient(
+            $this->makeOptions()
+                ->setServers(['foo.com'])
+                ->setSslValidateCert(false)
+                ->setUseSsl(true)
+                ->setPort(636)
+        );
 
         $this->client->read('');
 

--- a/tests/integration/FreeDSx/Ldap/LdapProxyTest.php
+++ b/tests/integration/FreeDSx/Ldap/LdapProxyTest.php
@@ -64,7 +64,7 @@ class LdapProxyTest extends ServerTestCase
         );
 
         while ($paging->hasEntries()) {
-            $entries->add(...$paging->getEntries());
+            $entries->add(...$paging->getEntries()->toArray());
         }
 
         $this->assertSame(

--- a/tests/integration/FreeDSx/Ldap/LdapTestCase.php
+++ b/tests/integration/FreeDSx/Ldap/LdapTestCase.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace integration\FreeDSx\Ldap;
 
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\LdapClient;
 use PHPUnit\Framework\TestCase;
 use Throwable;
@@ -21,22 +22,22 @@ class LdapTestCase extends TestCase
 {
     protected static ?bool $isActiveDirectory = null;
 
-    /**
-     * @param array<string, mixed> $options
-     */
-    protected function getClient(array $options = []): LdapClient
+    protected function makeOptions(): ClientOptions
     {
-        return new LdapClient(array_merge(
-            [
-                'servers' => $_ENV['LDAP_SERVER'],
-                'port' => $_ENV['LDAP_PORT'],
-                'ssl_ca_cert' => $_ENV['LDAP_CA_CERT'] === ''
+        return (new ClientOptions())
+            ->setBaseDn((string) $_ENV['LDAP_BASE_DN'])
+            ->setServers([(string) $_ENV['LDAP_SERVER']])
+            ->setSslCaCert(
+                $_ENV['LDAP_CA_CERT'] === ''
                     ? __DIR__ . '/../../../resources/cert/ca.crt'
-                    : $_ENV['LDAP_CA_CERT'],
-                'base_dn' => $_ENV['LDAP_BASE_DN'],
-            ],
-            $options,
-        ));
+                    : (string) $_ENV['LDAP_CA_CERT']
+            )
+            ->setBaseDn((string) $_ENV['LDAP_BASE_DN']);
+    }
+
+    protected function getClient(?ClientOptions $options = null): LdapClient
+    {
+        return new LdapClient($options ?? $this->makeOptions());
     }
 
     protected function bindClient(LdapClient $client): void

--- a/tests/integration/FreeDSx/Ldap/ServerTestCase.php
+++ b/tests/integration/FreeDSx/Ldap/ServerTestCase.php
@@ -96,13 +96,14 @@ class ServerTestCase extends LdapTestCase
             $servers = '/var/run/ldap.socket';
         }
 
-        $this->client = $this->getClient([
-            'port' => 3389,
-            'transport' => $transport,
-            'servers' => $servers,
-            'ssl_validate_cert' => false,
-            'use_ssl' => $useSsl,
-        ]);
+        $this->client = $this->getClient(
+            $this->makeOptions()
+                ->setPort(3389)
+                ->setTransport($transport)
+                ->setServers((array) $servers)
+                ->setSslValidateCert(false)
+                ->setUseSsl($useSsl)
+        );
     }
 
     protected function stopServer(): void

--- a/tests/spec/FreeDSx/Ldap/LdapClientSpec.php
+++ b/tests/spec/FreeDSx/Ldap/LdapClientSpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\FreeDSx\Ldap;
 
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Entry\Entries;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -405,9 +406,11 @@ class LdapClientSpec extends ObjectBehavior
             );
     }
 
-    public function it_should_get_the_options(): void
+    public function it_should_get_the_default_options(): void
     {
-        $this->getOptions()->shouldBeEqualTo([
+        $this->getOptions()
+            ->toArray()
+            ->shouldBeEqualTo([
             'version' => 3,
             'servers' => [],
             'port' => 389,
@@ -416,7 +419,7 @@ class LdapClientSpec extends ObjectBehavior
             'page_size' => 1000,
             'use_ssl' => false,
             'ssl_validate_cert' => true,
-            'ssl_allow_self_signed' => null,
+            'ssl_allow_self_signed' => false,
             'ssl_ca_cert' => null,
             'ssl_peer_name' => null,
             'timeout_connect' => 3,
@@ -429,20 +432,15 @@ class LdapClientSpec extends ObjectBehavior
 
     public function it_should_set_the_options(): void
     {
-        $this->setOptions([
-            'servers' => [
-                'bar',
+        $options = (new ClientOptions())
+            ->setServers([
                 'foo',
-            ]
-        ]);
+                'bar',
+            ]);
+
+        $this->setOptions($options);
 
         $this->getOptions()
-            ->shouldHaveKeyWithValue(
-                'servers',
-                [
-                    'bar',
-                    'foo',
-                ]
-            );
+            ->shouldBeEqualTo($options);
     }
 }

--- a/tests/spec/FreeDSx/Ldap/LdapServerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/LdapServerSpec.php
@@ -13,11 +13,16 @@ declare(strict_types=1);
 
 namespace spec\FreeDSx\Ldap;
 
+use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
+use FreeDSx\Ldap\Server\RequestHandler\ProxyHandler;
+use FreeDSx\Ldap\Server\RequestHandler\ProxyPagingHandler;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
+use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\SocketServer;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -28,7 +33,7 @@ class LdapServerSpec extends ObjectBehavior
     public function let(ServerRunnerInterface $serverRunner): void
     {
         $this->beConstructedWith(
-            ['port' => 33389],
+            (new ServerOptions())->setPort(33389),
             $serverRunner
         );
     }
@@ -51,10 +56,8 @@ class LdapServerSpec extends ObjectBehavior
         $this->useRequestHandler($requestHandler);
 
         $this->getOptions()
-            ->shouldHaveKeyWithValue(
-                'request_handler',
-                $requestHandler
-            );
+            ->getRequestHandler()
+            ->shouldBeEqualTo($requestHandler);
     }
 
     public function it_should_use_the_rootdse_handler_specified(RootDseHandlerInterface $rootDseHandler): void
@@ -62,10 +65,8 @@ class LdapServerSpec extends ObjectBehavior
         $this->useRootDseHandler($rootDseHandler);
 
         $this->getOptions()
-            ->shouldHaveKeyWithValue(
-                'rootdse_handler',
-                $rootDseHandler
-            );
+            ->getRootDseHandler()
+            ->shouldBeEqualTo($rootDseHandler);
     }
 
     public function it_should_use_the_paging_handler_specified(PagingHandlerInterface $pagingHandler): void
@@ -73,10 +74,8 @@ class LdapServerSpec extends ObjectBehavior
         $this->usePagingHandler($pagingHandler);
 
         $this->getOptions()
-            ->shouldHaveKeyWithValue(
-                'paging_handler',
-                $pagingHandler
-            );
+            ->getPagingHandler()
+            ->shouldBeEqualTo($pagingHandler);
     }
 
     public function it_should_use_the_logger_specified(LoggerInterface $logger): void
@@ -84,48 +83,53 @@ class LdapServerSpec extends ObjectBehavior
         $this->useLogger($logger);
 
         $this->getOptions()
-            ->shouldHaveKeyWithValue(
-                'logger',
-                $logger
-            );
+            ->getLogger()
+            ->shouldBeEqualTo($logger);
     }
 
-    public function it_should_get_the_default_options_with_any_merged_values(): void
+    public function it_should_get_the_default_options(): void
     {
-        $this->getOptions()->shouldBeEqualTo([
-            'ip' => "0.0.0.0",
-            'port' => 33389,
-            'unix_socket' => "/var/run/ldap.socket",
-            'transport' => "tcp",
-            'idle_timeout' => 600,
-            'require_authentication' => true,
-            'allow_anonymous' => false,
-            'request_handler' => null,
-            'rootdse_handler' => null,
-            'paging_handler' => null,
-            'logger' => null,
-            'use_ssl' => false,
-            'ssl_cert' => null,
-            'ssl_cert_passphrase' => null,
-            'dse_alt_server' => null,
-            'dse_naming_contexts' => "dc=FreeDSx,dc=local",
-            'dse_vendor_name' => "FreeDSx",
-            'dse_vendor_version' => null,
-        ]);
+        $this->getOptions()
+            ->toArray()
+            ->shouldBeEqualTo([
+                'ip' => "0.0.0.0",
+                'port' => 33389,
+                'unix_socket' => "/var/run/ldap.socket",
+                'transport' => "tcp",
+                'idle_timeout' => 600,
+                'require_authentication' => true,
+                'allow_anonymous' => false,
+                'request_handler' => null,
+                'rootdse_handler' => null,
+                'paging_handler' => null,
+                'logger' => null,
+                'use_ssl' => false,
+                'ssl_cert' => null,
+                'ssl_cert_key' => null,
+                'ssl_cert_passphrase' => null,
+                'dse_alt_server' => null,
+                'dse_naming_contexts' => [
+                    "dc=FreeDSx,dc=local"
+                ],
+                'dse_vendor_name' => "FreeDSx",
+                'dse_vendor_version' => null,
+            ]);
     }
 
     public function it_should_make_a_proxy_server(): void
     {
-        $this->beConstructedThrough(
-            'makeProxy',
-            ['localhost']
+        $client = new LdapClient(
+            (new ClientOptions())
+                ->setServers(['localhost'])
         );
+        $serverOptions = new ServerOptions();
+        $proxyRequestHandler = new ProxyHandler($client);
+        $server = new LdapServer($serverOptions);
+        $server->useRequestHandler($proxyRequestHandler);
+        $server->useRootDseHandler($proxyRequestHandler);
+        $server->usePagingHandler(new ProxyPagingHandler($client));
 
-        $this->getOptions()
-            ->shouldHaveKey('request_handler');
-        $this->getOptions()
-            ->shouldHaveKey('paging_handler');
-        $this->getOptions()
-            ->shouldHaveKey('rootdse_handler');
+        $this::makeProxy('localhost')
+            ->shouldBeLike($server);
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientBasicHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientBasicHandlerSpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\CompareRequest;
@@ -71,25 +72,44 @@ class ClientBasicHandlerSpec extends ObjectBehavior
         $messageRequest = new LdapMessageRequest(1, new SimpleBindRequest('foo', 'bar'));
         $messageFrom = new LdapMessageResponse(1, new BindResponse(new LdapResult(0)));
 
-        $options = [];
-        $this->handleResponse($messageRequest, $messageFrom, $queue, $options)->shouldBeEqualTo($messageFrom);
+        $this->handleResponse(
+            $messageRequest,
+            $messageFrom,
+            $queue,
+            new ClientOptions()
+        )->shouldBeEqualTo($messageFrom);
     }
 
     public function it_should_handle_a_response_with_non_error_codes(ClientQueue $queue): void
     {
-        $options = [];
+        $options = new ClientOptions();
         $messageRequest = new LdapMessageRequest(1, new CompareRequest('foo', new EqualityFilter('foo', 'bar')));
         $messageFrom = new LdapMessageResponse(1, new CompareResponse(ResultCode::COMPARE_FALSE));
 
-        $this->handleResponse($messageRequest, $messageFrom, $queue, $options)->shouldBeEqualTo($messageFrom);
+        $this->handleResponse(
+            $messageRequest,
+            $messageFrom,
+            $queue,
+            $options
+        )->shouldBeEqualTo($messageFrom);
 
         $messageFrom = new LdapMessageResponse(1, new CompareResponse(ResultCode::COMPARE_TRUE));
 
-        $this->handleResponse($messageRequest, $messageFrom, $queue, $options)->shouldBeEqualTo($messageFrom);
+        $this->handleResponse(
+            $messageRequest,
+            $messageFrom,
+            $queue,
+            $options
+        )->shouldBeEqualTo($messageFrom);
 
         $messageFrom = new LdapMessageResponse(1, new CompareResponse(ResultCode::REFERRAL));
 
-        $this->handleResponse($messageRequest, $messageFrom, $queue, $options)->shouldBeEqualTo($messageFrom);
+        $this->handleResponse(
+            $messageRequest,
+            $messageFrom,
+            $queue,
+            $options
+        )->shouldBeEqualTo($messageFrom);
     }
 
     public function it_should_throw_an_operation_exception_on_errors(ClientQueue $queue): void
@@ -97,8 +117,12 @@ class ClientBasicHandlerSpec extends ObjectBehavior
         $messageRequest = new LdapMessageRequest(1, new CompareRequest('foo', new EqualityFilter('foo', 'bar')));
         $messageFrom = new LdapMessageResponse(1, new CompareResponse(ResultCode::COMPARE_FALSE));
 
-        $options = [];
-        $this->handleResponse($messageRequest, $messageFrom, $queue, $options)->shouldBeEqualTo($messageFrom);
+        $this->handleResponse(
+            $messageRequest,
+            $messageFrom,
+            $queue,
+            new ClientOptions()
+        )->shouldBeEqualTo($messageFrom);
     }
 
     public function it_should_throw_a_specific_bind_exception_for_a_bind_response(ClientQueue $queue): void
@@ -106,7 +130,17 @@ class ClientBasicHandlerSpec extends ObjectBehavior
         $messageRequest = new LdapMessageRequest(1, new SimpleBindRequest('foo', 'bar'));
         $messageFrom = new LdapMessageResponse(1, new BindResponse(new LdapResult(ResultCode::INVALID_CREDENTIALS, 'foo', 'message')));
 
-        $options = [];
-        $this->shouldThrow(new BindException('Unable to bind to LDAP. message', ResultCode::INVALID_CREDENTIALS))->during('handleResponse', [$messageRequest, $messageFrom, $queue, $options]);
+        $this->shouldThrow(new BindException(
+            'Unable to bind to LDAP. message',
+            ResultCode::INVALID_CREDENTIALS
+        ))->during(
+            'handleResponse',
+            [
+                $messageRequest,
+                $messageFrom,
+                $queue,
+                new ClientOptions(),
+            ]
+        );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientExtendedOperationHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientExtendedOperationHandlerSpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
@@ -54,7 +55,7 @@ class ClientExtendedOperationHandlerSpec extends ObjectBehavior
             new LdapMessageRequest(1, new ExtendedRequest('foo', 'bar')),
             $response,
             $queue,
-            []
+            new ClientOptions(),
         )->shouldBeEqualTo($response);
     }
 

--- a/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientProtocolContextSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientProtocolContextSpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
@@ -26,7 +27,13 @@ class ClientProtocolContextSpec extends ObjectBehavior
 {
     public function let(ClientQueue $queue, ClientProtocolHandler $protocolHandler): void
     {
-        $this->beConstructedWith(new DeleteRequest('foo'), [], $protocolHandler, $queue, ['foo']);
+        $this->beConstructedWith(
+            new DeleteRequest('foo'),
+            [],
+            $protocolHandler,
+            $queue,
+            new ClientOptions()
+        );
     }
 
     public function it_is_initializable(): void
@@ -64,7 +71,7 @@ class ClientProtocolContextSpec extends ObjectBehavior
 
     public function it_should_get_the_options(): void
     {
-        $this->getOptions()->shouldBeEqualTo(['foo']);
+        $this->getOptions()->shouldBeLike(new ClientOptions());
     }
 
     public function it_should_get_the_queue(ClientQueue $queue): void

--- a/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientStartTlsHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientStartTlsHandlerSpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Exception\ConnectionException;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
@@ -43,7 +44,7 @@ class ClientStartTlsHandlerSpec extends ObjectBehavior
         $response = new LdapMessageResponse(1, new ExtendedResponse(new LdapResult(0), ExtendedRequest::OID_START_TLS));
 
         $queue->encrypt()->shouldBeCalledOnce()->willReturn($queue);
-        $this->handleResponse($startTls, $response, $queue, [])->shouldBeAnInstanceOf(LdapMessageResponse::class);
+        $this->handleResponse($startTls, $response, $queue, new ClientOptions())->shouldBeAnInstanceOf(LdapMessageResponse::class);
     }
 
     public function it_should_throw_an_exception_if_the_message_response_is_unsuccessful(ClientQueue $queue): void
@@ -52,6 +53,6 @@ class ClientStartTlsHandlerSpec extends ObjectBehavior
         $response = new LdapMessageResponse(1, new ExtendedResponse(new LdapResult(ResultCode::UNAVAILABLE_CRITICAL_EXTENSION), ExtendedRequest::OID_START_TLS));
 
         $queue->encrypt(true)->shouldNotBeCalled();
-        $this->shouldThrow(ConnectionException::class)->during('handleResponse', [$startTls, $response, $queue, []]);
+        $this->shouldThrow(ConnectionException::class)->during('handleResponse', [$startTls, $response, $queue, new ClientOptions()]);
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerAuthorizationSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerAuthorizationSpec.php
@@ -83,7 +83,7 @@ class ServerAuthorizationSpec extends ObjectBehavior
 
     public function it_should_not_require_authentication_if_it_has_been_explicitly_disabled(): void
     {
-        $this->beConstructedWith(null, ['require_authentication' => false]);
+        $this->beConstructedWith(new AnonToken(), false, false);
 
         $this->isAuthenticationRequired(Operations::read('cn=bar'))->shouldBeEqualTo(false);
         $this->isAuthenticationRequired(Operations::list(new EqualityFilter('foo', 'bar'), 'cn=foo'))->shouldBeEqualTo(false);
@@ -104,7 +104,7 @@ class ServerAuthorizationSpec extends ObjectBehavior
 
     public function it_should_respect_the_option_for_whether_anon_binds_are_allowed(): void
     {
-        $this->beConstructedWith(null, ['allow_anonymous' => true]);
+        $this->beConstructedWith(new AnonToken(), true);
 
         $this->isAuthenticationTypeSupported(Operations::bindAnonymously())->shouldBeEqualTo(true);
     }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAnonBindHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAnonBindHandlerSpec.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerAnonBindHandler;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\AnonToken;
+use FreeDSx\Ldap\ServerOptions;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -44,7 +45,7 @@ class ServerAnonBindHandlerSpec extends ObjectBehavior
 
         $this->shouldThrow(OperationException::class)->during(
             'handleBind',
-            [$bind, $dispatcher, $queue, []]
+            [$bind, $dispatcher, $queue]
         );
     }
 
@@ -59,7 +60,7 @@ class ServerAnonBindHandlerSpec extends ObjectBehavior
             new LdapResult(0)
         )))->shouldBeCalled()->willReturn($queue);
 
-        $this->handleBind($bind, $dispatcher, $queue, [])->shouldBeLike(
+        $this->handleBind($bind, $dispatcher, $queue)->shouldBeLike(
             new AnonToken('foo')
         );
     }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerBindHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerBindHandlerSpec.php
@@ -45,7 +45,7 @@ class ServerBindHandlerSpec extends ObjectBehavior
             new LdapResult(0)
         )))->shouldBeCalled()->willReturn($queue);
 
-        $this->handleBind($bind, $dispatcher, $queue, [])->shouldBeLike(
+        $this->handleBind($bind, $dispatcher, $queue)->shouldBeLike(
             new BindToken('foo@bar', 'bar')
         );
     }
@@ -62,7 +62,7 @@ class ServerBindHandlerSpec extends ObjectBehavior
         $this->shouldThrow(new OperationException('Invalid credentials.', ResultCode::INVALID_CREDENTIALS))
             ->during(
                 'handleBind',
-                [$bind, $dispatcher, $queue, []]
+                [$bind, $dispatcher, $queue]
             );
     }
 
@@ -75,7 +75,7 @@ class ServerBindHandlerSpec extends ObjectBehavior
         $this->shouldThrow(OperationException::class)
             ->during(
                 'handleBind',
-                [$bind, $dispatcher, $queue, []]
+                [$bind, $dispatcher, $queue]
             );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandlerSpec.php
@@ -29,6 +29,7 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerDispatchHandler;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -49,7 +50,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $add = new LdapMessageRequest(1, new AddRequest(Entry::create('cn=foo,dc=bar')));
 
         $handler->add(Argument::any(), $add->getRequest())->shouldBeCalled();
-        $this->handleRequest($add, $token, $handler, $queue, []);
+        $this->handleRequest($add, $token, $handler, $queue, new ServerOptions());
     }
 
     public function it_should_send_a_delete_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
@@ -57,7 +58,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $delete = new LdapMessageRequest(1, new DeleteRequest('cn=foo,dc=bar'));
 
         $handler->delete(Argument::any(), $delete->getRequest())->shouldBeCalled();
-        $this->handleRequest($delete, $token, $handler, $queue, []);
+        $this->handleRequest($delete, $token, $handler, $queue, new ServerOptions());
     }
 
     public function it_should_send_a_modify_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
@@ -65,7 +66,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $modify = new LdapMessageRequest(1, new ModifyRequest('cn=foo,dc=bar', Change::add('foo', 'bar')));
 
         $handler->modify(Argument::any(), $modify->getRequest())->shouldBeCalled();
-        $this->handleRequest($modify, $token, $handler, $queue, []);
+        $this->handleRequest($modify, $token, $handler, $queue, new ServerOptions());
     }
 
     public function it_should_send_a_modify_dn_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
@@ -73,7 +74,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $modifyDn = new LdapMessageRequest(1, new ModifyDnRequest('cn=foo,dc=bar', 'cn=bar', true));
 
         $handler->modifyDn(Argument::any(), $modifyDn->getRequest())->shouldBeCalled();
-        $this->handleRequest($modifyDn, $token, $handler, $queue, []);
+        $this->handleRequest($modifyDn, $token, $handler, $queue, new ServerOptions());
     }
 
     public function it_should_send_an_extended_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
@@ -81,7 +82,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $ext = new LdapMessageRequest(1, new ExtendedRequest('foo', 'bar'));
 
         $handler->extended(Argument::any(), $ext->getRequest())->shouldBeCalled();
-        $this->handleRequest($ext, $token, $handler, $queue, []);
+        $this->handleRequest($ext, $token, $handler, $queue, new ServerOptions());
     }
 
     public function it_should_send_a_compare_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
@@ -89,7 +90,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $compare = new LdapMessageRequest(1, new CompareRequest('cn=foo,dc=bar', Filters::equal('foo', 'bar')));
 
         $handler->compare(Argument::any(), $compare->getRequest())->shouldBeCalled()->willReturn(true);
-        $this->handleRequest($compare, $token, $handler, $queue, []);
+        $this->handleRequest($compare, $token, $handler, $queue, new ServerOptions());
     }
 
     public function it_should_throw_an_operation_exception_if_the_request_is_unsupported(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
@@ -98,7 +99,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
 
         $this->shouldThrow(OperationException::class)->during(
             'handleRequest',
-            [$request, $token, $handler, $queue, []]
+            [$request, $token, $handler, $queue, new ServerOptions()]
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandlerSpec.php
@@ -34,6 +34,7 @@ use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHistory;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -100,7 +101,7 @@ class ServerPagingHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            []
+            new ServerOptions()
         );
     }
 
@@ -151,7 +152,7 @@ class ServerPagingHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            []
+            new ServerOptions()
         );
     }
 
@@ -188,7 +189,7 @@ class ServerPagingHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            []
+            new ServerOptions()
         );
     }
 
@@ -229,7 +230,7 @@ class ServerPagingHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            []
+            new ServerOptions()
         );
     }
 
@@ -249,7 +250,7 @@ class ServerPagingHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            []
+            new ServerOptions()
         ]);
     }
 

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandlerSpec.php
@@ -28,6 +28,7 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerPagingUnsupportedHandler;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -80,7 +81,7 @@ class ServerPagingUnsupportedHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            []
+            new ServerOptions()
         );
     }
 
@@ -103,7 +104,7 @@ class ServerPagingUnsupportedHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            []
+            new ServerOptions()
         ]);
     }
 
@@ -145,7 +146,7 @@ class ServerPagingUnsupportedHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            []
+            new ServerOptions()
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandlerSpec.php
@@ -30,6 +30,7 @@ use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -72,14 +73,17 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            ['dse_vendor_name' => 'Foo', 'dse_naming_contexts' => ['dc=Foo,dc=Bar']]
+            (new ServerOptions())
+                ->setDseVendorName('Foo')
+                ->setDseNamingContexts('dc=Foo,dc=Bar')
         );
     }
 
     public function it_should_send_back_a_RootDSE_with_paging_support_if_the_paging_handler_is_set(
         ServerQueue $queue,
         RequestHandlerInterface $handler,
-        TokenInterface $token
+        TokenInterface $token,
+        PagingHandlerInterface $pagingHandler,
     ): void {
         $search = new LdapMessageRequest(
             1,
@@ -103,11 +107,10 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            [
-                'paging_handler' => PagingHandlerInterface::class,
-                'dse_vendor_name' => 'Foo',
-                'dse_naming_contexts' => ['dc=Foo,dc=Bar'],
-            ]
+            (new ServerOptions())
+                ->setDseVendorName('Foo')
+                ->setDseNamingContexts('dc=Foo,dc=Bar')
+                ->setPagingHandler($pagingHandler->getWrappedObject())
         );
     }
 
@@ -148,7 +151,9 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            ['dse_vendor_name' => 'Foo', 'dse_naming_contexts' => ['dc=Foo,dc=Bar']]
+            (new ServerOptions())
+                ->setDseVendorName('Foo')
+                ->setDseNamingContexts('dc=Foo,dc=Bar')
         );
     }
 
@@ -180,7 +185,9 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            ['dse_vendor_name' => 'Foo', 'dse_naming_contexts' => ['dc=Foo,dc=Bar']]
+            (new ServerOptions())
+                ->setDseVendorName('Foo')
+                ->setDseNamingContexts('dc=Foo,dc=Bar')
         );
     }
 
@@ -215,7 +222,9 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            ['dse_vendor_name' => 'Foo', 'dse_naming_contexts' => ['dc=Foo,dc=Bar']]
+            (new ServerOptions())
+                ->setDseVendorName('Foo')
+                ->setDseNamingContexts('dc=Foo,dc=Bar')
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandlerSpec.php
@@ -27,6 +27,7 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerSearchHandler;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -58,7 +59,7 @@ class ServerSearchHandlerSpec extends ObjectBehavior
             new LdapMessageResponse(2, new SearchResultDone(0, 'dc=foo,dc=bar'))
         )->shouldBeCalled();
 
-        $this->handleRequest($search, $token, $handler, $queue, []);
+        $this->handleRequest($search, $token, $handler, $queue, new ServerOptions());
     }
 
     public function it_should_send_a_SearchResultDone_with_an_operation_exception_thrown_from_the_handler(
@@ -95,7 +96,7 @@ class ServerSearchHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            []
+            new ServerOptions()
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandlerSpec.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerStartTlsHandler;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 use PhpSpec\ObjectBehavior;
 
 class ServerStartTlsHandlerSpec extends ObjectBehavior
@@ -46,7 +47,14 @@ class ServerStartTlsHandlerSpec extends ObjectBehavior
         ))->shouldBeCalled();
 
         $startTls = new LdapMessageRequest(1, new ExtendedRequest(ExtendedRequest::OID_START_TLS));
-        $this->handleRequest($startTls, $token, $dispatcher, $queue, ['ssl_cert' => 'foo']);
+        $this->handleRequest(
+            $startTls,
+            $token,
+            $dispatcher,
+            $queue,
+            (new ServerOptions())
+                ->setSslCert('foo')
+        );
     }
 
     public function it_should_send_back_an_error_if_the_queue_is_already_encrypted(ServerQueue $queue, TokenInterface $token, RequestHandlerInterface $dispatcher): void
@@ -63,7 +71,14 @@ class ServerStartTlsHandlerSpec extends ObjectBehavior
         ))->shouldBeCalled();
 
         $startTls = new LdapMessageRequest(1, new ExtendedRequest(ExtendedRequest::OID_START_TLS));
-        $this->handleRequest($startTls, $token, $dispatcher, $queue, ['ssl_cert' => 'foo']);
+        $this->handleRequest(
+            $startTls,
+            $token,
+            $dispatcher,
+            $queue,
+            (new ServerOptions())
+                ->setSslCert('foo')
+        );
     }
 
     public function it_should_send_back_an_error_if_encryption_is_not_supported(ServerQueue $queue, TokenInterface $token, RequestHandlerInterface $dispatcher): void
@@ -80,6 +95,12 @@ class ServerStartTlsHandlerSpec extends ObjectBehavior
         ))->shouldBeCalled();
 
         $startTls = new LdapMessageRequest(1, new ExtendedRequest(ExtendedRequest::OID_START_TLS));
-        $this->handleRequest($startTls, $token, $dispatcher, $queue, []);
+        $this->handleRequest(
+            $startTls,
+            $token,
+            $dispatcher,
+            $queue,
+            new ServerOptions()
+        );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandlerSpec.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerUnbindHandler;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -35,6 +36,6 @@ class ServerUnbindHandlerSpec extends ObjectBehavior
         $queue->sendMessage(Argument::any())->shouldNotBeCalled();
 
         $unbind = new LdapMessageRequest(1, new UnbindRequest());
-        $this->handleRequest($unbind, $token, $dispatcher, $queue, []);
+        $this->handleRequest($unbind, $token, $dispatcher, $queue, new ServerOptions());
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerSpec.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerWhoAmIHandler;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use FreeDSx\Ldap\Server\Token\BindToken;
+use FreeDSx\Ldap\ServerOptions;
 use PhpSpec\ObjectBehavior;
 
 class ServerWhoAmIHandlerSpec extends ObjectBehavior
@@ -46,7 +47,7 @@ class ServerWhoAmIHandlerSpec extends ObjectBehavior
             new BindToken('cn=foo,dc=foo,dc=bar', '12345'),
             $handler,
             $queue,
-            []
+            new ServerOptions()
         );
     }
 
@@ -64,7 +65,7 @@ class ServerWhoAmIHandlerSpec extends ObjectBehavior
             new BindToken('foo@bar.local', '12345'),
             $handler,
             $queue,
-            []
+            new ServerOptions()
         );
     }
 
@@ -83,7 +84,7 @@ class ServerWhoAmIHandlerSpec extends ObjectBehavior
             new AnonToken(),
             $handler,
             $queue,
-            []
+            new ServerOptions()
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandlerSpec.php
@@ -36,6 +36,7 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\BindToken;
+use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\Exception\ConnectionException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -62,7 +63,7 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
         $this->beConstructedWith(
             $queue,
             $handlerFactory,
-            [],
+            new ServerOptions(),
             $protocolHandlerFactory,
             $bindHandlerFactory
         );
@@ -101,7 +102,7 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
             null
         );
 
-        $bindHandler->handleBind(Argument::any(), Argument::any(), Argument::any(), Argument::any())->willReturn(
+        $bindHandler->handleBind(Argument::any(), Argument::any(), Argument::any())->willReturn(
             new BindToken('foo', 'bar')
         );
         $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())
@@ -196,7 +197,7 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
             null
         );
 
-        $bindHandler->handleBind(Argument::any(), Argument::any(), Argument::any(), Argument::any())
+        $bindHandler->handleBind(Argument::any(), Argument::any(), Argument::any())
             ->shouldBeCalledOnce()
             ->willReturn(new BindToken('foo@bar', 'bar'));
         $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())
@@ -214,7 +215,7 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
             null
         );
 
-        $bindHandler->handleBind(Argument::any(), Argument::any(), Argument::any(), Argument::any())
+        $bindHandler->handleBind(Argument::any(), Argument::any(), Argument::any())
             ->willReturn(new BindToken('foo@bar', 'bar'));
 
         $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())

--- a/tests/spec/FreeDSx/Ldap/Server/RequestHandler/HandlerFactorySpec.php
+++ b/tests/spec/FreeDSx/Ldap/Server/RequestHandler/HandlerFactorySpec.php
@@ -13,17 +13,12 @@ declare(strict_types=1);
 
 namespace spec\FreeDSx\Ldap\Server\RequestHandler;
 
-use FreeDSx\Ldap\Entry\Entries;
-use FreeDSx\Ldap\Entry\Entry;
-use FreeDSx\Ldap\Exception\RuntimeException;
-use FreeDSx\Ldap\Operation\Request\SearchRequest;
-use FreeDSx\Ldap\Server\Paging\PagingRequest;
-use FreeDSx\Ldap\Server\Paging\PagingResponse;
-use FreeDSx\Ldap\Server\RequestContext;
+use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Server\RequestHandler\GenericRequestHandler;
 use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
-use FreeDSx\Ldap\Server\RequestHandler\ProxyRequestHandler;
-use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
+use FreeDSx\Ldap\Server\RequestHandler\ProxyHandler;
+use FreeDSx\Ldap\Server\RequestHandler\ProxyPagingHandler;
+use FreeDSx\Ldap\ServerOptions;
 use PhpSpec\ObjectBehavior;
 
 class HandlerFactorySpec extends ObjectBehavior
@@ -31,116 +26,47 @@ class HandlerFactorySpec extends ObjectBehavior
     public function it_should_allow_a_request_handler_as_an_object(): void
     {
         $handler = new GenericRequestHandler();
-        $this->beConstructedWith([
-            'request_handler' => $handler,
-        ]);
+        $this->beConstructedWith(
+            (new ServerOptions())->setRequestHandler($handler)
+        );
 
         $this->makeRequestHandler()->shouldBeEqualTo($handler);
     }
 
-    public function it_should_only_allow_a_request_handler_implementing_request_handler_interface(): void
+    public function it_should_allow_a_rootdse_handler_as_an_object(): void
     {
-        $this->beConstructedWith([
-            'request_handler' => new Entry('foo'),
-        ]);
-
-        $this->shouldThrow(RuntimeException::class)->during('makeRequestHandler');
-    }
-
-    public function it_should_allow_a_request_handler_as_a_string_implementing_request_handler_interface(): void
-    {
-        $this->beConstructedWith([
-            'request_handler' => ProxyRequestHandler::class,
-        ]);
-
-        $this->shouldNotThrow(RuntimeException::class)->during('makeRequestHandler');
-    }
-
-    public function it_should_allow_a_rootdse_handler_as_an_object(RootDseHandlerInterface $rootDseHandler): void
-    {
-        $this->beConstructedWith([
-            'rootdse_handler' => $rootDseHandler,
-        ]);
+        $rootDseHandler = new ProxyHandler(new LdapClient());
+        $this->beConstructedWith(
+            (new ServerOptions())->setRootDseHandler($rootDseHandler)
+        );
 
         $this->makeRootDseHandler()->shouldBeEqualTo($rootDseHandler);
     }
 
-    public function it_should_only_allow_a_rootdse_handler_implementing_rootdse_handler_interface(): void
-    {
-        $this->beConstructedWith([
-            'rootdse_handler' => new Entry('foo'),
-        ]);
-
-        $this->shouldThrow(RuntimeException::class)->during('makeRootDseHandler');
-    }
-
-    public function it_should_allow_a_rootdse_handler_as_a_string_implementing_rootdse_handler_interface(): void
-    {
-        $handler = new class() implements RootDseHandlerInterface {
-            public function rootDse(RequestContext $context, SearchRequest $request, Entry $rootDse): Entry
-            {
-                return new Entry('');
-            }
-        };
-
-        $this->beConstructedWith([
-            'rootdse_handler' => get_class($handler),
-        ]);
-
-        $this->shouldNotThrow(RuntimeException::class)->during('makeRootDseHandler');
-    }
-
     public function it_should_allow_a_null_rootdse_handler(): void
     {
-        $this->beConstructedWith([
-            'rootdse_handler' => null,
-        ]);
+        $this->beConstructedWith(
+            (new ServerOptions())->setRootDseHandler(null)
+        );
 
         $this->makeRootDseHandler()->shouldBeNull();
-    }
-    public function it_should_allow_a_paging_handler_implementing_paging_handler_interface(): void
-    {
-        $this->beConstructedWith([
-            'paging_handler' => new Entry('foo'),
-        ]);
-
-        $this->shouldThrow(RuntimeException::class)->during('makePagingHandler');
-    }
-
-    public function it_should_allow_a_paging_handler_as_a_string_implementing_paging_handler_interface(): void
-    {
-        $handler = new class() implements PagingHandlerInterface {
-            public function page(PagingRequest $pagingRequest, RequestContext $context): PagingResponse
-            {
-                return PagingResponse::make(new Entries());
-            }
-
-            public function remove(PagingRequest $pagingRequest, RequestContext $context): void
-            {
-            }
-        };
-
-        $this->beConstructedWith([
-            'paging_handler' => get_class($handler),
-        ]);
-
-        $this->shouldNotThrow(RuntimeException::class)->during('makePagingHandler');
     }
 
     public function it_should_allow_a_paging_handler_as_an_object(PagingHandlerInterface $pagingHandler): void
     {
-        $this->beConstructedWith([
-            'paging_handler' => $pagingHandler,
-        ]);
+        $pagingHandler = new ProxyPagingHandler(new LdapClient());
+        $this->beConstructedWith(
+            (new ServerOptions())->setPagingHandler($pagingHandler)
+        );
 
         $this->makePagingHandler()->shouldBeEqualTo($pagingHandler);
     }
 
     public function it_should_allow_a_null_paging_handler(): void
     {
-        $this->beConstructedWith([
-            'paging_handler' => null,
-        ]);
+        $this->beConstructedWith(
+            (new ServerOptions())->setPagingHandler(null)
+        );
 
         $this->makePagingHandler()->shouldBeNull();
     }


### PR DESCRIPTION
This is a large breaking change, but it is necessary. The array options have been a pain for quite some time. This provides type safety and less confusion over making sure every option is named properly in the array. It also provides a way to reject certain bad option values.

For most users of the library, switching over to this should be straight forward, and the `1.0.0` release will be the one time to finally make this change.

https://github.com/FreeDSx/LDAP/issues/50