### PR TITLE
[1.0.0] Document the new ClientOptions and ServerOptions classes.

### DIFF
--- a/docs/Client/Configuration.md
+++ b/docs/Client/Configuration.md
@@ -2,48 +2,54 @@ LDAP Client Configuration
 ================
 
 * [General Options](#general-options)
-    * [base_dn](#base_dn)
-    * [page_size](#page_size)
-    * [transport](#transport)
-    * [port](#port)
-    * [servers](#servers)
-    * [timeout_connect](#timeout_connect)
-    * [timeout_read](#timeout_read)
-    * [version](#version)
-    * [referral](#referral)
-    * [referral_limit](#referral_limit)
-    * [referral_chaser](#referral_chaser)
+    * [ClientOptions::setBaseDn](#setbasedn)
+    * [ClientOptions::setPageSize](#setpagesize)
+    * [ClientOptions::setTransport](#settransport)
+    * [ClientOptions::setPort](#setport)
+    * [ClientOptions::setServers](#setservers)
+    * [ClientOptions::settimeoutConnect](#settimeoutconnect)
+    * [ClientOptions::setTimeoutTead](#settimeoutread)
+    * [ClientOptions::setVersion](#setversion)
+    * [ClientOptions::setReferral](#setreferral)
+    * [ClientOptions::setReferralLimit](#setreferrallimit)
+    * [ClientOptions::setReferralChaser](#setreferralchaser)
 * [SSL and TLS Options](#ssl-and-tls-options)
-    * [use_ssl](#use_ssl)
-    * [ssl_validate_cert](#ssl_validate_cert)
-    * [ssl_ca_cert](#ssl_ca_cert)
-    * [ssl_allow_self_signed](#ssl_allow_self_signed)
+    * [ClientOptions::setUseSsl](#setusessl)
+    * [ClientOptions::setSslValidateCert](#setsslvalidatecert)
+    * [ClientOptions::setSslCaCert](#setsslcacert)
+    * [ClientOptions::setSslAllowSelfSigned](#setsslallowselfsigned)
 
-The LDAP client is configured through an array of configuration values. The configuration is simply passed to the client
+The LDAP client is configured through a `ClientOptions` object. The configuration object is passed to the client
 on construction:
 
 ```php
 use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Ldap\ClientOptions;
 
-$ldap = new LdapClient([
-    'servers' => ['dc1', 'dc2', 'dc3'],
-    'timeout_connect' => 1,
-]);
+$options = (new ClientOptions)
+    ->setServers([
+        'dc1',
+        'dc2',
+        'dc3',
+    ])
+    ->setTimeoutConnect(1)
+
+$ldap = new LdapClient($options);
 ```
 
-The following documents these various configuration options and how they impact the client.
+The following documents these various configuration option setter methods and how they impact the client.
 
 ## General Options
 
 ------------------
-#### base_dn
+#### setBaseDn
 
 A default base DN to use when searching. This will be used if a base DN is not supplied explicitly in a search.
 
 **Default**: `(null)`
 
 ------------------
-#### page_size
+#### setPageSize
 
 A default page size to use for paging operations. This will be used if a page size is not explicitly passed on the
 client's paging method.
@@ -51,7 +57,7 @@ client's paging method.
 **Default**: `1000`
 
 ------------------
-#### transport
+#### setTransport
 
 The transport mechanism to connect to LDAP with. Use either:
 
@@ -63,36 +69,36 @@ If using `unix` for the transport you should set the `servers` to a file represe
 **Default**: `tcp`
 
 ------------------
-#### port
+#### setPort
 
 The port to connect to on the LDAP server.
 
 **Default**: `389`
 
 ------------------
-#### servers
+#### setServers
 
-An array of LDAP servers or a single server name as a string. When connecting the servers are tried in order until one 
+An array of LDAP server(s) to connect to. When connecting the servers are tried in order until one 
 connects. 
 
 **Default**: `[]`
 
 ------------------
-#### timeout_connect
+#### setTimeoutConnect
 
 The timeout period (in seconds) when connecting to an LDAP server initially.
 
 **Default**: `3`
 
 ------------------
-#### timeout_read
+#### setTimeoutRead
 
 The timeout period (in seconds) when reading data from a server.
 
 **Default**: `10`
 
 ------------------
-#### version
+#### setVersion
 
 The LDAP version to use.
 
@@ -101,20 +107,20 @@ The LDAP version to use.
 **Default**: `3`
 
 ------------------
-#### referral
+#### setReferral
 
 The referral handling strategy to use. It must be one of:
 
 * `throw`: When a referral is encountered it throws a ReferralException, which contains the referral object(s).
-* `follow`: Referrals will be followed until a result is found or the `referral_limit` is reached.  
+* `follow`: Referrals will be followed until a result is found or the `ClientOptions::setReferralLimit()` is reached.  
 
 When you choose to follow referrals, it will bind to the referral destination using your previous bind request (if there
-was one). If you need more control over the bind or what referrals are followed then use the `referral_chaser` option.
+was one). If you need more control over the bind or what referrals are followed then use the `ClientOptions::setReferralChaser()` option.
 
 **Default**: `throw`
 
 ------------------
-#### referral_limit
+#### setReferralLimit
 
 The limit to the number of referrals to follow while trying to complete a request. Once this limit is reached an
 OperationException with a code of referral is thrown. 
@@ -122,18 +128,22 @@ OperationException with a code of referral is thrown.
 **Default**: 10
 
 ------------------
-#### referral_chaser
+#### setReferralChaser
 
-Use this with the referral option set to `follow`. Set this option to a class implementing `FreeDSx\Ldap\ReferralChaserInterface`.
+Use this with the referral option set to `follow`. Set this option to a class instance implementing `FreeDSx\Ldap\ReferralChaserInterface`.
 You must implement two methods:
 
 ```php
-public function chase(LdapMessageRequest $request, LdapUrl $referral, ?BindRequest $bind) : ?BindRequest;
+public function chase(
+    LdapMessageRequest $request,
+    LdapUrl $referral,
+    ?BindRequest $bind
+) : ?BindRequest;
 
-public function client(array $options) : LdapClient;
+public function client(ClientOptions $options) : LdapClient;
 ```
 
-Using this you can implement your own logic for whether or not to follow a referral and what credentials should be used.
+Using this you can implement your own logic for whether to follow a referral and what credentials should be used.
 You can skip a referral by throwing `FreeDSx\Ldap\Exception\SkipReferralException`. If you skip all referrals then a 
 ReferralException will be thrown.
 
@@ -145,7 +155,7 @@ needed logic beforehand, such as a StartTLS command.
 ## SSL and TLS Options
 
 ------------------
-#### use_ssl
+#### setUseSsl
 
 If set to true, the client will use an SSL stream to connect to the server. This would mostly be used for servers running
 over port 636 using SSL only. You still must change the port number if you choose this option.
@@ -155,16 +165,16 @@ over port 636 using SSL only. You still must change the port number if you choos
 **Default**: `false`
 
 ------------------
-#### ssl_validate_cert
+#### setSslValidateCert
 
 If this is set to false then no LDAP server certificate validation is performed when connecting via StartTLS or SSL.
-This can be useful for trouble shooting, but it is recommended to set the certificate with `ssl_ca_cert` and keep this
+This can be useful for troubleshooting, but it is recommended to set the certificate with ``ClientOptions::setSslCaCert()`` and keep this
 set to true.
 
 **Default**: `true`
 
 ------------------
-#### ssl_ca_cert
+#### setSslCaCert
 
 The full path to the trusted CA certificate for the LDAP server certificate. This is used for SSL certificate validation
 when connecting over StartTLS or SSL. 
@@ -172,8 +182,8 @@ when connecting over StartTLS or SSL.
 **Default**: `(null)`
 
 ------------------
-#### ssl_allow_self_signed
+#### setSslAllowSelfSigned
 
-Whether or not self-signed certificates are valid when LDAP server certificate validation is done.
+Whether self-signed certificates are valid when LDAP server certificate validation is done.
 
 **Default**: `false`

--- a/docs/Client/SASL-Bind-Authentication.md
+++ b/docs/Client/SASL-Bind-Authentication.md
@@ -10,12 +10,14 @@ using the client methods.
 An example of letting it auto-detect a mechanism:
 
 ```php
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\LdapClient;
 
-$ldap = new LdapClient([
-    'servers' => 'ldap.example.com',
-    'base_dn' => 'dc=example,dc=local'
-]);
+$ldap = new LdapClient(
+    (new ClientOptions)
+        ->setServers(['ldap.example.com'])
+        ->setBaseDn('dc=example,dc=local')
+);
 
 # Bind using SASL, let it automatically detect an available supported mechanism.
 # The first parameter to bindSasl is an array of options for SASL to use.
@@ -28,12 +30,14 @@ $ldap->bindSasl([
 An example of specifying a mechanism:
 
 ```php
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\LdapClient;
 
-$ldap = new LdapClient([
-    'servers' => 'ldap.example.com',
-    'base_dn' => 'dc=example,dc=local'
-]);
+$ldap = new LdapClient(
+    (new ClientOptions)
+        ->setServers(['ldap.example.com'])
+        ->setBaseDn('dc=example,dc=local')
+);
 
 # Use the second parameter of bindSasl to specify a mechanism.
 $ldap->bindSasl([
@@ -48,13 +52,13 @@ $ldap->bindSasl([
 
 The following table details mechanisms / options that are recognized when doing a SASL bind:
 
-|                  | `DIGEST-MD5`  | `CRAM-MD5` | `PLAIN` | `ANONYMOUS` |
-| ---------------- | :-----------: | :--------: | :-----: | :---------: |
-| `username`       | X             | X          | X       | X           |
-| `password`       | X             | X          | X       |             |
-| `use_integrity`  | X             |            |         |             |
-| `trace`          |               |            |         | X           |
-| `host`           | X             |            |         |             |
+|                 | `DIGEST-MD5` | `CRAM-MD5` | `PLAIN` | `ANONYMOUS` |
+|-----------------|:------------:|:----------:|:-------:|:-----------:|
+| `username`      |      X       |     X      |    X    |      X      |
+| `password`      |      X       |     X      |    X    |             |
+| `use_integrity` |      X       |            |         |             |
+| `trace`         |              |            |         |      X      |
+| `host`          |      X       |            |         |             |
 
 ## Options
 

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -2,38 +2,40 @@ LDAP Server Configuration
 ================
 
 * [General Options](#general-options)
-    * [ip](#ip)
-    * [port](#port)
-    * [unix_socket](#unix_socket)
-    * [transport](#transport)
-    * [logger](#logger)
-    * [idle_timeout](#idle_timeout)
-    * [require_authentication](#require_authentication)
-    * [allow_anonymous](#allow_anonymous)
+    * [ServerOptions:setIp](#setip)
+    * [ServerOptions:setPort](#setport)
+    * [ServerOptions:setUnixSocket](#setunixsocket)
+    * [ServerOptions:setTransport](#settransport)
+    * [ServerOptions:setLogger](#setlogger)
+    * [ServerOptions:setIdleTimeout](#setidletimeout)
+    * [ServerOptions:setRequireAuthentication](#setrequireauthentication)
+    * [ServerOptions:setAllowAnonymous](#setallowanonymous)
 * [LDAP Protocol Handlers](#ldap-protocol-handlers)
-   * [request_handler](#request_handler)
-   * [rootdse_handler](#rootdse_handler)
-   * [paging_handler](#paging_handler)
+   * [ServerOptions:setRequestHandler](#setrequesthandler)
+   * [ServerOptions:setRootDseHandler](#setrootdsehandler)
+   * [ServerOptions:setPagingHandler](#setpaginghandler)
 * [RootDSE Options](#rootdse-options)
-    * [dse_naming_contexts](#dse_naming_contexts)
-    * [dse_alt_server](#dse_alt_server)
-    * [dse_vendor_name](#dse_vendor_name)
-    * [dse_vendor_version](#dse_vendor_version)
+    * [ServerOptions:setDseNamingContexts](#setdsenamingcontexts)
+    * [ServerOptions:setDseAltServer](#setdsealtserver)
+    * [ServerOptions:setDseVendorName](#setdsevendorname)
+    * [ServerOptions:setDseVendorVersion](#setdsevendorversion)
 * [SSL and TLS Options](#ssl-and-tls-options)
-    * [ssl_cert](#ssl_cert)
-    * [ssl_cert_key](#ssl_cert_key)
-    * [ssl_cert_passphrase](#ssl_cert_passphrase)
+    * [ServerOptions:setSslCert](#setsslcert)
+    * [ServerOptions:setSslCertKey](#setsslcertkey)
+    * [ServerOptions:setSslCertPassphrase](#setsslcertpassphrase)
 
-The LDAP server is configured through an array of configuration values. The configuration is simply passed to the server
+The LDAP server is configured through aa `ServerOptions` object. The configuration object is passed to the server
 on construction:
 
 ```php
+use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Ldap\LdapServer;
 
-$ldap = new LdapServer([
-    'dse_alt_server' => 'dc2.local',
-    'port' => 33389,
-]);
+$options = (new ServerOptions)
+  ->setDseAlServer('dc2.local')
+  ->setPort(33389);
+  
+$ldap = new LdapServer($options);
 ```
 
 The following documents these various configuration options and how they impact the server.
@@ -41,7 +43,7 @@ The following documents these various configuration options and how they impact 
 ## General Options
 
 ------------------
-#### ip
+#### setIp
 
 The IP address to bind and listen to while the server is running. By default it will bind to `0.0.0.0`, which will listen
 on all IP addresses of the machine.
@@ -49,7 +51,7 @@ on all IP addresses of the machine.
 **Default**: `0.0.0.0`
 
 ------------------
-#### port
+#### setPort
 
 The port to bind to and accept client connections on. By default this is port 389. Since this port is underneath the
 first 1024 ports, it will require administrative access when running the server. You can change this to something higher
@@ -58,14 +60,14 @@ than 1024 instead if needed.
 **Default**: `389`
 
 ------------------
-#### unix_socket
+#### setUnixSocket
 
 When using `unix` as the transport type, this is the full path to the socket file the client must interact with. 
 
 **Default**: `/var/run/ldap.socket`
 
 ------------------
-#### transport
+#### setTransport
 
 The transport mechanism for the server to use. Use either:
 
@@ -77,7 +79,7 @@ If using `unix` for the transport you can change set the `unix_socket` to a file
 **Default**: `tcp`
 
 ------------------
-#### logger
+#### setLogger
 
 Specify a PSR-3 compatible logging instance to use. This will log various server events and errors.
 
@@ -96,7 +98,7 @@ $server->useLogger($logger);
 **Default**: `null`
 
 ------------------
-#### idle_timeout
+#### setIdleTimeout
 
 Consider an idle client to timeout after this period of time (in seconds) and disconnect their LDAP session. If set to
 -1, the client can idle indefinitely and not timeout the connection to the server.
@@ -104,18 +106,18 @@ Consider an idle client to timeout after this period of time (in seconds) and di
 **Default**: `600`
 
 ------------------
-#### require_authentication
+#### setRequireAuthentication
 
-Whether or not authentication (bind) should be required before an operation is allowed.
+Whether authentication (bind) should be required before an operation is allowed.
 
 **Note**: Certain LDAP operations implicitly do not require authentication: StartTLS, RootDSE requests, WhoAmI
 
 **Default**: `true`
 
 ------------------
-#### allow_anonymous
+#### setAllowAnonymous
 
-Whether or not anonymous binds should be allowed.
+Whether anonymous binds should be allowed.
 
 **Default**: `false`
 
@@ -128,70 +130,61 @@ option, or provide an instance of the class. There are also methods available on
 handlers (which will be detailed below).
 
 ------------------
-#### request_handler
+#### setRequestHandler
 
-This should be a string class name or object instance that implements `FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface`. Server 
+This should be an object instance that implements `FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface`. Server 
 request operations are then passed to this class along with the request context.
 
 This request handler is used for each client connection.
 
-You can also set this handler after instantiating the server and before running it:
-
 ```php
+use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Ldap\LdapServer;
 use App\MySpecialRequestHandler;
 
-$server = new LdapServer([
-    'dse_alt_server' => 'dc2.local',
-    'port' => 33389,
-]);
-
-$server->useRequestHandler(new MySpecialRequestHandler());
+$server = new LdapServer(
+    (new ServerOptions)
+        ->setRequestHandler(new MySpecialRequestHandler())
+);
 ```
 
 **Default**: `FreeDSx\Ldap\Server\RequestHandler\GenericRequestHandler`
 
-#### rootdse_handler
+#### setRootDseHandler
 
-This should be a fully qualified class name string or object instance that implements `FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface`. If this is defined,
+This should be an object instance that implements `FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface`. If this is defined,
 the server will use it when responding to RootDSE requests from clients. If it is not defined, then the server will always
-respond with a default RootDSE entry composed of values provided in the `dse_*` config options.
-
-You can also set this handler after instantiating the server and before running it:
+respond with a default RootDSE entry composed of values provided in the `ServerOptions::getDse*()` config options.
 
 ```php
+use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Ldap\LdapServer;
 use App\MySpecialRootDseHandler;
 
-$server = new LdapServer([
-    'dse_alt_server' => 'dc2.local',
-    'port' => 33389,
-]);
-
-$server->useRootDseHandler(new MySpecialRootDseHandler());
+$server = new LdapServer(
+    (new ServerOptions)
+        ->setRootDseHandler(new MySpecialRootDseHandler())
+);
 ```
 
 **Default**: `null`
 
-#### paging_handler
+#### setPagingHandler
 
-This should be a fully qualified class name string or object instance that implements `FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface`. If this is defined,
+This should be an object instance that implements `FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface`. If this is defined,
 the server will use it when responding to client paged search requests. If it is not defined, then the server may
 send an operation error to the client if it requested a paged search as critical. If the paged search was not marked as
-critical, then the server will ignore the client paging control and send the search through the standard `request_handler` class.
-
-You can also set this handler after instantiating the server and before running it:
+critical, then the server will ignore the client paging control and send the search through the standard `ServerOptions::getRequestHandler()` class instance.
 
 ```php
+use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Ldap\LdapServer;
 use App\MySpecialPagingHandler;
 
-$server = new LdapServer([
-    'dse_alt_server' => 'dc2.local',
-    'port' => 33389,
-]);
-
-$server->usePagingHandler(new MySpecialPagingHandler());
+$server = new LdapServer(
+    (new ServerOptions)
+        ->setPagingHandler(new MySpecialPagingHandler())
+);
 ```
 
 **Default**: `null`
@@ -199,28 +192,28 @@ $server->usePagingHandler(new MySpecialPagingHandler());
 ## RootDSE Options
 
 ------------------
-#### dse_naming_contexts
+#### setDseNamingContexts
 
-The namingContexts attribute for the RootDSE. 
+The namingContexts attribute for the RootDSE as an array of strings.
 
-**Default**: `dc=FreeDSx,dc=local`
+**Default**: `['dc=FreeDSx,dc=local']`
 
 ------------------
-#### dse_alt_server
+#### setDseAltServer
 
 The altServer attribute for the RootDSE. These should be alternate servers to be used if this one becomes unavailable.
 
 **Default**: `(null)`
 
 ------------------
-#### dse_vendor_name
+#### setDseVendorName
 
 The vendorName attribute for the RootDSE.
 
 **Default**: `FreeDSx`
 
 ------------------
-#### dse_vendor_version
+#### setDseVendorVersion
 
 The vendorVersion attribute for the RootDSE.
 
@@ -229,7 +222,7 @@ The vendorVersion attribute for the RootDSE.
 ## SSL and TLS Options
 
 ------------------
-#### ssl_cert
+#### setSslCert
 
 The server certificate to use for clients issuing StartTLS commands to encrypt their TCP session.
 
@@ -238,25 +231,25 @@ The server certificate to use for clients issuing StartTLS commands to encrypt t
 **Default**: `(null)`
 
 ------------------
-#### ssl_cert_key
+#### setSslCertKey
 
-The server certificate private key. This can also be bundled with the certificate in the `ssl_cert` option.
+The server certificate private key. This can also be bundled with the certificate in the `ServerOptions::setSslCert` option.
 
 **Default**: `(null)`
 
 ------------------
-#### ssl_cert_passphrase
+#### setSslCertPassphrase
 
 The passphrase needed for the server certificate's private key. 
 
 **Default**: `(null)`
 
 ------------------
-#### use_ssl
+#### setUseSsl
 
 If set to true, and the transport is `tcp`, the server will use an SSL stream to bind to the IP address. This forces clients
 to use an encrypted stream only for communication to the server.
 
-**Note**: LDAP over SSL, commonly referred to as LDAPS, is not an official LDAP standard. Support is dependent on the client.
+**Note**: LDAP over SSL, commonly referred to as LDAPS, is not an official LDAP standard. Support is dependent on the client / server specific implementations.
 
 **Default**: `false`

--- a/src/FreeDSx/Ldap/ClientOptions.php
+++ b/src/FreeDSx/Ldap/ClientOptions.php
@@ -47,18 +47,6 @@ final class ClientOptions
     
     private int $referralLimit = 10;
 
-    /**
-     * A helper method designed to ease migration from array options to the new options object.
-     *
-     * @param array<string, mixed> $options
-     */
-    public static function fromArray(array $options): self
-    {
-        $instance = new self();
-        
-        return $instance;
-    }
-
     public function getVersion(): int
     {
         return $this->version;

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
@@ -79,8 +79,8 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
         if ($options->getDseVendorVersion()) {
             $entry->set('vendorVersion', (string) $options->getDseVendorVersion());
         }
-        if ($options->getDseAlServer()) {
-            $entry->set('altServer', (string) $options->getDseAlServer());
+        if ($options->getDseAltServer()) {
+            $entry->set('altServer', (string) $options->getDseAltServer());
         }
 
         /** @var SearchRequest $request */

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -42,7 +42,7 @@ final class ServerOptions
 
     private ?string $sslCertPassphrase = null;
     
-    private ?string $dseAlServer = null;
+    private ?string $dseAltServer = null;
 
     /**
      * @var string[]
@@ -193,14 +193,14 @@ final class ServerOptions
         return $this;
     }
 
-    public function getDseAlServer(): ?string
+    public function getDseAltServer(): ?string
     {
-        return $this->dseAlServer;
+        return $this->dseAltServer;
     }
 
-    public function setDseAlServer(?string $dseAlServer): self
+    public function setDseAltServer(?string $dseAlServer): self
     {
-        $this->dseAlServer = $dseAlServer;
+        $this->dseAltServer = $dseAlServer;
 
         return $this;
     }
@@ -313,7 +313,7 @@ final class ServerOptions
             'ssl_cert' => $this->getSslCert(),
             'ssl_cert_key' => $this->getSslCertKey(),
             'ssl_cert_passphrase' => $this->getSslCertPassphrase(),
-            'dse_alt_server' => $this->getDseAlServer(),
+            'dse_alt_server' => $this->getDseAltServer(),
             'dse_naming_contexts' => $this->getDseNamingContexts(),
             'dse_vendor_name' => $this->getDseVendorName(),
             'dse_vendor_version' => $this->getDseVendorVersion(),

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -61,18 +61,6 @@ final class ServerOptions
     
     private ?LoggerInterface $logger = null;
 
-    /**
-     * A helper method designed to ease migration from array options to the new options object.
-     *
-     * @param array<string, mixed> $options
-     */
-    public static function fromArray(array $options): self
-    {
-        $instance = new self();
-
-        return $instance;
-    }
-
     public function getIp(): string
     {
         return $this->ip;


### PR DESCRIPTION
This documents the new ClientOptions and ServerOptions classes that replace the old associative array options that were passed into the client / server. It also replaces usage in the readme. Now that the options objects are in place, I can remove some redundant methods no the LdapServer class as well.

https://github.com/FreeDSx/LDAP/issues/50