### PR TITLE
V1 sync fixes

### DIFF
--- a/docs/Client/SyncRepl.md
+++ b/docs/Client/SyncRepl.md
@@ -15,6 +15,7 @@ helper class in this library for performing a SyncRepl request more easily.
     * [The IdSet Handler](#the-idset-handler)
     * [The Referral Handler](#the-referral-handler)
     * [The Cookie Handler](#the-cookie-handler)
+* [The Session Object](#the-session-object)
 * [Cancelling a Sync](#cancelling-a-sync)
 * [SyncRepl Class Methods](#syncrepl-class-methods)
     * [useFilter](#usefilter)
@@ -88,10 +89,15 @@ $ldap
 
 ## The Listen Method
 
-The listen method iterates waits for sync changes in a never-ending search operation. 
+The listen method waits for sync changes in a never-ending search operation.
+
+The handler closure receives a `SyncEntryResult` as its first argument and a `Session` as its optional second argument.
+The `Session` object provides context about the current state of the sync, such as whether the initial refresh phase has
+completed. See [The Session Object](#the-session-object) for more details.
 
 ```php
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Session;
 
 // Saving the cookie to a file.
 // With the cookie handler, you determine where to save it.
@@ -107,20 +113,27 @@ $ldap
     // The cookie may change at many points during a sync. This handler should react to the new cookie to save it off
     // somewhere to be used in the future.
     ->useCookieHandler(fn (string $cookie) => file_put_contents($cookieFile, $cookie))
-    ->listen(function(SyncEntryResult $result) {
+    ->listen(function(SyncEntryResult $result, Session $session) {
+        // Entries received before isRefreshComplete() are initial content from the refresh phase.
+        // Entries received after isRefreshComplete() are change notifications from the persist phase.
+        if (!$session->isRefreshComplete()) {
+            // Refresh phase: initial content delivery
+            // Do what you wish with the initial data...
+            return;
+        }
+
         $entry = $result->getEntry();
         $uuid = $result->getEntryUuid();
-        
+
+        // Persist phase: change notifications.
         // "Add" here means either it changed **or** was added.
         if ($result->isAdd()) {
-       
+
         // This should represent an entry being modified...but in OpenLDAP, I have not seen this used?
         } elseif ($result->isModify()) {
         // The entry was removed. Note that the entry attributes will be empty in this case.
         // Use the UUID from the result to remove it on the sync side.
         } elseif ($result->isDelete()) {
-        // The entry is present and has not changed.
-        } elseif ($result->isPresent()) {
         }
     });
 ```
@@ -133,10 +146,10 @@ could choose to ignore referrals. However, you should take action on both Entry 
 ## The Entry Handler
 
 The Entry handler should always be defined. It is passed to either the `poll()` or `listen()` method directly, or can optionally
-be passed to the `useEntryHandler()` method. This handler must be a closure that receives a `SyncEntryResult` as the first argument.
-The `SyncEntryResult` represents a single sync entry change.
+be passed to the `useEntryHandler()` method. This handler must be a closure that receives a `SyncEntryResult` as the first
+argument and optionally a `Session` as the second argument. The `SyncEntryResult` represents a single sync entry change.
 
-For more details, see [useEntryHandler](#useentryhandler).
+For more details, see [useEntryHandler](#useentryhandler) and [The Session Object](#the-session-object).
 
 ## The IdSet Handler
 
@@ -163,6 +176,51 @@ the changed cookie somewhere and reload it before starting the sync again.
 
 For more details, see [useCookieHandler](#usecookiehandler) and [useCookie](#usecookie).
 
+
+# The Session Object
+
+The `Session` object is passed as the second argument to the entry handler closure and provides context about the current
+state of the sync operation.
+
+## isRefreshComplete
+
+In `listen()` mode the sync operates in two phases:
+
+1. **Refresh phase** — The server delivers its initial content. Entries here represent the current state of the directory,
+   not necessarily changes.
+2. **Persist phase** — After the refresh completes, the server sends change notifications indefinitely as entries are
+   added, modified, or deleted.
+
+The `isRefreshComplete()` method returns `false` during the refresh phase and `true` once the server has signaled that
+the refresh is done and the persist phase has begun. This is the reliable way to distinguish between the two phases:
+
+```php
+use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Session;
+
+$ldap
+    ->syncRepl()
+    ->listen(function(SyncEntryResult $result, Session $session) {
+        if (!$session->isRefreshComplete()) {
+            // Still in the refresh phase — skip or handle initial content.
+            return;
+        }
+
+        // Persist phase — this is a real change notification.
+    });
+```
+
+## getPhase
+
+Returns the current sub-phase of the refresh, if the server has explicitly signaled one. This will be one of:
+
+- `Session::PHASE_DELETE` — The server is using the refreshDelete strategy.
+- `Session::PHASE_PRESENT` — The server is using the refreshPresent strategy.
+- `null` — No explicit sub-phase is currently active.
+
+Note that not all servers signal an explicit sub-phase before sending refresh entries (OpenLDAP does not), so
+`getPhase()` returning `null` does not necessarily mean the refresh phase is complete. Use `isRefreshComplete()` instead
+to reliably determine when the persist phase begins.
 
 # Cancelling a Sync
 
@@ -227,19 +285,22 @@ $syncRepl->useCookieHandler(
 ## useEntryHandler
 
 This method takes a closure that reacts to a single entry change / sync. It is basically required if you want to get
-anything useful from the sync.
+anything useful from the sync. The closure receives a `SyncEntryResult` as the first argument and optionally a `Session`
+as the second argument.
 
 ```php
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
-use FreeDSx\Ldap\Control\Sync\SyncStateControl;
+use FreeDSx\Ldap\Sync\Session;
 
-$syncRepl->useEntryHandler(function(SyncEntryResult $result) {
-    // The Entry object associated with this sync change. 
+$syncRepl->useEntryHandler(function(SyncEntryResult $result, Session $session) {
+    // The Entry object associated with this sync change.
     $result->getEntry();
     // The raw result state of the entry. See "SyncStateControl::STATE_*"
     $result->getState();
     // The raw LDAP message for this entry. Can get the result code / controls / etc.
     $result->getMessage();
+    // Whether the initial refresh phase has completed (listen() mode only).
+    $session->isRefreshComplete();
 });
 ```
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
          bootstrap="vendor/autoload.php"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
 >
-    <source>
+    <source restrictDeprecations="true">
         <include>
             <directory suffix=".php">./src</directory>
         </include>

--- a/src/FreeDSx/Ldap/LdapUrl.php
+++ b/src/FreeDSx/Ldap/LdapUrl.php
@@ -264,7 +264,7 @@ class LdapUrl implements Stringable
         if ($pieces === false || !isset($pieces['scheme'])) {
             # We are on our own here if it's an empty host, as parse_url will not treat it as valid, though it is valid
             # for LDAP URLs. In the case of an empty host a client should determine what host to connect to.
-            if (preg_match('/^(ldaps?)\:\/\/\/(.*)$/', $url, $matches) === 0) {
+            if (preg_match('/^(ldaps?)\:\/\/\/(.*)$/', $url, $matches) !== 1) {
                 throw new UrlParseException(sprintf('The LDAP URL is malformed: %s', $url));
             }
             $query = null;

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSearchTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSearchTrait.php
@@ -43,6 +43,8 @@ trait ClientSearchTrait
 
     private ?ExtendedResponse $canceledResponse = null;
 
+    private ?LdapMessageResponse $canceledSearchDone = null;
+
     private function search(
         LdapMessageResponse $messageFrom,
         LdapMessageRequest $messageTo,
@@ -87,14 +89,19 @@ trait ClientSearchTrait
         // This is just to use less logic to account whether a handler was used / no search results were returned.
         // This just returns the search result done wrapped in a SearchResponse. The SearchResponse extends
         // SearchResultDone.
+        //
+        // When a cancel is in progress, prefer the captured SearchResultDone so its controls (e.g. SyncDoneControl)
+        // are preserved on the returned message rather than the entry message that triggered the cancel.
+        $finalMessage = $this->canceledSearchDone ?? $messageFrom;
+
         return new LdapMessageResponse(
-            $messageFrom->getMessageId(),
+            $finalMessage->getMessageId(),
             new SearchResponse(
                 $this->canceledResponse ?? $response,
                 $entryResults,
                 $referralResults,
             ),
-            ...$messageFrom->controls()->toArray()
+            ...$finalMessage->controls()->toArray()
         );
     }
 
@@ -109,6 +116,8 @@ trait ClientSearchTrait
                 ($this->referralHandler)(new ReferralResult($messageFrom));
             } elseif ($response instanceof IntermediateResponse && $this->intermediateHandler) {
                 ($this->intermediateHandler)($messageFrom);
+            } elseif ($response instanceof SearchResultDone) {
+                $this->canceledSearchDone = $messageFrom;
             }
         } catch (CancelRequestException $cancelException) {
             // If the strategy is "continue", we only handle the first cancellation exception.

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSyncHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSyncHandler.php
@@ -104,7 +104,7 @@ class ClientSyncHandler extends ClientBasicHandler
                     $messageTo = new LdapMessageRequest(
                         $this->queue->generateId(),
                         $this->syncRequest,
-                        ...$messageFrom->controls()->toArray()
+                        ...$messageTo->controls()->toArray()
                     );
                     $messageFrom = $this->queue->sendMessage($messageTo)
                         ->getMessage($messageTo->getMessageId());
@@ -196,10 +196,18 @@ class ClientSyncHandler extends ClientBasicHandler
 
         if ($response instanceof SyncRefreshDelete) {
             $this->updateCookie($response->getCookie());
-            $this->session->updatePhase(Session::PHASE_DELETE);
+            if ($response->getRefreshDone()) {
+                $this->session->updatePhase(null)->markRefreshComplete();
+            } else {
+                $this->session->updatePhase(Session::PHASE_DELETE);
+            }
         } elseif ($response instanceof SyncRefreshPresent) {
             $this->updateCookie($response->getCookie());
-            $this->session->updatePhase(Session::PHASE_PRESENT);
+            if ($response->getRefreshDone()) {
+                $this->session->updatePhase(null)->markRefreshComplete();
+            } else {
+                $this->session->updatePhase(Session::PHASE_PRESENT);
+            }
         } elseif ($response instanceof SyncNewCookie) {
             $this->updateCookie($response->getCookie());
         } elseif ($response instanceof SyncIdSet) {

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/RequestCanceler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/RequestCanceler.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
+use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
@@ -54,7 +55,11 @@ class RequestCanceler
         do {
             $received = $this->queue->getMessage();
 
-            if ($received->getMessageId() === $idToCancel && $this->strategy === SearchRequest::CANCEL_CONTINUE) {
+            if ($received->getMessageId() !== $idToCancel) {
+                continue;
+            }
+
+            if ($this->strategy === SearchRequest::CANCEL_CONTINUE || $received->getResponse() instanceof SearchResultDone) {
                 ($this->messageProcessor)($received);
             }
         } while ($received->getMessageId() !== $cancelId);

--- a/src/FreeDSx/Ldap/Protocol/Factory/FilterFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/FilterFactory.php
@@ -58,11 +58,12 @@ class FilterFactory
      */
     public static function get(AbstractType $type): FilterInterface
     {
-        $filterClass = self::$map[$type->getTagNumber()] ?? null;
+        $tagNumber = $type->getTagNumber();
+        $filterClass = $tagNumber !== null ? (self::$map[$tagNumber] ?? null) : null;
         if ($filterClass === null) {
             throw new ProtocolException(sprintf(
                 'The received filter "%s" is not recognized.',
-                $type->getTagNumber()
+                $tagNumber
             ));
         }
         $filterConstruct = $filterClass . '::fromAsn1';

--- a/src/FreeDSx/Ldap/Sync/Session.php
+++ b/src/FreeDSx/Ldap/Sync/Session.php
@@ -29,6 +29,7 @@ final class Session
         private readonly int $mode,
         private ?string $cookie,
         private ?int $phase = null,
+        private bool $refreshComplete = false,
     ) {
     }
 
@@ -65,11 +66,30 @@ final class Session
     }
 
     /**
+     * Whether the initial refresh phase has completed. Once true, any later entries received are persist phase change
+     * notifications rather than initial content.
+     */
+    public function isRefreshComplete(): bool
+    {
+        return $this->refreshComplete;
+    }
+
+    /**
      * @internal
      */
     public function updatePhase(?int $phase): self
     {
         $this->phase = $phase;
+
+        return $this;
+    }
+
+    /**
+     * @internal
+     */
+    public function markRefreshComplete(): self
+    {
+        $this->refreshComplete = true;
 
         return $this;
     }

--- a/src/FreeDSx/Ldap/Sync/SyncRepl.php
+++ b/src/FreeDSx/Ldap/Sync/SyncRepl.php
@@ -168,7 +168,7 @@ class SyncRepl
      * A poll based sync gets any initial content / updates and then ends.
      *
      * If a cookie is provided, then it is a poll for content update. If no cookie is provided, then it is a poll for
-     * content update. To provide a cookie from a previous poll {@see self::useCookie()}.
+     * initial content. To provide a cookie from a previous poll {@see self::useCookie()}.
      */
     public function poll(?Closure $entryHandler = null): void
     {

--- a/tests/bin/ldapsyncwrite.php
+++ b/tests/bin/ldapsyncwrite.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\LdapClient;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$signalFile = $argv[1] ?? null;
+
+if ($signalFile === null) {
+    fwrite(STDERR, 'Usage: ldapsyncwrite.php <signal_file>' . PHP_EOL);
+
+    exit(1);
+}
+
+$deadline = time() + 30;
+while (!file_exists($signalFile) && time() < $deadline) {
+    usleep(100_000);
+    clearstatcache(true, $signalFile);
+}
+
+if (!file_exists($signalFile)) {
+    fwrite(STDERR, 'Timed out waiting for signal file.' . PHP_EOL);
+
+    exit(1);
+}
+
+$caCert = (string) getenv('LDAP_CA_CERT');
+
+$options = (new ClientOptions())
+    ->setServers([(string) getenv('LDAP_SERVER')])
+    ->setBaseDn((string) getenv('LDAP_BASE_DN'))
+    ->setSslCaCert(
+        $caCert === ''
+            ? __DIR__ . '/../resources/cert/ca.crt'
+            : $caCert
+    );
+
+$client = new LdapClient($options);
+$client->bind(
+    (string) getenv('LDAP_USERNAME'),
+    (string) getenv('LDAP_PASSWORD'),
+);
+
+$entry = new Entry('cn=Birgit Pankhurst,ou=Janitorial,ou=FreeDSx-Test,dc=example,dc=com');
+$entry->set('description', 'sync-test-' . time());
+$client->update($entry);
+$client->unbind();
+
+echo 'write-complete' . PHP_EOL;

--- a/tests/integration/Sync/SyncListenState.php
+++ b/tests/integration/Sync/SyncListenState.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Sync;
+
+/**
+ * Simple DTO for testing.
+ *
+ * @internal
+ */
+final class SyncListenState
+{
+    public bool $seenRefreshPhase = false;
+
+    public bool $seenPersistPhase = false;
+
+    public bool $signaled = false;
+}

--- a/tests/integration/Sync/SyncReplTest.php
+++ b/tests/integration/Sync/SyncReplTest.php
@@ -15,10 +15,27 @@ namespace Tests\Integration\FreeDSx\Ldap\Sync;
 
 use FreeDSx\Ldap\Exception\CancelRequestException;
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Session;
+use Symfony\Component\Process\Process;
 use Tests\Integration\FreeDSx\Ldap\LdapTestCase;
 
 class SyncReplTest extends LdapTestCase
 {
+    private ?Process $syncWriteProcess = null;
+
+    private ?string $syncSignalFile = null;
+
+    public function tearDown(): void
+    {
+        $this->syncWriteProcess?->stop();
+        $this->syncWriteProcess = null;
+
+        if ($this->syncSignalFile !== null && file_exists($this->syncSignalFile)) {
+            unlink($this->syncSignalFile);
+            $this->syncSignalFile = null;
+        }
+    }
+
     public function testItCanPerformPollingSync(): void
     {
         $entries = [];
@@ -56,5 +73,69 @@ class SyncReplTest extends LdapTestCase
             $count,
             'It stopped on the 10th result.'
         );
+    }
+
+    public function testListenObservesBothRefreshAndPersistPhases(): void
+    {
+        $this->syncSignalFile = tempnam(sys_get_temp_dir(), 'ldap_sync_test_');
+        unlink($this->syncSignalFile);
+
+        $process = $this->syncWriteProcess();
+        $process->start();
+
+        $state = new SyncListenState();
+
+        $listenClient = $this->getClient(
+            $this->makeOptions()->setTimeoutRead(180)
+        );
+        $this->bindClient($listenClient);
+
+        $listenClient->syncRepl()
+            ->listen(function (SyncEntryResult $result, Session $session) use ($state): void {
+                // Signal the write process on the first entry received (we are in the refresh phase).
+                // OpenLDAP queues writes that happen during refresh and delivers them in the persist phase.
+                if (!$state->signaled) {
+                    touch((string) $this->syncSignalFile);
+                    $state->signaled = true;
+                }
+
+                if (!$session->isRefreshComplete()) {
+                    $state->seenRefreshPhase = true;
+                    return;
+                }
+
+                // we are in the persist phase.
+                $state->seenPersistPhase = true;
+
+                throw new CancelRequestException();
+            });
+
+        $process->wait();
+
+        $this->assertTrue(
+            $process->isSuccessful(),
+            'The sync write should run successfully. Instead received: '. $process->getErrorOutput(),
+        );
+        $this->assertTrue(
+            $state->seenRefreshPhase,
+            'Entries were received during the refresh phase.'
+        );
+        $this->assertTrue(
+            $state->seenPersistPhase,
+            'An entry was received during the persist phase.'
+        );
+    }
+
+    private function syncWriteProcess(): Process
+    {
+        $process = new Process([
+            'php',
+            __DIR__ . '/../../bin/ldapsyncwrite.php',
+            $this->syncSignalFile,
+        ]);
+        $process->setTimeout(60);
+        $this->syncWriteProcess = $process;
+
+        return $process;
     }
 }

--- a/tests/unit/Protocol/ClientProtocolHandler/ClientSaslBindHandlerTest.php
+++ b/tests/unit/Protocol/ClientProtocolHandler/ClientSaslBindHandlerTest.php
@@ -245,16 +245,17 @@ final class ClientSaslBindHandlerTest extends TestCase
             ->method('challenge')
             ->willReturn($this->mockChallenge);
 
+        $completedContext = new SaslContext();
+        $completedContext->setResponse('foo');
+        $completedContext->setHasSecurityLayer(true);
+        $completedContext->setIsAuthenticated(true);
+        $completedContext->setIsComplete(true);
+
         $this->mockChallenge
             ->method('challenge')
             ->will(self::onConsecutiveCalls(
                 (new SaslContext())->setResponse('foo'),
-                // The return types for SaslContext need to be updated.
-                // @phpstan-ignore-next-line
-                (new SaslContext())->setResponse('foo')
-                    ->setHasSecurityLayer(true)
-                    ->setIsAuthenticated(true)
-                    ->setIsComplete(true)
+                $completedContext,
             ));
 
         $mockSecurityLayer = $this->createMock(SecurityLayerInterface::class);

--- a/tests/unit/Protocol/ClientProtocolHandler/ClientSyncHandlerTest.php
+++ b/tests/unit/Protocol/ClientProtocolHandler/ClientSyncHandlerTest.php
@@ -18,13 +18,19 @@ use FreeDSx\Ldap\Control\Sync\SyncDoneControl;
 use FreeDSx\Ldap\Control\Sync\SyncRequestControl;
 use FreeDSx\Ldap\Control\Sync\SyncStateControl;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\CancelRequestException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\LdapUrl;
+use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\SyncRequest;
+use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\Response\SearchResultReference;
 use FreeDSx\Ldap\Operation\Response\SyncInfo\SyncIdSet;
+use FreeDSx\Ldap\Operation\Response\SyncInfo\SyncRefreshDelete;
+use FreeDSx\Ldap\Operation\Response\SyncInfo\SyncRefreshPresent;
 use FreeDSx\Ldap\Protocol\ClientProtocolHandler\ClientSyncHandler;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
@@ -32,6 +38,7 @@ use FreeDSx\Ldap\Protocol\Queue\ClientQueue;
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
 use FreeDSx\Ldap\Sync\Result\SyncIdSetResult;
 use FreeDSx\Ldap\Sync\Result\SyncReferralResult;
+use FreeDSx\Ldap\Sync\Session;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Tests\Unit\FreeDSx\Ldap\TestFactoryTrait;
@@ -278,6 +285,164 @@ final class ClientSyncHandlerTest extends TestCase
         );
     }
 
+    public function test_a_refresh_delete_in_progress_sets_phase_delete_and_refresh_is_not_complete(): void
+    {
+        $capturedSession = null;
+        $messageTo = new LdapMessageRequest(
+            1,
+            (new SyncRequest())
+                ->useEntryHandler(function (SyncEntryResult $_result, Session $session) use (&$capturedSession): void {
+                    $capturedSession = $session;
+                }),
+            new SyncRequestControl(),
+        );
+
+        $this->mockQueue
+            ->expects($this->exactly(2))
+            ->method('getMessage')
+            ->with(1)
+            ->willReturnOnConsecutiveCalls(
+                new LdapMessageResponse(
+                    1,
+                    new SearchResultEntry(new Entry('bar')),
+                    new SyncStateControl(SyncStateControl::STATE_ADD, 'foo'),
+                ),
+                new LdapMessageResponse(
+                    1,
+                    new SearchResultDone(0, '', ''),
+                    new SyncDoneControl(),
+                ),
+            );
+
+        $this->subject->handleResponse(
+            $messageTo,
+            new LdapMessageResponse(1, new SyncRefreshDelete(refreshDone: false)),
+        );
+
+        self::assertSame(
+            Session::PHASE_DELETE,
+            $capturedSession?->getPhase()
+        );
+        self::assertFalse($capturedSession->isRefreshComplete());
+    }
+
+    public function test_a_refresh_delete_done_sets_null_phase_and_marks_refresh_complete(): void
+    {
+        $capturedSession = null;
+        $messageTo = new LdapMessageRequest(
+            1,
+            (new SyncRequest())
+                ->useEntryHandler(function (SyncEntryResult $_result, Session $session) use (&$capturedSession): void {
+                    $capturedSession = $session;
+                }),
+            new SyncRequestControl(),
+        );
+
+        $this->mockQueue
+            ->expects($this->exactly(2))
+            ->method('getMessage')
+            ->with(1)
+            ->willReturnOnConsecutiveCalls(
+                new LdapMessageResponse(
+                    1,
+                    new SearchResultEntry(new Entry('bar')),
+                    new SyncStateControl(SyncStateControl::STATE_ADD, 'foo'),
+                ),
+                new LdapMessageResponse(
+                    1,
+                    new SearchResultDone(0, '', ''),
+                    new SyncDoneControl(),
+                ),
+            );
+
+        $this->subject->handleResponse(
+            $messageTo,
+            new LdapMessageResponse(1, new SyncRefreshDelete(refreshDone: true)),
+        );
+
+        self::assertNull($capturedSession?->getPhase());
+        self::assertTrue($capturedSession?->isRefreshComplete());
+    }
+
+    public function test_a_refresh_present_in_progress_sets_phase_present_and_refresh_is_not_complete(): void
+    {
+        $capturedSession = null;
+        $messageTo = new LdapMessageRequest(
+            1,
+            (new SyncRequest())
+                ->useEntryHandler(function (SyncEntryResult $_result, Session $session) use (&$capturedSession): void {
+                    $capturedSession = $session;
+                }),
+            new SyncRequestControl(),
+        );
+
+        $this->mockQueue
+            ->expects($this->exactly(2))
+            ->method('getMessage')
+            ->with(1)
+            ->willReturnOnConsecutiveCalls(
+                new LdapMessageResponse(
+                    1,
+                    new SearchResultEntry(new Entry('bar')),
+                    new SyncStateControl(SyncStateControl::STATE_ADD, 'foo'),
+                ),
+                new LdapMessageResponse(
+                    1,
+                    new SearchResultDone(0, '', ''),
+                    new SyncDoneControl(),
+                ),
+            );
+
+        $this->subject->handleResponse(
+            $messageTo,
+            new LdapMessageResponse(1, new SyncRefreshPresent(refreshDone: false)),
+        );
+
+        self::assertSame(
+            Session::PHASE_PRESENT,
+            $capturedSession?->getPhase()
+        );
+        self::assertFalse($capturedSession->isRefreshComplete());
+    }
+
+    public function test_a_refresh_present_done_sets_null_phase_and_marks_refresh_complete(): void
+    {
+        $capturedSession = null;
+        $messageTo = new LdapMessageRequest(
+            1,
+            (new SyncRequest())
+                ->useEntryHandler(function (SyncEntryResult $_result, Session $session) use (&$capturedSession): void {
+                    $capturedSession = $session;
+                }),
+            new SyncRequestControl(),
+        );
+
+        $this->mockQueue
+            ->expects($this->exactly(2))
+            ->method('getMessage')
+            ->with(1)
+            ->willReturnOnConsecutiveCalls(
+                new LdapMessageResponse(
+                    1,
+                    new SearchResultEntry(new Entry('bar')),
+                    new SyncStateControl(SyncStateControl::STATE_ADD, 'foo'),
+                ),
+                new LdapMessageResponse(
+                    1,
+                    new SearchResultDone(0, '', ''),
+                    new SyncDoneControl(),
+                ),
+            );
+
+        $this->subject->handleResponse(
+            $messageTo,
+            new LdapMessageResponse(1, new SyncRefreshPresent(refreshDone: true)),
+        );
+
+        self::assertNull($capturedSession?->getPhase());
+        self::assertTrue($capturedSession?->isRefreshComplete());
+    }
+
     public function test_it_should_process_a_sync_referral(): void
     {
         $referral = new LdapUrl('bar');
@@ -336,6 +501,58 @@ final class ClientSyncHandlerTest extends TestCase
         self::assertSame(
             [$referral],
             $referralsProcessed,
+        );
+    }
+
+    public function test_the_sync_done_cookie_is_captured_when_a_cancel_is_requested(): void
+    {
+        $syncRequest = new SyncRequest();
+        $syncRequest->useEntryHandler(function (): void {
+            throw new CancelRequestException();
+        });
+
+        $messageTo = new LdapMessageRequest(
+            1,
+            $syncRequest,
+            new SyncRequestControl(),
+        );
+
+        $this->mockQueue
+            ->method('generateId')
+            ->willReturn(2);
+
+        $drainCallCount = 0;
+        $this->mockQueue
+            ->method('getMessage')
+            ->willReturnCallback(
+                function () use (&$drainCallCount): LdapMessageResponse {
+                    $cancelResponse = new LdapMessageResponse(
+                        2,
+                        new ExtendedResponse(new LdapResult(ResultCode::CANCELED)),
+                    );
+                    $searchDone = new LdapMessageResponse(
+                        1,
+                        new SearchResultDone(ResultCode::CANCELED, '', ''),
+                        new SyncDoneControl('final-cookie'),
+                    );
+                    $drainCallCount++;
+
+                    return $drainCallCount === 1 ? $searchDone : $cancelResponse;
+                }
+            );
+
+        $result = $this->subject->handleResponse(
+            $messageTo,
+            new LdapMessageResponse(
+                1,
+                new SearchResultEntry(new Entry('foo')),
+                new SyncStateControl(SyncStateControl::STATE_ADD, 'uuid'),
+            ),
+        );
+
+        self::assertSame(
+            'final-cookie',
+            $result?->controls()->getByClass(SyncDoneControl::class)?->getCookie(),
         );
     }
 }


### PR DESCRIPTION
This fixes some issues related to the SyncRepl client implementation. Added an integration test that covers the different phases getting hit, so it's also verified outside of just unit tests. This was a blocker for the actual 1.0 release since the initial listen logic was busted.