### PR TITLE
[1.0.0] Support the SensitiveParameter attribute (PHP 8.2).

### DIFF
--- a/src/FreeDSx/Ldap/LdapClient.php
+++ b/src/FreeDSx/Ldap/LdapClient.php
@@ -66,7 +66,8 @@ class LdapClient
      */
     public function bind(
         string $username,
-        string $password
+        #[\SensitiveParameter]
+        string $password,
     ): LdapMessageResponse {
         return $this->sendAndReceive(
             Operations::bind($username, $password)
@@ -84,6 +85,7 @@ class LdapClient
      * @throws SaslException
      */
     public function bindSasl(
+        #[\SensitiveParameter]
         array $options = [],
         string $mechanism = ''
     ): LdapMessageResponse {

--- a/src/FreeDSx/Ldap/Operation/Request/SimpleBindRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/SimpleBindRequest.php
@@ -34,6 +34,7 @@ class SimpleBindRequest extends BindRequest
 
     public function __construct(
         string $username,
+        #[\SensitiveParameter]
         string $password,
         int $version = 3
     ) {

--- a/src/FreeDSx/Ldap/Operations.php
+++ b/src/FreeDSx/Ldap/Operations.php
@@ -68,6 +68,7 @@ class Operations
      */
     public static function bind(
         string $username,
+        #[\SensitiveParameter]
         string $password,
     ): SimpleBindRequest {
         return new SimpleBindRequest(

--- a/src/FreeDSx/Ldap/Server/RequestHandler/GenericRequestHandler.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/GenericRequestHandler.php
@@ -44,7 +44,8 @@ class GenericRequestHandler implements RequestHandlerInterface
 
     public function bind(
         string $username,
-        string $password
+        #[\SensitiveParameter]
+        string $password,
     ): bool {
         return false;
     }

--- a/src/FreeDSx/Ldap/Server/RequestHandler/ProxyRequestHandler.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/ProxyRequestHandler.php
@@ -51,7 +51,8 @@ class ProxyRequestHandler implements RequestHandlerInterface
      */
     public function bind(
         string $username,
-        string $password
+        #[\SensitiveParameter]
+        string $password,
     ): bool {
         try {
             return (bool) $this->ldap()->bind($username, $password);

--- a/src/FreeDSx/Ldap/Server/Token/BindToken.php
+++ b/src/FreeDSx/Ldap/Server/Token/BindToken.php
@@ -28,6 +28,7 @@ class BindToken implements TokenInterface
 
     public function __construct(
         string $username,
+        #[\SensitiveParameter]
         string $password,
         int $version = 3
     ) {


### PR DESCRIPTION
This adds support for the SensitiveParameter attribute. This prevents leaking the bind password in exceptions if it is not caught or bubbles up / ends up in logging.

https://github.com/FreeDSx/LDAP/issues/50