### PR TITLE
[1.0.0] Fix issues preventing PHPStan from being a max level.

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -33,7 +33,9 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Run Static Analysis
-        run: composer run-script analyse
+        run: |
+          composer run-script analyse
+          composer run-script analyse-tests
 
       - name: Run Test Coverage
         env:

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,9 @@
     "analyse": [
       "phpstan analyse"
     ],
+    "analyse-tests": [
+      "phpstan analyse -c phpstan.tests.neon"
+    ],
     "cs-fix": [
       "phpcbf --standard=ruleset.xml --extensions=php --tab-width=4 -sp src",
       "ecs --fix"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 8
+    level: max
     paths:
         - %currentWorkingDirectory%/src
     checkMissingIterableValueType: false

--- a/phpstan.tests.neon
+++ b/phpstan.tests.neon
@@ -1,0 +1,7 @@
+parameters:
+    level: 1
+    paths:
+        - %currentWorkingDirectory%/tests
+    ignoreErrors:
+        # Does not seem to be a great extension for phpspec :(
+        - '#Call to an undefined (static )?method spec\\FreeDSx\\Ldap\\.*Spec::#'

--- a/src/FreeDSx/Ldap/Operation/LdapResult.php
+++ b/src/FreeDSx/Ldap/Operation/LdapResult.php
@@ -181,7 +181,7 @@ class LdapResult implements ResponseInterface
     }
 
     /**
-     * @return array{0: mixed, 1: mixed, 2: mixed, 3: list<LdapUrl>}
+     * @return array{0: int, 1: string, 2: string, 3: LdapUrl[]}
      * @throws ProtocolException
      * @throws EncoderException
      */
@@ -205,7 +205,7 @@ class LdapResult implements ResponseInterface
                     $child = (new LdapEncoder())->complete($child, AbstractType::TAG_TYPE_SEQUENCE);
                     foreach ($child->getChildren() as $ldapUrl) {
                         try {
-                            $referrals[] = LdapUrl::parse($ldapUrl->getValue());
+                            $referrals[] = LdapUrl::parse((string) $ldapUrl->getValue());
                         } catch (UrlParseException $e) {
                             throw new ProtocolException($e->getMessage());
                         }

--- a/src/FreeDSx/Ldap/Operation/Request/ExtendedRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/ExtendedRequest.php
@@ -141,7 +141,7 @@ class ExtendedRequest implements RequestInterface
 
     /**
      * @throws ProtocolException
-     * @return array{0: mixed, 1: mixed|null}
+     * @return array{0: string, 1: null|string}
      */
     protected static function parseAsn1ExtendedRequest(AbstractType $type): array
     {

--- a/src/FreeDSx/Ldap/Operation/Response/IntermediateResponse.php
+++ b/src/FreeDSx/Ldap/Operation/Response/IntermediateResponse.php
@@ -74,8 +74,8 @@ class IntermediateResponse implements ResponseInterface
         }
 
         return new self(
-            $name,
-            $value
+            $name === null ? null : (string) $name,
+            $value === null ? null : (string) $value
         );
     }
 

--- a/src/FreeDSx/Ldap/Operation/Response/SearchResultEntry.php
+++ b/src/FreeDSx/Ldap/Operation/Response/SearchResultEntry.php
@@ -75,14 +75,14 @@ class SearchResultEntry implements ResponseInterface
                 }
 
                 $attributes[] = new Attribute(
-                    $partialAttribute->getChild(0)?->getValue(),
+                    (string) $partialAttribute->getChild(0)?->getValue(),
                     ...$values
                 );
             }
         }
 
         return new self(new Entry(
-            new Dn($dn->getValue()),
+            new Dn((string) $dn->getValue()),
             ...$attributes
         ));
     }

--- a/src/FreeDSx/Ldap/Operation/Response/SearchResultReference.php
+++ b/src/FreeDSx/Ldap/Operation/Response/SearchResultReference.php
@@ -59,7 +59,7 @@ class SearchResultReference implements ResponseInterface
 
         foreach ($type->getChildren() as $referral) {
             try {
-                $referrals[] = LdapUrl::parse($referral->getValue());
+                $referrals[] = LdapUrl::parse((string) $referral->getValue());
             } catch (UrlParseException $e) {
                 throw new ProtocolException($e->getMessage());
             }

--- a/src/FreeDSx/Ldap/Protocol/Factory/ExtendedResponseFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ExtendedResponseFactory.php
@@ -29,7 +29,7 @@ use FreeDSx\Ldap\Operation\Response\PasswordModifyResponse;
 class ExtendedResponseFactory
 {
     /**
-     * @var array<string, string>
+     * @var array<string, class-string>
      */
     private static array $map = [
         ExtendedRequest::OID_PWD_MODIFY => PasswordModifyResponse::class,
@@ -57,7 +57,20 @@ class ExtendedResponseFactory
             ));
         }
 
-        return call_user_func($responseConstruct, $asn1);
+        $response = call_user_func(
+            $responseConstruct,
+            $asn1
+        );
+
+        if (!$response instanceof ExtendedResponse) {
+            throw new RuntimeException(sprintf(
+                'Expected an instance of %s, but received: %s',
+                ExtendedResponse::class,
+                is_object($response) ? $response::class : gettype($response)
+            ));
+        }
+
+        return $response;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/Factory/FilterFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/FilterFactory.php
@@ -37,7 +37,7 @@ use FreeDSx\Ldap\Search\Filter\SubstringFilter;
 class FilterFactory
 {
     /**
-     * @var array<string>
+     * @var array<int, class-string>
      */
     private static array $map = [
         0 => AndFilter::class,
@@ -73,7 +73,20 @@ class FilterFactory
             ));
         }
 
-        return call_user_func($filterConstruct, $type);
+        $filter = call_user_func(
+            $filterConstruct,
+            $type
+        );
+
+        if (!$filter instanceof FilterInterface) {
+            throw new RuntimeException(sprintf(
+                'Expected an instance of %s, but received: %s',
+                FilterInterface::class,
+                is_object($filter) ? $filter::class : gettype($filter)
+            ));
+        }
+
+        return $filter;
     }
 
     public static function has(int $filterType): bool

--- a/src/FreeDSx/Ldap/Protocol/Queue/ClientQueue.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/ClientQueue.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Protocol\Queue;
 use FreeDSx\Asn1\Encoder\EncoderInterface;
 use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Asn1\Exception\PartialPduException;
+use FreeDSx\Asn1\Type\AbstractType;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Exception\UnsolicitedNotificationException;
@@ -115,7 +116,13 @@ class ClientQueue extends LdapQueue
         Message $message,
         ?int $id = null
     ): LdapMessageResponse {
-        return LdapMessageResponse::fromAsn1($message->getMessage());
+        $type = $message->getMessage();
+
+        if (!$type instanceof AbstractType) {
+            throw new ProtocolException('The message received is invalid.');
+        }
+
+        return LdapMessageResponse::fromAsn1($type);
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/Queue/ServerQueue.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/ServerQueue.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Protocol\Queue;
 
 use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Asn1\Exception\PartialPduException;
+use FreeDSx\Asn1\Type\AbstractType;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Exception\UnsolicitedNotificationException;
@@ -69,6 +70,12 @@ class ServerQueue extends LdapQueue
      */
     protected function constructMessage(Message $message, ?int $id = null): LdapMessageRequest
     {
-        return LdapMessageRequest::fromAsn1($message->getMessage());
+        $type = $message->getMessage();
+
+        if (!$type instanceof AbstractType) {
+            throw new ProtocolException('The message received is invalid.');
+        }
+
+        return LdapMessageRequest::fromAsn1($type);
     }
 }


### PR DESCRIPTION
This resolves the issues preventing us from setting PHPStan to the max level since I updated it and changed all the prop types to have actual types. I also had to make changes in the ASN1 library for this.

Also adding some basic analysis for tests. This is made somewhat difficult because PHPSpec doesn't have a good PHPStan extension available, and it uses a lot of magic methods to do its thing.

https://github.com/FreeDSx/LDAP/issues/50