### PR TITLE
[1.0.0] Support cancelling search / sync operations.

### DIFF
--- a/docs/Client/SyncRepl.md
+++ b/docs/Client/SyncRepl.md
@@ -15,6 +15,7 @@ helper class in this library for performing a SyncRepl request more easily.
     * [The IdSet Handler](#the-idset-handler)
     * [The Referral Handler](#the-referral-handler)
     * [The Cookie Handler](#the-cookie-handler)
+* [Cancelling a Sync](#cancelling-a-sync)
 * [SyncRepl Class Methods](#syncrepl-class-methods)
     * [useFilter](#usefilter)
     * [useCookie](#usecookie)
@@ -161,6 +162,31 @@ the sync session cookie. If you wish to restart this sync session at some later 
 the changed cookie somewhere and reload it before starting the sync again.
 
 For more details, see [useCookieHandler](#usecookiehandler) and [useCookie](#usecookie).
+
+
+# Cancelling a Sync
+
+Cancelling a sync provides a way to tell the server to gracefully end the sync operation. To initiate the cancellation
+process, you must throw a `CancelRequestException` within one of the [sync handlers](#sync-handlers).
+
+**Note**: By default, the handlers will not receive any further messages once a cancellation is issued. To continue to
+receive messages until the server processes the cancellation, you can call `useContinueOnCancel()` on the SyncRepl client.
+
+```php
+use FreeDSx\Ldap\Exception\CancelRequestException;
+use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+
+$ldap
+    ->syncRepl()
+    ->listen(function(SyncEntryResult $result) {
+        $entry = $result->getEntry();
+        $uuid = $result->getEntryUuid();
+        
+        // Add some logic for when this should be thrown...
+        // But this will initiate a cancellation.
+        throw new CancelRequestException();
+    });
+```
 
 # SyncRepl Class Methods
 

--- a/src/FreeDSx/Ldap/Exception/CancelRequestException.php
+++ b/src/FreeDSx/Ldap/Exception/CancelRequestException.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FreeDSx\Ldap\Exception;
+
+use Exception;
+
+/**
+ * Thrown during a client operation to indicate that the current operation should be canceled.
+ */
+class CancelRequestException extends Exception
+{
+}

--- a/src/FreeDSx/Ldap/Operation/Response/SearchResponse.php
+++ b/src/FreeDSx/Ldap/Operation/Response/SearchResponse.php
@@ -38,10 +38,10 @@ class SearchResponse extends SearchResultDone
         private readonly array $referralResults = [],
     ) {
         parent::__construct(
-            $result->resultCode,
-            $result->dn->toString(),
-            $result->diagnosticMessage,
-            ...$result->referrals
+            $result->getResultCode(),
+            $result->getDn()->toString(),
+            $result->getDiagnosticMessage(),
+            ...$result->getReferrals()
         );
     }
 

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientBasicHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientBasicHandler.php
@@ -44,6 +44,7 @@ class ClientBasicHandler implements RequestHandlerInterface, ResponseHandlerInte
         ResultCode::COMPARE_TRUE,
         ResultCode::REFERRAL,
         ResultCode::SASL_BIND_IN_PROGRESS,
+        ResultCode::CANCELED,
     ];
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSearchTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSearchTrait.php
@@ -13,7 +13,11 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 
+use Closure;
+use FreeDSx\Ldap\Exception\CancelRequestException;
+use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\Response\IntermediateResponse;
 use FreeDSx\Ldap\Operation\Response\SearchResponse;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
@@ -27,7 +31,19 @@ use FreeDSx\Ldap\Search\Result\ReferralResult;
 
 trait ClientSearchTrait
 {
-    private static function search(
+    private RequestCanceler $requestCanceler;
+
+    private Closure $entryHandler;
+
+    private Closure $referralHandler;
+
+    private ?Closure $intermediateHandler = null;
+
+    private bool $wasCancelHandled = false;
+
+    private ?ExtendedResponse $canceledResponse = null;
+
+    private function search(
         LdapMessageResponse $messageFrom,
         LdapMessageRequest $messageTo,
         ClientQueue $queue,
@@ -35,31 +51,38 @@ trait ClientSearchTrait
         /** @var SearchRequest $searchRequest */
         $searchRequest = $messageTo->getRequest();
 
+        $cancelled = null;
         $entryResults = [];
         $referralResults = [];
 
-        $entryHandler = $searchRequest->getEntryHandler() ??
+        $this->requestCanceler = new RequestCanceler(
+            queue: $queue,
+            strategy: $searchRequest->getCancelStrategy(),
+            messageProcessor: $this->processSearchMessage(...),
+        );
+
+        $this->entryHandler = $searchRequest->getEntryHandler() ??
             function (EntryResult $result) use (&$entryResults): void {
                 $entryResults[] = $result;
             };
-        $referralHandler = $searchRequest->getReferralHandler() ??
+        $this->referralHandler = $searchRequest->getReferralHandler() ??
             function (ReferralResult $result) use (&$referralResults): void {
                 $referralResults[] = $result;
             };
-        $intermediateHandler = $searchRequest->getIntermediateResponseHandler();
+        $this->intermediateHandler = $searchRequest->getIntermediateResponseHandler();
 
-        while (!$messageFrom->getResponse() instanceof SearchResultDone) {
-            $response = $messageFrom->getResponse();
-
-            if ($response instanceof SearchResultEntry) {
-                $entryHandler(new EntryResult($messageFrom));
-            } elseif ($response instanceof SearchResultReference) {
-                $referralHandler(new ReferralResult($messageFrom));
-            } elseif ($response instanceof IntermediateResponse && $intermediateHandler) {
-                $intermediateHandler($messageFrom);
+        /** @var LdapResult $response */
+        $response = $messageFrom->getResponse();
+        while (!$response instanceof SearchResultDone) {
+            try {
+                $this->processSearchMessage($messageFrom);
+            } catch (CancelRequestException) {
+                break;
             }
 
             $messageFrom = $queue->getMessage($messageTo->getMessageId());
+            /** @var LdapResult $response */
+            $response = $messageFrom->getResponse();
         }
 
         // This is just to use less logic to account whether a handler was used / no search results were returned.
@@ -68,12 +91,35 @@ trait ClientSearchTrait
         return new LdapMessageResponse(
             $messageFrom->getMessageId(),
             new SearchResponse(
-                $messageFrom->getResponse(),
+                $this->canceledResponse ?? $response,
                 $entryResults,
                 $referralResults,
             ),
-            ...$messageFrom->controls()
-            ->toArray()
+            ...$messageFrom->controls()->toArray()
         );
+    }
+
+    private function processSearchMessage(LdapMessageResponse $messageFrom): void
+    {
+        $response = $messageFrom->getResponse();
+
+        try {
+            if ($response instanceof SearchResultEntry) {
+                ($this->entryHandler)(new EntryResult($messageFrom));
+            } elseif ($response instanceof SearchResultReference) {
+                ($this->referralHandler)(new ReferralResult($messageFrom));
+            } elseif ($response instanceof IntermediateResponse && $this->intermediateHandler) {
+                ($this->intermediateHandler)($messageFrom);
+            }
+        } catch (CancelRequestException $cancelException) {
+            // If the strategy is "continue", we only handle the first cancellation exception.
+            // The entry handler may continue to throw it, but we will only send one cancel request.
+            if (!$this->wasCancelHandled) {
+                $this->wasCancelHandled = true;
+                $this->canceledResponse = $this->requestCanceler->cancel($messageFrom->getMessageId());
+
+                throw $cancelException;
+            }
+        }
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSyncHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSyncHandler.php
@@ -222,7 +222,8 @@ class ClientSyncHandler extends ClientBasicHandler
         }
         $this->updateCookie($syncDone->getCookie());
 
-        return $result->getResultCode() === ResultCode::SUCCESS;
+        return $result->getResultCode() === ResultCode::SUCCESS
+            || $result->getResultCode() === ResultCode::CANCELED;
     }
 
     private function isRefreshRequired(LdapMessageResponse $response): bool

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/RequestCanceler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/RequestCanceler.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FreeDSx\Ldap\Protocol\ClientProtocolHandler;
+
+use Closure;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Exception\ProtocolException;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\ClientQueue;
+
+class RequestCanceler
+{
+    private Closure $messageProcessor;
+
+    /**
+     * @phpstan-param 'stop'|'continue' $strategy
+     */
+    public function __construct(
+        private readonly ClientQueue $queue,
+        private readonly string $strategy = SearchRequest::CANCEL_STOP,
+        ?Closure $messageProcessor = null,
+    ) {
+        $this->messageProcessor = $messageProcessor ?? fn() => null;
+    }
+
+    /**
+     * @throws OperationException
+     */
+    public function cancel(int $idToCancel): ExtendedResponse
+    {
+        $cancelId = $this->queue->generateId();
+
+        $this->queue->sendMessage(new LdapMessageRequest(
+            $cancelId,
+            Operations::cancel($idToCancel)
+        ));
+
+        do {
+            $received = $this->queue->getMessage();
+
+            if ($received->getMessageId() === $idToCancel && $this->strategy === SearchRequest::CANCEL_CONTINUE) {
+                ($this->messageProcessor)($received);
+            }
+        } while ($received->getMessageId() !== $cancelId);
+
+        /** @var ExtendedResponse $response */
+        $response = $received->getResponse();
+        $this->validateCancelation($received);
+
+        return $response;
+    }
+
+    /**
+     * @throws ProtocolException
+     * @throws OperationException
+     */
+    private function validateCancelation(LdapMessageResponse $response): void
+    {
+        $result = $response->getResponse();
+
+        if (!$result instanceof ExtendedResponse) {
+            throw new ProtocolException(sprintf(
+                'Expected an extended response from a cancel operation, but received: %s',
+                get_class($result)
+            ));
+        }
+
+        // This indicates the operation was canceled successfully. So there is nothing to do.
+        if ($result->getResultCode() === ResultCode::CANCELED || $result->getResultCode() === ResultCode::SUCCESS) {
+            return;
+        }
+
+        throw new OperationException(
+            $result->getDiagnosticMessage(),
+            $result->getResultCode()
+        );
+    }
+}

--- a/tests/integration/FreeDSx/Ldap/Sync/SyncReplTest.php
+++ b/tests/integration/FreeDSx/Ldap/Sync/SyncReplTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace integration\FreeDSx\Ldap\Sync;
 
+use FreeDSx\Ldap\Exception\CancelRequestException;
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
 use integration\FreeDSx\Ldap\LdapTestCase;
 
@@ -32,6 +33,28 @@ class SyncReplTest extends LdapTestCase
         $this->assertGreaterThan(
             0,
             $entries,
+        );
+    }
+
+    public function testItCanCancelTheSync(): void
+    {
+        $client = $this->getClient();
+        $this->bindClient($client);
+
+        $count = 0;
+        $client
+            ->syncRepl()
+            ->listen(function () use (&$count): void {
+                if ($count === 10) {
+                    throw new CancelRequestException();
+                }
+                $count++;
+            });
+
+        $this->assertSame(
+            10,
+            $count,
+            'It stopped on the 10th result.'
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Operation/Request/SearchRequestSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Operation/Request/SearchRequestSpec.php
@@ -17,6 +17,7 @@ use FreeDSx\Asn1\Asn1;
 use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\ProtocolException;
+use FreeDSx\Ldap\Exception\UnexpectedValueException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Search\Result\EntryResult;
@@ -117,7 +118,21 @@ class SearchRequestSpec extends ObjectBehavior
         $this->useReferralHandler($handler)
             ->shouldReturn($this);
         $this->getReferralHandler()
-            ->shouldReturn($handler);
+            ->shouldBe($handler);
+    }
+
+    public function it_should_set_and_get_the_cancel_strategy(): void
+    {
+        $this->useCancelStrategy(SearchRequest::CANCEL_CONTINUE);
+
+        $this->getCancelStrategy()
+            ->shouldBe(SearchRequest::CANCEL_CONTINUE);
+    }
+
+    public function it_should_not_allow_invalid_cancel_stragegies(): void
+    {
+        $this->shouldThrow(UnexpectedValueException::class)
+            ->during('useCancelStrategy', ['foo']);
     }
 
     public function it_should_generate_correct_asn1(): void

--- a/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/MockCancelResponseProcessor.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/MockCancelResponseProcessor.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\FreeDSx\Ldap\Protocol\ClientProtocolHandler;
+
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+
+/**
+ * Only used to test message handler processing during cancellations.
+ *
+ * @internal
+ */
+class MockCancelResponseProcessor
+{
+    public function __invoke(LdapMessageResponse $messageResponse,): void
+    {
+    }
+}

--- a/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/RequestCancelerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/RequestCancelerSpec.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\FreeDSx\Ldap\Protocol\ClientProtocolHandler;
+
+use Closure;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\LdapResult;
+use FreeDSx\Ldap\Operation\Request\CancelRequest;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
+use FreeDSx\Ldap\Operation\Response\SearchResultDone;
+use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
+use FreeDSx\Ldap\Operation\Response\SearchResultReference;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\ClientQueue;
+use PhpParser\Node\Arg;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use spec\FreeDSx\Ldap\TestFactoryTrait;
+
+class RequestCancelerSpec extends ObjectBehavior
+{
+    public function it_should_return_the_cancel_response(ClientQueue $queue): void
+    {
+        $this->beConstructedWith($queue);
+
+        $cancelResponse = new ExtendedResponse(new LdapResult(ResultCode::CANCELED));
+        $queue
+            ->getMessage()
+            ->willReturn(
+                new LdapMessageResponse(1, new SearchResultEntry(Entry::create(''))),
+                new LdapMessageResponse(1, new SearchResultReference()),
+                new LdapMessageResponse(2, $cancelResponse),
+            )
+        ;
+        $queue
+            ->generateId()
+            ->willReturn(2)
+        ;
+
+        $queue
+            ->sendMessage(Argument::that(
+                fn(LdapMessageRequest $request) =>
+                    $request->getRequest() instanceof CancelRequest
+            ))
+            ->shouldBeCalledOnce();
+
+        $this->cancel(1)
+            ->shouldBe($cancelResponse);
+    }
+
+    public function it_should_keep_processing_on_the_continue_strategy(
+        ClientQueue $queue,
+        MockCancelResponseProcessor $mockResponseProcessor,
+    ): void {
+        $this->beConstructedWith(
+            $queue,
+            SearchRequest::CANCEL_CONTINUE,
+            Closure::fromCallable($mockResponseProcessor->getWrappedObject()),
+        );
+
+        $queue
+            ->sendMessage(Argument::any())
+            ->willReturn($queue);
+        $queue
+            ->getMessage()
+            ->willReturn(
+                new LdapMessageResponse(1, new SearchResultEntry(Entry::create(''))),
+                new LdapMessageResponse(1, new SearchResultReference()),
+                new LdapMessageResponse(2, new ExtendedResponse(new LdapResult(ResultCode::CANCELED))),
+            )
+        ;
+        $queue
+            ->generateId()
+            ->willReturn(2)
+        ;
+
+        $this->cancel(1);
+
+        $mockResponseProcessor
+            ->__invoke(Argument::any())
+            ->shouldHaveBeenCalledTimes(2);
+    }
+
+    public function it_should_throw_an_operation_error_if_the_cancel_result_code_was_not_success(ClientQueue $queue): void
+    {
+        $this->beConstructedWith($queue);
+
+        $cancelResponse = new ExtendedResponse(new LdapResult(
+            ResultCode::TOO_LATE,
+            '',
+            'Fail'
+        ));
+        $queue
+            ->getMessage()
+            ->willReturn(new LdapMessageResponse(2, $cancelResponse))
+        ;
+        $queue
+            ->generateId()
+            ->willReturn(2)
+        ;
+
+        $queue
+            ->sendMessage(Argument::any())
+            ->willReturn($queue);
+
+        $this
+            ->shouldThrow(new OperationException(
+                $cancelResponse->getDiagnosticMessage(),
+                $cancelResponse->getResultCode()
+            ))
+            ->during('cancel', [1])
+        ;
+    }
+}

--- a/tests/spec/FreeDSx/Ldap/Sync/SyncReplSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Sync/SyncReplSpec.php
@@ -16,8 +16,8 @@ namespace spec\FreeDSx\Ldap\Sync;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\Sync\SyncDoneControl;
 use FreeDSx\Ldap\Control\Sync\SyncRequestControl;
-use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\Request\SyncRequest;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
@@ -202,23 +202,12 @@ class SyncReplSpec extends ObjectBehavior
         $this->poll();
     }
 
-    public function it_should_throw_an_exception_if_a_sync_done_control_is_not_returned(LdapClient $client): void
+    public function it_should_use_the_continue_strategy_if_specified(): void
     {
-        $client->sendAndReceive(
-            Argument::any(),
-            Argument::any(),
-            Argument::any(),
-        )->shouldBeCalledOnce()
-            ->willReturn(new LdapMessageResponse(
-                1,
-                new SearchResultDone(0)
-            ));
+        $this->useContinueOnCancel();
 
-        $this->shouldThrow(
-            new ProtocolException(sprintf(
-                'Expected a "%s" control, but none was received.',
-                SyncDoneControl::class,
-            ))
-        )->during('poll');
+        $this->request()
+            ->getCancelStrategy()
+            ->shouldBe(SearchRequest::CANCEL_CONTINUE);
     }
 }

--- a/tests/spec/FreeDSx/Ldap/TestFactoryTrait.php
+++ b/tests/spec/FreeDSx/Ldap/TestFactoryTrait.php
@@ -7,8 +7,8 @@ namespace spec\FreeDSx\Ldap;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Entry\Entries;
 use FreeDSx\Ldap\LdapUrl;
-use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Response\SearchResponse;
+use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\Response\SearchResultReference;
 use FreeDSx\Ldap\Operation\ResultCode;
@@ -66,7 +66,7 @@ trait TestFactoryTrait
         return new LdapMessageResponse(
             $messageId,
             new SearchResponse(
-                new LdapResult(
+                new SearchResultDone(
                     $resultCode,
                     $dn,
                     $diagnostic,


### PR DESCRIPTION
This adds some special handling for cancelling search / sync operations. These are arguably the only requests it makes practical sense to support handling for cancellations. As in general, it makes little sense to try to cancel a request that will not have multiple responses / is not long running. The usage of cancellations is also somewhat questionable with paging being widely supported. However, it does make some sense in the context of a sync operation. As cancellation allows ending it in a more graceful manner.

https://github.com/FreeDSx/LDAP/issues/50