### PR TITLE
[1.0.0] Use the container for the LdapServer.

### DIFF
--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -16,48 +16,50 @@ namespace FreeDSx\Ldap;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 use FreeDSx\Ldap\Protocol\Factory\ClientProtocolHandlerFactory;
+use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\Queue\ClientQueueInstantiator;
 use FreeDSx\Ldap\Protocol\RootDseLoader;
+use FreeDSx\Ldap\Protocol\ServerAuthorization;
+use FreeDSx\Ldap\Server\HandlerFactoryInterface;
+use FreeDSx\Ldap\Server\RequestHandler\HandlerFactory;
+use FreeDSx\Ldap\Server\RequestHistory;
+use FreeDSx\Ldap\Server\ServerProtocolFactory;
 use FreeDSx\Ldap\Server\ServerRunner\PcntlServerRunner;
+use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Socket\SocketPool;
 
 class Container
 {
-    private ClientOptions $clientOptions;
-
-    private ServerOptions $serverOptions;
-
     /**
      * @var array<class-string, callable>
      */
     private array $instanceFactory = [];
 
     /**
+     * These are classes that should never cache an instance when retrieved from the container.
+     */
+    private const FACTORY_ONLY = [
+        HandlerFactoryInterface::class,
+        ServerAuthorization::class,
+        ServerProtocolHandlerFactory::class,
+    ];
+
+    /**
      * @var array<class-string, object>
      */
     private array $instances = [];
 
-    public function __construct(
-        ?ClientOptions $clientOptions = null,
-        ?ServerOptions $serverOptions = null,
-        private readonly ?LdapClient $client = null,
-    ) {
-        if ($clientOptions) {
-            $this->clientOptions = $clientOptions;
-        }
-        if ($serverOptions) {
-            $this->serverOptions = $serverOptions;
+    /**
+     * @param array<class-string, object> $instances
+     */
+    public function __construct(array $instances)
+    {
+        foreach ($instances as $className => $instance) {
+            $this->instances[$className] = $instance;
         }
 
-        if ($this->client) {
-            $this->instances[$this->client::class] = $this->client;
-        }
-        if ($clientOptions) {
-            $this->registerClientClasses();
-        }
-        if ($serverOptions) {
-            $this->registerServerClasses();
-        }
+        $this->registerClientClasses();
+        $this->registerServerClasses();
     }
 
     /**
@@ -78,29 +80,88 @@ class Container
             ));
         }
 
-        $this->instances[$className] = ($this->instanceFactory[$className])();
+        $instance = ($this->instanceFactory[$className])();
+        if (!in_array($className, self::FACTORY_ONLY, true)) {
+            $this->instances[$className] = $instance;
+        }
 
-        return $this->instances[$className];
+        return $instance;
+    }
+
+    /**
+     * @param class-string $className
+     */
+    private function registerFactory(
+        string $className,
+        callable $factory,
+    ): void {
+        $this->instanceFactory[$className] = $factory;
     }
 
     private function registerClientClasses(): void
     {
-        $this->instanceFactory[ClientProtocolHandler::class] = $this->makeClientProtocolHandler(...);
-        $this->instanceFactory[SocketPool::class] = $this->makeSocketPool(...);
-        $this->instanceFactory[ClientProtocolHandlerFactory::class] = $this->makeClientProtocolHandlerFactory(...);
-        $this->instanceFactory[ClientQueueInstantiator::class] = $this->makeClientQueueInstantiator(...);
-        $this->instanceFactory[RootDseLoader::class] = $this->makeRootDseLoader(...);
+        if (!isset($this->instances[ClientOptions::class])) {
+            return;
+        }
+
+        $this->registerFactory(
+            className: ClientProtocolHandler::class,
+            factory: $this->makeClientProtocolHandler(...),
+        );
+        $this->registerFactory(
+            className: SocketPool::class,
+            factory: $this->makeSocketPool(...),
+        );
+        $this->registerFactory(
+            className: ClientProtocolHandlerFactory::class,
+            factory: $this->makeClientProtocolHandlerFactory(...),
+        );
+        $this->registerFactory(
+            className: ClientQueueInstantiator::class,
+            factory: $this->makeClientQueueInstantiator(...)
+        );
+        $this->registerFactory(
+            className: RootDseLoader::class,
+            factory: $this->makeRootDseLoader(...),
+        );
     }
 
     private function registerServerClasses(): void
     {
-        $this->instanceFactory[PcntlServerRunner::class] = $this->makePcntlServerRunner(...);
+        if (!isset($this->instances[ServerOptions::class])) {
+            return;
+        }
+
+        $this->registerFactory(
+            className: SocketServerFactory::class,
+            factory: $this->makeSocketServerFactory(...),
+        );
+        $this->registerFactory(
+            className: HandlerFactoryInterface::class,
+            factory: $this->makeHandlerFactory(...),
+        );
+        $this->registerFactory(
+            className: ServerProtocolFactory::class,
+            factory: $this->makeServerProtocolFactory(...),
+        );
+        $this->registerFactory(
+            className: PcntlServerRunner::class,
+            factory: $this->makePcntlServerRunner(...),
+        );
+        $this->registerFactory(
+            className: ServerAuthorization::class,
+            factory: $this->makeServerAuthorizer(...),
+        );
+        $this->registerFactory(
+            className: ServerProtocolHandlerFactory::class,
+            factory: $this->makeServerProtocolHandlerFactory(...),
+        );
     }
 
     private function makeClientProtocolHandler(): ClientProtocolHandler
     {
         return new ClientProtocolHandler(
-            options: $this->clientOptions,
+            options: $this->get(ClientOptions::class),
             clientQueueInstantiator: $this->get(ClientQueueInstantiator::class),
             protocolHandlerFactory: $this->get(ClientProtocolHandlerFactory::class),
         );
@@ -113,13 +174,16 @@ class Container
 
     private function makeSocketPool(): SocketPool
     {
-        return new SocketPool($this->clientOptions->toArray());
+        return new SocketPool(
+            $this->get(ClientOptions::class)
+                ->toArray()
+        );
     }
 
     private function makeClientProtocolHandlerFactory(): ClientProtocolHandlerFactory
     {
         return new ClientProtocolHandlerFactory(
-            clientOptions: $this->clientOptions,
+            clientOptions: $this->get(ClientOptions::class),
             queueInstantiator: $this->get(ClientQueueInstantiator::class),
             rootDseLoader: $this->get(RootDseLoader::class),
         );
@@ -127,17 +191,50 @@ class Container
 
     private function makeRootDseLoader(): RootDseLoader
     {
-        if ($this->client === null) {
-            throw new RuntimeException(
-                'Unable to instantiate the RootDseLoader without a LdapClient instance.'
-            );
-        }
+        return new RootDseLoader($this->get(LdapClient::class));
+    }
 
-        return new RootDseLoader($this->get($this->client::class));
+    private function makeServerProtocolFactory(): ServerProtocolFactory
+    {
+        return new ServerProtocolFactory(
+            $this->get(HandlerFactory::class),
+            $this->get(ServerOptions::class),
+        );
+    }
+
+    private function makeHandlerFactory(): HandlerFactory
+    {
+        return new HandlerFactory($this->get(ServerOptions::class));
     }
 
     private function makePcntlServerRunner(): PcntlServerRunner
     {
-        return new PcntlServerRunner($this->serverOptions);
+        return new PcntlServerRunner(
+            $this->get(ServerProtocolFactory::class),
+            $this->get(ServerOptions::class)->getLogger(),
+        );
+    }
+
+    private function makeSocketServerFactory(): SocketServerFactory
+    {
+        $serverOptions = $this->get(ServerOptions::class);
+
+        return new SocketServerFactory(
+            $serverOptions,
+            $serverOptions->getLogger(),
+        );
+    }
+
+    private function makeServerAuthorizer(): ServerAuthorization
+    {
+        return new ServerAuthorization($this->get(ServerOptions::class));
+    }
+
+    private function makeServerProtocolHandlerFactory(): ServerProtocolHandlerFactory
+    {
+        return new ServerProtocolHandlerFactory(
+            $this->get(HandlerFactoryInterface::class),
+            new RequestHistory()
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -22,7 +22,6 @@ use FreeDSx\Ldap\Protocol\RootDseLoader;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
 use FreeDSx\Ldap\Server\RequestHandler\HandlerFactory;
-use FreeDSx\Ldap\Server\RequestHistory;
 use FreeDSx\Ldap\Server\ServerProtocolFactory;
 use FreeDSx\Ldap\Server\ServerRunner\PcntlServerRunner;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
@@ -153,10 +152,6 @@ class Container
             className: ServerAuthorization::class,
             factory: $this->makeServerAuthorizer(...),
         );
-        $this->registerFactory(
-            className: ServerProtocolHandlerFactory::class,
-            factory: $this->makeServerProtocolHandlerFactory(...),
-        );
     }
 
     private function makeClientProtocolHandler(): ClientProtocolHandler
@@ -199,8 +194,7 @@ class Container
     {
         return new ServerProtocolFactory(
             handlerFactory: $this->get(HandlerFactoryInterface::class),
-            logger: $this->get(ServerOptions::class)->getLogger(),
-            serverProtocolHandlerFactory: $this->get(ServerProtocolHandlerFactory::class),
+            options: $this->get(ServerOptions::class),
             serverAuthorization: $this->get(ServerAuthorization::class),
         );
     }
@@ -231,14 +225,5 @@ class Container
     private function makeServerAuthorizer(): ServerAuthorization
     {
         return new ServerAuthorization($this->get(ServerOptions::class));
-    }
-
-    private function makeServerProtocolHandlerFactory(): ServerProtocolHandlerFactory
-    {
-        return new ServerProtocolHandlerFactory(
-            handlerFactory: $this->get(HandlerFactoryInterface::class),
-            options: $this->get(ServerOptions::class),
-            requestHistory: new RequestHistory(),
-        );
     }
 }

--- a/src/FreeDSx/Ldap/Control/Control.php
+++ b/src/FreeDSx/Ldap/Control/Control.php
@@ -81,7 +81,7 @@ class Control implements ProtocolElementInterface, Stringable
     public function __construct(
         protected string $controlType,
         protected bool $criticality = false,
-        protected AbstractType|ProtocolElementInterface|string|null $controlValue = null
+        protected AbstractType | ProtocolElementInterface | string | null $controlValue = null
     ) {
     }
 

--- a/src/FreeDSx/Ldap/LdapClient.php
+++ b/src/FreeDSx/Ldap/LdapClient.php
@@ -61,10 +61,10 @@ class LdapClient
         private ClientOptions $options = new ClientOptions(),
         ?Container $container = null,
     ) {
-        $this->container = $container ?? new Container(
-            clientOptions: $this->options,
-            client: $this,
-        );
+        $this->container = $container ?? new Container([
+            ClientOptions::class => $this->options,
+            LdapClient::class => $this,
+        ]);
     }
 
     /**

--- a/src/FreeDSx/Ldap/LdapClient.php
+++ b/src/FreeDSx/Ldap/LdapClient.php
@@ -38,6 +38,7 @@ use FreeDSx\Ldap\Search\RangeRetrieval;
 use FreeDSx\Ldap\Search\Vlv;
 use FreeDSx\Ldap\Sync\SyncRepl;
 use FreeDSx\Sasl\Exception\SaslException;
+use SensitiveParameter;
 use Stringable;
 
 /**
@@ -74,7 +75,7 @@ class LdapClient
      */
     public function bind(
         string $username,
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $password,
     ): LdapMessageResponse {
         return $this->sendAndReceive(
@@ -93,7 +94,7 @@ class LdapClient
      * @throws SaslException
      */
     public function bindSasl(
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         array $options = [],
         string $mechanism = ''
     ): LdapMessageResponse {

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap;
 
-use FreeDSx\Ldap\Server\LoggerTrait;
 use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\ProxyHandler;
 use FreeDSx\Ldap\Server\RequestHandler\ProxyPagingHandler;
@@ -31,8 +30,6 @@ use Psr\Log\LoggerInterface;
  */
 class LdapServer
 {
-    use LoggerTrait;
-
     private Container $container;
 
     public function __construct(

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -19,10 +19,9 @@ use FreeDSx\Ldap\Server\RequestHandler\ProxyHandler;
 use FreeDSx\Ldap\Server\RequestHandler\ProxyPagingHandler;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
-use FreeDSx\Ldap\Server\ServerRunner\PcntlServerRunner;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
+use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Socket\Exception\ConnectionException;
-use FreeDSx\Socket\SocketServer;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -34,10 +33,15 @@ class LdapServer
 {
     use LoggerTrait;
 
+    private Container $container;
+
     public function __construct(
         private readonly ServerOptions $options = new ServerOptions(),
-        private ?ServerRunnerInterface $runner = null
+        ?Container $container = null,
     ) {
+        $this->container = $container ?? new Container([
+            ServerOptions::class => $this->options,
+        ]);
     }
 
     /**
@@ -47,22 +51,13 @@ class LdapServer
      */
     public function run(): void
     {
-        $isUnixSocket = $this->options->getTransport() === 'unix';
-        $resource = $isUnixSocket
-            ? $this->options->getUnixSocket()
-            : $this->options->getIp();
+        $socketServer = $this->container
+            ->get(SocketServerFactory::class)
+            ->makeAndBind();
 
-        if ($isUnixSocket) {
-            $this->removeExistingSocketIfNeeded($resource);
-        }
+        $runner = $this->options->getServerRunner() ?? $this->container->get(ServerRunnerInterface::class);
 
-        $socketServer = SocketServer::bind(
-            $resource,
-            $this->options->getPort(),
-            $this->options->toArray(),
-        );
-
-        $this->runner()->run($socketServer);
+        $runner->run($socketServer);
     }
 
     /**
@@ -138,35 +133,5 @@ class LdapServer
         $server->usePagingHandler(new ProxyPagingHandler($client));
 
         return $server;
-    }
-
-    private function runner(): ServerRunnerInterface
-    {
-        if (!$this->runner) {
-            $this->runner = new PcntlServerRunner($this->options);
-        }
-
-        return $this->runner;
-    }
-
-    private function removeExistingSocketIfNeeded(string $socket): void
-    {
-        if (!file_exists($socket)) {
-            return;
-        }
-
-        if (!is_writeable($socket)) {
-            $this->logAndThrow(sprintf(
-                'The socket "%s" already exists and is not writeable. To run the LDAP server, you must remove the existing socket.',
-                $socket
-            ));
-        }
-
-        if (!unlink($socket)) {
-            $this->logAndThrow(sprintf(
-                'The existing socket "%s" could not be removed. To run the LDAP server, you must remove the existing socket.',
-                $socket
-            ));
-        }
     }
 }

--- a/src/FreeDSx/Ldap/Operation/Request/SearchRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/SearchRequest.php
@@ -338,7 +338,7 @@ class SearchRequest implements RequestInterface
      */
     public function useCancelStrategy(string $strategy): self
     {
-        if ($strategy !== self::CANCEL_STOP && $strategy!== self::CANCEL_CONTINUE) {
+        if ($strategy !== self::CANCEL_STOP && $strategy !== self::CANCEL_CONTINUE) {
             throw new UnexpectedValueException(sprintf(
                 'The cancel strategy must be one of: %s',
                 implode(
@@ -387,7 +387,8 @@ class SearchRequest implements RequestInterface
         }
         $filter = FilterFactory::get($filter);
 
-        if (!($baseDn instanceof OctetStringType
+        if (
+            !($baseDn instanceof OctetStringType
             && $scope instanceof EnumeratedType
             && $deref instanceof EnumeratedType
             && $sizeLimit instanceof IntegerType

--- a/src/FreeDSx/Ldap/Operation/Request/SimpleBindRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/SimpleBindRequest.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Operation\Request;
 use FreeDSx\Asn1\Asn1;
 use FreeDSx\Asn1\Type\AbstractType;
 use FreeDSx\Ldap\Exception\BindException;
+use SensitiveParameter;
 
 /**
  * Represents a simple bind request consisting of a username (dn, etc) and a password.
@@ -34,7 +35,7 @@ class SimpleBindRequest extends BindRequest
 
     public function __construct(
         string $username,
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $password,
         int $version = 3
     ) {

--- a/src/FreeDSx/Ldap/Operations.php
+++ b/src/FreeDSx/Ldap/Operations.php
@@ -38,6 +38,7 @@ use FreeDSx\Ldap\Operation\Request\UnbindRequest;
 use FreeDSx\Ldap\Protocol\ProtocolElementInterface;
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
 use FreeDSx\Ldap\Search\Filters;
+use SensitiveParameter;
 use Stringable;
 
 /**
@@ -68,7 +69,7 @@ class Operations
      */
     public static function bind(
         string $username,
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $password,
     ): SimpleBindRequest {
         return new SimpleBindRequest(

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientReferralHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientReferralHandler.php
@@ -29,7 +29,6 @@ use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ClientQueue;
 use FreeDSx\Ldap\Protocol\ReferralContext;
 use FreeDSx\Ldap\ReferralChaserInterface;
 use FreeDSx\Ldap\Search\Filters;

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/RequestCanceler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/RequestCanceler.php
@@ -36,7 +36,7 @@ class RequestCanceler
         private readonly string $strategy = SearchRequest::CANCEL_STOP,
         ?Closure $messageProcessor = null,
     ) {
-        $this->messageProcessor = $messageProcessor ?? fn() => null;
+        $this->messageProcessor = $messageProcessor ?? fn () => null;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/Factory/ClientProtocolHandlerFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ClientProtocolHandlerFactory.php
@@ -92,7 +92,7 @@ class ClientProtocolHandlerFactory
             return new ClientProtocolHandler\ClientBasicHandler($this->queue());
         }
     }
-    
+
     private function queue(): ClientQueue
     {
         return $this->queueInstantiator->make();

--- a/src/FreeDSx/Ldap/Protocol/Factory/ServerBindHandlerFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ServerBindHandlerFactory.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Operation\Request\AnonBindRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\BindHandlerInterface;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerAnonBindHandler;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerBindHandler;
@@ -29,6 +30,10 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerBindHandler;
  */
 class ServerBindHandlerFactory
 {
+    public function __construct(private readonly ServerQueue $queue)
+    {
+    }
+
     /**
      * Get the bind handler specific to the request.
      *
@@ -37,9 +42,9 @@ class ServerBindHandlerFactory
     public function get(RequestInterface $request): BindHandlerInterface
     {
         if ($request instanceof SimpleBindRequest) {
-            return new ServerBindHandler();
+            return new ServerBindHandler($this->queue);
         } elseif ($request instanceof AnonBindRequest) {
-            return new ServerAnonBindHandler();
+            return new ServerAnonBindHandler($this->queue);
         } else {
             throw new OperationException(
                 'The authentication type requested is not supported.',

--- a/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
@@ -57,11 +57,17 @@ class ServerProtocolHandlerFactory
         } elseif ($this->isPagingSearch($request, $controls)) {
             return $this->getPagingHandler();
         } elseif ($request instanceof SearchRequest) {
-            return new ServerProtocolHandler\ServerSearchHandler($this->queue);
+            return new ServerProtocolHandler\ServerSearchHandler(
+                queue: $this->queue,
+                dispatcher: $this->handlerFactory->makeRequestHandler(),
+            );
         } elseif ($request instanceof UnbindRequest) {
             return new ServerProtocolHandler\ServerUnbindHandler($this->queue);
         } else {
-            return new ServerProtocolHandler\ServerDispatchHandler($this->queue);
+            return new ServerProtocolHandler\ServerDispatchHandler(
+                queue: $this->queue,
+                dispatcher: $this->handlerFactory->makeRequestHandler(),
+            );
         }
     }
 
@@ -99,7 +105,10 @@ class ServerProtocolHandlerFactory
         $pagingHandler = $this->handlerFactory->makePagingHandler();
 
         if (!$pagingHandler) {
-            return new ServerProtocolHandler\ServerPagingUnsupportedHandler($this->queue);
+            return new ServerProtocolHandler\ServerPagingUnsupportedHandler(
+                queue: $this->queue,
+                dispatcher: $this->handlerFactory->makeRequestHandler(),
+            );
         }
 
         return new ServerProtocolHandler\ServerPagingHandler(

--- a/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Operation\Request\UnbindRequest;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 
 /**
  * Abstracts out some of the server authorization logic.
@@ -32,9 +33,8 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
 class ServerAuthorization
 {
     public function __construct(
+        private readonly ServerOptions $options,
         private TokenInterface $token = new AnonToken(),
-        private readonly bool $isAnonymousAllowed = false,
-        private readonly bool $isAuthRequired = true,
     ) {
     }
 
@@ -43,7 +43,7 @@ class ServerAuthorization
      */
     public function isAuthenticationRequired(RequestInterface $request): bool
     {
-        if ($this->isAuthRequired === false) {
+        if ($this->options->isRequireAuthentication() === false) {
             return  false;
         }
 
@@ -68,7 +68,7 @@ class ServerAuthorization
     public function isAuthenticationTypeSupported(RequestInterface $request): bool
     {
         if ($request instanceof AnonBindRequest) {
-            return $this->isAnonymousAllowed;
+            return $this->options->isAllowAnonymous();
         }
 
         return $request instanceof SimpleBindRequest;
@@ -88,7 +88,7 @@ class ServerAuthorization
      */
     public function isAuthenticated(): bool
     {
-        if ($this->isAuthRequired === false) {
+        if ($this->options->isRequireAuthentication() === false) {
             return true;
         }
 

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -170,8 +170,7 @@ class ServerProtocolHandler
                 $message,
                 $this->authorizer->getToken(),
                 $this->handlerFactory->makeRequestHandler(),
-                $this->queue,
-                $this->options
+                $this->queue
             );
         # Authentication is required, but they have not authenticated...
         } else {

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -26,10 +26,9 @@ use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
 use FreeDSx\Ldap\Server\LoggerTrait;
-use FreeDSx\Ldap\Server\RequestHistory;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
-use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\Exception\ConnectionException;
+use Psr\Log\LoggerInterface;
 use Throwable;
 use function array_merge;
 use function in_array;
@@ -48,27 +47,15 @@ class ServerProtocolHandler
      */
     private array $messageIds = [];
 
-    private ServerAuthorization $authorizer;
-
-    private ServerProtocolHandlerFactory $protocolHandlerFactory;
-
     public function __construct(
         private readonly ServerQueue $queue,
         private readonly HandlerFactoryInterface $handlerFactory,
-        private readonly ServerOptions $options,
-        ServerProtocolHandlerFactory $protocolHandlerFactory = null,
-        ServerAuthorization $authorizer = null,
+        private readonly ?LoggerInterface $logger,
+        private readonly ServerProtocolHandlerFactory $protocolHandlerFactory,
+        private readonly ServerAuthorization $authorizer,
         private readonly ServerBindHandlerFactory $bindHandlerFactory = new ServerBindHandlerFactory(),
         private readonly ResponseFactory $responseFactory = new ResponseFactory()
     ) {
-        $this->authorizer = $authorizer ?? new ServerAuthorization(
-            isAnonymousAllowed: $options->isAllowAnonymous(),
-            isAuthRequired: $options->isRequireAuthentication(),
-        );
-        $this->protocolHandlerFactory = $protocolHandlerFactory ?? new ServerProtocolHandlerFactory(
-            handlerFactory: $handlerFactory,
-            requestHistory: new RequestHistory(),
-        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -53,7 +53,7 @@ class ServerProtocolHandler
         private readonly ?LoggerInterface $logger,
         private readonly ServerProtocolHandlerFactory $protocolHandlerFactory,
         private readonly ServerAuthorization $authorizer,
-        private readonly ServerBindHandlerFactory $bindHandlerFactory = new ServerBindHandlerFactory(),
+        private readonly ServerBindHandlerFactory $bindHandlerFactory,
         private readonly ResponseFactory $responseFactory = new ResponseFactory()
     ) {
     }
@@ -169,8 +169,7 @@ class ServerProtocolHandler
             $handler->handleRequest(
                 $message,
                 $this->authorizer->getToken(),
-                $this->handlerFactory->makeRequestHandler(),
-                $this->queue
+                $this->handlerFactory->makeRequestHandler()
             );
         # Authentication is required, but they have not authenticated...
         } else {

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -169,7 +169,6 @@ class ServerProtocolHandler
             $handler->handleRequest(
                 $message,
                 $this->authorizer->getToken(),
-                $this->handlerFactory->makeRequestHandler()
             );
         # Authentication is required, but they have not authenticated...
         } else {

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/BaseServerHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/BaseServerHandler.php
@@ -22,10 +22,7 @@ use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
  */
 abstract class BaseServerHandler
 {
-    protected ResponseFactory $responseFactory;
-
-    public function __construct(ResponseFactory $responseFactory = null)
+    public function __construct(protected readonly ResponseFactory $responseFactory = new ResponseFactory())
     {
-        $this->responseFactory = $responseFactory ?? new ResponseFactory();
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAnonBindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAnonBindHandler.php
@@ -17,7 +17,6 @@ use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Operation\Request\AnonBindRequest;
-use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAnonBindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAnonBindHandler.php
@@ -17,6 +17,7 @@ use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Operation\Request\AnonBindRequest;
+use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
@@ -30,6 +31,11 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  */
 class ServerAnonBindHandler extends ServerBindHandler
 {
+    public function __construct(private readonly ServerQueue $queue)
+    {
+        parent::__construct($this->queue);
+    }
+
     /**
      * {@inheritDoc}
      * @throws EncoderException
@@ -50,7 +56,7 @@ class ServerAnonBindHandler extends ServerBindHandler
         }
 
         $this->validateVersion($request);
-        $queue->sendMessage($this->responseFactory->getStandardResponse($message));
+        $this->queue->sendMessage($this->responseFactory->getStandardResponse($message));
 
         return new AnonToken(
             $request->getUsername(),

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerBindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerBindHandler.php
@@ -18,7 +18,6 @@ use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Operation\Request\BindRequest;
 use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
-use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerBindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerBindHandler.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Operation\Request\BindRequest;
 use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
@@ -31,6 +32,11 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  */
 class ServerBindHandler extends BaseServerHandler implements BindHandlerInterface
 {
+    public function __construct(private readonly ServerQueue $queue)
+    {
+        parent::__construct();
+    }
+
     /**
      * {@inheritDoc}
      * @throws RuntimeException
@@ -52,7 +58,7 @@ class ServerBindHandler extends BaseServerHandler implements BindHandlerInterfac
 
         $this->validateVersion($request);
         $token = $this->simpleBind($dispatcher, $request);
-        $queue->sendMessage($this->responseFactory->getStandardResponse($message));
+        $this->queue->sendMessage($this->responseFactory->getStandardResponse($message));
 
         return $token;
     }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -22,7 +22,6 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestContext;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
-use FreeDSx\Ldap\ServerOptions;
 
 /**
  * Handles generic requests that can be sent to the user supplied dispatcher / handler.
@@ -40,8 +39,7 @@ class ServerDispatchHandler extends BaseServerHandler implements ServerProtocolH
         LdapMessageRequest $message,
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
-        ServerQueue $queue,
-        ServerOptions $options
+        ServerQueue $queue
     ): void {
         $context = new RequestContext($message->controls(), $token);
         $request = $message->getRequest();

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -17,6 +17,7 @@ use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestContext;
@@ -30,6 +31,11 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  */
 class ServerDispatchHandler extends BaseServerHandler implements ServerProtocolHandlerInterface
 {
+    public function __construct(private readonly ServerQueue $queue)
+    {
+        parent::__construct();
+    }
+
     /**
      * {@inheritDoc}
      * @throws OperationException
@@ -38,8 +44,7 @@ class ServerDispatchHandler extends BaseServerHandler implements ServerProtocolH
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-        RequestHandlerInterface $dispatcher,
-        ServerQueue $queue
+        RequestHandlerInterface $dispatcher
     ): void {
         $context = new RequestContext($message->controls(), $token);
         $request = $message->getRequest();
@@ -63,6 +68,6 @@ class ServerDispatchHandler extends BaseServerHandler implements ServerProtocolH
             );
         }
 
-        $queue->sendMessage($this->responseFactory->getStandardResponse($message));
+        $this->queue->sendMessage($this->responseFactory->getStandardResponse($message));
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -27,7 +27,6 @@ use FreeDSx\Ldap\Server\Paging\PagingRequestComparator;
 use FreeDSx\Ldap\Server\Paging\PagingResponse;
 use FreeDSx\Ldap\Server\RequestContext;
 use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
-use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHistory;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use Throwable;
@@ -55,8 +54,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
      */
     public function handleRequest(
         LdapMessageRequest $message,
-        TokenInterface $token,
-        RequestHandlerInterface $dispatcher
+        TokenInterface $token
     ): void {
         $context = new RequestContext(
             $message->controls(),

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -30,7 +30,6 @@ use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHistory;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
-use FreeDSx\Ldap\ServerOptions;
 use Throwable;
 
 /**
@@ -66,8 +65,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
-        ServerQueue $queue,
-        ServerOptions $options
+        ServerQueue $queue
     ): void {
         $context = new RequestContext(
             $message->controls(),

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -41,20 +41,12 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
 {
     use ServerSearchTrait;
 
-    private PagingHandlerInterface $pagingHandler;
-
-    private RequestHistory $requestHistory;
-
-    private PagingRequestComparator $requestComparator;
-
     public function __construct(
-        PagingHandlerInterface $pagingHandler,
-        RequestHistory $requestHistory,
-        ?PagingRequestComparator $requestComparator = null
+        private readonly ServerQueue $queue,
+        private readonly PagingHandlerInterface $pagingHandler,
+        private readonly RequestHistory $requestHistory,
+        private readonly PagingRequestComparator $requestComparator = new PagingRequestComparator(),
     ) {
-        $this->pagingHandler = $pagingHandler;
-        $this->requestHistory = $requestHistory;
-        $this->requestComparator = $requestComparator ?? new PagingRequestComparator();
     }
 
     /**
@@ -64,8 +56,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-        RequestHandlerInterface $dispatcher,
-        ServerQueue $queue
+        RequestHandlerInterface $dispatcher
     ): void {
         $context = new RequestContext(
             $message->controls(),
@@ -128,7 +119,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         $this->sendEntriesToClient(
             $searchResult,
             $message,
-            $queue,
+            $this->queue,
             ...$controls
         );
     }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandler.php
@@ -30,14 +30,17 @@ class ServerPagingUnsupportedHandler implements ServerProtocolHandlerInterface
 {
     use ServerSearchTrait;
 
+    public function __construct(private readonly ServerQueue $queue)
+    {
+    }
+
     /**
      * @inheritDoc
      */
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-        RequestHandlerInterface $dispatcher,
-        ServerQueue $queue
+        RequestHandlerInterface $dispatcher
     ): void {
         $context = new RequestContext(
             $message->controls(),
@@ -80,7 +83,7 @@ class ServerPagingUnsupportedHandler implements ServerProtocolHandlerInterface
         $this->sendEntriesToClient(
             $searchResult,
             $message,
-            $queue
+            $this->queue
         );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandler.php
@@ -20,7 +20,6 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestContext;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
-use FreeDSx\Ldap\ServerOptions;
 
 /**
  * Determines whether we can page results if no paging handler is defined.
@@ -38,8 +37,7 @@ class ServerPagingUnsupportedHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
-        ServerQueue $queue,
-        ServerOptions $options
+        ServerQueue $queue
     ): void {
         $context = new RequestContext(
             $message->controls(),

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandler.php
@@ -30,8 +30,10 @@ class ServerPagingUnsupportedHandler implements ServerProtocolHandlerInterface
 {
     use ServerSearchTrait;
 
-    public function __construct(private readonly ServerQueue $queue)
-    {
+    public function __construct(
+        private readonly ServerQueue $queue,
+        private readonly RequestHandlerInterface $dispatcher,
+    ) {
     }
 
     /**
@@ -39,8 +41,7 @@ class ServerPagingUnsupportedHandler implements ServerProtocolHandlerInterface
      */
     public function handleRequest(
         LdapMessageRequest $message,
-        TokenInterface $token,
-        RequestHandlerInterface $dispatcher
+        TokenInterface $token
     ): void {
         $context = new RequestContext(
             $message->controls(),
@@ -66,7 +67,7 @@ class ServerPagingUnsupportedHandler implements ServerProtocolHandlerInterface
 
         try {
             $searchResult = SearchResult::makeSuccessResult(
-                $dispatcher->search(
+                $this->dispatcher->search(
                     $context,
                     $request
                 ),

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerProtocolHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerProtocolHandlerInterface.php
@@ -15,7 +15,6 @@ namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Socket\Exception\ConnectionException;
 
@@ -36,6 +35,5 @@ interface ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-        RequestHandlerInterface $dispatcher,
     ): void;
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerProtocolHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerProtocolHandlerInterface.php
@@ -15,7 +15,6 @@ namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Socket\Exception\ConnectionException;
@@ -38,6 +37,5 @@ interface ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
-        ServerQueue $queue,
     ): void;
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerProtocolHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerProtocolHandlerInterface.php
@@ -18,7 +18,6 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
-use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\Exception\ConnectionException;
 
 /**
@@ -32,7 +31,6 @@ interface ServerProtocolHandlerInterface
     /**
      * Handle protocol actions specific to the request received.
      *
-     * @param ServerOptions $options
      * @throws OperationException
      * @throws ConnectionException
      */
@@ -41,6 +39,5 @@ interface ServerProtocolHandlerInterface
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
         ServerQueue $queue,
-        ServerOptions $options
     ): void;
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
@@ -25,7 +25,6 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestContext;
-use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\ServerOptions;
@@ -51,8 +50,7 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
      */
     public function handleRequest(
         LdapMessageRequest $message,
-        TokenInterface $token,
-        RequestHandlerInterface $dispatcher
+        TokenInterface $token
     ): void {
         $entry = Entry::fromArray('', [
             'namingContexts' => $this->options->getDseNamingContexts(),

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
@@ -40,6 +40,7 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
 {
     public function __construct(
         private readonly ServerOptions $options,
+        private readonly ServerQueue $queue,
         private readonly ?RootDseHandlerInterface $rootDseHandler = null
     ) {
     }
@@ -51,8 +52,7 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-        RequestHandlerInterface $dispatcher,
-        ServerQueue $queue
+        RequestHandlerInterface $dispatcher
     ): void {
         $entry = Entry::fromArray('', [
             'namingContexts' => $this->options->getDseNamingContexts(),
@@ -93,7 +93,7 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
             );
         }
 
-        $queue->sendMessage(
+        $this->queue->sendMessage(
             new LdapMessageResponse(
                 $message->getMessageId(),
                 new SearchResultEntry($entry)

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
@@ -38,8 +38,10 @@ use function count;
  */
 class ServerRootDseHandler implements ServerProtocolHandlerInterface
 {
-    public function __construct(private ?RootDseHandlerInterface $rootDseHandler = null)
-    {
+    public function __construct(
+        private readonly ServerOptions $options,
+        private readonly ?RootDseHandlerInterface $rootDseHandler = null
+    ) {
     }
 
     /**
@@ -50,34 +52,33 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
-        ServerQueue $queue,
-        ServerOptions $options
+        ServerQueue $queue
     ): void {
         $entry = Entry::fromArray('', [
-            'namingContexts' => $options->getDseNamingContexts(),
+            'namingContexts' => $this->options->getDseNamingContexts(),
             'supportedExtension' => [
                 ExtendedRequest::OID_WHOAMI,
             ],
             'supportedLDAPVersion' => ['3'],
-            'vendorName' => $options->getDseVendorName(),
+            'vendorName' => $this->options->getDseVendorName(),
         ]);
-        if ($options->getSslCert()) {
+        if ($this->options->getSslCert()) {
             $entry->add(
                 'supportedExtension',
                 ExtendedRequest::OID_START_TLS
             );
         }
-        if ($options->getPagingHandler()) {
+        if ($this->options->getPagingHandler()) {
             $entry->add(
                 'supportedControl',
                 Control::OID_PAGING
             );
         }
-        if ($options->getDseVendorVersion()) {
-            $entry->set('vendorVersion', (string) $options->getDseVendorVersion());
+        if ($this->options->getDseVendorVersion()) {
+            $entry->set('vendorVersion', (string) $this->options->getDseVendorVersion());
         }
-        if ($options->getDseAltServer()) {
-            $entry->set('altServer', (string) $options->getDseAltServer());
+        if ($this->options->getDseAltServer()) {
+            $entry->set('altServer', (string) $this->options->getDseAltServer());
         }
 
         /** @var SearchRequest $request */

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -19,7 +19,6 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestContext;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
-use FreeDSx\Ldap\ServerOptions;
 
 /**
  * Handles search request logic.
@@ -37,8 +36,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
-        ServerQueue $queue,
-        ServerOptions $options
+        ServerQueue $queue
     ): void {
         $context = new RequestContext(
             $message->controls(),

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -29,8 +29,10 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
 {
     use ServerSearchTrait;
 
-    public function __construct(private readonly ServerQueue $queue)
-    {
+    public function __construct(
+        private readonly ServerQueue $queue,
+        private readonly RequestHandlerInterface $dispatcher,
+    ) {
     }
 
     /**
@@ -38,8 +40,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
      */
     public function handleRequest(
         LdapMessageRequest $message,
-        TokenInterface $token,
-        RequestHandlerInterface $dispatcher
+        TokenInterface $token
     ): void {
         $context = new RequestContext(
             $message->controls(),
@@ -49,7 +50,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
 
         try {
             $searchResult = SearchResult::makeSuccessResult(
-                $dispatcher->search(
+                $this->dispatcher->search(
                     $context,
                     $request
                 ),

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -29,14 +29,17 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
 {
     use ServerSearchTrait;
 
+    public function __construct(private readonly ServerQueue $queue)
+    {
+    }
+
     /**
      * @inheritDoc
      */
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-        RequestHandlerInterface $dispatcher,
-        ServerQueue $queue
+        RequestHandlerInterface $dispatcher
     ): void {
         $context = new RequestContext(
             $message->controls(),
@@ -63,7 +66,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         $this->sendEntriesToClient(
             $searchResult,
             $message,
-            $queue
+            $this->queue
         );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
@@ -36,7 +36,7 @@ class ServerStartTlsHandler implements ServerProtocolHandlerInterface
 {
     private static ?bool $hasOpenssl = null;
 
-    public function __construct()
+    public function __construct(private readonly ServerOptions $options)
     {
         if (self::$hasOpenssl === null) {
             $this::$hasOpenssl = extension_loaded('openssl');
@@ -52,11 +52,10 @@ class ServerStartTlsHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
-        ServerQueue $queue,
-        ServerOptions $options
+        ServerQueue $queue
     ): void {
         # If we don't have a SSL cert or the OpenSSL extension is not available, then we can do nothing...
-        if ($options->getSslCert() === null || !self::$hasOpenssl) {
+        if ($this->options->getSslCert() === null || !self::$hasOpenssl) {
             $queue->sendMessage(new LdapMessageResponse($message->getMessageId(), new ExtendedResponse(
                 new LdapResult(ResultCode::PROTOCOL_ERROR),
                 ExtendedRequest::OID_START_TLS

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
@@ -21,7 +21,6 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
-use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\Exception\ConnectionException;
@@ -52,8 +51,7 @@ class ServerStartTlsHandler implements ServerProtocolHandlerInterface
      */
     public function handleRequest(
         LdapMessageRequest $message,
-        TokenInterface $token,
-        RequestHandlerInterface $dispatcher
+        TokenInterface $token
     ): void {
         # If we don't have a SSL cert or the OpenSSL extension is not available, then we can do nothing...
         if ($this->options->getSslCert() === null || !self::$hasOpenssl) {

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandler.php
@@ -17,7 +17,6 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
-use FreeDSx\Ldap\ServerOptions;
 
 /**
  * Handles an un-bind. Which just closes the connection.
@@ -33,8 +32,7 @@ class ServerUnbindHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
-        ServerQueue $queue,
-        ServerOptions $options
+        ServerQueue $queue
     ): void {
         $queue->close();
     }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandler.php
@@ -25,15 +25,18 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  */
 class ServerUnbindHandler implements ServerProtocolHandlerInterface
 {
+    public function __construct(private readonly ServerQueue $queue)
+    {
+    }
+
     /**
      * {@inheritDoc}
      */
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-        RequestHandlerInterface $dispatcher,
-        ServerQueue $queue
+        RequestHandlerInterface $dispatcher
     ): void {
-        $queue->close();
+        $this->queue->close();
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandler.php
@@ -15,7 +15,6 @@ namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
-use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -34,8 +33,7 @@ class ServerUnbindHandler implements ServerProtocolHandlerInterface
      */
     public function handleRequest(
         LdapMessageRequest $message,
-        TokenInterface $token,
-        RequestHandlerInterface $dispatcher
+        TokenInterface $token
     ): void {
         $this->queue->close();
     }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
@@ -22,7 +22,6 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
-use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -42,8 +41,7 @@ class ServerWhoAmIHandler implements ServerProtocolHandlerInterface
      */
     public function handleRequest(
         LdapMessageRequest $message,
-        TokenInterface $token,
-        RequestHandlerInterface $dispatcher
+        TokenInterface $token
     ): void {
         $userId = $token->getUsername();
 

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
@@ -32,6 +32,10 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  */
 class ServerWhoAmIHandler implements ServerProtocolHandlerInterface
 {
+    public function __construct(private readonly ServerQueue $queue)
+    {
+    }
+
     /**
      * {@inheritDoc}
      * @throws EncoderException
@@ -39,8 +43,7 @@ class ServerWhoAmIHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-        RequestHandlerInterface $dispatcher,
-        ServerQueue $queue
+        RequestHandlerInterface $dispatcher
     ): void {
         $userId = $token->getUsername();
 
@@ -53,7 +56,7 @@ class ServerWhoAmIHandler implements ServerProtocolHandlerInterface
             }
         }
 
-        $queue->sendMessage(new LdapMessageResponse(
+        $this->queue->sendMessage(new LdapMessageResponse(
             $message->getMessageId(),
             new ExtendedResponse(new LdapResult(ResultCode::SUCCESS), null, $userId)
         ));

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
@@ -24,7 +24,6 @@ use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
-use FreeDSx\Ldap\ServerOptions;
 
 /**
  * Handles a whoami request.
@@ -41,8 +40,7 @@ class ServerWhoAmIHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
         RequestHandlerInterface $dispatcher,
-        ServerQueue $queue,
-        ServerOptions $options
+        ServerQueue $queue
     ): void {
         $userId = $token->getUsername();
 

--- a/src/FreeDSx/Ldap/Server/LoggerTrait.php
+++ b/src/FreeDSx/Ldap/Server/LoggerTrait.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server;
 
 use FreeDSx\Ldap\Exception\RuntimeException;
-use FreeDSx\Ldap\ServerOptions;
+use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
 /**
@@ -24,7 +24,7 @@ use Psr\Log\LogLevel;
  */
 trait LoggerTrait
 {
-    private readonly ServerOptions $options;
+    private readonly ?LoggerInterface $logger;
 
     /**
      * Logs a message and then throws a runtime exception.
@@ -82,7 +82,7 @@ trait LoggerTrait
         string $message,
         array $context = []
     ): void {
-        $this->options->getLogger()?->log(
+        $this->logger?->log(
             level: $level,
             message: $message,
             context: $context,

--- a/src/FreeDSx/Ldap/Server/Paging/PagingRequest.php
+++ b/src/FreeDSx/Ldap/Server/Paging/PagingRequest.php
@@ -26,37 +26,22 @@ use FreeDSx\Ldap\Operation\Request\SearchRequest;
  */
 final class PagingRequest
 {
-    private PagingControl $control;
-
-    private SearchRequest $request;
-
-    private ControlBag $controls;
-
     private int $iteration = 1;
 
-    private string $nextCookie;
-
     private ?DateTimeInterface $lastProcessed = null;
-
-    private DateTimeInterface|DateTime $created;
 
     private string $uniqueId;
 
     private bool $hasProcessed = false;
 
     public function __construct(
-        PagingControl $control,
-        SearchRequest $request,
-        ControlBag $controls,
-        string $nextCookie,
-        ?DateTimeInterface $created = null,
+        private PagingControl $control,
+        private readonly SearchRequest $request,
+        private readonly ControlBag $controls,
+        private string $nextCookie,
+        private readonly DateTimeInterface $created = new DateTime(),
         ?string $uniqueId = null
     ) {
-        $this->control = $control;
-        $this->request = $request;
-        $this->controls = $controls;
-        $this->nextCookie = $nextCookie;
-        $this->created = $created ?? new DateTime();
         $this->uniqueId = $uniqueId ?? random_bytes(16);
     }
 

--- a/src/FreeDSx/Ldap/Server/Paging/PagingRequestComparator.php
+++ b/src/FreeDSx/Ldap/Server/Paging/PagingRequestComparator.php
@@ -33,11 +33,8 @@ use FreeDSx\Ldap\Protocol\LdapEncoder;
  */
 class PagingRequestComparator
 {
-    private LdapEncoder $encoder;
-
-    public function __construct(LdapEncoder $encoder = null)
+    public function __construct(private readonly LdapEncoder $encoder = new LdapEncoder())
     {
-        $this->encoder = $encoder ?? new LdapEncoder();
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Paging/PagingRequests.php
+++ b/src/FreeDSx/Ldap/Server/Paging/PagingRequests.php
@@ -23,16 +23,10 @@ use FreeDSx\Ldap\Exception\ProtocolException;
 final class PagingRequests
 {
     /**
-     * @var PagingRequest[]
+     * @param PagingRequest[] $requests
      */
-    private array $requests;
-
-    /**
-     * @param PagingRequest[] $pagingRequests
-     */
-    public function __construct(array $pagingRequests = [])
+    public function __construct(private array $requests = [])
     {
-        $this->requests = $pagingRequests;
     }
 
     public function add(PagingRequest $request): void

--- a/src/FreeDSx/Ldap/Server/Paging/PagingResponse.php
+++ b/src/FreeDSx/Ldap/Server/Paging/PagingResponse.php
@@ -22,20 +22,11 @@ use FreeDSx\Ldap\Entry\Entries;
  */
 final class PagingResponse
 {
-    private Entries $entries;
-
-    private int $remaining;
-
-    private bool $isComplete;
-
     public function __construct(
-        Entries $entries,
-        bool $isComplete = false,
-        int $remaining = 0
+        private readonly Entries $entries,
+        private readonly bool $isComplete = false,
+        private readonly int $remaining = 0
     ) {
-        $this->entries = $entries;
-        $this->isComplete = $isComplete;
-        $this->remaining = $remaining;
     }
 
     public function getEntries(): Entries

--- a/src/FreeDSx/Ldap/Server/RequestHandler/GenericRequestHandler.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/GenericRequestHandler.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Server\RequestContext;
+use SensitiveParameter;
 
 /**
  * This allows the LDAP server to run, but rejects everything. You can extend and selectively override specific request
@@ -44,7 +45,7 @@ class GenericRequestHandler implements RequestHandlerInterface
 
     public function bind(
         string $username,
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $password,
     ): bool {
         return false;

--- a/src/FreeDSx/Ldap/Server/RequestHandler/ProxyRequestHandler.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/ProxyRequestHandler.php
@@ -28,6 +28,7 @@ use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\RequestContext;
+use SensitiveParameter;
 
 /**
  * Proxies requests to an LDAP server and returns the response. You should extend this to add your own constructor and
@@ -51,7 +52,7 @@ class ProxyRequestHandler implements RequestHandlerInterface
      */
     public function bind(
         string $username,
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $password,
     ): bool {
         try {

--- a/src/FreeDSx/Ldap/Server/RequestHandler/RequestHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/RequestHandlerInterface.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Server\RequestContext;
+use SensitiveParameter;
 
 /**
  * Handler methods for LDAP server requests.
@@ -110,7 +111,7 @@ interface RequestHandlerInterface
      */
     public function bind(
         string $username,
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $password,
     ): bool;
 }

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -17,15 +17,14 @@ use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
-use FreeDSx\Ldap\Server\RequestHandler\HandlerFactory;
 use FreeDSx\Socket\Socket;
 use Psr\Log\LoggerInterface;
 
 class ServerProtocolFactory
 {
     public function __construct(
-        private readonly HandlerFactory $handlerFactory,
-        private readonly LoggerInterface $logger,
+        private readonly HandlerFactoryInterface $handlerFactory,
+        private readonly ?LoggerInterface $logger,
         private readonly ServerProtocolHandlerFactory $serverProtocolHandlerFactory,
         private readonly ServerAuthorization $serverAuthorization,
     ) {

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server;
+
+use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\ServerAuthorization;
+use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+use FreeDSx\Ldap\Server\RequestHandler\HandlerFactory;
+use FreeDSx\Socket\Socket;
+use Psr\Log\LoggerInterface;
+
+class ServerProtocolFactory
+{
+    public function __construct(
+        private readonly HandlerFactory $handlerFactory,
+        private readonly LoggerInterface $logger,
+        private readonly ServerProtocolHandlerFactory $serverProtocolHandlerFactory,
+        private readonly ServerAuthorization $serverAuthorization,
+    ) {
+    }
+
+    public function make(Socket $socket): ServerProtocolHandler
+    {
+        return new ServerProtocolHandler(
+            queue: new ServerQueue($socket),
+            handlerFactory: $this->handlerFactory,
+            logger: $this->logger,
+            protocolHandlerFactory:$this->serverProtocolHandlerFactory,
+            authorizer: $this->serverAuthorization,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/SocketServerFactory.php
+++ b/src/FreeDSx/Ldap/Server/SocketServerFactory.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server;
+
+use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Socket\SocketServer;
+use Psr\Log\LoggerInterface;
+
+class SocketServerFactory
+{
+    use LoggerTrait;
+
+    public function __construct(
+        private readonly ServerOptions $options,
+        private readonly ?LoggerInterface $logger,
+    ) {
+    }
+
+    public function makeAndBind(): SocketServer
+    {
+        $isUnixSocket = $this->options->getTransport() === 'unix';
+        $resource = $isUnixSocket
+            ? $this->options->getUnixSocket()
+            : $this->options->getIp();
+
+        if ($isUnixSocket) {
+            $this->removeExistingSocketIfNeeded($resource);
+        }
+
+        return SocketServer::bind(
+            $resource,
+            $this->options->getPort(),
+            $this->options->toArray(),
+        );
+    }
+
+    private function removeExistingSocketIfNeeded(string $socket): void
+    {
+        if (!file_exists($socket)) {
+            return;
+        }
+
+        if (!is_writeable($socket)) {
+            $this->logAndThrow(sprintf(
+                'The socket "%s" already exists and is not writeable. To run the LDAP server, you must remove the existing socket.',
+                $socket
+            ));
+        }
+
+        if (!unlink($socket)) {
+            $this->logAndThrow(sprintf(
+                'The existing socket "%s" could not be removed. To run the LDAP server, you must remove the existing socket.',
+                $socket
+            ));
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Token/BindToken.php
+++ b/src/FreeDSx/Ldap/Server/Token/BindToken.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Token;
 
+use SensitiveParameter;
+
 /**
  * Represents a username/password token that is bound and authorized.
  *
@@ -28,7 +30,7 @@ class BindToken implements TokenInterface
 
     public function __construct(
         string $username,
-        #[\SensitiveParameter]
+        #[SensitiveParameter]
         string $password,
         int $version = 3
     ) {

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap;
 use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
+use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
 use Psr\Log\LoggerInterface;
 
 final class ServerOptions
@@ -60,6 +61,8 @@ final class ServerOptions
     private ?PagingHandlerInterface $pagingHandler = null;
 
     private ?LoggerInterface $logger = null;
+
+    private ?ServerRunnerInterface $serverRunner = null;
 
     public function getIp(): string
     {
@@ -290,6 +293,18 @@ final class ServerOptions
         $this->logger = $logger;
 
         return $this;
+    }
+
+    public function setServerRunner(ServerRunnerInterface $serverRunner): self
+    {
+        $this->serverRunner = $serverRunner;
+
+        return $this;
+    }
+
+    public function getServerRunner(): ?ServerRunnerInterface
+    {
+        return $this->serverRunner;
     }
 
     /**

--- a/tests/integration/FreeDSx/Ldap/Search/PagingTest.php
+++ b/tests/integration/FreeDSx/Ldap/Search/PagingTest.php
@@ -88,7 +88,7 @@ class PagingTest extends LdapTestCase
             ),
             'cn'
         );
-        $operation->useEntryHandler(fn(EntryResult $result)=> $entries->add($result->getEntry()));
+        $operation->useEntryHandler(fn (EntryResult $result) => $entries->add($result->getEntry()));
 
         $this->paging = $this->client->paging($operation);
 

--- a/tests/integration/FreeDSx/Ldap/ServerTestCase.php
+++ b/tests/integration/FreeDSx/Ldap/ServerTestCase.php
@@ -61,9 +61,10 @@ class ServerTestCase extends LdapTestCase
         }
 
         throw new Exception(sprintf(
-            'The expected output (%s) was not received after %d seconds.',
+            'The expected output (%s) was not received after %d seconds. Received: %s',
             $marker,
-            $i
+            $i,
+            PHP_EOL . $this->subject->getErrorOutput()
         ));
     }
 

--- a/tests/spec/FreeDSx/Ldap/ContainerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/ContainerSpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\FreeDSx\Ldap;
 
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Protocol\ClientProtocolHandler;
@@ -28,11 +29,10 @@ class ContainerSpec extends ObjectBehavior
     {
         $client = new LdapClient();
 
-        $this->beConstructedWith(
-            $client->getOptions(),
-            null,
-            $client,
-        );
+        $this->beConstructedWith([
+            LdapClient::class => $client,
+            ClientOptions::class => $client->getOptions(),
+        ]);
     }
 
     public function it_is_initializable(): void

--- a/tests/spec/FreeDSx/Ldap/ContainerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/ContainerSpec.php
@@ -119,10 +119,4 @@ class ContainerSpec extends ObjectBehavior
         $this->get(SocketServerFactory::class)
             ->shouldBeAnInstanceOf(SocketServerFactory::class);
     }
-
-    public function it_should_make_the_ServerProtocolHandlerFactory(): void
-    {
-        $this->get(ServerProtocolHandlerFactory::class)
-            ->shouldBeAnInstanceOf(ServerProtocolHandlerFactory::class);
-    }
 }

--- a/tests/spec/FreeDSx/Ldap/ContainerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/ContainerSpec.php
@@ -18,9 +18,17 @@ use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 use FreeDSx\Ldap\Protocol\Factory\ClientProtocolHandlerFactory;
+use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\Queue\ClientQueueInstantiator;
 use FreeDSx\Ldap\Protocol\RootDseLoader;
+use FreeDSx\Ldap\Protocol\ServerAuthorization;
+use FreeDSx\Ldap\Server\HandlerFactoryInterface;
+use FreeDSx\Ldap\Server\ServerProtocolFactory;
+use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
+use FreeDSx\Ldap\Server\SocketServerFactory;
+use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\SocketPool;
+use PhpSpec\Exception\Example\SkippingException;
 use PhpSpec\ObjectBehavior;
 
 class ContainerSpec extends ObjectBehavior
@@ -28,10 +36,12 @@ class ContainerSpec extends ObjectBehavior
     public function let(): void
     {
         $client = new LdapClient();
+        $serverOptions = new ServerOptions();
 
         $this->beConstructedWith([
             LdapClient::class => $client,
             ClientOptions::class => $client->getOptions(),
+            ServerOptions::class => $serverOptions,
         ]);
     }
 
@@ -74,5 +84,45 @@ class ContainerSpec extends ObjectBehavior
     {
         $this->get(RootDseLoader::class)
             ->shouldBeAnInstanceOf(RootDseLoader::class);
+    }
+
+    public function it_should_make_the_ServerProtocolFactory(): void
+    {
+        $this->get(ServerProtocolFactory::class)
+            ->shouldBeAnInstanceOf(ServerProtocolFactory::class);
+    }
+
+    public function it_should_make_the_default_ServerRunner(): void
+    {
+        if (str_starts_with(strtoupper(PHP_OS), 'WIN')) {
+            throw new SkippingException('Cannot construct the default PCNTL runner on Windows.');
+        }
+
+        $this->get(ServerRunnerInterface::class)
+            ->shouldBeAnInstanceOf(ServerRunnerInterface::class);
+    }
+
+    public function it_should_make_the_default_HandlerFactory(): void
+    {
+        $this->get(HandlerFactoryInterface::class)
+            ->shouldBeAnInstanceOf(HandlerFactoryInterface::class);
+    }
+
+    public function it_should_make_the_ServerAuthorization(): void
+    {
+        $this->get(ServerAuthorization::class)
+            ->shouldBeAnInstanceOf(ServerAuthorization::class);
+    }
+
+    public function it_should_make_the_ServerSocketFactory(): void
+    {
+        $this->get(SocketServerFactory::class)
+            ->shouldBeAnInstanceOf(SocketServerFactory::class);
+    }
+
+    public function it_should_make_the_ServerProtocolHandlerFactory(): void
+    {
+        $this->get(ServerProtocolHandlerFactory::class)
+            ->shouldBeAnInstanceOf(ServerProtocolHandlerFactory::class);
     }
 }

--- a/tests/spec/FreeDSx/Ldap/ContainerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/ContainerSpec.php
@@ -18,7 +18,6 @@ use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 use FreeDSx\Ldap\Protocol\Factory\ClientProtocolHandlerFactory;
-use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\Queue\ClientQueueInstantiator;
 use FreeDSx\Ldap\Protocol\RootDseLoader;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;

--- a/tests/spec/FreeDSx/Ldap/LdapClientSpec.php
+++ b/tests/spec/FreeDSx/Ldap/LdapClientSpec.php
@@ -18,7 +18,6 @@ use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\Entry\Entries;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
-use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;

--- a/tests/spec/FreeDSx/Ldap/LdapServerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/LdapServerSpec.php
@@ -34,8 +34,9 @@ class LdapServerSpec extends ObjectBehavior
     public function let(ServerRunnerInterface $serverRunner): void
     {
         $this->beConstructedWith(
-            (new ServerOptions())->setPort(33389),
-            $serverRunner
+            (new ServerOptions())
+                ->setPort(33389)
+                ->setServerRunner($serverRunner->getWrappedObject())
         );
     }
 

--- a/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientBasicHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientBasicHandlerSpec.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace spec\FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 
-use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\CompareRequest;
@@ -55,7 +54,7 @@ class ClientBasicHandlerSpec extends ObjectBehavior
         $this->shouldBeAnInstanceOf(RequestHandlerInterface::class);
     }
 
-    public function it_should_handle_a_request_and_return_a_response(ClientQueue $queue,): void
+    public function it_should_handle_a_request_and_return_a_response(ClientQueue $queue, ): void
     {
         $queue->sendMessage(Argument::type(LdapMessageRequest::class))->shouldBeCalledOnce();
         $queue->getMessage(1)->willReturn(

--- a/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSaslBindHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSaslBindHandlerSpec.php
@@ -54,7 +54,7 @@ class ClientSaslBindHandlerSpec extends ObjectBehavior
             ->willReturn(
                 Entry::fromArray(
                     '',
-                    ['supportedSaslMechanisms' => ['DIGEST-MD5', 'CRAM-MD5'],]
+                    ['supportedSaslMechanisms' => ['DIGEST-MD5', 'CRAM-MD5'], ]
                 )
             );
         $queue

--- a/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/MockCancelResponseProcessor.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/MockCancelResponseProcessor.php
@@ -22,7 +22,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageResponse;
  */
 class MockCancelResponseProcessor
 {
-    public function __invoke(LdapMessageResponse $messageResponse,): void
+    public function __invoke(LdapMessageResponse $messageResponse): void
     {
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/RequestCancelerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ClientProtocolHandler/RequestCancelerSpec.php
@@ -20,17 +20,14 @@ use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\CancelRequest;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
-use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\Response\SearchResultReference;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ClientQueue;
-use PhpParser\Node\Arg;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use spec\FreeDSx\Ldap\TestFactoryTrait;
 
 class RequestCancelerSpec extends ObjectBehavior
 {
@@ -54,7 +51,7 @@ class RequestCancelerSpec extends ObjectBehavior
 
         $queue
             ->sendMessage(Argument::that(
-                fn(LdapMessageRequest $request) =>
+                fn (LdapMessageRequest $request) =>
                     $request->getRequest() instanceof CancelRequest
             ))
             ->shouldBeCalledOnce();

--- a/tests/spec/FreeDSx/Ldap/Protocol/Factory/ServerBindHandlerFactorySpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/Factory/ServerBindHandlerFactorySpec.php
@@ -18,12 +18,18 @@ use FreeDSx\Ldap\Operation\Request\AnonBindRequest;
 use FreeDSx\Ldap\Operation\Request\BindRequest;
 use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
 use FreeDSx\Ldap\Protocol\Factory\ServerBindHandlerFactory;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerAnonBindHandler;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerBindHandler;
 use PhpSpec\ObjectBehavior;
 
 class ServerBindHandlerFactorySpec extends ObjectBehavior
 {
+    public function let(ServerQueue $queue): void
+    {
+        $this->beConstructedWith($queue);
+    }
+
     public function it_is_initializable(): void
     {
         $this->shouldHaveType(ServerBindHandlerFactory::class);
@@ -31,12 +37,14 @@ class ServerBindHandlerFactorySpec extends ObjectBehavior
 
     public function it_should_get_an_anon_bind_handler(): void
     {
-        $this->get(new AnonBindRequest())->shouldBeLike(new ServerAnonBindHandler());
+        $this->get(new AnonBindRequest())
+            ->shouldBeAnInstanceOf(ServerAnonBindHandler::class);
     }
 
     public function it_should_get_a_simple_bind_handler(): void
     {
-        $this->get(new SimpleBindRequest('foo', 'bar'))->shouldBeLike(new ServerBindHandler());
+        $this->get(new SimpleBindRequest('foo', 'bar'))
+            ->shouldBeAnInstanceOf(ServerBindHandler::class);
     }
 
     public function it_should_throw_an_exception_on_an_unknown_bind_type(BindRequest $request): void

--- a/tests/spec/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactorySpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactorySpec.php
@@ -31,6 +31,7 @@ use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
 use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHistory;
+use FreeDSx\Ldap\ServerOptions;
 use PhpSpec\ObjectBehavior;
 
 class ServerProtocolHandlerFactorySpec extends ObjectBehavior
@@ -39,6 +40,7 @@ class ServerProtocolHandlerFactorySpec extends ObjectBehavior
     {
         $this->beConstructedWith(
             $handlerFactory,
+            new ServerOptions(),
             new RequestHistory()
         );
     }
@@ -50,7 +52,8 @@ class ServerProtocolHandlerFactorySpec extends ObjectBehavior
 
     public function it_should_get_a_start_tls_hanlder(): void
     {
-        $this->get(Operations::extended(ExtendedRequest::OID_START_TLS), new ControlBag())->shouldBeLike(new ServerStartTlsHandler());
+        $this->get(Operations::extended(ExtendedRequest::OID_START_TLS), new ControlBag())
+            ->shouldBeLike(new ServerStartTlsHandler(new ServerOptions()));
     }
 
     public function it_should_get_a_whoami_handler(): void
@@ -89,7 +92,8 @@ class ServerProtocolHandlerFactorySpec extends ObjectBehavior
 
     public function it_should_get_a_root_dse_handler(): void
     {
-        $this->get(Operations::read(''), new ControlBag())->shouldBeLike(new ServerRootDseHandler());
+        $this->get(Operations::read(''), new ControlBag())
+            ->shouldBeLike(new ServerRootDseHandler(new ServerOptions()));
     }
 
     public function it_should_get_an_unbind_handler(): void

--- a/tests/spec/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactorySpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactorySpec.php
@@ -18,7 +18,6 @@ use FreeDSx\Ldap\Control\PagingControl;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operations;
-use FreeDSx\Ldap\Protocol\ClientProtocolHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerDispatchHandler;
@@ -116,7 +115,7 @@ class ServerProtocolHandlerFactorySpec extends ObjectBehavior
             ->shouldBeAnInstanceOf(ServerUnbindHandler::class);
     }
 
-    public function it_should_get_the_dispatch_handler_for_common_requests(HandlerFactoryInterface $handlerFactory,): void
+    public function it_should_get_the_dispatch_handler_for_common_requests(HandlerFactoryInterface $handlerFactory, ): void
     {
         $handlerFactory->makeRequestHandler()
             ->willReturn(new GenericRequestHandler());

--- a/tests/spec/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactorySpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactorySpec.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerDispatchHandler;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerPagingHandler;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerPagingUnsupportedHandler;
@@ -36,12 +37,15 @@ use PhpSpec\ObjectBehavior;
 
 class ServerProtocolHandlerFactorySpec extends ObjectBehavior
 {
-    public function let(HandlerFactoryInterface $handlerFactory): void
-    {
+    public function let(
+        HandlerFactoryInterface $handlerFactory,
+        ServerQueue $queue,
+    ): void {
         $this->beConstructedWith(
             $handlerFactory,
             new ServerOptions(),
-            new RequestHistory()
+            new RequestHistory(),
+            $queue,
         );
     }
 
@@ -50,20 +54,22 @@ class ServerProtocolHandlerFactorySpec extends ObjectBehavior
         $this->shouldHaveType(ServerProtocolHandlerFactory::class);
     }
 
-    public function it_should_get_a_start_tls_hanlder(): void
+    public function it_should_get_a_start_tls_hanlder(ServerQueue $queue): void
     {
         $this->get(Operations::extended(ExtendedRequest::OID_START_TLS), new ControlBag())
-            ->shouldBeLike(new ServerStartTlsHandler(new ServerOptions()));
+            ->shouldBeAnInstanceOf(ServerStartTlsHandler::class);
     }
 
-    public function it_should_get_a_whoami_handler(): void
+    public function it_should_get_a_whoami_handler(ServerQueue $queue): void
     {
-        $this->get(Operations::whoami(), new ControlBag())->shouldBeLike(new ServerWhoAmIHandler());
+        $this->get(Operations::whoami(), new ControlBag())
+            ->shouldBeAnInstanceOf(ServerWhoAmIHandler::class);
     }
 
-    public function it_should_get_a_search_handler(): void
+    public function it_should_get_a_search_handler(ServerQueue $queue): void
     {
-        $this->get(Operations::list(new EqualityFilter('foo', 'bar'), 'cn=foo'), new ControlBag())->shouldBeLike(new ServerSearchHandler());
+        $this->get(Operations::list(new EqualityFilter('foo', 'bar'), 'cn=foo'), new ControlBag())
+            ->shouldBeAnInstanceOf(ServerSearchHandler::class);
     }
 
     public function it_should_get_a_paging_handler_when_supported(
@@ -90,24 +96,31 @@ class ServerProtocolHandlerFactorySpec extends ObjectBehavior
         $this->get(Operations::list(new EqualityFilter('foo', 'bar'), 'cn=foo'), $controls)->shouldBeAnInstanceOf(ServerPagingUnsupportedHandler::class);
     }
 
-    public function it_should_get_a_root_dse_handler(): void
+    public function it_should_get_a_root_dse_handler(ServerQueue $queue): void
     {
         $this->get(Operations::read(''), new ControlBag())
-            ->shouldBeLike(new ServerRootDseHandler(new ServerOptions()));
+            ->shouldBeAnInstanceOf(ServerRootDseHandler::class);
     }
 
-    public function it_should_get_an_unbind_handler(): void
+    public function it_should_get_an_unbind_handler(ServerQueue $queue): void
     {
-        $this->get(Operations::unbind(), new ControlBag())->shouldBeLike(new ServerUnbindHandler());
+        $this->get(Operations::unbind(), new ControlBag())
+            ->shouldBeAnInstanceOf(ServerUnbindHandler::class);
     }
 
-    public function it_should_get_the_dispatch_handler_for_common_requests(): void
+    public function it_should_get_the_dispatch_handler_for_common_requests(ServerQueue $queue): void
     {
-        $this->get(Operations::add(Entry::fromArray('cn=foo')), new ControlBag())->shouldBeLike(new ServerDispatchHandler());
-        $this->get(Operations::delete('cn=foo'), new ControlBag())->shouldBeLike(new ServerDispatchHandler());
-        $this->get(Operations::compare('cn=foo', 'foo', 'bar'), new ControlBag())->shouldBeLike(new ServerDispatchHandler());
-        $this->get(Operations::modify('cn=foo'), new ControlBag())->shouldBeLike(new ServerDispatchHandler());
-        $this->get(Operations::move('cn=foo', 'foo=bar'), new ControlBag())->shouldBeLike(new ServerDispatchHandler());
-        $this->get(Operations::rename('cn=foo', 'cn=foo'), new ControlBag())->shouldBeLike(new ServerDispatchHandler());
+        $this->get(Operations::add(Entry::fromArray('cn=foo')), new ControlBag())
+            ->shouldBeAnInstanceOf(ServerDispatchHandler::class);
+        $this->get(Operations::delete('cn=foo'), new ControlBag())
+            ->shouldBeAnInstanceOf(ServerDispatchHandler::class);
+        $this->get(Operations::compare('cn=foo', 'foo', 'bar'), new ControlBag())
+            ->shouldBeAnInstanceOf(ServerDispatchHandler::class);
+        $this->get(Operations::modify('cn=foo'), new ControlBag())
+            ->shouldBeAnInstanceOf(ServerDispatchHandler::class);
+        $this->get(Operations::move('cn=foo', 'foo=bar'), new ControlBag())
+            ->shouldBeAnInstanceOf(ServerDispatchHandler::class);
+        $this->get(Operations::rename('cn=foo', 'cn=foo'), new ControlBag())
+            ->shouldBeAnInstanceOf(ServerDispatchHandler::class);
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactorySpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactorySpec.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Control\PagingControl;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\Protocol\ClientProtocolHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerDispatchHandler;
@@ -30,6 +31,7 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerUnbindHandler;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerWhoAmIHandler;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
+use FreeDSx\Ldap\Server\RequestHandler\GenericRequestHandler;
 use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHistory;
 use FreeDSx\Ldap\ServerOptions;
@@ -66,8 +68,11 @@ class ServerProtocolHandlerFactorySpec extends ObjectBehavior
             ->shouldBeAnInstanceOf(ServerWhoAmIHandler::class);
     }
 
-    public function it_should_get_a_search_handler(ServerQueue $queue): void
+    public function it_should_get_a_search_handler(HandlerFactoryInterface $handlerFactory): void
     {
+        $handlerFactory->makeRequestHandler()
+            ->willReturn(new GenericRequestHandler());
+
         $this->get(Operations::list(new EqualityFilter('foo', 'bar'), 'cn=foo'), new ControlBag())
             ->shouldBeAnInstanceOf(ServerSearchHandler::class);
     }
@@ -93,6 +98,9 @@ class ServerProtocolHandlerFactorySpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn(null);
 
+        $handlerFactory->makeRequestHandler()
+            ->willReturn(new GenericRequestHandler());
+
         $this->get(Operations::list(new EqualityFilter('foo', 'bar'), 'cn=foo'), $controls)->shouldBeAnInstanceOf(ServerPagingUnsupportedHandler::class);
     }
 
@@ -108,8 +116,11 @@ class ServerProtocolHandlerFactorySpec extends ObjectBehavior
             ->shouldBeAnInstanceOf(ServerUnbindHandler::class);
     }
 
-    public function it_should_get_the_dispatch_handler_for_common_requests(ServerQueue $queue): void
+    public function it_should_get_the_dispatch_handler_for_common_requests(HandlerFactoryInterface $handlerFactory,): void
     {
+        $handlerFactory->makeRequestHandler()
+            ->willReturn(new GenericRequestHandler());
+
         $this->get(Operations::add(Entry::fromArray('cn=foo')), new ControlBag())
             ->shouldBeAnInstanceOf(ServerDispatchHandler::class);
         $this->get(Operations::delete('cn=foo'), new ControlBag())

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerAuthorizationSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerAuthorizationSpec.php
@@ -90,7 +90,7 @@ class ServerAuthorizationSpec extends ObjectBehavior
     public function it_should_not_require_authentication_if_it_has_been_explicitly_disabled(): void
     {
         $this->beConstructedWith(
-            (new ServerOptions)
+            (new ServerOptions())
                 ->setAllowAnonymous(false)
                 ->setRequireAuthentication(false),
             new AnonToken()
@@ -116,7 +116,7 @@ class ServerAuthorizationSpec extends ObjectBehavior
     public function it_should_respect_the_option_for_whether_anon_binds_are_allowed(): void
     {
         $this->beConstructedWith(
-            (new ServerOptions)
+            (new ServerOptions())
                 ->setAllowAnonymous(true),
             new AnonToken()
         );

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerAuthorizationSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerAuthorizationSpec.php
@@ -20,10 +20,16 @@ use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Server\Token\AnonToken;
+use FreeDSx\Ldap\ServerOptions;
 use PhpSpec\ObjectBehavior;
 
 class ServerAuthorizationSpec extends ObjectBehavior
 {
+    public function let(): void
+    {
+        $this->beConstructedWith(new ServerOptions());
+    }
+
     public function it_is_initializable(): void
     {
         $this->shouldHaveType(ServerAuthorization::class);
@@ -83,7 +89,12 @@ class ServerAuthorizationSpec extends ObjectBehavior
 
     public function it_should_not_require_authentication_if_it_has_been_explicitly_disabled(): void
     {
-        $this->beConstructedWith(new AnonToken(), false, false);
+        $this->beConstructedWith(
+            (new ServerOptions)
+                ->setAllowAnonymous(false)
+                ->setRequireAuthentication(false),
+            new AnonToken()
+        );
 
         $this->isAuthenticationRequired(Operations::read('cn=bar'))->shouldBeEqualTo(false);
         $this->isAuthenticationRequired(Operations::list(new EqualityFilter('foo', 'bar'), 'cn=foo'))->shouldBeEqualTo(false);
@@ -104,7 +115,11 @@ class ServerAuthorizationSpec extends ObjectBehavior
 
     public function it_should_respect_the_option_for_whether_anon_binds_are_allowed(): void
     {
-        $this->beConstructedWith(new AnonToken(), true);
+        $this->beConstructedWith(
+            (new ServerOptions)
+                ->setAllowAnonymous(true),
+            new AnonToken()
+        );
 
         $this->isAuthenticationTypeSupported(Operations::bindAnonymously())->shouldBeEqualTo(true);
     }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAnonBindHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAnonBindHandlerSpec.php
@@ -28,6 +28,11 @@ use Prophecy\Argument;
 
 class ServerAnonBindHandlerSpec extends ObjectBehavior
 {
+    public function let(ServerQueue $queue): void
+    {
+        $this->beConstructedWith($queue);
+    }
+
     public function it_is_initializable(): void
     {
         $this->shouldHaveType(ServerAnonBindHandler::class);

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerBindHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerBindHandlerSpec.php
@@ -29,6 +29,11 @@ use Prophecy\Argument;
 
 class ServerBindHandlerSpec extends ObjectBehavior
 {
+    public function let(ServerQueue $queue): void
+    {
+        $this->beConstructedWith($queue);
+    }
+
     public function it_is_initializable(): void
     {
         $this->shouldHaveType(ServerBindHandler::class);

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandlerSpec.php
@@ -38,6 +38,8 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
     public function let(ServerQueue $queue): void
     {
         $queue->sendMessage(Argument::any())->willReturn($queue);
+
+        $this->beConstructedWith($queue);
     }
 
     public function it_is_initializable(): void
@@ -50,7 +52,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $add = new LdapMessageRequest(1, new AddRequest(Entry::create('cn=foo,dc=bar')));
 
         $handler->add(Argument::any(), $add->getRequest())->shouldBeCalled();
-        $this->handleRequest($add, $token, $handler, $queue);
+        $this->handleRequest($add, $token, $handler);
     }
 
     public function it_should_send_a_delete_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
@@ -58,7 +60,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $delete = new LdapMessageRequest(1, new DeleteRequest('cn=foo,dc=bar'));
 
         $handler->delete(Argument::any(), $delete->getRequest())->shouldBeCalled();
-        $this->handleRequest($delete, $token, $handler, $queue);
+        $this->handleRequest($delete, $token, $handler);
     }
 
     public function it_should_send_a_modify_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
@@ -66,7 +68,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $modify = new LdapMessageRequest(1, new ModifyRequest('cn=foo,dc=bar', Change::add('foo', 'bar')));
 
         $handler->modify(Argument::any(), $modify->getRequest())->shouldBeCalled();
-        $this->handleRequest($modify, $token, $handler, $queue);
+        $this->handleRequest($modify, $token, $handler);
     }
 
     public function it_should_send_a_modify_dn_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
@@ -74,7 +76,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $modifyDn = new LdapMessageRequest(1, new ModifyDnRequest('cn=foo,dc=bar', 'cn=bar', true));
 
         $handler->modifyDn(Argument::any(), $modifyDn->getRequest())->shouldBeCalled();
-        $this->handleRequest($modifyDn, $token, $handler, $queue);
+        $this->handleRequest($modifyDn, $token, $handler);
     }
 
     public function it_should_send_an_extended_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
@@ -82,7 +84,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $ext = new LdapMessageRequest(1, new ExtendedRequest('foo', 'bar'));
 
         $handler->extended(Argument::any(), $ext->getRequest())->shouldBeCalled();
-        $this->handleRequest($ext, $token, $handler, $queue);
+        $this->handleRequest($ext, $token, $handler);
     }
 
     public function it_should_send_a_compare_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
@@ -90,7 +92,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $compare = new LdapMessageRequest(1, new CompareRequest('cn=foo,dc=bar', Filters::equal('foo', 'bar')));
 
         $handler->compare(Argument::any(), $compare->getRequest())->shouldBeCalled()->willReturn(true);
-        $this->handleRequest($compare, $token, $handler, $queue);
+        $this->handleRequest($compare, $token, $handler);
     }
 
     public function it_should_throw_an_operation_exception_if_the_request_is_unsupported(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandlerSpec.php
@@ -50,7 +50,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $add = new LdapMessageRequest(1, new AddRequest(Entry::create('cn=foo,dc=bar')));
 
         $handler->add(Argument::any(), $add->getRequest())->shouldBeCalled();
-        $this->handleRequest($add, $token, $handler, $queue, new ServerOptions());
+        $this->handleRequest($add, $token, $handler, $queue);
     }
 
     public function it_should_send_a_delete_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
@@ -58,7 +58,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $delete = new LdapMessageRequest(1, new DeleteRequest('cn=foo,dc=bar'));
 
         $handler->delete(Argument::any(), $delete->getRequest())->shouldBeCalled();
-        $this->handleRequest($delete, $token, $handler, $queue, new ServerOptions());
+        $this->handleRequest($delete, $token, $handler, $queue);
     }
 
     public function it_should_send_a_modify_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
@@ -66,7 +66,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $modify = new LdapMessageRequest(1, new ModifyRequest('cn=foo,dc=bar', Change::add('foo', 'bar')));
 
         $handler->modify(Argument::any(), $modify->getRequest())->shouldBeCalled();
-        $this->handleRequest($modify, $token, $handler, $queue, new ServerOptions());
+        $this->handleRequest($modify, $token, $handler, $queue);
     }
 
     public function it_should_send_a_modify_dn_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
@@ -74,7 +74,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $modifyDn = new LdapMessageRequest(1, new ModifyDnRequest('cn=foo,dc=bar', 'cn=bar', true));
 
         $handler->modifyDn(Argument::any(), $modifyDn->getRequest())->shouldBeCalled();
-        $this->handleRequest($modifyDn, $token, $handler, $queue, new ServerOptions());
+        $this->handleRequest($modifyDn, $token, $handler, $queue);
     }
 
     public function it_should_send_an_extended_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
@@ -82,7 +82,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $ext = new LdapMessageRequest(1, new ExtendedRequest('foo', 'bar'));
 
         $handler->extended(Argument::any(), $ext->getRequest())->shouldBeCalled();
-        $this->handleRequest($ext, $token, $handler, $queue, new ServerOptions());
+        $this->handleRequest($ext, $token, $handler, $queue);
     }
 
     public function it_should_send_a_compare_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
@@ -90,7 +90,7 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $compare = new LdapMessageRequest(1, new CompareRequest('cn=foo,dc=bar', Filters::equal('foo', 'bar')));
 
         $handler->compare(Argument::any(), $compare->getRequest())->shouldBeCalled()->willReturn(true);
-        $this->handleRequest($compare, $token, $handler, $queue, new ServerOptions());
+        $this->handleRequest($compare, $token, $handler, $queue);
     }
 
     public function it_should_throw_an_operation_exception_if_the_request_is_unsupported(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandlerSpec.php
@@ -35,11 +35,17 @@ use Prophecy\Argument;
 
 class ServerDispatchHandlerSpec extends ObjectBehavior
 {
-    public function let(ServerQueue $queue): void
-    {
-        $queue->sendMessage(Argument::any())->willReturn($queue);
+    public function let(
+        ServerQueue $queue,
+        RequestHandlerInterface $handler,
+    ): void {
+        $queue->sendMessage(Argument::any())
+            ->willReturn($queue);
 
-        $this->beConstructedWith($queue);
+        $this->beConstructedWith(
+            $queue,
+            $handler,
+        );
     }
 
     public function it_is_initializable(): void
@@ -47,61 +53,73 @@ class ServerDispatchHandlerSpec extends ObjectBehavior
         $this->shouldHaveType(ServerDispatchHandler::class);
     }
 
-    public function it_should_send_an_add_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
-    {
+    public function it_should_send_an_add_request_to_the_request_handler(
+        RequestHandlerInterface $handler,
+        TokenInterface $token
+    ): void {
         $add = new LdapMessageRequest(1, new AddRequest(Entry::create('cn=foo,dc=bar')));
 
         $handler->add(Argument::any(), $add->getRequest())->shouldBeCalled();
-        $this->handleRequest($add, $token, $handler);
+        $this->handleRequest($add, $token);
     }
 
-    public function it_should_send_a_delete_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
-    {
+    public function it_should_send_a_delete_request_to_the_request_handler(
+        RequestHandlerInterface $handler,
+        TokenInterface $token
+    ): void {
         $delete = new LdapMessageRequest(1, new DeleteRequest('cn=foo,dc=bar'));
 
         $handler->delete(Argument::any(), $delete->getRequest())->shouldBeCalled();
-        $this->handleRequest($delete, $token, $handler);
+        $this->handleRequest($delete, $token);
     }
 
-    public function it_should_send_a_modify_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
-    {
+    public function it_should_send_a_modify_request_to_the_request_handler(
+        RequestHandlerInterface $handler,
+        TokenInterface $token
+    ): void {
         $modify = new LdapMessageRequest(1, new ModifyRequest('cn=foo,dc=bar', Change::add('foo', 'bar')));
 
         $handler->modify(Argument::any(), $modify->getRequest())->shouldBeCalled();
-        $this->handleRequest($modify, $token, $handler);
+        $this->handleRequest($modify, $token);
     }
 
-    public function it_should_send_a_modify_dn_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
-    {
+    public function it_should_send_a_modify_dn_request_to_the_request_handler(
+        RequestHandlerInterface $handler,
+        TokenInterface $token
+    ): void {
         $modifyDn = new LdapMessageRequest(1, new ModifyDnRequest('cn=foo,dc=bar', 'cn=bar', true));
 
         $handler->modifyDn(Argument::any(), $modifyDn->getRequest())->shouldBeCalled();
-        $this->handleRequest($modifyDn, $token, $handler);
+        $this->handleRequest($modifyDn, $token);
     }
 
-    public function it_should_send_an_extended_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
-    {
+    public function it_should_send_an_extended_request_to_the_request_handler(
+        RequestHandlerInterface $handler,
+        TokenInterface $token
+    ): void {
         $ext = new LdapMessageRequest(1, new ExtendedRequest('foo', 'bar'));
 
         $handler->extended(Argument::any(), $ext->getRequest())->shouldBeCalled();
-        $this->handleRequest($ext, $token, $handler);
+        $this->handleRequest($ext, $token);
     }
 
-    public function it_should_send_a_compare_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
-    {
+    public function it_should_send_a_compare_request_to_the_request_handler(
+        RequestHandlerInterface $handler,
+        TokenInterface $token
+    ): void {
         $compare = new LdapMessageRequest(1, new CompareRequest('cn=foo,dc=bar', Filters::equal('foo', 'bar')));
 
         $handler->compare(Argument::any(), $compare->getRequest())->shouldBeCalled()->willReturn(true);
-        $this->handleRequest($compare, $token, $handler);
+        $this->handleRequest($compare, $token);
     }
 
-    public function it_should_throw_an_operation_exception_if_the_request_is_unsupported(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
+    public function it_should_throw_an_operation_exception_if_the_request_is_unsupported(TokenInterface $token): void
     {
         $request = new LdapMessageRequest(2, new AbandonRequest(1));
 
         $this->shouldThrow(OperationException::class)->during(
             'handleRequest',
-            [$request, $token, $handler, $queue, new ServerOptions()]
+            [$request, $token, new ServerOptions()]
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandlerSpec.php
@@ -101,7 +101,6 @@ class ServerPagingHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            new ServerOptions()
         );
     }
 
@@ -152,7 +151,6 @@ class ServerPagingHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            new ServerOptions()
         );
     }
 
@@ -189,7 +187,6 @@ class ServerPagingHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            new ServerOptions()
         );
     }
 
@@ -230,7 +227,6 @@ class ServerPagingHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            new ServerOptions()
         );
     }
 

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandlerSpec.php
@@ -42,11 +42,14 @@ class ServerPagingHandlerSpec extends ObjectBehavior
 {
     private RequestHistory $requestHistory;
 
-    public function let(PagingHandlerInterface $pagingHandler): void
-    {
+    public function let(
+        ServerQueue $queue,
+        PagingHandlerInterface $pagingHandler
+    ): void {
         $this->requestHistory = new RequestHistory();
 
         $this->beConstructedWith(
+            $queue,
             $pagingHandler,
             $this->requestHistory
         );
@@ -100,7 +103,6 @@ class ServerPagingHandlerSpec extends ObjectBehavior
             $message,
             $token,
             $handler,
-            $queue,
         );
     }
 
@@ -150,7 +152,6 @@ class ServerPagingHandlerSpec extends ObjectBehavior
             $message,
             $token,
             $handler,
-            $queue,
         );
     }
 
@@ -186,7 +187,6 @@ class ServerPagingHandlerSpec extends ObjectBehavior
             $message,
             $token,
             $handler,
-            $queue,
         );
     }
 
@@ -226,7 +226,6 @@ class ServerPagingHandlerSpec extends ObjectBehavior
             $message,
             $token,
             $handler,
-            $queue,
         );
     }
 

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandlerSpec.php
@@ -102,7 +102,6 @@ class ServerPagingHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $message,
             $token,
-            $handler,
         );
     }
 
@@ -151,7 +150,6 @@ class ServerPagingHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $message,
             $token,
-            $handler,
         );
     }
 
@@ -186,7 +184,6 @@ class ServerPagingHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $message,
             $token,
-            $handler,
         );
     }
 
@@ -225,7 +222,6 @@ class ServerPagingHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $message,
             $token,
-            $handler,
         );
     }
 

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandlerSpec.php
@@ -34,6 +34,11 @@ use Prophecy\Argument;
 
 class ServerPagingUnsupportedHandlerSpec extends ObjectBehavior
 {
+    public function let(ServerQueue $queue): void
+    {
+        $this->beConstructedWith($queue);
+    }
+
     public function it_is_initializable(): void
     {
         $this->shouldHaveType(ServerPagingUnsupportedHandler::class);
@@ -80,7 +85,6 @@ class ServerPagingUnsupportedHandlerSpec extends ObjectBehavior
             $search,
             $token,
             $handler,
-            $queue,
         );
     }
 
@@ -144,7 +148,6 @@ class ServerPagingUnsupportedHandlerSpec extends ObjectBehavior
             $search,
             $token,
             $handler,
-            $queue,
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandlerSpec.php
@@ -34,9 +34,14 @@ use Prophecy\Argument;
 
 class ServerPagingUnsupportedHandlerSpec extends ObjectBehavior
 {
-    public function let(ServerQueue $queue): void
-    {
-        $this->beConstructedWith($queue);
+    public function let(
+        ServerQueue $queue,
+        RequestHandlerInterface $handler,
+    ): void {
+        $this->beConstructedWith(
+            $queue,
+            $handler,
+        );
     }
 
     public function it_is_initializable(): void
@@ -84,7 +89,6 @@ class ServerPagingUnsupportedHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $search,
             $token,
-            $handler,
         );
     }
 
@@ -147,7 +151,6 @@ class ServerPagingUnsupportedHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $search,
             $token,
-            $handler,
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandlerSpec.php
@@ -81,7 +81,6 @@ class ServerPagingUnsupportedHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            new ServerOptions()
         );
     }
 
@@ -146,7 +145,6 @@ class ServerPagingUnsupportedHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            new ServerOptions()
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandlerSpec.php
@@ -36,10 +36,11 @@ use Prophecy\Argument;
 
 class ServerRootDseHandlerSpec extends ObjectBehavior
 {
-    public function let(): void
+    public function let(ServerQueue $queue): void
     {
         $this->beConstructedWith(
             new ServerOptions(),
+            $queue,
             null
         );
     }
@@ -57,7 +58,8 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
         $this->beConstructedWith(
             (new ServerOptions())
                 ->setDseVendorName('Foo')
-                ->setDseNamingContexts('dc=Foo,dc=Bar')
+                ->setDseNamingContexts('dc=Foo,dc=Bar'),
+            $queue,
         );
 
         $search = new LdapMessageRequest(
@@ -81,7 +83,6 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             $search,
             $token,
             $handler,
-            $queue,
         );
     }
 
@@ -95,7 +96,8 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             (new ServerOptions())
                 ->setDseVendorName('Foo')
                 ->setDseNamingContexts('dc=Foo,dc=Bar')
-                ->setPagingHandler($pagingHandler->getWrappedObject())
+                ->setPagingHandler($pagingHandler->getWrappedObject()),
+            $queue,
         );
 
         $search = new LdapMessageRequest(
@@ -119,7 +121,6 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             $search,
             $token,
             $handler,
-            $queue,
         );
     }
 
@@ -133,6 +134,7 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             (new ServerOptions())
                 ->setDseVendorName('Foo')
                 ->setDseNamingContexts('dc=Foo,dc=Bar'),
+            $queue,
             $rootDseHandler,
         );
 
@@ -164,7 +166,6 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             $search,
             $token,
             $handler,
-            $queue,
         );
     }
 
@@ -176,7 +177,8 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
         $this->beConstructedWith(
             (new ServerOptions())
                 ->setDseVendorName('Foo')
-                ->setDseNamingContexts('dc=Foo,dc=Bar')
+                ->setDseNamingContexts('dc=Foo,dc=Bar'),
+            $queue,
         );
 
         $search = new LdapMessageRequest(
@@ -201,7 +203,6 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             $search,
             $token,
             $handler,
-            $queue,
         );
     }
 
@@ -213,7 +214,8 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
         $this->beConstructedWith(
             (new ServerOptions())
                 ->setDseVendorName('Foo')
-                ->setDseNamingContexts('dc=Foo,dc=Bar')
+                ->setDseNamingContexts('dc=Foo,dc=Bar'),
+            $queue,
         );
 
         $search = new LdapMessageRequest(
@@ -241,7 +243,6 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             $search,
             $token,
             $handler,
-            $queue,
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandlerSpec.php
@@ -38,7 +38,10 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
 {
     public function let(): void
     {
-        $this->beConstructedWith(null);
+        $this->beConstructedWith(
+            new ServerOptions(),
+            null
+        );
     }
 
     public function it_is_initializable(): void
@@ -51,6 +54,12 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
         RequestHandlerInterface $handler,
         TokenInterface $token
     ): void {
+        $this->beConstructedWith(
+            (new ServerOptions())
+                ->setDseVendorName('Foo')
+                ->setDseNamingContexts('dc=Foo,dc=Bar')
+        );
+
         $search = new LdapMessageRequest(
             1,
             (new SearchRequest(Filters::present('objectClass')))->base('')->useBaseScope()
@@ -73,9 +82,6 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            (new ServerOptions())
-                ->setDseVendorName('Foo')
-                ->setDseNamingContexts('dc=Foo,dc=Bar')
         );
     }
 
@@ -85,6 +91,13 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
         TokenInterface $token,
         PagingHandlerInterface $pagingHandler,
     ): void {
+        $this->beConstructedWith(
+            (new ServerOptions())
+                ->setDseVendorName('Foo')
+                ->setDseNamingContexts('dc=Foo,dc=Bar')
+                ->setPagingHandler($pagingHandler->getWrappedObject())
+        );
+
         $search = new LdapMessageRequest(
             1,
             (new SearchRequest(Filters::present('objectClass')))->base('')->useBaseScope()
@@ -107,10 +120,6 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            (new ServerOptions())
-                ->setDseVendorName('Foo')
-                ->setDseNamingContexts('dc=Foo,dc=Bar')
-                ->setPagingHandler($pagingHandler->getWrappedObject())
         );
     }
 
@@ -120,7 +129,12 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
         TokenInterface $token,
         RootDseHandlerInterface $rootDseHandler
     ): void {
-        $this->beConstructedWith($rootDseHandler);
+        $this->beConstructedWith(
+            (new ServerOptions())
+                ->setDseVendorName('Foo')
+                ->setDseNamingContexts('dc=Foo,dc=Bar'),
+            $rootDseHandler,
+        );
 
         $searchReqeust = (new SearchRequest(Filters::present('objectClass')))->base('')->useBaseScope();
         $search = new LdapMessageRequest(
@@ -151,9 +165,6 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            (new ServerOptions())
-                ->setDseVendorName('Foo')
-                ->setDseNamingContexts('dc=Foo,dc=Bar')
         );
     }
 
@@ -162,6 +173,12 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
         RequestHandlerInterface $handler,
         TokenInterface $token
     ): void {
+        $this->beConstructedWith(
+            (new ServerOptions())
+                ->setDseVendorName('Foo')
+                ->setDseNamingContexts('dc=Foo,dc=Bar')
+        );
+
         $search = new LdapMessageRequest(
             1,
             (new SearchRequest(Filters::present('objectClass')))
@@ -185,9 +202,6 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            (new ServerOptions())
-                ->setDseVendorName('Foo')
-                ->setDseNamingContexts('dc=Foo,dc=Bar')
         );
     }
 
@@ -196,6 +210,12 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
         RequestHandlerInterface $handler,
         TokenInterface $token
     ): void {
+        $this->beConstructedWith(
+            (new ServerOptions())
+                ->setDseVendorName('Foo')
+                ->setDseNamingContexts('dc=Foo,dc=Bar')
+        );
+
         $search = new LdapMessageRequest(
             1,
             (new SearchRequest(Filters::present('objectClass')))
@@ -222,9 +242,6 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            (new ServerOptions())
-                ->setDseVendorName('Foo')
-                ->setDseNamingContexts('dc=Foo,dc=Bar')
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandlerSpec.php
@@ -52,7 +52,6 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
 
     public function it_should_send_back_a_RootDSE(
         ServerQueue $queue,
-        RequestHandlerInterface $handler,
         TokenInterface $token
     ): void {
         $this->beConstructedWith(
@@ -82,7 +81,6 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $search,
             $token,
-            $handler,
         );
     }
 
@@ -120,13 +118,11 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $search,
             $token,
-            $handler,
         );
     }
 
     public function it_should_send_a_request_to_the_dispatcher_if_it_implements_a_rootdse_aware_interface(
         ServerQueue $queue,
-        RequestHandlerInterface $handler,
         TokenInterface $token,
         RootDseHandlerInterface $rootDseHandler
     ): void {
@@ -165,13 +161,11 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $search,
             $token,
-            $handler,
         );
     }
 
     public function it_should_only_return_attribute_names_from_the_RootDSE_if_requested(
         ServerQueue $queue,
-        RequestHandlerInterface $handler,
         TokenInterface $token
     ): void {
         $this->beConstructedWith(
@@ -202,13 +196,11 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $search,
             $token,
-            $handler,
         );
     }
 
     public function it_should_only_return_specific_attributes_from_the_RootDSE_if_requested(
         ServerQueue $queue,
-        RequestHandlerInterface $handler,
         TokenInterface $token
     ): void {
         $this->beConstructedWith(
@@ -242,7 +234,6 @@ class ServerRootDseHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $search,
             $token,
-            $handler,
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandlerSpec.php
@@ -27,7 +27,6 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerSearchHandler;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
-use FreeDSx\Ldap\ServerOptions;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -59,7 +58,7 @@ class ServerSearchHandlerSpec extends ObjectBehavior
             new LdapMessageResponse(2, new SearchResultDone(0, 'dc=foo,dc=bar'))
         )->shouldBeCalled();
 
-        $this->handleRequest($search, $token, $handler, $queue, new ServerOptions());
+        $this->handleRequest($search, $token, $handler, $queue);
     }
 
     public function it_should_send_a_SearchResultDone_with_an_operation_exception_thrown_from_the_handler(
@@ -96,7 +95,6 @@ class ServerSearchHandlerSpec extends ObjectBehavior
             $token,
             $handler,
             $queue,
-            new ServerOptions()
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandlerSpec.php
@@ -32,6 +32,11 @@ use Prophecy\Argument;
 
 class ServerSearchHandlerSpec extends ObjectBehavior
 {
+    public function let(ServerQueue $queue): void
+    {
+        $this->beConstructedWith($queue);
+    }
+
     public function it_is_initializable(): void
     {
         $this->shouldHaveType(ServerSearchHandler::class);
@@ -58,7 +63,7 @@ class ServerSearchHandlerSpec extends ObjectBehavior
             new LdapMessageResponse(2, new SearchResultDone(0, 'dc=foo,dc=bar'))
         )->shouldBeCalled();
 
-        $this->handleRequest($search, $token, $handler, $queue);
+        $this->handleRequest($search, $token, $handler);
     }
 
     public function it_should_send_a_SearchResultDone_with_an_operation_exception_thrown_from_the_handler(
@@ -94,7 +99,6 @@ class ServerSearchHandlerSpec extends ObjectBehavior
             $search,
             $token,
             $handler,
-            $queue,
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandlerSpec.php
@@ -32,9 +32,14 @@ use Prophecy\Argument;
 
 class ServerSearchHandlerSpec extends ObjectBehavior
 {
-    public function let(ServerQueue $queue): void
-    {
-        $this->beConstructedWith($queue);
+    public function let(
+        ServerQueue $queue,
+        RequestHandlerInterface $handler,
+    ): void {
+        $this->beConstructedWith(
+            $queue,
+            $handler,
+        );
     }
 
     public function it_is_initializable(): void
@@ -42,8 +47,11 @@ class ServerSearchHandlerSpec extends ObjectBehavior
         $this->shouldHaveType(ServerSearchHandler::class);
     }
 
-    public function it_should_send_a_search_request_to_the_request_handler(ServerQueue $queue, RequestHandlerInterface $handler, TokenInterface $token): void
-    {
+    public function it_should_send_a_search_request_to_the_request_handler(
+        ServerQueue $queue,
+        RequestHandlerInterface $handler,
+        TokenInterface $token
+    ): void {
         $search = new LdapMessageRequest(
             2,
             (new SearchRequest(Filters::equal('foo', 'bar')))->base('dc=foo,dc=bar')
@@ -63,7 +71,7 @@ class ServerSearchHandlerSpec extends ObjectBehavior
             new LdapMessageResponse(2, new SearchResultDone(0, 'dc=foo,dc=bar'))
         )->shouldBeCalled();
 
-        $this->handleRequest($search, $token, $handler);
+        $this->handleRequest($search, $token);
     }
 
     public function it_should_send_a_SearchResultDone_with_an_operation_exception_thrown_from_the_handler(
@@ -98,7 +106,6 @@ class ServerSearchHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $search,
             $token,
-            $handler,
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandlerSpec.php
@@ -44,7 +44,6 @@ class ServerStartTlsHandlerSpec extends ObjectBehavior
     public function it_should_handle_a_start_tls_request(
         ServerQueue $queue,
         TokenInterface $token,
-        RequestHandlerInterface $dispatcher
     ): void {
         $this->beConstructedWith(
             (new ServerOptions())
@@ -67,14 +66,12 @@ class ServerStartTlsHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $startTls,
             $token,
-            $dispatcher,
         );
     }
 
     public function it_should_send_back_an_error_if_the_queue_is_already_encrypted(
         ServerQueue $queue,
         TokenInterface $token,
-        RequestHandlerInterface $dispatcher
     ): void {
         $this->beConstructedWith(
             (new ServerOptions())
@@ -97,12 +94,13 @@ class ServerStartTlsHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $startTls,
             $token,
-            $dispatcher,
         );
     }
 
-    public function it_should_send_back_an_error_if_encryption_is_not_supported(ServerQueue $queue, TokenInterface $token, RequestHandlerInterface $dispatcher): void
-    {
+    public function it_should_send_back_an_error_if_encryption_is_not_supported(
+        ServerQueue $queue,
+        TokenInterface $token
+    ): void {
         $queue->isEncrypted()->willReturn(false);
 
         $queue->encrypt()->shouldNotBeCalled();
@@ -118,7 +116,6 @@ class ServerStartTlsHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $startTls,
             $token,
-            $dispatcher,
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandlerSpec.php
@@ -28,6 +28,11 @@ use PhpSpec\ObjectBehavior;
 
 class ServerStartTlsHandlerSpec extends ObjectBehavior
 {
+    public function let(): void
+    {
+        $this->beConstructedWith(new ServerOptions());
+    }
+
     public function it_is_initializable(): void
     {
         $this->shouldHaveType(ServerStartTlsHandler::class);
@@ -35,6 +40,11 @@ class ServerStartTlsHandlerSpec extends ObjectBehavior
 
     public function it_should_handle_a_start_tls_request(ServerQueue $queue, TokenInterface $token, RequestHandlerInterface $dispatcher): void
     {
+        $this->beConstructedWith(
+            (new ServerOptions())
+                ->setSslCert('foo')
+        );
+
         $queue->isEncrypted()->willReturn(false);
 
         $queue->encrypt()->shouldBeCalled()->willReturn($queue);
@@ -52,13 +62,16 @@ class ServerStartTlsHandlerSpec extends ObjectBehavior
             $token,
             $dispatcher,
             $queue,
-            (new ServerOptions())
-                ->setSslCert('foo')
         );
     }
 
     public function it_should_send_back_an_error_if_the_queue_is_already_encrypted(ServerQueue $queue, TokenInterface $token, RequestHandlerInterface $dispatcher): void
     {
+        $this->beConstructedWith(
+            (new ServerOptions())
+                ->setSslCert('foo')
+        );
+
         $queue->isEncrypted()->willReturn(true);
 
         $queue->encrypt()->shouldNotBeCalled();
@@ -76,8 +89,6 @@ class ServerStartTlsHandlerSpec extends ObjectBehavior
             $token,
             $dispatcher,
             $queue,
-            (new ServerOptions())
-                ->setSslCert('foo')
         );
     }
 
@@ -100,7 +111,6 @@ class ServerStartTlsHandlerSpec extends ObjectBehavior
             $token,
             $dispatcher,
             $queue,
-            new ServerOptions()
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandlerSpec.php
@@ -21,7 +21,6 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerStartTlsHandler;
-use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\ServerOptions;
 use PhpSpec\ObjectBehavior;

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandlerSpec.php
@@ -28,9 +28,12 @@ use PhpSpec\ObjectBehavior;
 
 class ServerStartTlsHandlerSpec extends ObjectBehavior
 {
-    public function let(): void
+    public function let(ServerQueue $queue): void
     {
-        $this->beConstructedWith(new ServerOptions());
+        $this->beConstructedWith(
+            new ServerOptions(),
+            $queue,
+        );
     }
 
     public function it_is_initializable(): void
@@ -38,11 +41,15 @@ class ServerStartTlsHandlerSpec extends ObjectBehavior
         $this->shouldHaveType(ServerStartTlsHandler::class);
     }
 
-    public function it_should_handle_a_start_tls_request(ServerQueue $queue, TokenInterface $token, RequestHandlerInterface $dispatcher): void
-    {
+    public function it_should_handle_a_start_tls_request(
+        ServerQueue $queue,
+        TokenInterface $token,
+        RequestHandlerInterface $dispatcher
+    ): void {
         $this->beConstructedWith(
             (new ServerOptions())
-                ->setSslCert('foo')
+                ->setSslCert('foo'),
+            $queue,
         );
 
         $queue->isEncrypted()->willReturn(false);
@@ -61,15 +68,18 @@ class ServerStartTlsHandlerSpec extends ObjectBehavior
             $startTls,
             $token,
             $dispatcher,
-            $queue,
         );
     }
 
-    public function it_should_send_back_an_error_if_the_queue_is_already_encrypted(ServerQueue $queue, TokenInterface $token, RequestHandlerInterface $dispatcher): void
-    {
+    public function it_should_send_back_an_error_if_the_queue_is_already_encrypted(
+        ServerQueue $queue,
+        TokenInterface $token,
+        RequestHandlerInterface $dispatcher
+    ): void {
         $this->beConstructedWith(
             (new ServerOptions())
-                ->setSslCert('foo')
+                ->setSslCert('foo'),
+            $queue,
         );
 
         $queue->isEncrypted()->willReturn(true);
@@ -88,7 +98,6 @@ class ServerStartTlsHandlerSpec extends ObjectBehavior
             $startTls,
             $token,
             $dispatcher,
-            $queue,
         );
     }
 
@@ -110,7 +119,6 @@ class ServerStartTlsHandlerSpec extends ObjectBehavior
             $startTls,
             $token,
             $dispatcher,
-            $queue,
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandlerSpec.php
@@ -17,7 +17,6 @@ use FreeDSx\Ldap\Operation\Request\UnbindRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerUnbindHandler;
-use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -37,12 +36,11 @@ class ServerUnbindHandlerSpec extends ObjectBehavior
     public function it_should_handle_an_unbind_request(
         ServerQueue $queue,
         TokenInterface $token,
-        RequestHandlerInterface $dispatcher
     ): void {
         $queue->close()->shouldBeCalled();
         $queue->sendMessage(Argument::any())->shouldNotBeCalled();
 
         $unbind = new LdapMessageRequest(1, new UnbindRequest());
-        $this->handleRequest($unbind, $token, $dispatcher);
+        $this->handleRequest($unbind, $token);
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandlerSpec.php
@@ -19,7 +19,6 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerUnbindHandler;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
-use FreeDSx\Ldap\ServerOptions;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -36,6 +35,6 @@ class ServerUnbindHandlerSpec extends ObjectBehavior
         $queue->sendMessage(Argument::any())->shouldNotBeCalled();
 
         $unbind = new LdapMessageRequest(1, new UnbindRequest());
-        $this->handleRequest($unbind, $token, $dispatcher, $queue, new ServerOptions());
+        $this->handleRequest($unbind, $token, $dispatcher, $queue);
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandlerSpec.php
@@ -24,17 +24,25 @@ use Prophecy\Argument;
 
 class ServerUnbindHandlerSpec extends ObjectBehavior
 {
+    public function let(ServerQueue $queue): void
+    {
+        $this->beConstructedWith($queue);
+    }
+
     public function it_is_initializable(): void
     {
         $this->shouldHaveType(ServerUnbindHandler::class);
     }
 
-    public function it_should_handle_an_unbind_request(ServerQueue $queue, TokenInterface $token, RequestHandlerInterface $dispatcher): void
-    {
+    public function it_should_handle_an_unbind_request(
+        ServerQueue $queue,
+        TokenInterface $token,
+        RequestHandlerInterface $dispatcher
+    ): void {
         $queue->close()->shouldBeCalled();
         $queue->sendMessage(Argument::any())->shouldNotBeCalled();
 
         $unbind = new LdapMessageRequest(1, new UnbindRequest());
-        $this->handleRequest($unbind, $token, $dispatcher, $queue);
+        $this->handleRequest($unbind, $token, $dispatcher);
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerSpec.php
@@ -20,7 +20,6 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerWhoAmIHandler;
-use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use PhpSpec\ObjectBehavior;

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerSpec.php
@@ -27,6 +27,10 @@ use PhpSpec\ObjectBehavior;
 
 class ServerWhoAmIHandlerSpec extends ObjectBehavior
 {
+    public function let(ServerQueue $queue): void
+    {
+        $this->beConstructedWith($queue);
+    }
     public function it_is_initializable(): void
     {
         $this->shouldHaveType(ServerWhoAmIHandler::class);
@@ -45,7 +49,6 @@ class ServerWhoAmIHandlerSpec extends ObjectBehavior
             $request,
             new BindToken('cn=foo,dc=foo,dc=bar', '12345'),
             $handler,
-            $queue,
         );
     }
 
@@ -62,7 +65,6 @@ class ServerWhoAmIHandlerSpec extends ObjectBehavior
             $request,
             new BindToken('foo@bar.local', '12345'),
             $handler,
-            $queue,
         );
     }
 
@@ -80,7 +82,6 @@ class ServerWhoAmIHandlerSpec extends ObjectBehavior
             $request,
             new AnonToken(),
             $handler,
-            $queue,
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerSpec.php
@@ -23,7 +23,6 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerWhoAmIHandler;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use FreeDSx\Ldap\Server\Token\BindToken;
-use FreeDSx\Ldap\ServerOptions;
 use PhpSpec\ObjectBehavior;
 
 class ServerWhoAmIHandlerSpec extends ObjectBehavior
@@ -47,7 +46,6 @@ class ServerWhoAmIHandlerSpec extends ObjectBehavior
             new BindToken('cn=foo,dc=foo,dc=bar', '12345'),
             $handler,
             $queue,
-            new ServerOptions()
         );
     }
 
@@ -65,7 +63,6 @@ class ServerWhoAmIHandlerSpec extends ObjectBehavior
             new BindToken('foo@bar.local', '12345'),
             $handler,
             $queue,
-            new ServerOptions()
         );
     }
 
@@ -84,7 +81,6 @@ class ServerWhoAmIHandlerSpec extends ObjectBehavior
             new AnonToken(),
             $handler,
             $queue,
-            new ServerOptions()
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerSpec.php
@@ -36,7 +36,7 @@ class ServerWhoAmIHandlerSpec extends ObjectBehavior
         $this->shouldHaveType(ServerWhoAmIHandler::class);
     }
 
-    public function it_should_handle_a_who_am_i_when_there_is_a_token_with_a_DN_name(ServerQueue $queue, RequestHandlerInterface $handler): void
+    public function it_should_handle_a_who_am_i_when_there_is_a_token_with_a_DN_name(ServerQueue $queue): void
     {
         $request = new LdapMessageRequest(2, new ExtendedRequest(ExtendedRequest::OID_WHOAMI));
 
@@ -48,11 +48,10 @@ class ServerWhoAmIHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $request,
             new BindToken('cn=foo,dc=foo,dc=bar', '12345'),
-            $handler,
         );
     }
 
-    public function it_should_handle_a_who_am_i_when_there_is_a_token_with_a_non_DN_name(ServerQueue $queue, RequestHandlerInterface $handler): void
+    public function it_should_handle_a_who_am_i_when_there_is_a_token_with_a_non_DN_name(ServerQueue $queue): void
     {
         $request = new LdapMessageRequest(2, new ExtendedRequest(ExtendedRequest::OID_WHOAMI));
 
@@ -64,11 +63,10 @@ class ServerWhoAmIHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $request,
             new BindToken('foo@bar.local', '12345'),
-            $handler,
         );
     }
 
-    public function it_should_handle_a_who_am_i_when_there_is_no_token_yet(ServerQueue $queue, RequestHandlerInterface $handler): void
+    public function it_should_handle_a_who_am_i_when_there_is_no_token_yet(ServerQueue $queue): void
     {
         $request = new LdapMessageRequest(2, new ExtendedRequest(ExtendedRequest::OID_WHOAMI));
 
@@ -81,7 +79,6 @@ class ServerWhoAmIHandlerSpec extends ObjectBehavior
         $this->handleRequest(
             $request,
             new AnonToken(),
-            $handler,
         );
     }
 }

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandlerSpec.php
@@ -109,7 +109,7 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
         $bindHandler->handleBind(Argument::any(), Argument::any(), Argument::any())->willReturn(
             new BindToken('foo', 'bar')
         );
-        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())
+        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any())
             ->shouldNotBeCalled();
 
         $queue->sendMessage(new LdapMessageResponse(
@@ -144,7 +144,7 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
             )
         ))->shouldBeCalled()->willReturn($queue);
 
-        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())
+        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any())
             ->shouldNotBeCalled();
 
         $this->handle();
@@ -204,7 +204,7 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
         $bindHandler->handleBind(Argument::any(), Argument::any(), Argument::any())
             ->shouldBeCalledOnce()
             ->willReturn(new BindToken('foo@bar', 'bar'));
-        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())
+        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any())
             ->shouldNotBeCalled();
 
         $this->handle();
@@ -225,7 +225,7 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
         $bindHandler->handleBind(Argument::any(), Argument::any(), Argument::any())
             ->willReturn(new BindToken('foo@bar', 'bar'));
 
-        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())
+        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any())
             ->shouldBeCalled()
             ->willThrow(new OperationException('Foo.', ResultCode::CONFIDENTIALITY_REQUIRED));
 

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandlerSpec.php
@@ -109,7 +109,7 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
         $bindHandler->handleBind(Argument::any(), Argument::any(), Argument::any())->willReturn(
             new BindToken('foo', 'bar')
         );
-        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())
+        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())
             ->shouldNotBeCalled();
 
         $queue->sendMessage(new LdapMessageResponse(
@@ -144,7 +144,7 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
             )
         ))->shouldBeCalled()->willReturn($queue);
 
-        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())
+        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())
             ->shouldNotBeCalled();
 
         $this->handle();
@@ -204,7 +204,7 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
         $bindHandler->handleBind(Argument::any(), Argument::any(), Argument::any())
             ->shouldBeCalledOnce()
             ->willReturn(new BindToken('foo@bar', 'bar'));
-        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())
+        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())
             ->shouldNotBeCalled();
 
         $this->handle();
@@ -225,7 +225,7 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
         $bindHandler->handleBind(Argument::any(), Argument::any(), Argument::any())
             ->willReturn(new BindToken('foo@bar', 'bar'));
 
-        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any(), Argument::any())
+        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any(), Argument::any())
             ->shouldBeCalled()
             ->willThrow(new OperationException('Foo.', ResultCode::CONFIDENTIALITY_REQUIRED));
 

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandlerSpec.php
@@ -109,7 +109,7 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
         $bindHandler->handleBind(Argument::any(), Argument::any(), Argument::any())->willReturn(
             new BindToken('foo', 'bar')
         );
-        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any())
+        $protocolHandler->handleRequest(Argument::any(), Argument::any())
             ->shouldNotBeCalled();
 
         $queue->sendMessage(new LdapMessageResponse(
@@ -144,7 +144,7 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
             )
         ))->shouldBeCalled()->willReturn($queue);
 
-        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any())
+        $protocolHandler->handleRequest(Argument::any(), Argument::any())
             ->shouldNotBeCalled();
 
         $this->handle();
@@ -204,7 +204,7 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
         $bindHandler->handleBind(Argument::any(), Argument::any(), Argument::any())
             ->shouldBeCalledOnce()
             ->willReturn(new BindToken('foo@bar', 'bar'));
-        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any())
+        $protocolHandler->handleRequest(Argument::any(), Argument::any())
             ->shouldNotBeCalled();
 
         $this->handle();
@@ -225,7 +225,7 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
         $bindHandler->handleBind(Argument::any(), Argument::any(), Argument::any())
             ->willReturn(new BindToken('foo@bar', 'bar'));
 
-        $protocolHandler->handleRequest(Argument::any(), Argument::any(), Argument::any())
+        $protocolHandler->handleRequest(Argument::any(), Argument::any())
             ->shouldBeCalled()
             ->willThrow(new OperationException('Foo.', ResultCode::CONFIDENTIALITY_REQUIRED));
 

--- a/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandlerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/Protocol/ServerProtocolHandlerSpec.php
@@ -32,6 +32,7 @@ use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
@@ -40,12 +41,14 @@ use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\Exception\ConnectionException;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
 
 class ServerProtocolHandlerSpec extends ObjectBehavior
 {
     public function let(
         ServerQueue $queue,
         ServerProtocolHandlerFactory $protocolHandlerFactory,
+        LoggerInterface $logger,
         HandlerFactoryInterface $handlerFactory,
         ServerBindHandlerFactory $bindHandlerFactory,
         RequestHandlerInterface $dispatcher,
@@ -63,9 +66,9 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
         $this->beConstructedWith(
             $queue,
             $handlerFactory,
-            new ServerOptions(),
+            $logger,
             $protocolHandlerFactory,
-            null,
+            new ServerAuthorization(new ServerOptions()),
             $bindHandlerFactory,
         );
     }
@@ -207,8 +210,11 @@ class ServerProtocolHandlerSpec extends ObjectBehavior
         $this->handle();
     }
 
-    public function it_should_handle_operation_errors_thrown_from_the_request_handlers(ServerQueue $queue, ServerProtocolHandler\BindHandlerInterface $bindHandler, ServerProtocolHandler\ServerProtocolHandlerInterface $protocolHandler): void
-    {
+    public function it_should_handle_operation_errors_thrown_from_the_request_handlers(
+        ServerQueue $queue,
+        ServerProtocolHandler\BindHandlerInterface $bindHandler,
+        ServerProtocolHandler\ServerProtocolHandlerInterface $protocolHandler,
+    ): void {
         $queue->isConnected()->willReturn(true, false);
         $queue->getMessage()->willReturn(
             new LdapMessageRequest(1, new SimpleBindRequest('foo@bar', 'bar')),

--- a/tests/spec/FreeDSx/Ldap/Server/ServerProtocolFactorySpec.php
+++ b/tests/spec/FreeDSx/Ldap/Server/ServerProtocolFactorySpec.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\FreeDSx\Ldap\Server;
+
+use FreeDSx\Ldap\Protocol\ServerAuthorization;
+use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+use FreeDSx\Ldap\Server\HandlerFactoryInterface;
+use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Socket\Socket;
+use PhpSpec\ObjectBehavior;
+
+class ServerProtocolFactorySpec extends ObjectBehavior
+{
+    public function let(
+        HandlerFactoryInterface $handlerFactory,
+        ServerAuthorization $serverAuthorization,
+    ): void {
+        $this->beConstructedWith(
+            $handlerFactory,
+            new ServerOptions(),
+            $serverAuthorization,
+        );
+    }
+
+    public function it_should_malke_a_ServerProtocolInstance(Socket $socket): void
+    {
+        $this->make($socket)
+            ->shouldBeAnInstanceOf(ServerProtocolHandler::class);
+    }
+}

--- a/tests/spec/FreeDSx/Ldap/Server/SocketServerFactorySpec.php
+++ b/tests/spec/FreeDSx/Ldap/Server/SocketServerFactorySpec.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\FreeDSx\Ldap\Server;
+
+use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Socket\SocketServer;
+use PhpSpec\Exception\Example\SkippingException;
+use PhpSpec\ObjectBehavior;
+use Psr\Log\LoggerInterface;
+
+class SocketServerFactorySpec extends ObjectBehavior
+{
+    private $tmpUnixSocketResource;
+
+    private string $tmpUnixSocketFilePath;
+
+    public function let(LoggerInterface $logger): void
+    {
+        $this->tmpUnixSocketResource = tmpfile();
+        $this->tmpUnixSocketFilePath = stream_get_meta_data($this->tmpUnixSocketResource)['uri'];
+
+        $this->beConstructedWith(
+            (new ServerOptions)
+                ->setPort(3390),
+            $logger,
+        );
+    }
+
+    public function letGo(): void
+    {
+        fclose($this->tmpUnixSocketResource);
+    }
+
+    public function it_should_make_and_bind_the_socket_server(): void
+    {
+        $this->makeAndBind()
+            ->shouldBeAnInstanceOf(SocketServer::class);
+    }
+
+    public function it_should_make_a_unix_based_socket_server(LoggerInterface $logger): void
+    {
+        if (str_starts_with(strtoupper(PHP_OS), 'WIN')) {
+            throw new SkippingException('Cannot construct unix based socket on Windows.');
+        }
+        $this->beConstructedWith(
+            (new ServerOptions)
+                ->setUnixSocket($this->tmpUnixSocketFilePath)
+                ->setTransport('unix'),
+            $logger,
+        );
+
+        $this->makeAndBind()
+            ->shouldBeAnInstanceOf(SocketServer::class);
+    }
+}


### PR DESCRIPTION
In some recent work for a 1.0 release, I implemented a container to start to sort out the dependency graph / interfaces. That was initially focused on the client. I'm now doing the same thing for the LdapServer. Some care needs to be take as some of the instantiated classes should be be reused from the container.

https://github.com/FreeDSx/LDAP/issues/50