### PR TITLE
[1.0.0] Increase static analysis level in tests.

### DIFF
--- a/phpstan.tests.neon
+++ b/phpstan.tests.neon
@@ -1,4 +1,5 @@
 parameters:
-    level: 3
+    treatPhpDocTypesAsCertain: false
+    level: 10
     paths:
         - %currentWorkingDirectory%/tests

--- a/src/FreeDSx/Ldap/Entry/Entries.php
+++ b/src/FreeDSx/Ldap/Entry/Entries.php
@@ -31,27 +31,19 @@ use function reset;
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  *
  * @implements IteratorAggregate<Entry>
- * @template T of Entry
  */
 class Entries implements Countable, IteratorAggregate
 {
     /**
-     * @var array<T>
+     * @var array<Entry>
      */
     private array $entries;
 
-    /**
-     * @param T ...$entries
-     */
     public function __construct(Entry ...$entries)
     {
         $this->entries = $entries;
     }
 
-    /**
-     * @param T ...$entries
-     * @return $this
-     */
     public function add(Entry ...$entries): self
     {
         $this->entries = array_merge($this->entries, $entries);
@@ -59,10 +51,6 @@ class Entries implements Countable, IteratorAggregate
         return $this;
     }
 
-    /**
-     * @param T ...$entries
-     * @return $this
-     */
     public function remove(Entry ...$entries): self
     {
         foreach ($entries as $entry) {

--- a/src/FreeDSx/Ldap/Entry/Entry.php
+++ b/src/FreeDSx/Ldap/Entry/Entry.php
@@ -299,7 +299,7 @@ class Entry implements IteratorAggregate, Countable, Stringable
     /**
      * Construct an entry from an associative array.
      *
-     * @param array<string, string|array<string|Stringable>> $attributes
+     * @param array<string, scalar|array<scalar|Stringable>> $attributes
      */
     public static function fromArray(
         Dn|Stringable|string $dn,

--- a/tests/bin/ldapserver.php
+++ b/tests/bin/ldapserver.php
@@ -83,7 +83,10 @@ class LdapServerPagingHandler implements PagingHandlerInterface
 
 class LdapServerRequestHandler extends GenericRequestHandler
 {
-    private $users = [
+    /**
+     * @var array<string, string>
+     */
+    private array $users = [
         'cn=user,dc=foo,dc=bar' => '12345',
     ];
 

--- a/tests/integration/LdapClientTest.php
+++ b/tests/integration/LdapClientTest.php
@@ -51,8 +51,8 @@ class LdapClientTest extends LdapTestCase
     public function testUsernamePasswordBind(): void
     {
         $response = $this->client->bind(
-            $_ENV['LDAP_USERNAME'],
-            $_ENV['LDAP_PASSWORD']
+            (string) getenv('LDAP_USERNAME'),
+            (string) getenv('LDAP_PASSWORD'),
         )->getResponse();
 
         $this->assertInstanceOf(
@@ -309,10 +309,6 @@ class LdapClientTest extends LdapTestCase
             ModifyDnResponse::class,
             $result->getResponse()
         );
-        $this->assertInstanceOf(
-            Entry::class,
-            $entry
-        );
         $this->assertSame(
             ['Arleen Sevigny-Foo'],
             $entry->get('cn')?->getValues()
@@ -420,10 +416,6 @@ class LdapClientTest extends LdapTestCase
             Filters::raw('(&(objectClass=inetOrgPerson)(cn=A*))')
         ));
 
-        $this->assertInstanceOf(
-            Entries::class,
-            $entries
-        );
         $this->assertCount(
             843,
             $entries,
@@ -561,12 +553,15 @@ class LdapClientTest extends LdapTestCase
         $this->assertTrue($this->client->isConnected());
     }
 
+    /**
+     * @return array<string, string>
+     */
     protected function getSaslOptions(): array
     {
         if ($this->isActiveDirectory()) {
             return [
                 'username' => 'admin',
-                'password' => $_ENV['LDAP_PASSWORD'],
+                'password' => (string) getenv('LDAP_PASSWORD'),
                 'host' => 'ADDC3.example.com'
             ];
         } else {

--- a/tests/integration/LdapProxyTest.php
+++ b/tests/integration/LdapProxyTest.php
@@ -76,8 +76,8 @@ class LdapProxyTest extends ServerTestCase
     protected function authenticate(): void
     {
         $this->ldapClient()->bind(
-            $_ENV['LDAP_USERNAME'],
-            $_ENV['LDAP_PASSWORD']
+            (string) getenv('LDAP_USERNAME'),
+            (string) getenv('LDAP_PASSWORD'),
         );
     }
 }

--- a/tests/integration/LdapServerTest.php
+++ b/tests/integration/LdapServerTest.php
@@ -33,13 +33,12 @@ class LdapServerTest extends ServerTestCase
 
     public function testItCanBind(): void
     {
-        $response = $this->ldapClient()->bind(
+        $this->ldapClient()->bind(
             'cn=user,dc=foo,dc=bar',
             '12345'
         );
         $output = $this->waitForServerOutput('---bind---');
 
-        $this->assertNotNull($response);
         $this->assertStringContainsString(
             'username => cn=user,dc=foo,dc=bar',
             $output
@@ -69,7 +68,7 @@ class LdapServerTest extends ServerTestCase
     public function testItPerformsAnAdd(): void
     {
         $this->authenticate();
-        $response = $this->ldapClient()->create(Entry::fromArray(
+        $this->ldapClient()->create(Entry::fromArray(
             'cn=meh,dc=foo,dc=bar',
             [
                 'foo' => 'bar',
@@ -77,7 +76,6 @@ class LdapServerTest extends ServerTestCase
         ));
         $output = $this->waitForServerOutput('---add---');
 
-        $this->assertNotNull($response);
         $this->assertStringContainsString(
             'dn => cn=meh,dc=foo,dc=bar',
             $output
@@ -91,10 +89,9 @@ class LdapServerTest extends ServerTestCase
     public function testItPerformsDelete(): void
     {
         $this->authenticate();
-        $response = $this->ldapClient()->delete('cn=meh,dc=foo,dc=bar');
+        $this->ldapClient()->delete('cn=meh,dc=foo,dc=bar');
         $output = $this->waitForServerOutput('---delete---');
 
-        $this->assertNotNull($response);
         $this->assertStringContainsString(
             'dn => cn=meh,dc=foo,dc=bar',
             $output
@@ -119,10 +116,9 @@ class LdapServerTest extends ServerTestCase
         $entry->set('surname', 'LastName');
         $entry->reset('phone');
 
-        $response = $this->ldapClient()->update($entry);
+        $this->ldapClient()->update($entry);
         $output = $this->waitForServerOutput('---modify---');
 
-        $this->assertNotNull($response);
         $this->assertStringContainsString(
             'dn => cn=meh,dc=foo,dc=bar',
             $output
@@ -155,14 +151,13 @@ class LdapServerTest extends ServerTestCase
     {
         $this->authenticate();
 
-        $response = $this->ldapClient()->compare(
+        $this->ldapClient()->compare(
             'cn=meh,dc=foo,dc=bar',
             'foo',
             'bar'
         );
         $output = $this->waitForServerOutput('---compare---');
 
-        $this->assertNotNull($response);
         $this->assertStringContainsString(
             'dn => cn=meh,dc=foo,dc=bar',
             $output
@@ -181,13 +176,12 @@ class LdapServerTest extends ServerTestCase
     {
         $this->authenticate();
 
-        $response = $this->ldapClient()->move(
+        $this->ldapClient()->move(
             'cn=meh,dc=foo,dc=bar',
             'cn=bleh,dc=foo,dc=bar'
         );
         $output = $this->waitForServerOutput('---modify-dn---');
 
-        $this->assertNotNull($response);
         $this->assertStringContainsString(
             'dn => cn=meh,dc=foo,dc=bar',
             $output

--- a/tests/integration/LdapTestCase.php
+++ b/tests/integration/LdapTestCase.php
@@ -25,14 +25,14 @@ class LdapTestCase extends TestCase
     protected function makeOptions(): ClientOptions
     {
         return (new ClientOptions())
-            ->setBaseDn((string) $_ENV['LDAP_BASE_DN'])
-            ->setServers([(string) $_ENV['LDAP_SERVER']])
+            ->setBaseDn((string) getenv('LDAP_BASE_DN'))
+            ->setServers([(string) getenv('LDAP_SERVER')])
             ->setSslCaCert(
                 $_ENV['LDAP_CA_CERT'] === ''
                     ? __DIR__ . '/../resources/cert/ca.crt'
-                    : (string) $_ENV['LDAP_CA_CERT']
+                    : (string) getenv('LDAP_CA_CERT')
             )
-            ->setBaseDn((string) $_ENV['LDAP_BASE_DN']);
+            ->setBaseDn((string) getenv('LDAP_BASE_DN'));
     }
 
     protected function getClient(?ClientOptions $options = null): LdapClient
@@ -43,8 +43,8 @@ class LdapTestCase extends TestCase
     protected function bindClient(LdapClient $client): void
     {
         $client->bind(
-            $_ENV['LDAP_USERNAME'],
-            $_ENV['LDAP_PASSWORD'],
+            (string) getenv('LDAP_USERNAME'),
+            (string) getenv('LDAP_PASSWORD'),
         );
     }
 

--- a/tests/integration/Search/RangeRetrievalTest.php
+++ b/tests/integration/Search/RangeRetrievalTest.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Search\RangeRetrieval;
 use Tests\Integration\FreeDSx\Ldap\LdapTestCase;
+use Throwable;
 
 class RangeRetrievalTest extends LdapTestCase
 {
@@ -39,7 +40,7 @@ class RangeRetrievalTest extends LdapTestCase
     {
         try {
             $this->client->unbind();
-        } catch (\Exception|\Throwable $e) {
+        } catch (Throwable) {
         }
     }
     

--- a/tests/resources/activedirectory/generate-ldif.php
+++ b/tests/resources/activedirectory/generate-ldif.php
@@ -2,7 +2,7 @@
 
 # A simple script to modify the OpenLDAP LDIF data to work with AD so we are working with the same data set.
 
-$data = file_get_contents(__DIR__ . '/../openldap/ldif/data.ldif');
+$data = (string) file_get_contents(__DIR__ . '/../openldap/ldif/data.ldif');
 $ldif = explode("\n", $data);
 foreach ($ldif as $i => $line) {
     if (preg_match('/^userPassword/', $line)) {
@@ -11,7 +11,7 @@ foreach ($ldif as $i => $line) {
 }
 file_put_contents(__DIR__ . '/ldif/data.ldif', implode("\n", $ldif));
 
-$data = file_get_contents(__DIR__ . '/../openldap/ldif/data-group.ldif');
+$data = (string) file_get_contents(__DIR__ . '/../openldap/ldif/data-group.ldif');
 $ldif = explode("\n", $data);
 foreach ($ldif as $i => $line) {
     if (preg_match('/^objectClass/', $line)) {

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -47,6 +47,9 @@ class ContainerTest extends TestCase
         ]);
     }
 
+    /**
+     * @return array<array{class-string}>
+     */
     public static function buildableDependenciesDataProvider(): array
     {
         return [

--- a/tests/unit/Entry/EntryTest.php
+++ b/tests/unit/Entry/EntryTest.php
@@ -217,7 +217,7 @@ class EntryTest extends TestCase
         self::assertNull($this->subject->get('cn', true));
     }
 
-    public function if_should_check_if_it_has_an_attribute_using_a_string()
+    public function if_should_check_if_it_has_an_attribute_using_a_string(): void
     {
         self::assertTrue($this->subject->has('Cn'));
         self::assertFalse($this->subject->has('bleh'));

--- a/tests/unit/LdapClientTest.php
+++ b/tests/unit/LdapClientTest.php
@@ -155,46 +155,42 @@ class LdapClientTest extends TestCase
 
     public function test_it_should_construct_a_pager_helper(): void
     {
-        self::assertInstanceOf(
-            Paging::class,
-            $this->subject->paging(Operations::search(
-                Filters::equal(
-                    'foo',
-                    'bar'
-                ))
-            ),
+        self::expectNotToPerformAssertions();
+
+        $this->subject->paging(Operations::search(
+            Filters::equal(
+                'foo',
+                'bar'
+            ))
         );
     }
 
     public function test_it_should_construct_a_vlv_helper(): void
     {
-        self::assertInstanceOf(
-            Vlv::class,
-            $this->subject->vlv(
-                Operations::search(Filters::equal(
-                    'foo',
-                    'bar'
-                )),
-                'cn',
-                100
-            ),
+        self::expectNotToPerformAssertions();
+
+        $this->subject->vlv(
+            Operations::search(Filters::equal(
+                'foo',
+                'bar'
+            )),
+            'cn',
+            100
         );
     }
 
     public function test_it_should_construct_a_dirsync_helper(): void
     {
-        self::assertInstanceOf(
-            DirSync::class,
-            $this->subject->dirSync()
-        );
+        self::expectNotToPerformAssertions();
+
+        $this->subject->dirSync();
     }
 
     public function test_it_should_construct_a_range_retrieval_helper(): void
     {
-        self::assertInstanceOf(
-            RangeRetrieval::class,
-            $this->subject->range(),
-        );
+        self::expectNotToPerformAssertions();
+
+        $this->subject->range();
     }
     
     public function test_it_should_start_tls(): void

--- a/tests/unit/Operation/Request/AbandonRequestTest.php
+++ b/tests/unit/Operation/Request/AbandonRequestTest.php
@@ -28,11 +28,6 @@ final class AbandonRequestTest extends TestCase
         $this->subject = new AbandonRequest(1);
     }
 
-    public function testItIsInitializable(): void
-    {
-        $this->assertInstanceOf(AbandonRequest::class, $this->subject);
-    }
-
     public function testItShouldGetTheMessageId(): void
     {
         $this->assertEquals(1, $this->subject->getMessageId());

--- a/tests/unit/Operation/Request/SearchRequestTest.php
+++ b/tests/unit/Operation/Request/SearchRequestTest.php
@@ -214,6 +214,7 @@ final class SearchRequestTest extends TestCase
     {
         $this->expectException(UnexpectedValueException::class);
 
+        /** @phpstan-ignore-next-line */
         $this->subject->useCancelStrategy('foo');
     }
 

--- a/tests/unit/Operation/Request/SimpleBindRequestTest.php
+++ b/tests/unit/Operation/Request/SimpleBindRequestTest.php
@@ -15,6 +15,7 @@ namespace Tests\Unit\FreeDSx\Ldap\Operation\Request;
 
 use FreeDSx\Asn1\Asn1;
 use FreeDSx\Asn1\Type\AbstractType;
+use FreeDSx\Asn1\Type\SequenceType;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
@@ -67,7 +68,7 @@ final class SimpleBindRequestTest extends TestCase
             ->setPassword('bar');
 
         self::assertInstanceOf(
-            AbstractType::class,
+            SequenceType::class,
             $this->subject->toAsn1()
         );
     }
@@ -94,14 +95,7 @@ final class SimpleBindRequestTest extends TestCase
         $this->subject->setPassword('0');
 
         self::assertInstanceOf(
-            AbstractType::class,
-            $this->subject->toAsn1()
-        );
-
-        $this->subject->setUsername('0');
-
-        self::assertInstanceOf(
-            AbstractType::class,
+            SequenceType::class,
             $this->subject->toAsn1()
         );
     }

--- a/tests/unit/Operation/Response/AddResponseTest.php
+++ b/tests/unit/Operation/Response/AddResponseTest.php
@@ -29,7 +29,7 @@ final class AddResponseTest extends TestCase
         );
     }
 
-    public function test_it_has_the_expected_tag_number()
+    public function test_it_has_the_expected_tag_number(): void
     {
         self::assertSame(
             9,

--- a/tests/unit/Protocol/ClientProtocolHandler/ClientSaslBindHandlerTest.php
+++ b/tests/unit/Protocol/ClientProtocolHandler/ClientSaslBindHandlerTest.php
@@ -249,6 +249,8 @@ final class ClientSaslBindHandlerTest extends TestCase
             ->method('challenge')
             ->will(self::onConsecutiveCalls(
                 (new SaslContext())->setResponse('foo'),
+                // The return types for SaslContext need to be updated.
+                // @phpstan-ignore-next-line
                 (new SaslContext())->setResponse('foo')
                     ->setHasSecurityLayer(true)
                     ->setIsAuthenticated(true)

--- a/tests/unit/Protocol/Queue/ClientQueueTest.php
+++ b/tests/unit/Protocol/Queue/ClientQueueTest.php
@@ -104,10 +104,7 @@ final class ClientQueueTest extends TestCase
                 )
             );
 
-        self::assertInstanceOf(
-            LdapMessageResponse::class,
-            $this->subject->getMessage(),
-        );
+        $this->subject->getMessage();
     }
 
     public function test_it_should_throw_an_unsolicited_notification_exception_when_one_is_received(): void
@@ -201,9 +198,6 @@ final class ClientQueueTest extends TestCase
 
         $this->subject->setMessageWrapper($mockWrapper);
 
-        self::assertInstanceOf(
-            LdapMessageResponse::class,
-            $this->subject->getMessage(),
-        );
+        $this->subject->getMessage();
     }
 }

--- a/tests/unit/Protocol/Queue/ServerQueueTest.php
+++ b/tests/unit/Protocol/Queue/ServerQueueTest.php
@@ -76,6 +76,7 @@ final class ServerQueueTest extends TestCase
     public function test_it_should_get_a_request_message(): void
     {
         $this->mockEncoder
+            ->expects($this->once())
             ->method('decode')
             ->willReturn(
                 Asn1::sequence(
@@ -85,10 +86,7 @@ final class ServerQueueTest extends TestCase
                 ),
             );
 
-        self::assertInstanceOf(
-            LdapMessageRequest::class,
-            $this->subject->getMessage(),
-        );
+        $this->subject->getMessage();
     }
 
     public function test_it_should_send_multiple_messages_with_write_and_respect_the_buffer_size(): void
@@ -139,19 +137,18 @@ final class ServerQueueTest extends TestCase
         );
 
         $this->mockEncoder
+            ->expects($this->once())
             ->method('decode')
             ->willReturn($asn1);
 
         $mockWrapper = $this->createMock(MessageWrapperInterface::class);
         $mockWrapper
+            ->expects($this->once())
             ->method('unwrap')
             ->willReturn(new Buffer('bar', 3));
 
         $this->subject->setMessageWrapper($mockWrapper);
 
-        self::assertInstanceOf(
-            LdapMessageRequest::class,
-            $this->subject->getMessage(),
-        );
+        $this->subject->getMessage();
     }
 }

--- a/tests/unit/Protocol/ServerAuthorizationTest.php
+++ b/tests/unit/Protocol/ServerAuthorizationTest.php
@@ -148,6 +148,9 @@ final class ServerAuthorizationTest extends TestCase
         self::assertFalse($this->subject->isAuthenticationRequest($request));
     }
 
+    /**
+     * @return array<array{RequestInterface}>
+     */
     public static function authExpectedRequestsDataProvider(): array
     {
         return [

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerRootDseHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerRootDseHandlerTest.php
@@ -116,7 +116,7 @@ final class ServerRootDseHandlerTest extends TestCase
                     $entry = $search->getEntry();
 
                     return $entry->get('supportedControl')
-                        ->has(Control::OID_PAGING);
+                        ?->has(Control::OID_PAGING) ?? false;
                 }),
                 new LdapMessageResponse(1, new SearchResultDone(0)),
             );
@@ -226,10 +226,10 @@ final class ServerRootDseHandlerTest extends TestCase
                 ->setAttributes('namingcontexts')
         );
 
-        # The reset below is needed, unfortunately, to properly spec due to how the objects change...
+        # The reset below is needed, unfortunately, to properly test due to how the objects change...
         $entry = Entry::create('', ['namingContexts' => 'dc=Foo,dc=Bar', ]);
         $entry->changes()->reset();
-        $entry->get('namingContexts')->equals(new Attribute('foo'));
+        $entry->get('namingContexts')?->equals(new Attribute('foo'));
 
         $this->mockQueue
             ->expects($this->once())

--- a/tests/unit/Search/DirSyncTest.php
+++ b/tests/unit/Search/DirSyncTest.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Search\DirSync;
 use FreeDSx\Ldap\Search\Filters;
+use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
 use PHPUnit\Framework\TestCase;
@@ -265,18 +266,18 @@ final class DirSyncTest extends TestCase
     }
 
     /**
-     * @param mixed ...$arguments
+     * @param Constraint ...$arguments
      */
     private function addSendExpectation(...$arguments): void {
         $this->client
             ->expects($this->once())
             ->method('send')
-            ->with(...$arguments)
+            ->with(...array_values($arguments))
             ->willReturn($this->initialResponse);
     }
 
     /**
-     * @param mixed ...$arguments
+     * @param Constraint ...$arguments
      */
     private function addSendAndOrderExpectation(
         InvocationOrder $order,
@@ -285,7 +286,7 @@ final class DirSyncTest extends TestCase
         $this->client
             ->expects($order)
             ->method('send')
-            ->with(...$arguments)
+            ->with(...array_values($arguments))
             ->willReturn($this->initialResponse);
     }
 }

--- a/tests/unit/Search/RangeRetrievalTest.php
+++ b/tests/unit/Search/RangeRetrievalTest.php
@@ -116,8 +116,9 @@ final class RangeRetrievalTest extends TestCase
             ->with(
                 'dc=foo',
                 $this->callback(function ($attr) {
-                    return $attr[0]->getOptions()->first()->getLowRange() == '1501'
-                        && $attr[0]->getOptions()->first()->getHighRange() == '*';
+                    /** @var Attribute[] $attr */
+                    return $attr[0]->getOptions()->first()?->getLowRange() == '1501'
+                        && $attr[0]->getOptions()->first()?->getHighRange() == '*';
                 })
             )
             ->willReturn($entry);
@@ -142,7 +143,8 @@ final class RangeRetrievalTest extends TestCase
             ->with(
                 'dc=foo',
                 $this->callback(function ($attr) {
-                    return $attr[0]->getOptions()->first()->getLowRange() === '1501'
+                    /** @var Attribute[] $attr */
+                    return $attr[0]->getOptions()->first()?->getLowRange() === '1501'
                         && $attr[0]->getOptions()->first()->getHighRange() === '1600';
                 })
             )

--- a/tests/unit/Server/RequestHistoryTest.php
+++ b/tests/unit/Server/RequestHistoryTest.php
@@ -55,9 +55,8 @@ final class RequestHistoryTest extends TestCase
     public function test_it_should_get_the_paging_requests(): void
     {
 
-        self::assertInstanceOf(
-            PagingRequests::class,
-            $this->subject->pagingRequest()
+        self::assertFalse(
+            $this->subject->pagingRequest()->has('foo')
         );
     }
 }

--- a/tests/unit/Server/ServerProtocolFactoryTest.php
+++ b/tests/unit/Server/ServerProtocolFactoryTest.php
@@ -52,9 +52,6 @@ final class ServerProtocolFactoryTest extends TestCase
             ->method('makeRequestHandler')
             ->willReturn(new GenericRequestHandler());
 
-        self::assertInstanceOf(
-            ServerProtocolHandler::class,
-            $this->subject->make($mockSocket)
-        );
+        $this->subject->make($mockSocket);
     }
 }

--- a/tests/unit/Server/SocketServerFactoryTest.php
+++ b/tests/unit/Server/SocketServerFactoryTest.php
@@ -37,7 +37,7 @@ final class SocketServerFactoryTest extends TestCase
     protected function setUp(): void
     {
         $this->tmpUnixSocketResource = $this->makeTempFile();;
-        $this->tmpUnixSocketFilePath = stream_get_meta_data($this->tmpUnixSocketResource)['uri'];
+        $this->tmpUnixSocketFilePath = stream_get_meta_data($this->tmpUnixSocketResource)['uri'] ?? throw new RuntimeException('Unable to get temp file path for unix socket.');
         $this->mockLogger = $this->createMock(LoggerInterface::class);
 
         $this->subject = new SocketServerFactory(
@@ -54,10 +54,9 @@ final class SocketServerFactoryTest extends TestCase
 
     public function test_it_should_make_and_bind_the_socket_server(): void
     {
-        self::assertInstanceOf(
-            SocketServer::class,
-            $this->subject->makeAndBind(),
-        );
+        self::expectNotToPerformAssertions();
+
+        $this->subject->makeAndBind();
     }
 
     public function test_it_should_make_a_unix_based_socket_server(): void
@@ -65,6 +64,7 @@ final class SocketServerFactoryTest extends TestCase
         if (str_starts_with(strtoupper(PHP_OS), 'WIN')) {
             $this->markTestSkipped('Cannot construct unix based socket on Windows.');
         }
+        self::expectNotToPerformAssertions();
 
         $this->subject = new SocketServerFactory(
             (new ServerOptions())
@@ -73,10 +73,7 @@ final class SocketServerFactoryTest extends TestCase
             $this->mockLogger,
         );
 
-        self::assertInstanceOf(
-            SocketServer::class,
-            $this->subject->makeAndBind(),
-        );
+        $this->subject->makeAndBind();
     }
 
     /**


### PR DESCRIPTION
The current static analysis level in the tests is quite low. This is due to it having been on PHPSpec previously. Now that it is off PHPSpec, I can bump the static analysis level and fix up any issues. The will help reduce any potential errors in new unit / integration tests.