### PR TITLE
[1.0.0] Fix a state issue around e-syncRefreshRequired in SyncRepl.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 composer.phar
 vendor/
+.phpunit.result.cache

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSyncHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSyncHandler.php
@@ -101,6 +101,7 @@ class ClientSyncHandler extends ClientBasicHandler
                             ->getByClass(SyncDoneControl::class)
                             ?->getCookie()
                     );
+                    $this->session->resetRefreshState();
                     $messageTo = new LdapMessageRequest(
                         $this->queue->generateId(),
                         $this->syncRequest,

--- a/src/FreeDSx/Ldap/Sync/Session.php
+++ b/src/FreeDSx/Ldap/Sync/Session.php
@@ -97,6 +97,17 @@ final class Session
     /**
      * @internal
      */
+    public function resetRefreshState(): self
+    {
+        $this->phase = null;
+        $this->refreshComplete = false;
+
+        return $this;
+    }
+
+    /**
+     * @internal
+     */
     public function updateCookie(?string $cookie): self
     {
         $this->cookie = $cookie;

--- a/tests/integration/Sync/SyncReplTest.php
+++ b/tests/integration/Sync/SyncReplTest.php
@@ -45,7 +45,9 @@ class SyncReplTest extends LdapTestCase
 
         $client
             ->syncRepl()
-            ->poll(fn (SyncEntryResult $result) => array_push($entries, $result));
+            ->poll(function (SyncEntryResult $result) use (&$entries): void {
+                $entries[] = $result;
+            });
 
         $this->assertGreaterThan(0, count($entries));
     }

--- a/tests/integration/Sync/SyncReplTest.php
+++ b/tests/integration/Sync/SyncReplTest.php
@@ -47,10 +47,7 @@ class SyncReplTest extends LdapTestCase
             ->syncRepl()
             ->poll(fn (SyncEntryResult $result) => array_push($entries, $result));
 
-        $this->assertGreaterThan(
-            0,
-            $entries,
-        );
+        $this->assertGreaterThan(0, count($entries));
     }
 
     public function testItCanCancelTheSync(): void


### PR DESCRIPTION
Reset the session phase and refreshComplete flag when e-syncRefreshRequired triggers a retry.