### PR TITLE
Explicitly denote classes as Stringable

### DIFF
--- a/src/FreeDSx/Ldap/Control/Control.php
+++ b/src/FreeDSx/Ldap/Control/Control.php
@@ -33,7 +33,7 @@ use function count;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class Control implements ProtocolElementInterface
+class Control implements ProtocolElementInterface, Stringable
 {
     public const OID_DIR_SYNC = '1.2.840.113556.1.4.841';
 

--- a/src/FreeDSx/Ldap/Control/Control.php
+++ b/src/FreeDSx/Ldap/Control/Control.php
@@ -33,7 +33,7 @@ use function count;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class Control implements ProtocolElementInterface, Stringable
+class Control implements ProtocolElementInterface, \Stringable
 {
     public const OID_DIR_SYNC = '1.2.840.113556.1.4.841';
 

--- a/src/FreeDSx/Ldap/Entry/Attribute.php
+++ b/src/FreeDSx/Ldap/Entry/Attribute.php
@@ -31,7 +31,7 @@ use function strtolower;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class Attribute implements IteratorAggregate, Countable
+class Attribute implements IteratorAggregate, Countable, Stringable
 {
     use EscapeTrait;
 

--- a/src/FreeDSx/Ldap/Entry/Attribute.php
+++ b/src/FreeDSx/Ldap/Entry/Attribute.php
@@ -31,7 +31,7 @@ use function strtolower;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class Attribute implements IteratorAggregate, Countable, Stringable
+class Attribute implements IteratorAggregate, Countable, \Stringable
 {
     use EscapeTrait;
 

--- a/src/FreeDSx/Ldap/Entry/Dn.php
+++ b/src/FreeDSx/Ldap/Entry/Dn.php
@@ -28,7 +28,7 @@ use function preg_split;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class Dn implements IteratorAggregate, Countable
+class Dn implements IteratorAggregate, Countable, Stringable
 {
     /**
      * @var string

--- a/src/FreeDSx/Ldap/Entry/Dn.php
+++ b/src/FreeDSx/Ldap/Entry/Dn.php
@@ -28,7 +28,7 @@ use function preg_split;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class Dn implements IteratorAggregate, Countable, Stringable
+class Dn implements IteratorAggregate, Countable, \Stringable
 {
     /**
      * @var string

--- a/src/FreeDSx/Ldap/Entry/Entry.php
+++ b/src/FreeDSx/Ldap/Entry/Entry.php
@@ -23,7 +23,7 @@ use function is_array;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class Entry implements IteratorAggregate, Countable
+class Entry implements IteratorAggregate, Countable, Stringable
 {
     /**
      * @var Attribute[]

--- a/src/FreeDSx/Ldap/Entry/Entry.php
+++ b/src/FreeDSx/Ldap/Entry/Entry.php
@@ -23,7 +23,7 @@ use function is_array;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class Entry implements IteratorAggregate, Countable, Stringable
+class Entry implements IteratorAggregate, Countable, \Stringable
 {
     /**
      * @var Attribute[]

--- a/src/FreeDSx/Ldap/Entry/Option.php
+++ b/src/FreeDSx/Ldap/Entry/Option.php
@@ -21,7 +21,7 @@ use function substr;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class Option implements Stringable
+class Option implements \Stringable
 {
     protected const MATCH_RANGE = '/range=(\d+)-(.*)/';
 

--- a/src/FreeDSx/Ldap/Entry/Option.php
+++ b/src/FreeDSx/Ldap/Entry/Option.php
@@ -21,7 +21,7 @@ use function substr;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class Option
+class Option implements Stringable
 {
     protected const MATCH_RANGE = '/range=(\d+)-(.*)/';
 

--- a/src/FreeDSx/Ldap/Entry/Options.php
+++ b/src/FreeDSx/Ldap/Entry/Options.php
@@ -23,7 +23,7 @@ use function sort;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class Options implements Countable, IteratorAggregate
+class Options implements Countable, IteratorAggregate, Stringable
 {
     /**
      * @var Option[]

--- a/src/FreeDSx/Ldap/Entry/Options.php
+++ b/src/FreeDSx/Ldap/Entry/Options.php
@@ -23,7 +23,7 @@ use function sort;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class Options implements Countable, IteratorAggregate, Stringable
+class Options implements Countable, IteratorAggregate, \Stringable
 {
     /**
      * @var Option[]

--- a/src/FreeDSx/Ldap/Entry/Rdn.php
+++ b/src/FreeDSx/Ldap/Entry/Rdn.php
@@ -26,7 +26,7 @@ use function substr_replace;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class Rdn
+class Rdn implements Stringable
 {
     use EscapeTrait;
 

--- a/src/FreeDSx/Ldap/Entry/Rdn.php
+++ b/src/FreeDSx/Ldap/Entry/Rdn.php
@@ -26,7 +26,7 @@ use function substr_replace;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class Rdn implements Stringable
+class Rdn implements \Stringable
 {
     use EscapeTrait;
 

--- a/src/FreeDSx/Ldap/LdapUrl.php
+++ b/src/FreeDSx/Ldap/LdapUrl.php
@@ -35,7 +35,7 @@ use function strtolower;
  * @see https://tools.ietf.org/html/rfc4516
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class LdapUrl
+class LdapUrl implements Stringable
 {
     use LdapUrlTrait;
 

--- a/src/FreeDSx/Ldap/LdapUrl.php
+++ b/src/FreeDSx/Ldap/LdapUrl.php
@@ -35,7 +35,7 @@ use function strtolower;
  * @see https://tools.ietf.org/html/rfc4516
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class LdapUrl implements Stringable
+class LdapUrl implements \Stringable
 {
     use LdapUrlTrait;
 

--- a/src/FreeDSx/Ldap/LdapUrlExtension.php
+++ b/src/FreeDSx/Ldap/LdapUrlExtension.php
@@ -22,7 +22,7 @@ use function substr;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class LdapUrlExtension implements Stringable
+class LdapUrlExtension implements \Stringable
 {
     use LdapUrlTrait;
 

--- a/src/FreeDSx/Ldap/LdapUrlExtension.php
+++ b/src/FreeDSx/Ldap/LdapUrlExtension.php
@@ -22,7 +22,7 @@ use function substr;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class LdapUrlExtension
+class LdapUrlExtension implements Stringable
 {
     use LdapUrlTrait;
 

--- a/src/FreeDSx/Ldap/Search/Filter/AndFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/AndFilter.php
@@ -19,7 +19,7 @@ use IteratorAggregate;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class AndFilter implements FilterContainerInterface, IteratorAggregate, Countable, Stringable
+class AndFilter implements FilterContainerInterface, IteratorAggregate, Countable, \Stringable
 {
     use FilterContainerTrait;
 

--- a/src/FreeDSx/Ldap/Search/Filter/AndFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/AndFilter.php
@@ -19,7 +19,7 @@ use IteratorAggregate;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class AndFilter implements FilterContainerInterface, IteratorAggregate, Countable
+class AndFilter implements FilterContainerInterface, IteratorAggregate, Countable, Stringable
 {
     use FilterContainerTrait;
 

--- a/src/FreeDSx/Ldap/Search/Filter/ApproximateFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/ApproximateFilter.php
@@ -16,7 +16,7 @@ namespace FreeDSx\Ldap\Search\Filter;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class ApproximateFilter implements FilterInterface, Stringable
+class ApproximateFilter implements FilterInterface, \Stringable
 {
     use AttributeValueAssertionTrait;
 

--- a/src/FreeDSx/Ldap/Search/Filter/ApproximateFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/ApproximateFilter.php
@@ -16,7 +16,7 @@ namespace FreeDSx\Ldap\Search\Filter;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class ApproximateFilter implements FilterInterface
+class ApproximateFilter implements FilterInterface, Stringable
 {
     use AttributeValueAssertionTrait;
 

--- a/src/FreeDSx/Ldap/Search/Filter/EqualityFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/EqualityFilter.php
@@ -16,7 +16,7 @@ namespace FreeDSx\Ldap\Search\Filter;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class EqualityFilter implements FilterInterface
+class EqualityFilter implements FilterInterface, Stringable
 {
     use AttributeValueAssertionTrait;
 

--- a/src/FreeDSx/Ldap/Search/Filter/EqualityFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/EqualityFilter.php
@@ -16,7 +16,7 @@ namespace FreeDSx\Ldap\Search\Filter;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class EqualityFilter implements FilterInterface, Stringable
+class EqualityFilter implements FilterInterface, \Stringable
 {
     use AttributeValueAssertionTrait;
 

--- a/src/FreeDSx/Ldap/Search/Filter/GreaterThanOrEqualFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/GreaterThanOrEqualFilter.php
@@ -16,7 +16,7 @@ namespace FreeDSx\Ldap\Search\Filter;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class GreaterThanOrEqualFilter implements FilterInterface, Stringable
+class GreaterThanOrEqualFilter implements FilterInterface, \Stringable
 {
     use AttributeValueAssertionTrait;
 

--- a/src/FreeDSx/Ldap/Search/Filter/GreaterThanOrEqualFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/GreaterThanOrEqualFilter.php
@@ -16,7 +16,7 @@ namespace FreeDSx\Ldap\Search\Filter;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class GreaterThanOrEqualFilter implements FilterInterface
+class GreaterThanOrEqualFilter implements FilterInterface, Stringable
 {
     use AttributeValueAssertionTrait;
 

--- a/src/FreeDSx/Ldap/Search/Filter/LessThanOrEqualFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/LessThanOrEqualFilter.php
@@ -16,7 +16,7 @@ namespace FreeDSx\Ldap\Search\Filter;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class LessThanOrEqualFilter implements FilterInterface
+class LessThanOrEqualFilter implements FilterInterface, Stringable
 {
     use AttributeValueAssertionTrait;
 

--- a/src/FreeDSx/Ldap/Search/Filter/LessThanOrEqualFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/LessThanOrEqualFilter.php
@@ -16,7 +16,7 @@ namespace FreeDSx\Ldap\Search\Filter;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class LessThanOrEqualFilter implements FilterInterface, Stringable
+class LessThanOrEqualFilter implements FilterInterface, \Stringable
 {
     use AttributeValueAssertionTrait;
 

--- a/src/FreeDSx/Ldap/Search/Filter/MatchingRuleFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/MatchingRuleFilter.php
@@ -33,7 +33,7 @@ use FreeDSx\Ldap\Protocol\LdapEncoder;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class MatchingRuleFilter implements FilterInterface
+class MatchingRuleFilter implements FilterInterface, Stringable
 {
     protected const CHOICE_TAG = 9;
 

--- a/src/FreeDSx/Ldap/Search/Filter/MatchingRuleFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/MatchingRuleFilter.php
@@ -33,7 +33,7 @@ use FreeDSx\Ldap\Protocol\LdapEncoder;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class MatchingRuleFilter implements FilterInterface, Stringable
+class MatchingRuleFilter implements FilterInterface, \Stringable
 {
     protected const CHOICE_TAG = 9;
 

--- a/src/FreeDSx/Ldap/Search/Filter/NotFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/NotFilter.php
@@ -26,7 +26,7 @@ use FreeDSx\Ldap\Protocol\LdapEncoder;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class NotFilter implements FilterInterface
+class NotFilter implements FilterInterface, Stringable
 {
     protected const CHOICE_TAG = 2;
 

--- a/src/FreeDSx/Ldap/Search/Filter/NotFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/NotFilter.php
@@ -26,7 +26,7 @@ use FreeDSx\Ldap\Protocol\LdapEncoder;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class NotFilter implements FilterInterface, Stringable
+class NotFilter implements FilterInterface, \Stringable
 {
     protected const CHOICE_TAG = 2;
 

--- a/src/FreeDSx/Ldap/Search/Filter/OrFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/OrFilter.php
@@ -19,7 +19,7 @@ use IteratorAggregate;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class OrFilter implements FilterContainerInterface, IteratorAggregate, Countable, Stringable
+class OrFilter implements FilterContainerInterface, IteratorAggregate, Countable, \Stringable
 {
     use FilterContainerTrait;
 

--- a/src/FreeDSx/Ldap/Search/Filter/OrFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/OrFilter.php
@@ -19,7 +19,7 @@ use IteratorAggregate;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class OrFilter implements FilterContainerInterface, IteratorAggregate, Countable
+class OrFilter implements FilterContainerInterface, IteratorAggregate, Countable, Stringable
 {
     use FilterContainerTrait;
 

--- a/src/FreeDSx/Ldap/Search/Filter/PresentFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/PresentFilter.php
@@ -24,7 +24,7 @@ use FreeDSx\Ldap\Protocol\LdapEncoder;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class PresentFilter implements FilterInterface
+class PresentFilter implements FilterInterface, Stringable
 {
     use FilterAttributeTrait;
 

--- a/src/FreeDSx/Ldap/Search/Filter/PresentFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/PresentFilter.php
@@ -24,7 +24,7 @@ use FreeDSx\Ldap\Protocol\LdapEncoder;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class PresentFilter implements FilterInterface, Stringable
+class PresentFilter implements FilterInterface, \Stringable
 {
     use FilterAttributeTrait;
 

--- a/src/FreeDSx/Ldap/Search/Filter/SubstringFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/SubstringFilter.php
@@ -35,7 +35,7 @@ use FreeDSx\Ldap\Protocol\LdapEncoder;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class SubstringFilter implements FilterInterface, Stringable
+class SubstringFilter implements FilterInterface, \Stringable
 {
     use FilterAttributeTrait;
 

--- a/src/FreeDSx/Ldap/Search/Filter/SubstringFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/SubstringFilter.php
@@ -35,7 +35,7 @@ use FreeDSx\Ldap\Protocol\LdapEncoder;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class SubstringFilter implements FilterInterface
+class SubstringFilter implements FilterInterface, Stringable
 {
     use FilterAttributeTrait;
 


### PR DESCRIPTION
Explicitly denote classes that implement __toString as Stringable (as [suggested by the official PHP docs](https://www.php.net/manual/en/class.stringable.php)), which helps IDEs to check type safety.