### PR TITLE
[1.0.0] Add SASL server side support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": ">=8.1",
     "freedsx/asn1": ">=0.4.0",
     "freedsx/socket": ">=0.5.0",
-    "freedsx/sasl": ">=0.1.0",
+    "freedsx/sasl": ">=0.2.1",
     "psr/log": "^3"
   },
   "require-dev": {

--- a/docs/Client/SASL-Bind-Authentication.md
+++ b/docs/Client/SASL-Bind-Authentication.md
@@ -52,13 +52,16 @@ $ldap->bindSasl([
 
 The following table details mechanisms / options that are recognized when doing a SASL bind:
 
-|                 | `DIGEST-MD5` | `CRAM-MD5` | `PLAIN` | `ANONYMOUS` |
-|-----------------|:------------:|:----------:|:-------:|:-----------:|
-| `username`      |      X       |     X      |    X    |      X      |
-| `password`      |      X       |     X      |    X    |             |
-| `use_integrity` |      X       |            |         |             |
-| `trace`         |              |            |         |      X      |
-| `host`          |      X       |            |         |             |
+|                 | `DIGEST-MD5` | `CRAM-MD5` | `SCRAM-*` | `PLAIN` | `ANONYMOUS` |
+|-----------------|:------------:|:----------:|:---------:|:-------:|:-----------:|
+| `username`      |      X       |     X      |     X     |    X    |      X      |
+| `password`      |      X       |     X      |     X     |    X    |             |
+| `use_integrity` |      X       |            |           |         |             |
+| `trace`         |              |            |           |         |      X      |
+| `host`          |      X       |            |           |         |             |
+
+`SCRAM-*` refers to the SCRAM family of mechanisms: `SCRAM-SHA-1`, `SCRAM-SHA-256`, `SCRAM-SHA-384`, `SCRAM-SHA-512`,
+`SCRAM-SHA3-512`, and their channel-binding (`-PLUS`) variants. `SCRAM-SHA-256` is recommended for new deployments.
 
 ## Options
 

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -23,6 +23,8 @@ LDAP Server Configuration
     * [ServerOptions:setSslCert](#setsslcert)
     * [ServerOptions:setSslCertKey](#setsslcertkey)
     * [ServerOptions:setSslCertPassphrase](#setsslcertpassphrase)
+* [SASL Options](#sasl-options)
+    * [ServerOptions:setSaslMechanisms](#setsaslmechanisms)
 
 The LDAP server is configured through a `ServerOptions` object. The configuration object is passed to the server
 on construction:
@@ -253,3 +255,37 @@ to use an encrypted stream only for communication to the server.
 **Note**: LDAP over SSL, commonly referred to as LDAPS, is not an official LDAP standard. Support is dependent on the client / server specific implementations.
 
 **Default**: `false`
+
+## SASL Options
+
+------------------
+#### setSaslMechanisms
+
+The SASL mechanisms the server should support and advertise to clients via the `supportedSaslMechanisms` RootDSE attribute.
+Use the constants defined on `ServerOptions` to specify mechanisms:
+
+| Constant                         | Mechanism    | Handler Required                                     |
+|----------------------------------|--------------|------------------------------------------------------|
+| `ServerOptions::SASL_PLAIN`      | `PLAIN`      | `RequestHandlerInterface` (existing `bind()` method) |
+| `ServerOptions::SASL_CRAM_MD5`   | `CRAM-MD5`   | `SaslHandlerInterface`                               |
+| `ServerOptions::SASL_DIGEST_MD5` | `DIGEST-MD5` | `SaslHandlerInterface`                               |
+
+```php
+use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\LdapServer;
+
+$server = new LdapServer(
+    (new ServerOptions)
+        ->setSaslMechanisms(
+            ServerOptions::SASL_PLAIN,
+            ServerOptions::SASL_DIGEST_MD5,
+        )
+);
+```
+
+**Note**: The `PLAIN` mechanism transmits credentials in cleartext. It should only be enabled when the connection is
+protected by TLS (via StartTLS or `setUseSsl`).
+
+See [SASL Authentication](General-Usage.md#sasl-authentication) for full usage details.
+
+**Default**: `[]` (SASL disabled)

--- a/docs/Server/General-Usage.md
+++ b/docs/Server/General-Usage.md
@@ -9,6 +9,9 @@ General LDAP Server Usage
 * [Handling the RootDSE](#handling-the-rootdse)
 * [Handling Client Paging Requests](#handling-client-paging-requests)
 * [StartTLS SSL Certificate Support](#starttls-ssl-certificate-support)
+* [SASL Authentication](#sasl-authentication)
+  * [PLAIN Mechanism](#plain-mechanism)
+  * [Challenge-Based Mechanisms (CRAM-MD5, DIGEST-MD5, and SCRAM)](#challenge-based-mechanisms-cram-md5-digest-md5-and-scram)
 
 The LdapServer class is used to run a LDAP server process that accepts client requests and sends back a response. It
 defaults to using a forking method for client requests, which is only available on Linux.
@@ -366,6 +369,147 @@ $server = new LdapServer(
 
 $server->run();
 ```
+
+## SASL Authentication
+
+The server supports SASL (Simple Authentication and Security Layer) bind requests. SASL must be explicitly enabled by
+configuring the mechanisms you want to support via `ServerOptions::setSaslMechanisms()`. The configured mechanisms are
+advertised to clients through the `supportedSaslMechanisms` RootDSE attribute.
+
+```php
+use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\LdapServer;
+
+$server = new LdapServer(
+    (new ServerOptions)
+        ->setSaslMechanisms(
+            ServerOptions::SASL_PLAIN,
+            ServerOptions::SASL_CRAM_MD5,
+            ServerOptions::SASL_SCRAM_SHA_256,
+        )
+        ->setRequestHandler(new MyRequestHandler())
+);
+```
+
+### PLAIN Mechanism
+
+The `PLAIN` mechanism reuses your existing `RequestHandlerInterface::bind()` method. When a client authenticates with
+SASL PLAIN, the server extracts the username and password from the SASL credentials and calls `bind()` exactly as it
+would for a simple bind.
+
+**Note**: PLAIN transmits credentials in cleartext. Only enable it when the connection is protected by TLS (StartTLS
+or `setUseSsl`).
+
+```php
+namespace Foo;
+
+use FreeDSx\Ldap\Server\RequestHandler\GenericRequestHandler;
+
+class MyRequestHandler extends GenericRequestHandler
+{
+    public function bind(string $username, string $password): bool
+    {
+        // Called for both simple binds and SASL PLAIN binds.
+        return $username === 'user' && $password === 'secret';
+    }
+}
+```
+
+### Challenge-Based Mechanisms (CRAM-MD5, DIGEST-MD5, and SCRAM)
+
+`CRAM-MD5`, `DIGEST-MD5`, and the `SCRAM-*` family are challenge-response mechanisms. The server issues a challenge to
+the client and verifies the client's response against a digest computed from the user's plaintext password. Because the
+verification is cryptographic, the server must be able to look up the plaintext (or equivalent) password for a given
+username.
+
+To support these mechanisms, your request handler must additionally implement
+`FreeDSx\Ldap\Server\RequestHandler\SaslHandlerInterface`:
+
+```php
+interface SaslHandlerInterface
+{
+    public function getPassword(
+        string $username,
+        string $mechanism
+    ): ?string;
+}
+```
+
+Return the user's plaintext password for the given username and mechanism, or `null` if the user does not exist or
+should not be permitted to authenticate. Returning `null` results in a generic `invalidCredentials` error — the
+mechanism name and `null`/wrong-password cases are not distinguished in the response to avoid user enumeration.
+
+The `$mechanism` parameter lets you apply per-mechanism policy if needed (e.g. disallow weak mechanisms for certain
+users), but in most cases you can ignore it and return the same password regardless.
+
+Example handler supporting both simple binds and challenge-based SASL:
+
+```php
+namespace Foo;
+
+use FreeDSx\Ldap\Server\RequestHandler\GenericRequestHandler;
+use FreeDSx\Ldap\Server\RequestHandler\SaslHandlerInterface;
+
+class MyRequestHandler extends GenericRequestHandler implements SaslHandlerInterface
+{
+    private array $users = [
+        'alice' => 'her-plaintext-password',
+        'bob'   => 'his-plaintext-password',
+    ];
+
+    // Used for simple binds and SASL PLAIN.
+    public function bind(string $username, string $password): bool
+    {
+        return isset($this->users[$username])
+            && $this->users[$username] === $password;
+    }
+
+    // Used for CRAM-MD5, DIGEST-MD5, and all SCRAM variants.
+    public function getPassword(string $username, string $mechanism): ?string
+    {
+        return $this->users[$username] ?? null;
+    }
+}
+```
+
+Then enable the desired mechanisms on the server:
+
+```php
+use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\LdapServer;
+use Foo\MyRequestHandler;
+
+$server = new LdapServer(
+    (new ServerOptions)
+        ->setSaslMechanisms(
+            ServerOptions::SASL_CRAM_MD5,
+            ServerOptions::SASL_DIGEST_MD5,
+            ServerOptions::SASL_SCRAM_SHA_256,
+        )
+        ->setRequestHandler(new MyRequestHandler())
+);
+
+$server->run();
+```
+
+**SCRAM variants**: The following constants are available for the SCRAM family. `SCRAM-SHA-256` is the recommended
+choice for new deployments ([RFC 7677](https://www.rfc-editor.org/rfc/rfc7677) standardises it as the preferred
+mechanism, citing SHA-1's known weaknesses).
+
+| Constant                             | Mechanism                       |
+|--------------------------------------|---------------------------------|
+| `ServerOptions::SASL_SCRAM_SHA_1`    | `SCRAM-SHA-1`                   |
+| `ServerOptions::SASL_SCRAM_SHA_256`  | `SCRAM-SHA-256` *(recommended)* |
+| `ServerOptions::SASL_SCRAM_SHA_384`  | `SCRAM-SHA-384`                 |
+| `ServerOptions::SASL_SCRAM_SHA_512`  | `SCRAM-SHA-512`                 |
+| `ServerOptions::SASL_SCRAM_SHA3_512` | `SCRAM-SHA3-512`                |
+
+Channel-binding (`-PLUS`) variants of each are also available (e.g. `SASL_SCRAM_SHA_256_PLUS`) for environments where
+TLS channel binding is required.
+
+**Note**: Because `getPassword()` must return the plaintext password, you cannot store passwords as one-way hashes
+(e.g. bcrypt) when supporting CRAM-MD5, DIGEST-MD5, or SCRAM. If one-way hashing is a requirement, use `PLAIN` over
+TLS instead, which allows password verification via `bind()`.
 
 ## StartTLS SSL Certificate Support
 

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -13,11 +13,13 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap;
 
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\ProxyHandler;
 use FreeDSx\Ldap\Server\RequestHandler\ProxyPagingHandler;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
+use FreeDSx\Ldap\Server\RequestHandler\SaslHandlerInterface;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
 use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Socket\Exception\ConnectionException;
@@ -45,9 +47,12 @@ class LdapServer
      * Runs the LDAP server. Binds the socket on the request IP/port and sends it to the server runner.
      *
      * @throws ConnectionException
+     * @throws InvalidArgumentException
      */
     public function run(): void
     {
+        $this->validateSaslConfiguration();
+
         $socketServer = $this->container
             ->get(SocketServerFactory::class)
             ->makeAndBind();
@@ -103,6 +108,33 @@ class LdapServer
         $this->options->setLogger($logger);
 
         return $this;
+    }
+
+    /**
+     * Validates that the SASL configuration is consistent before the server starts.
+     *
+     * @throws InvalidArgumentException
+     */
+    private function validateSaslConfiguration(): void
+    {
+        $challengeMechanisms = array_diff(
+            $this->options->getSaslMechanisms(),
+            [ServerOptions::SASL_PLAIN],
+        );
+
+        if (empty($challengeMechanisms)) {
+            return;
+        }
+
+        $handler = $this->options->getRequestHandler();
+
+        if (!$handler instanceof SaslHandlerInterface) {
+            throw new InvalidArgumentException(sprintf(
+                'The SASL mechanism(s) [%s] require the request handler to implement %s.',
+                implode(', ', $challengeMechanisms),
+                SaslHandlerInterface::class,
+            ));
+        }
     }
 
     /**

--- a/src/FreeDSx/Ldap/Operation/Request/BindRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/BindRequest.php
@@ -97,9 +97,13 @@ abstract class BindRequest implements RequestInterface
         $version = $version->getValue();
         $name = $name->getValue();
 
+        if ($auth->getTagNumber() === 3) {
+            return SaslBindRequest::fromAsn1($auth);
+        }
+
         if ($auth->getTagNumber() !== 0) {
             throw new ProtocolException(sprintf(
-                'Only a simple bind is currently supported, but got: %s',
+                'The auth choice tag %s in the bind request is not supported.',
                 $auth->getTagNumber()
             ));
         }

--- a/src/FreeDSx/Ldap/Operation/Request/SaslBindRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/SaslBindRequest.php
@@ -15,7 +15,11 @@ namespace FreeDSx\Ldap\Operation\Request;
 
 use FreeDSx\Asn1\Asn1;
 use FreeDSx\Asn1\Type\AbstractType;
+use FreeDSx\Asn1\Type\IncompleteType;
+use FreeDSx\Asn1\Type\OctetStringType;
 use FreeDSx\Ldap\Exception\BindException;
+use FreeDSx\Ldap\Exception\ProtocolException;
+use FreeDSx\Ldap\Protocol\LdapEncoder;
 
 /**
  * Represents a SASL bind request consisting of a mechanism challenge / response.
@@ -68,6 +72,31 @@ class SaslBindRequest extends BindRequest
     public function getOptions(): array
     {
         return $this->options;
+    }
+
+    /**
+     * @return SaslBindRequest
+     * @throws ProtocolException
+     * @throws \FreeDSx\Asn1\Exception\EncoderException
+     */
+    public static function fromAsn1(AbstractType $type): SaslBindRequest
+    {
+        if ($type instanceof IncompleteType) {
+            $type = (new LdapEncoder())->complete(
+                $type,
+                AbstractType::TAG_TYPE_SEQUENCE,
+            );
+        }
+        $mechanism = $type->getChild(0);
+        if (!$mechanism instanceof OctetStringType) {
+            throw new ProtocolException('The SASL mechanism in the bind request is malformed.');
+        }
+        $credentials = $type->getChild(1);
+
+        return new SaslBindRequest(
+            $mechanism->getValue(),
+            $credentials instanceof OctetStringType ? $credentials->getValue() : null,
+        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/ChallengeAdvancement.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/ChallengeAdvancement.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl;
+
+use FreeDSx\Sasl\SaslContext;
+
+/**
+ * Bundles the outcome of a single challenge advancement step.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class ChallengeAdvancement
+{
+    public function __construct(
+        public readonly SaslContext $context,
+        public readonly bool $complete,
+    ) {
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/CramMD5MechanismOptionsBuilder.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/CramMD5MechanismOptionsBuilder.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
+
+use FreeDSx\Ldap\Server\RequestHandler\SaslHandlerInterface;
+use FreeDSx\Sasl\Mechanism\CramMD5Mechanism;
+
+/**
+ * Builds options for the CRAM-MD5 SASL mechanism on the server side.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class CramMD5MechanismOptionsBuilder implements MechanismOptionsBuilderInterface
+{
+    use RequiresPasswordTrait;
+
+    public function __construct(private readonly SaslHandlerInterface $handler)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function buildOptions(
+        ?string $received,
+        string $mechanism,
+    ): array {
+        if ($received === null) {
+            return [];
+        }
+
+        return [
+            'password' => function (string $username, string $challenge): string {
+                $password = $this->requirePassword($this->handler->getPassword(
+                    $username,
+                    CramMD5Mechanism::NAME
+                ));
+
+                return hash_hmac(
+                    'md5',
+                    $challenge,
+                    $password,
+                );
+            },
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports(string $mechanism): bool
+    {
+        return $mechanism === CramMD5Mechanism::NAME;
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/DigestMD5MechanismOptionsBuilder.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/DigestMD5MechanismOptionsBuilder.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Server\RequestHandler\SaslHandlerInterface;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\SaslUsernameExtractorInterface;
+use FreeDSx\Sasl\Mechanism\DigestMD5Mechanism;
+
+/**
+ * Builds options for the DIGEST-MD5 SASL mechanism on the server side.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class DigestMD5MechanismOptionsBuilder implements MechanismOptionsBuilderInterface
+{
+    use RequiresPasswordTrait;
+
+    public function __construct(
+        private readonly SaslHandlerInterface $handler,
+        private readonly SaslUsernameExtractorInterface $usernameExtractor,
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws OperationException
+     */
+    public function buildOptions(
+        ?string $received,
+        string $mechanism)
+    : array {
+        if ($received === null) {
+            return [];
+        }
+
+        $username = $this->usernameExtractor->extractUsername(DigestMD5Mechanism::NAME, $received);
+        $password = $this->requirePassword($this->handler->getPassword($username, DigestMD5Mechanism::NAME));
+
+        return ['password' => $password];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports(string $mechanism): bool
+    {
+        return $mechanism === DigestMD5Mechanism::NAME;
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/MechanismOptionsBuilderFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/MechanismOptionsBuilderFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
+
+use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\UsernameFieldExtractor;
+use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
+use FreeDSx\Ldap\Server\RequestHandler\SaslHandlerInterface;
+use FreeDSx\Sasl\Mechanism\CramMD5Mechanism;
+use FreeDSx\Sasl\Mechanism\DigestMD5Mechanism;
+use FreeDSx\Sasl\Mechanism\PlainMechanism;
+use FreeDSx\Sasl\Mechanism\ScramMechanism;
+
+/**
+ * Creates a single MechanismOptionsBuilderInterface instance for the requested SASL mechanism.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class MechanismOptionsBuilderFactory
+{
+    /**
+     * @throws RuntimeException if no builder is registered for the given mechanism.
+     */
+    public function make(
+        string $mechanism,
+        RequestHandlerInterface $dispatcher,
+    ): MechanismOptionsBuilderInterface {
+        return match (true) {
+            $mechanism === PlainMechanism::NAME
+                => new PlainMechanismOptionsBuilder($dispatcher),
+            $mechanism === CramMD5Mechanism::NAME && $dispatcher instanceof SaslHandlerInterface
+                => new CramMD5MechanismOptionsBuilder($dispatcher),
+            $mechanism === DigestMD5Mechanism::NAME && $dispatcher instanceof SaslHandlerInterface
+                => new DigestMD5MechanismOptionsBuilder($dispatcher, new UsernameFieldExtractor()),
+            in_array($mechanism, ScramMechanism::VARIANTS, true) && $dispatcher instanceof SaslHandlerInterface
+                => new ScramMechanismOptionsBuilder($dispatcher),
+            default => throw new RuntimeException(
+                sprintf('No options builder is registered for the SASL mechanism "%s".', $mechanism)
+            ),
+        };
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/MechanismOptionsBuilderInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/MechanismOptionsBuilderInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
+
+/**
+ * Builds the options array passed to a SASL mechanism's challenge() call for a specific mechanism.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface MechanismOptionsBuilderInterface
+{
+    /**
+     * Build the options for the next challenge() call.
+     *
+     * @return array<string, mixed>
+     */
+    public function buildOptions(
+        ?string $received,
+        string $mechanism,
+    ): array;
+
+    /**
+     * Whether this builder handles the given mechanism name.
+     */
+    public function supports(string $mechanism): bool;
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/PlainMechanismOptionsBuilder.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/PlainMechanismOptionsBuilder.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
+
+use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
+use FreeDSx\Sasl\Mechanism\PlainMechanism;
+
+/**
+ * Builds options for the PLAIN SASL mechanism on the server side.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class PlainMechanismOptionsBuilder implements MechanismOptionsBuilderInterface
+{
+    public function __construct(private readonly RequestHandlerInterface $dispatcher)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function buildOptions(
+        ?string $received,
+        string $mechanism,
+    ): array {
+        return [
+            'validate' => fn (?string $authzId, string $authcId, string $password): bool =>
+                $this->dispatcher->bind($authcId, $password),
+        ];
+    }
+
+    public function supports(string $mechanism): bool
+    {
+        return $mechanism === PlainMechanism::NAME;
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/RequiresPasswordTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/RequiresPasswordTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+
+/**
+ * Shared logic for validating that a password was returned for a SASL mechanism.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+trait RequiresPasswordTrait
+{
+    /**
+     * @throws OperationException if the password is null (user not found or not allowed).
+     */
+    private function requirePassword(?string $password): string
+    {
+        if ($password === null) {
+            throw new OperationException(
+                'Invalid credentials.',
+                ResultCode::INVALID_CREDENTIALS
+            );
+        }
+
+        return $password;
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/ScramMechanismOptionsBuilder.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/ScramMechanismOptionsBuilder.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\RequestHandler\SaslHandlerInterface;
+use FreeDSx\Sasl\Mechanism\ScramMechanism;
+
+/**
+ * Builds options for SCRAM SASL mechanisms on the server side.
+ *
+ * SCRAM is client-initiated: the client sends its username in the client-first-message.
+ * This builder is stateful — it extracts and stores the username from the client-first
+ * round so it can look up the password for the client-final round.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class ScramMechanismOptionsBuilder implements MechanismOptionsBuilderInterface
+{
+    use RequiresPasswordTrait;
+
+    private ?string $username = null;
+
+    public function __construct(private readonly SaslHandlerInterface $handler)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function buildOptions(?string $received, string $mechanism): array
+    {
+        if ($received === null) {
+            return [];
+        }
+
+        // Client-final-message contains the proof field 'p='.
+        // At this point we need the password to verify the client's proof.
+        if (str_contains($received, ',p=')) {
+            if ($this->username === null) {
+                throw new OperationException(
+                    'Received a SCRAM client-final-message before client-first-message.',
+                    ResultCode::PROTOCOL_ERROR
+                );
+            }
+
+            return [
+                'password' => $this->requirePassword(
+                    $this->handler->getPassword($this->username, $mechanism)
+                ),
+            ];
+        }
+
+        // Client-first-message: extract and store the username for the next round.
+        $this->username = $this->parseUsername($received);
+
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports(string $mechanism): bool
+    {
+        return in_array($mechanism, ScramMechanism::VARIANTS, true);
+    }
+
+    /**
+     * Extracts the username from a SCRAM client-first-message.
+     *
+     * The client-first-message format is: <gs2-header> <client-first-bare>
+     * where gs2-header ends with ',,' and client-first-bare contains 'n=<username>,r=<nonce>'.
+     *
+     * @throws OperationException if no username can be found.
+     */
+    private function parseUsername(string $clientFirst): string
+    {
+        // Strip the GS2 header (everything up to and including ',,').
+        $pos = strpos($clientFirst, ',,');
+        $bare = $pos !== false ? substr($clientFirst, $pos + 2) : $clientFirst;
+
+        // Extract the 'n=' field. RFC 5802: ',' and '=' are encoded as '=2C' and '=3D'.
+        if (preg_match('/(?:^|,)n=([^,]*)/', $bare, $m)) {
+            return str_replace(['=2C', '=3D'], [',', '='], $m[1]);
+        }
+
+        throw new OperationException(
+            'The SCRAM client-first-message did not contain a username.',
+            ResultCode::PROTOCOL_ERROR
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/SaslExchange.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/SaslExchange.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl;
+
+use Closure;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\LdapResult;
+use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
+use FreeDSx\Ldap\Operation\Response\BindResponse;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\MechanismOptionsBuilderFactory;
+use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
+use FreeDSx\Sasl\SaslContext;
+
+/**
+ * Drives the SASL challenge-response loop on the server side.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class SaslExchange
+{
+    public function __construct(
+        private readonly ServerQueue $queue,
+        private readonly ResponseFactory $responseFactory,
+        private readonly MechanismOptionsBuilderFactory $optionsBuilderFactory,
+        private readonly RequestHandlerInterface $dispatcher,
+    ) {
+    }
+
+    /**
+     * Runs the full SASL exchange until the mechanism reports completion.
+     *
+     * @throws OperationException if the client sends a non-SASL request mid-exchange.
+     */
+    public function run(SaslExchangeInput $input): SaslExchangeResult
+    {
+        $mechName = $input->getMechName();
+        $optionsBuilder = $this->optionsBuilderFactory->make($mechName, $this->dispatcher);
+        $challenge = $input->getChallenge();
+        $message = $input->getInitialMessage();
+        $received = $input->getInitialCredentials();
+
+        // Tracks the credentials that contain the username (differs per mechanism).
+        // For PLAIN, it's the initial credentials. For challenge-based mechanisms,
+        // it's the first non-null response received back from the client.
+        $usernameCredentials = $received;
+        $context = null;
+        $prevContextResponse = null;
+
+        /** @var Closure(?string): SaslContext $challengeProcessor */
+        $challengeProcessor = fn(?string $challengeReceived): SaslContext => $challenge->challenge(
+            $challengeReceived,
+            $optionsBuilder->buildOptions($challengeReceived, $mechName),
+        );
+
+        while (true) {
+            // DIGEST-MD5 re-entry: context is already complete from the previous iteration
+            // (server-final sent, client ack received) — break to preserve the authenticated context.
+            if ($context !== null && $context->isComplete()) {
+                break;
+            }
+
+            $advancement = $this->advanceChallenge(
+                $challengeProcessor,
+                $received,
+                $prevContextResponse,
+            );
+            $context = $advancement->context;
+            $prevContextResponse = $context->getResponse();
+            if ($advancement->complete) {
+                break;
+            }
+
+            // Send the server's message to the client: a challenge, an empty credential prompt
+            // (e.g. PLAIN when credentials are absent from the initial bind), or a server-final.
+            $this->sendBindInProgress(
+                $message,
+                $prevContextResponse,
+            );
+
+            // Update $message before any throw so the correct ID is used if we send a
+            // response directly (the outer handler always sees the first bind's ID).
+            $message = $this->queue->getMessage();
+            $nextRequest = $this->requireSaslContinuation($message);
+            $received = $nextRequest->getCredentials();
+
+            if ($usernameCredentials === null && $received !== null) {
+                $usernameCredentials = $received;
+            }
+        }
+
+        return new SaslExchangeResult(
+            $context,
+            $message,
+            $usernameCredentials,
+        );
+    }
+
+    /**
+     * Advances the mechanism by one step and enforces all completion break conditions.
+     *
+     * @param Closure(?string): SaslContext $doChallenge
+     */
+    private function advanceChallenge(
+        Closure $doChallenge,
+        ?string $received,
+        ?string $prevContextResponse,
+    ): ChallengeAdvancement {
+        $context = $doChallenge($received);
+        $contextResponse = $context->getResponse();
+        $responseIsNew = ($contextResponse !== $prevContextResponse);
+
+        // Some mechanisms (e.g. CRAM-MD5) do not clear the context response after the final
+        // validation step — the stale value from the previous round remains. By comparing to
+        // what we sent last time we can detect this and avoid sending a spurious second round.
+        if ($context->isComplete() && !$responseIsNew) {
+            return new ChallengeAdvancement($context, complete: true);
+        }
+
+        // If the mechanism reports completion with a failure (e.g. SCRAM e=invalid-proof),
+        // skip sending the server-final and fall through to the INVALID_CREDENTIALS path.
+        // This avoids a protocol deadlock where the client throws a SaslException on
+        // receiving the e= response and never sends the ack the server would wait for.
+        if ($context->isComplete() && !$context->isAuthenticated()) {
+            return new ChallengeAdvancement($context, complete: true);
+        }
+
+        return new ChallengeAdvancement($context, complete: false);
+    }
+
+    /**
+     * Sends a SASL_BIND_IN_PROGRESS response carrying the server's challenge or server-final data.
+     */
+    private function sendBindInProgress(LdapMessageRequest $message, ?string $response): void
+    {
+        $this->queue->sendMessage(new LdapMessageResponse(
+            $message->getMessageId(),
+            new BindResponse(
+                new LdapResult(ResultCode::SASL_BIND_IN_PROGRESS),
+                $response,
+            ),
+        ));
+    }
+
+    /**
+     * Validates that the message received mid-exchange is a SASL bind continuation.
+     *
+     * @throws OperationException if the client sends a non-SASL request.
+     */
+    private function requireSaslContinuation(LdapMessageRequest $message): SaslBindRequest
+    {
+        $request = $message->getRequest();
+
+        if (!$request instanceof SaslBindRequest) {
+            $this->queue->sendMessage($this->responseFactory->getStandardResponse(
+                $message,
+                ResultCode::PROTOCOL_ERROR,
+                'Expected a SASL bind continuation during the exchange.',
+            ));
+
+            throw new OperationException(
+                'Expected a SASL bind continuation during the exchange.',
+                ResultCode::PROTOCOL_ERROR
+            );
+        }
+
+        return $request;
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/SaslExchangeInput.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/SaslExchangeInput.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl;
+
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Sasl\Challenge\ChallengeInterface;
+
+/**
+ * Bundles the per-invocation parameters for SaslExchange::run().
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class SaslExchangeInput
+{
+    public function __construct(
+        private readonly ChallengeInterface $challenge,
+        private readonly string $mechName,
+        private readonly LdapMessageRequest $initialMessage,
+        private readonly ?string $initialCredentials,
+    ) {
+    }
+
+    public function getChallenge(): ChallengeInterface
+    {
+        return $this->challenge;
+    }
+
+    public function getMechName(): string
+    {
+        return $this->mechName;
+    }
+
+    public function getInitialMessage(): LdapMessageRequest
+    {
+        return $this->initialMessage;
+    }
+
+    public function getInitialCredentials(): ?string
+    {
+        return $this->initialCredentials;
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/SaslExchangeResult.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/SaslExchangeResult.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl;
+
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Sasl\SaslContext;
+
+/**
+ * Aggregates the outcome of a SASL challenge-response exchange.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class SaslExchangeResult
+{
+    public function __construct(
+        private readonly SaslContext $context,
+        private readonly LdapMessageRequest $lastMessage,
+        private readonly ?string $usernameCredentials,
+    ) {
+    }
+
+    public function getContext(): SaslContext
+    {
+        return $this->context;
+    }
+
+    public function getLastMessage(): LdapMessageRequest
+    {
+        return $this->lastMessage;
+    }
+
+    public function getUsernameCredentials(): ?string
+    {
+        return $this->usernameCredentials;
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/PlainUsernameExtractor.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/PlainUsernameExtractor.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
+
+use FreeDSx\Sasl\Encoder\PlainEncoder;
+use FreeDSx\Sasl\Mechanism\PlainMechanism;
+use FreeDSx\Sasl\SaslContext;
+
+/**
+ * Extracts the username from PLAIN SASL credential bytes (the authcid field).
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class PlainUsernameExtractor implements SaslUsernameExtractorInterface
+{
+    use UsernameExtractionTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function extractUsername(
+        string $mechanism,
+        string $credentials
+    ): string {
+        $message = (new PlainEncoder())->decode($credentials, new SaslContext());
+
+        return $this->requireUsername($message, 'authcid', $mechanism);
+    }
+
+    public function supports(string $mechanism): bool
+    {
+        return $mechanism === PlainMechanism::NAME;
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/SaslUsernameExtractorFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/SaslUsernameExtractorFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
+
+use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Sasl\Mechanism\CramMD5Mechanism;
+use FreeDSx\Sasl\Mechanism\DigestMD5Mechanism;
+use FreeDSx\Sasl\Mechanism\PlainMechanism;
+use FreeDSx\Sasl\Mechanism\ScramMechanism;
+
+/**
+ * Creates a single SaslUsernameExtractorInterface instance for the requested SASL mechanism.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class SaslUsernameExtractorFactory
+{
+    /**
+     * @throws RuntimeException if no extractor is registered for the given mechanism.
+     */
+    public function make(string $mechanism): SaslUsernameExtractorInterface
+    {
+        return match (true) {
+            $mechanism === PlainMechanism::NAME
+                => new PlainUsernameExtractor(),
+            in_array($mechanism, ScramMechanism::VARIANTS, true)
+                => new ScramUsernameExtractor(),
+            $mechanism === CramMD5Mechanism::NAME,
+            $mechanism === DigestMD5Mechanism::NAME
+                => new UsernameFieldExtractor(),
+            default => throw new RuntimeException(
+                sprintf('No username extractor is registered for the SASL mechanism "%s".', $mechanism)
+            ),
+        };
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/SaslUsernameExtractorInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/SaslUsernameExtractorInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
+
+use FreeDSx\Ldap\Exception\OperationException;
+
+/**
+ * Extracts a username from raw SASL credential bytes for a specific set of mechanisms.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface SaslUsernameExtractorInterface
+{
+    /**
+     * Extract the username from raw SASL credential bytes for the given mechanism.
+     *
+     * @throws OperationException if the username cannot be extracted from the credentials.
+     */
+    public function extractUsername(string $mechanism, string $credentials): string;
+
+    /**
+     * Whether this extractor handles the given mechanism name.
+     */
+    public function supports(string $mechanism): bool;
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/ScramUsernameExtractor.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/ScramUsernameExtractor.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Sasl\Mechanism\ScramMechanism;
+
+/**
+ * Extracts the username from a SCRAM client-first-message.
+ *
+ * SCRAM is client-initiated: the username is sent in the first message as 'n=<username>'
+ * within the client-first-message-bare (after the GS2 header). RFC 5802 encodes ',' as
+ * '=2C' and '=' as '=3D' within the username field.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class ScramUsernameExtractor implements SaslUsernameExtractorInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function extractUsername(string $mechanism, string $credentials): string
+    {
+        // Strip the GS2 header (everything up to and including ',,').
+        $pos = strpos($credentials, ',,');
+        $bare = $pos !== false
+            ? substr($credentials, $pos + 2)
+            : $credentials;
+
+        // Extract the 'n=' field.
+        if (preg_match('/(?:^|,)n=([^,]*)/', $bare, $m)) {
+            // Unescape RFC 5802 username encoding.
+            return str_replace(
+                ['=2C', '=3D'],
+                [',', '='],
+                $m[1]
+            );
+        }
+
+        throw new OperationException(
+            sprintf('The %s credentials did not contain a username.', $mechanism),
+            ResultCode::PROTOCOL_ERROR
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports(string $mechanism): bool
+    {
+        return in_array(
+            $mechanism,
+            ScramMechanism::VARIANTS,
+            true,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/UsernameExtractionTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/UsernameExtractionTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Sasl\Message;
+
+/**
+ * Shared logic for validating and returning a username value extracted from SASL credentials.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+trait UsernameExtractionTrait
+{
+    /**
+     * @throws OperationException if the named field is not a non-empty string.
+     */
+    private function requireUsername(
+        Message $message,
+        string $field,
+        string $mechanism
+    ): string {
+        $value = $message->get($field);
+
+        if (!is_string($value) || $value === '') {
+            throw new OperationException(
+                sprintf('The %s credentials did not contain a username.', $mechanism),
+                ResultCode::PROTOCOL_ERROR
+            );
+        }
+
+        return $value;
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/UsernameFieldExtractor.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/UsernameFieldExtractor.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
+
+use FreeDSx\Sasl\Encoder\CramMD5Encoder;
+use FreeDSx\Sasl\Encoder\DigestMD5Encoder;
+use FreeDSx\Sasl\Encoder\EncoderInterface;
+use FreeDSx\Sasl\Mechanism\CramMD5Mechanism;
+use FreeDSx\Sasl\Mechanism\DigestMD5Mechanism;
+use FreeDSx\Sasl\SaslContext;
+
+/**
+ * Extracts the username from SASL credential bytes for mechanisms whose client response
+ * contains a 'username' field (e.g. CRAM-MD5, DIGEST-MD5).
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class UsernameFieldExtractor implements SaslUsernameExtractorInterface
+{
+    use UsernameExtractionTrait;
+
+    /**
+     * @var array<string, EncoderInterface>
+     */
+    private array $encoders;
+
+    /**
+     * @param array<string, EncoderInterface> $encoders Map of mechanism name to its encoder.
+     *                                                   Defaults to CRAM-MD5 and DIGEST-MD5.
+     */
+    public function __construct(array $encoders = [])
+    {
+        $this->encoders = $encoders ?: [
+            CramMD5Mechanism::NAME => new CramMD5Encoder(),
+            DigestMD5Mechanism::NAME => new DigestMD5Encoder(),
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function extractUsername(
+        string $mechanism,
+        string $credentials
+    ): string {
+        $encoder = $this->encoders[$mechanism];
+
+        // Always decode as server-side: we are parsing a client response, not a server challenge.
+        // For DIGEST-MD5 this is required; for others it is harmless.
+        $context = new SaslContext();
+        $context->setIsServerMode(true);
+        $message = $encoder->decode(
+            $credentials,
+            $context
+        );
+
+        return $this->requireUsername($message, 'username', $mechanism);
+    }
+
+    public function supports(string $mechanism): bool
+    {
+        return isset($this->encoders[$mechanism]);
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Bind/SaslBind.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/SaslBind.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Bind;
+
+use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\MechanismOptionsBuilderFactory;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\SaslExchange;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\SaslExchangeInput;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\SaslExchangeResult;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\SaslUsernameExtractorFactory;
+use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\Queue\MessageWrapper\SaslMessageWrapper;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
+use FreeDSx\Ldap\Server\RequestHandler\SaslHandlerInterface;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
+use FreeDSx\Sasl\Challenge\ChallengeInterface;
+use FreeDSx\Sasl\Exception\SaslException;
+use FreeDSx\Sasl\Mechanism\PlainMechanism;
+use FreeDSx\Sasl\Sasl;
+
+/**
+ * Handles a SASL bind request on the server side.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class SaslBind implements BindInterface
+{
+    use VersionValidatorTrait;
+
+    private readonly SaslExchange $exchange;
+
+    /**
+     * @param string[] $mechanisms
+     */
+    public function __construct(
+        private readonly ServerQueue $queue,
+        private readonly RequestHandlerInterface $dispatcher,
+        private readonly Sasl $sasl = new Sasl(),
+        private readonly array $mechanisms = [],
+        private readonly ResponseFactory $responseFactory = new ResponseFactory(),
+        private readonly SaslUsernameExtractorFactory $usernameExtractorFactory = new SaslUsernameExtractorFactory(),
+        ?SaslExchange $exchange = null,
+        MechanismOptionsBuilderFactory $optionsBuilderFactory = new MechanismOptionsBuilderFactory(),
+    ) {
+        $this->exchange = $exchange ?? new SaslExchange(
+            $this->queue,
+            $this->responseFactory,
+            $optionsBuilderFactory,
+            $this->dispatcher,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports(LdapMessageRequest $request): bool
+    {
+        return $request->getRequest() instanceof SaslBindRequest;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws OperationException
+     */
+    public function bind(LdapMessageRequest $message): TokenInterface
+    {
+        $request = $this->validateRequest($message);
+        $mechName = $request->getMechanism();
+        $this->validateMechanism($mechName);
+
+        $result = $this->exchange->run(new SaslExchangeInput(
+            challenge: $this->getServerChallenge($mechName),
+            mechName: $mechName,
+            initialMessage: $message,
+            initialCredentials: $request->getCredentials(),
+        ));
+
+        return $this->finalize(
+            $result,
+            $mechName,
+        );
+    }
+
+    /**
+     * @throws RuntimeException
+     * @throws OperationException
+     */
+    private function validateRequest(LdapMessageRequest $message): SaslBindRequest
+    {
+        $request = $message->getRequest();
+
+        if (!$request instanceof SaslBindRequest) {
+            throw new RuntimeException(sprintf(
+                'Expected a SaslBindRequest, got: %s',
+                get_class($request)
+            ));
+        }
+
+        self::validateVersion($request);
+
+        return $request;
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function validateMechanism(string $mechName): void
+    {
+        if (!in_array($mechName, $this->mechanisms, true)) {
+            throw new OperationException(
+                sprintf('The SASL mechanism "%s" is not supported.', $mechName),
+                ResultCode::AUTH_METHOD_UNSUPPORTED
+            );
+        }
+
+        if ($mechName !== PlainMechanism::NAME && !$this->dispatcher instanceof SaslHandlerInterface) {
+            throw new OperationException(
+                sprintf(
+                    'The SASL mechanism "%s" requires the request handler to implement %s.',
+                    $mechName,
+                    SaslHandlerInterface::class
+                ),
+                ResultCode::OTHER
+            );
+        }
+    }
+
+    private function getServerChallenge(string $mechName): ChallengeInterface
+    {
+        return $this->sasl
+            ->get($mechName)
+            ->challenge(true);
+    }
+
+    /**
+     * @throws OperationException
+     * @throws EncoderException
+     * @throws SaslException
+     */
+    private function finalize(
+        SaslExchangeResult $result,
+        string $mechName,
+    ): TokenInterface {
+        $context = $result->getContext();
+        $message = $result->getLastMessage();
+
+        if (!$context->isAuthenticated()) {
+            // Send the failure response directly using the current $message, which reflects
+            // the latest message consumed from the queue (correct ID for multi-round exchanges).
+            // Without this, the outer OperationException handler would use the stale first
+            // message ID and the client would receive a response with the wrong message ID.
+            $this->queue->sendMessage($this->responseFactory->getStandardResponse(
+                $message,
+                ResultCode::INVALID_CREDENTIALS,
+                'Invalid credentials.',
+            ));
+
+            throw new OperationException(
+                'Invalid credentials.',
+                ResultCode::INVALID_CREDENTIALS
+            );
+        }
+
+        // Extract the username before sending the success response so that if extraction
+        // fails we haven't committed to SUCCESS yet and can send the correct error response.
+        try {
+            $usernameCredentials = $result->getUsernameCredentials();
+
+            if ($usernameCredentials === null) {
+                throw new OperationException(
+                    sprintf('Unable to extract username for mechanism "%s": no credentials were received.', $mechName),
+                    ResultCode::PROTOCOL_ERROR
+                );
+            }
+
+            $username = $this->usernameExtractorFactory
+                ->make($mechName)
+                ->extractUsername(
+                    $mechName,
+                    $usernameCredentials,
+                );
+        } catch (OperationException $e) {
+            $this->queue->sendMessage($this->responseFactory->getStandardResponse(
+                $message,
+                $e->getCode(),
+                $e->getMessage(),
+            ));
+
+            throw $e;
+        }
+
+        // The success response must be sent before activating the security layer.
+        $this->queue->sendMessage($this->responseFactory->getStandardResponse($message));
+
+        if ($context->hasSecurityLayer()) {
+            $mech = $this->sasl->get($mechName);
+            $this->queue->setMessageWrapper(new SaslMessageWrapper($mech->securityLayer(), $context));
+        }
+
+        return new BindToken(
+            $username,
+            '',
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Operation\Request\AnonBindRequest;
 use FreeDSx\Ldap\Operation\Request\BindRequest;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
 use FreeDSx\Ldap\Operation\Request\UnbindRequest;
@@ -69,6 +70,11 @@ class ServerAuthorization
     {
         if ($request instanceof AnonBindRequest) {
             return $this->options->isAllowAnonymous();
+        }
+
+        if ($request instanceof SaslBindRequest) {
+            return !empty($this->options->getSaslMechanisms())
+                && in_array($request->getMechanism(), $this->options->getSaslMechanisms(), true);
         }
 
         return $request instanceof SimpleBindRequest;

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
@@ -75,6 +75,9 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
         if ($this->options->getDseVendorVersion()) {
             $entry->set('vendorVersion', (string) $this->options->getDseVendorVersion());
         }
+        if (!empty($this->options->getSaslMechanisms())) {
+            $entry->set('supportedSaslMechanisms', ...$this->options->getSaslMechanisms());
+        }
         if ($this->options->getDseAltServer()) {
             $entry->set('altServer', (string) $this->options->getDseAltServer());
         }

--- a/src/FreeDSx/Ldap/Server/RequestHandler/SaslHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/SaslHandlerInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\RequestHandler;
+
+/**
+ * Implement this interface alongside RequestHandlerInterface to support server-side SASL authentication
+ * with challenge-based mechanisms (DIGEST-MD5, CRAM-MD5) that require plaintext password lookup.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface SaslHandlerInterface
+{
+    /**
+     * Return the plaintext password for a given username and SASL mechanism. This is needed so the server
+     * can compute and verify the expected digest / response from the client.
+     *
+     * Return null if the user does not exist or should not be allowed to authenticate.
+     */
+    public function getPassword(
+        string $username,
+        string $mechanism,
+    ): ?string;
+}

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -15,7 +15,9 @@ namespace FreeDSx\Ldap\Server;
 
 use FreeDSx\Ldap\Protocol\Authenticator;
 use FreeDSx\Ldap\Protocol\Bind\AnonymousBind;
+use FreeDSx\Ldap\Protocol\Bind\SaslBind;
 use FreeDSx\Ldap\Protocol\Bind\SimpleBind;
+use FreeDSx\Sasl\Sasl;
 use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
@@ -36,6 +38,26 @@ class ServerProtocolFactory
     {
         $serverQueue = new ServerQueue($socket);
 
+        $requestHandler = $this->handlerFactory->makeRequestHandler();
+
+        $authenticators = [
+            new SimpleBind(
+                queue: $serverQueue,
+                dispatcher: $requestHandler,
+            ),
+            new AnonymousBind($serverQueue),
+        ];
+        $saslMechanisms = $this->options->getSaslMechanisms();
+
+        if (!empty($saslMechanisms)) {
+            $authenticators[] = new SaslBind(
+                queue: $serverQueue,
+                dispatcher: $requestHandler,
+                sasl: new Sasl(['supported' => $saslMechanisms]),
+                mechanisms: $saslMechanisms,
+            );
+        }
+
         return new ServerProtocolHandler(
             queue: $serverQueue,
             protocolHandlerFactory: new ServerProtocolHandlerFactory(
@@ -45,13 +67,7 @@ class ServerProtocolFactory
                 queue: $serverQueue,
             ),
             authorizer: $this->serverAuthorization,
-            authenticator: new Authenticator([
-                new SimpleBind(
-                    queue: $serverQueue,
-                    dispatcher: $this->handlerFactory->makeRequestHandler(),
-                ),
-                new AnonymousBind($serverQueue),
-            ]),
+            authenticator: new Authenticator($authenticators),
             logger: $this->options->getLogger(),
         );
     }

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap;
 
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
@@ -21,6 +22,54 @@ use Psr\Log\LoggerInterface;
 
 final class ServerOptions
 {
+    public const SASL_PLAIN = 'PLAIN';
+
+    public const SASL_CRAM_MD5 = 'CRAM-MD5';
+
+    public const SASL_DIGEST_MD5 = 'DIGEST-MD5';
+
+    public const SASL_SCRAM_SHA_1 = 'SCRAM-SHA-1';
+
+    public const SASL_SCRAM_SHA_1_PLUS = 'SCRAM-SHA-1-PLUS';
+
+    public const SASL_SCRAM_SHA_224 = 'SCRAM-SHA-224';
+
+    public const SASL_SCRAM_SHA_224_PLUS = 'SCRAM-SHA-224-PLUS';
+
+    public const SASL_SCRAM_SHA_256 = 'SCRAM-SHA-256';
+
+    public const SASL_SCRAM_SHA_256_PLUS = 'SCRAM-SHA-256-PLUS';
+
+    public const SASL_SCRAM_SHA_384 = 'SCRAM-SHA-384';
+
+    public const SASL_SCRAM_SHA_384_PLUS = 'SCRAM-SHA-384-PLUS';
+
+    public const SASL_SCRAM_SHA_512 = 'SCRAM-SHA-512';
+
+    public const SASL_SCRAM_SHA_512_PLUS = 'SCRAM-SHA-512-PLUS';
+
+    public const SASL_SCRAM_SHA3_512 = 'SCRAM-SHA3-512';
+
+    public const SASL_SCRAM_SHA3_512_PLUS = 'SCRAM-SHA3-512-PLUS';
+
+    private const SUPPORTED_SASL_MECHANISMS = [
+        self::SASL_PLAIN,
+        self::SASL_CRAM_MD5,
+        self::SASL_DIGEST_MD5,
+        self::SASL_SCRAM_SHA_1,
+        self::SASL_SCRAM_SHA_1_PLUS,
+        self::SASL_SCRAM_SHA_224,
+        self::SASL_SCRAM_SHA_224_PLUS,
+        self::SASL_SCRAM_SHA_256,
+        self::SASL_SCRAM_SHA_256_PLUS,
+        self::SASL_SCRAM_SHA_384,
+        self::SASL_SCRAM_SHA_384_PLUS,
+        self::SASL_SCRAM_SHA_512,
+        self::SASL_SCRAM_SHA_512_PLUS,
+        self::SASL_SCRAM_SHA3_512,
+        self::SASL_SCRAM_SHA3_512_PLUS,
+    ];
+
     private string $ip = '0.0.0.0';
 
     private int $port = 389;
@@ -63,6 +112,11 @@ final class ServerOptions
     private ?LoggerInterface $logger = null;
 
     private ?ServerRunnerInterface $serverRunner = null;
+
+    /**
+     * @var string[]
+     */
+    private array $saslMechanisms = [];
 
     public function getIp(): string
     {
@@ -295,6 +349,31 @@ final class ServerOptions
         return $this;
     }
 
+    /**
+     * @return string[]
+     */
+    public function getSaslMechanisms(): array
+    {
+        return $this->saslMechanisms;
+    }
+
+    public function setSaslMechanisms(string ...$mechanisms): self
+    {
+        foreach ($mechanisms as $mechanism) {
+            if (!in_array($mechanism, self::SUPPORTED_SASL_MECHANISMS, true)) {
+                throw new InvalidArgumentException(sprintf(
+                    'The SASL mechanism "%s" is not supported. Supported mechanisms: %s.',
+                    $mechanism,
+                    implode(', ', self::SUPPORTED_SASL_MECHANISMS)
+                ));
+            }
+        }
+
+        $this->saslMechanisms = array_values($mechanisms);
+
+        return $this;
+    }
+
     public function setServerRunner(ServerRunnerInterface $serverRunner): self
     {
         $this->serverRunner = $serverRunner;
@@ -308,7 +387,7 @@ final class ServerOptions
     }
 
     /**
-     * @return array{ip: string, port: int, unix_socket: string, transport: string, idle_timeout: int, require_authentication: bool, allow_anonymous: bool, request_handler: ?RequestHandlerInterface, rootdse_handler: ?RootDseHandlerInterface, paging_handler: ?PagingHandlerInterface, logger: ?LoggerInterface, use_ssl: bool, ssl_cert: ?string, ssl_cert_key: ?string, ssl_cert_passphrase: ?string, dse_alt_server: ?string, dse_naming_contexts: string[], dse_vendor_name: string, dse_vendor_version: ?string}
+     * @return array{ip: string, port: int, unix_socket: string, transport: string, idle_timeout: int, require_authentication: bool, allow_anonymous: bool, request_handler: ?RequestHandlerInterface, rootdse_handler: ?RootDseHandlerInterface, paging_handler: ?PagingHandlerInterface, logger: ?LoggerInterface, use_ssl: bool, ssl_cert: ?string, ssl_cert_key: ?string, ssl_cert_passphrase: ?string, dse_alt_server: ?string, dse_naming_contexts: string[], dse_vendor_name: string, dse_vendor_version: ?string, sasl_mechanisms: string[]}
      */
     public function toArray(): array
     {
@@ -332,6 +411,7 @@ final class ServerOptions
             'dse_naming_contexts' => $this->getDseNamingContexts(),
             'dse_vendor_name' => $this->getDseVendorName(),
             'dse_vendor_version' => $this->getDseVendorVersion(),
+            'sasl_mechanisms' => $this->getSaslMechanisms(),
         ];
     }
 }

--- a/tests/bin/ldapserver.php
+++ b/tests/bin/ldapserver.php
@@ -16,6 +16,7 @@ use FreeDSx\Ldap\Server\Paging\PagingResponse;
 use FreeDSx\Ldap\Server\RequestContext;
 use FreeDSx\Ldap\Server\RequestHandler\GenericRequestHandler;
 use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
+use FreeDSx\Ldap\Server\RequestHandler\SaslHandlerInterface;
 use FreeDSx\Ldap\ServerOptions;
 
 require __DIR__ . '/../../vendor/autoload.php';
@@ -81,7 +82,7 @@ class LdapServerPagingHandler implements PagingHandlerInterface
     }
 }
 
-class LdapServerRequestHandler extends GenericRequestHandler
+class LdapServerRequestHandler extends GenericRequestHandler implements SaslHandlerInterface
 {
     /**
      * @var array<string, string>
@@ -89,6 +90,13 @@ class LdapServerRequestHandler extends GenericRequestHandler
     private array $users = [
         'cn=user,dc=foo,dc=bar' => '12345',
     ];
+
+    public function getPassword(
+        string $username,
+        string $mechanism,
+    ): ?string {
+        return $this->users[$username] ?? null;
+    }
 
     public function bind(string $username, string $password): bool
     {
@@ -204,20 +212,28 @@ if ($transport === 'ssl') {
     $useSsl = true;
 }
 
-$server = new LdapServer(
-    (new ServerOptions())
-        ->setRequestHandler(new LdapServerRequestHandler())
-        ->setPort(3389)
-        ->setTransport($transport)
-        ->setSslCert($sslCert)
-        ->setSslCertKey($sslKey)
-        ->setUseSsl($useSsl)
-        ->setPagingHandler(
-            $handler === 'paging'
-                ? new LdapServerPagingHandler()
-                : null
-        )
-);
+$options = (new ServerOptions())
+    ->setRequestHandler(new LdapServerRequestHandler())
+    ->setPort(3389)
+    ->setTransport($transport)
+    ->setSslCert($sslCert)
+    ->setSslCertKey($sslKey)
+    ->setUseSsl($useSsl)
+    ->setPagingHandler(
+        $handler === 'paging'
+            ? new LdapServerPagingHandler()
+            : null
+    );
+
+if ($handler === 'sasl') {
+    $options->setSaslMechanisms(
+        ServerOptions::SASL_PLAIN,
+        ServerOptions::SASL_CRAM_MD5,
+        ServerOptions::SASL_SCRAM_SHA_256,
+    );
+}
+
+$server = new LdapServer($options);
 
 echo "server starting..." . PHP_EOL;
 

--- a/tests/integration/LdapSaslServerTest.php
+++ b/tests/integration/LdapSaslServerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap;
+
+use FreeDSx\Ldap\Exception\BindException;
+use FreeDSx\Ldap\Operation\Response\BindResponse;
+use FreeDSx\Ldap\ServerOptions;
+
+final class LdapSaslServerTest extends ServerTestCase
+{
+    public function setUp(): void
+    {
+        $this->setServerMode('ldapserver');
+
+        parent::setUp();
+
+        $this->createServerProcess(
+            'tcp',
+            'sasl'
+        );
+    }
+
+    public function testItCanAuthenticateWithSaslPlain(): void
+    {
+        $response = $this->ldapClient()->bindSasl(
+            ['username' => 'cn=user,dc=foo,dc=bar', 'password' => '12345'],
+            ServerOptions::SASL_PLAIN,
+        )->getResponse();
+
+        $this->assertInstanceOf(BindResponse::class, $response);
+        $this->assertSame(0, $response->getResultCode());
+    }
+
+    public function testSaslPlainFailsWithInvalidCredentials(): void
+    {
+        $this->expectException(BindException::class);
+
+        $this->ldapClient()->bindSasl(
+            ['username' => 'cn=user,dc=foo,dc=bar', 'password' => 'wrong'],
+            ServerOptions::SASL_PLAIN,
+        );
+    }
+
+    public function testItCanAuthenticateWithSaslCramMD5(): void
+    {
+        $response = $this->ldapClient()->bindSasl(
+            ['username' => 'cn=user,dc=foo,dc=bar', 'password' => '12345'],
+            ServerOptions::SASL_CRAM_MD5,
+        )->getResponse();
+
+        $this->assertInstanceOf(BindResponse::class, $response);
+        $this->assertSame(0, $response->getResultCode());
+    }
+
+    public function testSaslCramMD5FailsWithInvalidCredentials(): void
+    {
+        $this->expectException(BindException::class);
+
+        $this->ldapClient()->bindSasl(
+            ['username' => 'cn=user,dc=foo,dc=bar', 'password' => 'wrong'],
+            ServerOptions::SASL_CRAM_MD5,
+        );
+    }
+
+    public function testItCanAuthenticateWithSaslScramSha256(): void
+    {
+        $response = $this->ldapClient()->bindSasl(
+            ['username' => 'cn=user,dc=foo,dc=bar', 'password' => '12345'],
+            ServerOptions::SASL_SCRAM_SHA_256,
+        )->getResponse();
+
+        $this->assertInstanceOf(
+            BindResponse::class,
+            $response
+        );
+        $this->assertSame(
+            0,
+            $response->getResultCode()
+        );
+    }
+
+    public function testSaslScramSha256FailsWithInvalidCredentials(): void
+    {
+        $this->expectException(BindException::class);
+
+        $this->ldapClient()->bindSasl(
+            ['username' => 'cn=user,dc=foo,dc=bar', 'password' => 'wrong'],
+            ServerOptions::SASL_SCRAM_SHA_256,
+        );
+    }
+
+    public function testRootDseAdvertisesSaslMechanisms(): void
+    {
+        $rootDse = $this->ldapClient()->read('');
+
+        $this->assertNotNull($rootDse);
+
+        $mechanisms = $rootDse->toArray()['supportedSaslMechanisms'] ?? [];
+
+        $this->assertContains(
+            ServerOptions::SASL_PLAIN,
+            $mechanisms,
+        );
+        $this->assertContains(
+            ServerOptions::SASL_CRAM_MD5,
+            $mechanisms,
+        );
+        $this->assertContains(
+            ServerOptions::SASL_SCRAM_SHA_256,
+            $mechanisms,
+        );
+    }
+}

--- a/tests/unit/LdapServerTest.php
+++ b/tests/unit/LdapServerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap;
 
 use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
@@ -22,12 +23,18 @@ use FreeDSx\Ldap\Server\RequestHandler\ProxyPagingHandler;
 use FreeDSx\Ldap\Server\RequestHandler\ProxyRequestHandler;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
+use FreeDSx\Ldap\Server\RequestHandler\SaslHandlerInterface;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\SocketServer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+
+/**
+ * Combined interface so PHPUnit can mock both at once.
+ */
+interface SaslRequestHandlerInterface extends RequestHandlerInterface, SaslHandlerInterface {}
 
 class LdapServerTest extends TestCase
 {
@@ -135,9 +142,57 @@ class LdapServerTest extends TestCase
                 ],
                 'dse_vendor_name' => "FreeDSx",
                 'dse_vendor_version' => null,
+                'sasl_mechanisms' => [],
             ],
             $this->subject->getOptions()->toArray(),
         );
+    }
+
+    public function test_it_throws_when_challenge_mechanisms_are_configured_without_a_sasl_handler(): void
+    {
+        $this->options->setSaslMechanisms(ServerOptions::SASL_CRAM_MD5);
+
+        self::expectException(InvalidArgumentException::class);
+
+        $this->subject->run();
+    }
+
+    public function test_it_throws_when_challenge_mechanisms_are_configured_with_a_non_sasl_handler(): void
+    {
+        $this->options
+            ->setSaslMechanisms(ServerOptions::SASL_CRAM_MD5)
+            ->setRequestHandler($this->createMock(RequestHandlerInterface::class));
+
+        self::expectException(InvalidArgumentException::class);
+
+        $this->subject->run();
+    }
+
+    public function test_it_does_not_throw_when_challenge_mechanisms_are_configured_with_a_sasl_handler(): void
+    {
+        /** @var RequestHandlerInterface&SaslHandlerInterface&MockObject $mockSaslHandler */
+        $mockSaslHandler = $this->createMock(SaslRequestHandlerInterface::class);
+
+        $this->mockServerRunner->method('run');
+
+        $this->options
+            ->setSaslMechanisms(ServerOptions::SASL_CRAM_MD5)
+            ->setRequestHandler($mockSaslHandler);
+
+        $this->subject->run();
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function test_it_does_not_throw_for_plain_mechanism_without_a_sasl_handler(): void
+    {
+        $this->mockServerRunner->method('run');
+
+        $this->options->setSaslMechanisms(ServerOptions::SASL_PLAIN);
+
+        $this->subject->run();
+
+        $this->expectNotToPerformAssertions();
     }
 
     public function test_it_should_make_a_proxy_server(): void

--- a/tests/unit/Operation/Request/SaslBindRequestTest.php
+++ b/tests/unit/Operation/Request/SaslBindRequestTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Operation\Request;
+
+use FreeDSx\Asn1\Asn1;
+use FreeDSx\Ldap\Exception\BindException;
+use FreeDSx\Ldap\Exception\ProtocolException;
+use FreeDSx\Ldap\Operation\Request\BindRequest;
+use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
+use PHPUnit\Framework\TestCase;
+
+final class SaslBindRequestTest extends TestCase
+{
+    public function test_bind_request_returns_sasl_bind_request_from_asn1_with_mechanism_only(): void
+    {
+        $request = new SaslBindRequest('PLAIN');
+
+        /** @var SaslBindRequest $result */
+        $result = BindRequest::fromAsn1($request->toAsn1());
+
+        self::assertInstanceOf(SaslBindRequest::class, $result);
+        self::assertSame('PLAIN', $result->getMechanism());
+        self::assertNull($result->getCredentials());
+    }
+
+    public function test_bind_request_returns_sasl_bind_request_from_asn1_with_mechanism_and_credentials(): void
+    {
+        $request = new SaslBindRequest(
+            'PLAIN',
+            "\x00user\x00pass"
+        );
+
+        /** @var SaslBindRequest $result */
+        $result = BindRequest::fromAsn1($request->toAsn1());
+
+        self::assertInstanceOf(SaslBindRequest::class, $result);
+        self::assertSame(
+            'PLAIN',
+            $result->getMechanism()
+        );
+        self::assertSame(
+            "\x00user\x00pass",
+            $result->getCredentials()
+        );
+    }
+
+    public function test_sasl_bind_request_throws_a_protocol_exception_for_a_malformed_sasl_mechanism(): void
+    {
+        // Build just the SaslCredentials [3] context part with a non-OctetString as the mechanism.
+        $malformedAuth = Asn1::context(
+            tagNumber: 3,
+            type: Asn1::sequence(
+                Asn1::integer(99),  // mechanism must be an OctetString, not an integer
+            ),
+        );
+
+        self::expectException(ProtocolException::class);
+
+        SaslBindRequest::fromAsn1($malformedAuth);
+    }
+
+    public function test_sasl_bind_request_throws_when_the_mechanism_is_empty(): void
+    {
+        self::expectException(BindException::class);
+
+        (new SaslBindRequest(''))->toAsn1();
+    }
+
+    public function test_it_can_change_the_mechanism(): void
+    {
+        $request = new SaslBindRequest('PLAIN');
+        $result = $request->setMechanism('GSSAPI');
+
+        self::assertSame($request, $result);
+        self::assertSame('GSSAPI', $request->getMechanism());
+    }
+
+    public function test_it_returns_options_set_via_constructor(): void
+    {
+        $request = new SaslBindRequest('PLAIN', null, ['foo' => 'bar']);
+
+        self::assertSame(['foo' => 'bar'], $request->getOptions());
+    }
+
+    public function test_bind_request_throws_for_an_unsupported_authentication_tag(): void
+    {
+        // Tag 1 and 2 are reserved in the AuthenticationChoice — only 0 (simple/anon) and 3 (SASL) are valid.
+        $request = Asn1::application(0, Asn1::sequence(
+            Asn1::integer(3),
+            Asn1::octetString(''),
+            Asn1::context(tagNumber: 1, type: Asn1::octetString('')),
+        ));
+
+        self::expectException(ProtocolException::class);
+
+        BindRequest::fromAsn1($request);
+    }
+}

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/CramMD5MechanismOptionsBuilderTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/CramMD5MechanismOptionsBuilderTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\CramMD5MechanismOptionsBuilder;
+use FreeDSx\Ldap\Server\RequestHandler\SaslHandlerInterface;
+use FreeDSx\Sasl\Mechanism\CramMD5Mechanism;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class CramMD5MechanismOptionsBuilderTest extends TestCase
+{
+    private SaslHandlerInterface&MockObject $mockHandler;
+
+    private CramMD5MechanismOptionsBuilder $subject;
+
+    protected function setUp(): void
+    {
+        $this->mockHandler = $this->createMock(SaslHandlerInterface::class);
+        $this->subject = new CramMD5MechanismOptionsBuilder($this->mockHandler);
+    }
+
+    public function test_it_supports_the_cram_md5_mechanism(): void
+    {
+        self::assertTrue($this->subject->supports(CramMD5Mechanism::NAME));
+    }
+
+    public function test_it_does_not_support_other_mechanisms(): void
+    {
+        self::assertFalse($this->subject->supports('PLAIN'));
+        self::assertFalse($this->subject->supports('DIGEST-MD5'));
+    }
+
+    public function test_it_returns_empty_options_when_no_bytes_received(): void
+    {
+        self::assertSame(
+            [],
+            $this->subject->buildOptions(null, CramMD5Mechanism::NAME)
+        );
+    }
+
+    public function test_it_builds_options_with_a_password_callable_when_bytes_are_received(): void
+    {
+        $options = $this->subject->buildOptions(
+            'some-client-response',
+            CramMD5Mechanism::NAME,
+        );
+
+        self::assertArrayHasKey(
+            'password',
+            $options
+        );
+        self::assertIsCallable($options['password']);
+    }
+
+    public function test_the_password_callable_returns_an_hmac_of_the_challenge(): void
+    {
+        $this->mockHandler
+            ->method('getPassword')
+            ->with('cn=user,dc=foo,dc=bar', CramMD5Mechanism::NAME)
+            ->willReturn('12345');
+
+        $options = $this->subject->buildOptions('some-bytes', CramMD5Mechanism::NAME);
+        $password = $options['password'];
+        assert(is_callable($password));
+        // The challenge passed to the callable is the encoded challenge string exactly as the
+        // client received it (e.g. "<nonce>"), per RFC 2195.
+        $challenge = '<challenge@example.com>';
+        $result = $password('cn=user,dc=foo,dc=bar', $challenge);
+
+        self::assertSame(
+            hash_hmac('md5', '<challenge@example.com>', '12345'),
+            $result
+        );
+    }
+
+    public function test_the_password_callable_throws_invalid_credentials_when_user_not_found(): void
+    {
+        $this->mockHandler
+            ->method('getPassword')
+            ->willReturn(null);
+
+        $options = $this->subject->buildOptions(
+            'some-bytes',
+            CramMD5Mechanism::NAME
+        );
+        $password = $options['password'];
+        assert(is_callable($password));
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        $password('unknown-user', 'challenge');
+    }
+}

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/DigestMD5MechanismOptionsBuilderTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/DigestMD5MechanismOptionsBuilderTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\DigestMD5MechanismOptionsBuilder;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\SaslUsernameExtractorInterface;
+use FreeDSx\Ldap\Server\RequestHandler\SaslHandlerInterface;
+use FreeDSx\Sasl\Mechanism\DigestMD5Mechanism;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class DigestMD5MechanismOptionsBuilderTest extends TestCase
+{
+    private SaslHandlerInterface&MockObject $mockHandler;
+
+    private SaslUsernameExtractorInterface&MockObject $mockUsernameExtractor;
+
+    private DigestMD5MechanismOptionsBuilder $subject;
+
+    protected function setUp(): void
+    {
+        $this->mockHandler = $this->createMock(SaslHandlerInterface::class);
+        $this->mockUsernameExtractor = $this->createMock(SaslUsernameExtractorInterface::class);
+
+        $this->subject = new DigestMD5MechanismOptionsBuilder(
+            $this->mockHandler,
+            $this->mockUsernameExtractor,
+        );
+    }
+
+    public function test_it_supports_the_digest_md5_mechanism(): void
+    {
+        self::assertTrue($this->subject->supports(DigestMD5Mechanism::NAME));
+    }
+
+    public function test_it_does_not_support_other_mechanisms(): void
+    {
+        self::assertFalse($this->subject->supports('PLAIN'));
+        self::assertFalse($this->subject->supports('CRAM-MD5'));
+    }
+
+    public function test_it_returns_empty_options_when_no_bytes_received(): void
+    {
+        self::assertSame(
+            [],
+            $this->subject->buildOptions(null, DigestMD5Mechanism::NAME)
+        );
+    }
+
+    public function test_it_builds_options_with_the_password_when_bytes_are_received(): void
+    {
+        $this->mockUsernameExtractor
+            ->method('extractUsername')
+            ->with(DigestMD5Mechanism::NAME, 'client-response')
+            ->willReturn('cn=user,dc=foo,dc=bar');
+
+        $this->mockHandler
+            ->method('getPassword')
+            ->with('cn=user,dc=foo,dc=bar', DigestMD5Mechanism::NAME)
+            ->willReturn('12345');
+
+        $options = $this->subject->buildOptions('client-response', DigestMD5Mechanism::NAME);
+
+        self::assertSame(
+            ['password' => '12345'],
+            $options,
+        );
+    }
+
+    public function test_it_throws_invalid_credentials_when_password_is_not_found(): void
+    {
+        $this->mockUsernameExtractor
+            ->method('extractUsername')
+            ->willReturn('unknown-user');
+
+        $this->mockHandler
+            ->method('getPassword')
+            ->willReturn(null);
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        $this->subject->buildOptions('client-response', DigestMD5Mechanism::NAME);
+    }
+}

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/MechanismOptionsBuilderFactoryTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/MechanismOptionsBuilderFactoryTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
+
+use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\CramMD5MechanismOptionsBuilder;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\DigestMD5MechanismOptionsBuilder;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\MechanismOptionsBuilderFactory;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\PlainMechanismOptionsBuilder;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\ScramMechanismOptionsBuilder;
+use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
+use FreeDSx\Ldap\Server\RequestHandler\SaslHandlerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Combined interface so PHPUnit can mock both at once.
+ */
+interface SaslRequestHandlerInterface extends RequestHandlerInterface, SaslHandlerInterface {}
+
+final class MechanismOptionsBuilderFactoryTest extends TestCase
+{
+    private MechanismOptionsBuilderFactory $subject;
+
+    private RequestHandlerInterface&MockObject $mockDispatcher;
+
+    private SaslRequestHandlerInterface&MockObject $mockSaslDispatcher;
+
+    protected function setUp(): void
+    {
+        $this->subject = new MechanismOptionsBuilderFactory();
+        $this->mockDispatcher = $this->createMock(RequestHandlerInterface::class);
+        $this->mockSaslDispatcher = $this->createMock(SaslRequestHandlerInterface::class);
+    }
+
+    public function test_make_plain_with_non_sasl_dispatcher_returns_plain_builder(): void
+    {
+        self::assertInstanceOf(
+            PlainMechanismOptionsBuilder::class,
+            $this->subject->make('PLAIN', $this->mockDispatcher)
+        );
+    }
+
+    public function test_make_plain_with_sasl_dispatcher_returns_plain_builder(): void
+    {
+        self::assertInstanceOf(
+            PlainMechanismOptionsBuilder::class,
+            $this->subject->make('PLAIN', $this->mockSaslDispatcher)
+        );
+    }
+
+    public function test_make_cram_md5_with_sasl_dispatcher_returns_cram_md5_builder(): void
+    {
+        self::assertInstanceOf(
+            CramMD5MechanismOptionsBuilder::class,
+            $this->subject->make('CRAM-MD5', $this->mockSaslDispatcher)
+        );
+    }
+
+    public function test_make_digest_md5_with_sasl_dispatcher_returns_digest_md5_builder(): void
+    {
+        self::assertInstanceOf(
+            DigestMD5MechanismOptionsBuilder::class,
+            $this->subject->make('DIGEST-MD5', $this->mockSaslDispatcher)
+        );
+    }
+
+    public function test_make_scram_sha256_with_sasl_dispatcher_returns_scram_builder(): void
+    {
+        self::assertInstanceOf(
+            ScramMechanismOptionsBuilder::class,
+            $this->subject->make('SCRAM-SHA-256', $this->mockSaslDispatcher)
+        );
+    }
+
+    public function test_make_cram_md5_with_non_sasl_dispatcher_throws(): void
+    {
+        self::expectException(RuntimeException::class);
+
+        $this->subject->make('CRAM-MD5', $this->mockDispatcher);
+    }
+
+    public function test_make_unknown_mechanism_throws(): void
+    {
+        self::expectException(RuntimeException::class);
+
+        $this->subject->make('UNKNOWN', $this->mockSaslDispatcher);
+    }
+}

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/PlainMechanismOptionsBuilderTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/PlainMechanismOptionsBuilderTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
+
+use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\PlainMechanismOptionsBuilder;
+use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
+use FreeDSx\Sasl\Mechanism\PlainMechanism;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class PlainMechanismOptionsBuilderTest extends TestCase
+{
+    private RequestHandlerInterface&MockObject $mockDispatcher;
+
+    private PlainMechanismOptionsBuilder $subject;
+
+    protected function setUp(): void
+    {
+        $this->mockDispatcher = $this->createMock(RequestHandlerInterface::class);
+        $this->subject = new PlainMechanismOptionsBuilder($this->mockDispatcher);
+    }
+
+    public function test_it_supports_the_plain_mechanism(): void
+    {
+        self::assertTrue($this->subject->supports(PlainMechanism::NAME));
+    }
+
+    public function test_it_does_not_support_other_mechanisms(): void
+    {
+        self::assertFalse($this->subject->supports('CRAM-MD5'));
+    }
+
+    public function test_it_builds_options_with_a_validate_callable(): void
+    {
+        $options = $this->subject->buildOptions(null, PlainMechanism::NAME);
+
+        self::assertArrayHasKey(
+            'validate',
+            $options,
+        );
+        self::assertIsCallable($options['validate']);
+    }
+
+    public function test_the_validate_callable_delegates_to_dispatcher_bind(): void
+    {
+        $this->mockDispatcher
+            ->expects(self::once())
+            ->method('bind')
+            ->with('cn=user,dc=foo,dc=bar', '12345')
+            ->willReturn(true);
+
+        $options = $this->subject->buildOptions(null, PlainMechanism::NAME);
+        $validate = $options['validate'];
+        assert(is_callable($validate));
+        $result = $validate('authzid', 'cn=user,dc=foo,dc=bar', '12345');
+
+        self::assertTrue($result);
+    }
+
+    public function test_the_validate_callable_returns_false_when_bind_fails(): void
+    {
+        $this->mockDispatcher
+            ->method('bind')
+            ->willReturn(false);
+
+        $options = $this->subject->buildOptions(null, PlainMechanism::NAME);
+        $validate = $options['validate'];
+        assert(is_callable($validate));
+        $result = $validate(null, 'user', 'wrong');
+
+        self::assertFalse($result);
+    }
+
+    public function test_it_builds_the_same_options_regardless_of_received_bytes(): void
+    {
+        $optionsWithNull = $this->subject->buildOptions(null, PlainMechanism::NAME);
+        $optionsWithBytes = $this->subject->buildOptions('some-bytes', PlainMechanism::NAME);
+
+        self::assertArrayHasKey('validate', $optionsWithNull);
+        self::assertArrayHasKey('validate', $optionsWithBytes);
+    }
+}

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/ScramMechanismOptionsBuilderTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/ScramMechanismOptionsBuilderTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\ScramMechanismOptionsBuilder;
+use FreeDSx\Ldap\Server\RequestHandler\SaslHandlerInterface;
+use FreeDSx\Sasl\Mechanism\ScramMechanism;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class ScramMechanismOptionsBuilderTest extends TestCase
+{
+    private SaslHandlerInterface&MockObject $mockHandler;
+
+    private ScramMechanismOptionsBuilder $subject;
+
+    protected function setUp(): void
+    {
+        $this->mockHandler = $this->createMock(SaslHandlerInterface::class);
+        $this->subject = new ScramMechanismOptionsBuilder($this->mockHandler);
+    }
+
+    public function test_it_supports_all_scram_variants(): void
+    {
+        foreach (ScramMechanism::VARIANTS as $variant) {
+            self::assertTrue($this->subject->supports($variant), "Expected support for $variant");
+        }
+    }
+
+    public function test_it_does_not_support_other_mechanisms(): void
+    {
+        self::assertFalse($this->subject->supports('PLAIN'));
+        self::assertFalse($this->subject->supports('CRAM-MD5'));
+        self::assertFalse($this->subject->supports('DIGEST-MD5'));
+    }
+
+    public function test_it_returns_empty_options_when_no_bytes_received(): void
+    {
+        self::assertSame([], $this->subject->buildOptions(null, ScramMechanism::SHA256));
+    }
+
+    public function test_it_returns_empty_options_for_client_first_message(): void
+    {
+        // Client-first: GS2 header + username + cnonce, no proof field.
+        $clientFirst = 'n,,n=testuser,r=clientnonce123';
+
+        self::assertSame([], $this->subject->buildOptions($clientFirst, ScramMechanism::SHA256));
+    }
+
+    public function test_it_extracts_username_from_client_first_and_provides_password_on_client_final(): void
+    {
+        $this->mockHandler
+            ->expects(self::once())
+            ->method('getPassword')
+            ->with('testuser', ScramMechanism::SHA256)
+            ->willReturn('secret');
+
+        $this->subject->buildOptions('n,,n=testuser,r=clientnonce123', ScramMechanism::SHA256);
+        $options = $this->subject->buildOptions('c=biws,r=clientnonce123servernonce,p=dGVzdA==', ScramMechanism::SHA256);
+
+        self::assertArrayHasKey('password', $options);
+        self::assertSame('secret', $options['password']);
+    }
+
+    public function test_it_passes_the_mechanism_name_to_the_handler(): void
+    {
+        $this->mockHandler
+            ->expects(self::once())
+            ->method('getPassword')
+            ->with('user', ScramMechanism::SHA512)
+            ->willReturn('pw');
+
+        $this->subject->buildOptions('n,,n=user,r=nonce', ScramMechanism::SHA512);
+        $this->subject->buildOptions('c=biws,r=fullnonce,p=proof==', ScramMechanism::SHA512);
+    }
+
+    public function test_it_throws_invalid_credentials_when_user_not_found(): void
+    {
+        $this->mockHandler
+            ->method('getPassword')
+            ->willReturn(null);
+
+        $this->subject->buildOptions('n,,n=unknown,r=nonce', ScramMechanism::SHA256);
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        $this->subject->buildOptions('c=biws,r=fullnonce,p=someproof==', ScramMechanism::SHA256);
+    }
+
+    public function test_it_throws_protocol_error_when_client_final_received_before_client_first(): void
+    {
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::PROTOCOL_ERROR);
+
+        // Client-final arrives without a prior client-first.
+        $this->subject->buildOptions('c=biws,r=fullnonce,p=proof==', ScramMechanism::SHA256);
+    }
+
+    public function test_it_decodes_rfc5802_encoded_username(): void
+    {
+        $this->mockHandler
+            ->expects(self::once())
+            ->method('getPassword')
+            ->with('user,name=test', ScramMechanism::SHA256)
+            ->willReturn('pw');
+
+        // ',' encoded as '=2C', '=' encoded as '=3D'
+        $this->subject->buildOptions('n,,n=user=2Cname=3Dtest,r=nonce', ScramMechanism::SHA256);
+        $this->subject->buildOptions('c=biws,r=fullnonce,p=proof==', ScramMechanism::SHA256);
+    }
+
+    public function test_it_handles_channel_binding_gs2_header(): void
+    {
+        $this->mockHandler
+            ->method('getPassword')
+            ->willReturn('pw');
+
+        // 'p=tls-unique,,' GS2 header for channel-binding variants
+        $this->subject->buildOptions('p=tls-unique,,n=user,r=nonce', ScramMechanism::SHA256_PLUS);
+        $options = $this->subject->buildOptions('c=cD10bHMtdW5pcXVlLCwx,r=fullnonce,p=proof==', ScramMechanism::SHA256_PLUS);
+
+        self::assertArrayHasKey('password', $options);
+    }
+
+    public function test_it_parses_username_from_client_first_without_gs2_header(): void
+    {
+        $this->mockHandler
+            ->expects(self::once())
+            ->method('getPassword')
+            ->with('user', ScramMechanism::SHA256)
+            ->willReturn('pw');
+
+        // No ',,' separator — treat the whole string as the bare client-first-message.
+        $this->subject->buildOptions('n=user,r=nonce', ScramMechanism::SHA256);
+        $options = $this->subject->buildOptions('c=biws,r=fullnonce,p=proof==', ScramMechanism::SHA256);
+
+        self::assertArrayHasKey('password', $options);
+    }
+
+    public function test_it_throws_protocol_error_when_client_first_has_no_username_field(): void
+    {
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::PROTOCOL_ERROR);
+
+        // After stripping the GS2 header the bare message contains no 'n=' field.
+        $this->subject->buildOptions('n,,r=nonce-only', ScramMechanism::SHA256);
+    }
+}

--- a/tests/unit/Protocol/Bind/Sasl/SaslExchangeTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/SaslExchangeTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind\Sasl;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
+use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\MechanismOptionsBuilderFactory;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\SaslExchange;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\SaslExchangeInput;
+use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
+use FreeDSx\Sasl\Challenge\ChallengeInterface;
+use FreeDSx\Sasl\SaslContext;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SaslExchangeTest extends TestCase
+{
+    /**
+     * Using 'PLAIN' as the mechanism name so that the real MechanismOptionsBuilderFactory
+     * can produce a PlainMechanismOptionsBuilder (which only requires RequestHandlerInterface,
+     * not SaslHandlerInterface). The mock challenge ignores the option array, so the
+     * specific mechanism does not affect the exchange-loop behavior under test.
+     */
+    private const MECH = 'PLAIN';
+
+    private SaslExchange $subject;
+
+    private ServerQueue&MockObject $mockQueue;
+
+    private ChallengeInterface&MockObject $mockChallenge;
+
+    protected function setUp(): void
+    {
+        $this->mockQueue = $this->createMock(ServerQueue::class);
+        $this->mockChallenge = $this->createMock(ChallengeInterface::class);
+
+        $this->subject = new SaslExchange(
+            queue: $this->mockQueue,
+            responseFactory: new ResponseFactory(),
+            optionsBuilderFactory: new MechanismOptionsBuilderFactory(),
+            dispatcher: $this->createMock(RequestHandlerInterface::class),
+        );
+    }
+
+    private function makeInput(?string $initialCredentials = null): SaslExchangeInput
+    {
+        return new SaslExchangeInput(
+            challenge: $this->mockChallenge,
+            mechName: self::MECH,
+            initialMessage: new LdapMessageRequest(1, new SaslBindRequest(self::MECH)),
+            initialCredentials: $initialCredentials,
+        );
+    }
+
+    private function makeContext(
+        bool $isComplete,
+        bool $isAuthenticated = true,
+        ?string $response = null,
+    ): SaslContext {
+        return (new SaslContext())
+            ->setIsComplete($isComplete)
+            ->setIsAuthenticated($isAuthenticated)
+            ->setResponse($response);
+    }
+
+    public function test_it_breaks_immediately_on_invalid_proof(): void
+    {
+        // Context is complete but not authenticated (e.g. SCRAM e=invalid-proof).
+        // The loop must break without sending SASL_BIND_IN_PROGRESS.
+        $this->mockChallenge
+            ->expects(self::once())
+            ->method('challenge')
+            ->willReturn($this->makeContext(
+                isComplete: true,
+                isAuthenticated: false,
+                response: 'e=invalid-proof'
+            ));
+
+        $this->mockQueue
+            ->expects(self::never())
+            ->method('sendMessage');
+
+        $result = $this->subject->run($this->makeInput());
+
+        self::assertFalse($result->getContext()->isAuthenticated());
+    }
+
+    public function test_it_breaks_on_stale_context_response(): void
+    {
+        // CRAM-MD5 pattern: after validation the mechanism leaves the old server-challenge
+        // as the response instead of clearing it. The stale-response guard detects this and
+        // breaks without sending a spurious second round.
+        $this->mockChallenge
+            ->expects(self::exactly(2))
+            ->method('challenge')
+            ->willReturnOnConsecutiveCalls(
+                $this->makeContext(isComplete: false, response: 'server-challenge'),
+                $this->makeContext(isComplete: true, response: 'server-challenge'), // stale
+            );
+
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('sendMessage'); // only the first SASL_BIND_IN_PROGRESS
+
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('getMessage')
+            ->willReturn(new LdapMessageRequest(2, new SaslBindRequest(self::MECH, 'client-response')));
+
+        $result = $this->subject->run($this->makeInput());
+
+        self::assertTrue($result->getContext()->isAuthenticated());
+        // Username credentials are set from the client response received in round 1.
+        self::assertSame(
+            'client-response',
+            $result->getUsernameCredentials()
+        );
+    }
+
+    public function test_it_breaks_on_context_already_complete_at_top_of_loop(): void
+    {
+        // DIGEST-MD5 pattern: server sends a server-final (isComplete=true, response!=null),
+        // client sends an empty ack, and on the next loop iteration the context is already
+        // complete so we break before calling challenge() again.
+        $this->mockChallenge
+            ->expects(self::exactly(2))
+            ->method('challenge')
+            ->willReturnOnConsecutiveCalls(
+                $this->makeContext(isComplete: false, response: 'server-challenge'),
+                $this->makeContext(isComplete: true, response: 'rspauth=xyz'), // server-final
+            );
+
+        // Two sendMessage calls: one challenge prompt + one server-final.
+        $this->mockQueue
+            ->expects(self::exactly(2))
+            ->method('sendMessage');
+
+        $this->mockQueue
+            ->expects(self::exactly(2))
+            ->method('getMessage')
+            ->willReturnOnConsecutiveCalls(
+                new LdapMessageRequest(2, new SaslBindRequest(self::MECH, 'client-response')),
+                new LdapMessageRequest(3, new SaslBindRequest(self::MECH)), // empty ack
+            );
+
+        $result = $this->subject->run($this->makeInput());
+
+        self::assertTrue($result->getContext()->isAuthenticated());
+        // The last message is the empty ack (message ID 3).
+        self::assertSame(
+            3,
+            $result->getLastMessage()->getMessageId(),
+        );
+    }
+
+    public function test_it_tracks_username_credentials_from_first_non_null_response(): void
+    {
+        // Initial credentials are null; username credentials should come from the
+        // first non-null response received from the client.
+        $this->mockChallenge
+            ->method('challenge')
+            ->willReturnOnConsecutiveCalls(
+                $this->makeContext(isComplete: false, response: 'server-challenge'),
+                $this->makeContext(isComplete: true, response: 'server-challenge'), // stale
+            );
+
+        $this->mockQueue->method('sendMessage');
+        $this->mockQueue
+            ->method('getMessage')
+            ->willReturn(new LdapMessageRequest(2, new SaslBindRequest('TEST', 'username-in-response')));
+
+        $result = $this->subject->run($this->makeInput());
+
+        self::assertSame(
+            'username-in-response',
+            $result->getUsernameCredentials()
+        );
+    }
+
+    public function test_it_preserves_initial_credentials_as_username_credentials(): void
+    {
+        // When credentials are present in the initial bind (e.g. PLAIN), they become
+        // the username credentials without waiting for a client response.
+        $this->mockChallenge
+            ->expects(self::once())
+            ->method('challenge')
+            ->willReturn($this->makeContext(isComplete: true, isAuthenticated: true, response: null));
+
+        // isComplete && response==null → responseIsNew = (null !== null) = false → stale break.
+        $this->mockQueue->expects(self::never())->method('sendMessage');
+
+        $result = $this->subject->run($this->makeInput(initialCredentials: 'authzid\x00user\x00pass'));
+
+        self::assertSame(
+            'authzid\x00user\x00pass',
+            $result->getUsernameCredentials()
+        );
+    }
+
+    public function test_it_throws_protocol_error_when_non_sasl_request_received_mid_exchange(): void
+    {
+        $this->mockChallenge
+            ->method('challenge')
+            ->willReturn($this->makeContext(isComplete: false, response: 'server-challenge'));
+
+        $this->mockQueue
+            ->expects(self::exactly(2))
+            ->method('sendMessage'); // SASL_BIND_IN_PROGRESS + error response
+
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('getMessage')
+            ->willReturn(new LdapMessageRequest(2, new SimpleBindRequest('cn=user', 'pass')));
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::PROTOCOL_ERROR);
+
+        $this->subject->run($this->makeInput());
+    }
+}

--- a/tests/unit/Protocol/Bind/Sasl/UsernameExtractor/PlainUsernameExtractorTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/UsernameExtractor/PlainUsernameExtractorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
+
+use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\PlainUsernameExtractor;
+use FreeDSx\Sasl\Mechanism\PlainMechanism;
+use PHPUnit\Framework\TestCase;
+
+final class PlainUsernameExtractorTest extends TestCase
+{
+    private PlainUsernameExtractor $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new PlainUsernameExtractor();
+    }
+
+    public function test_it_supports_the_plain_mechanism(): void
+    {
+        self::assertTrue($this->subject->supports(PlainMechanism::NAME));
+    }
+
+    public function test_it_does_not_support_other_mechanisms(): void
+    {
+        self::assertFalse($this->subject->supports('CRAM-MD5'));
+        self::assertFalse($this->subject->supports('DIGEST-MD5'));
+    }
+
+    public function test_it_extracts_the_authcid_as_the_username(): void
+    {
+        // PLAIN format: "authzid\x00authcid\x00passwd"
+        $credentials = "authzid\x00cn=user,dc=foo,dc=bar\x0012345";
+
+        self::assertSame(
+            'cn=user,dc=foo,dc=bar',
+            $this->subject->extractUsername(PlainMechanism::NAME, $credentials),
+        );
+    }
+}

--- a/tests/unit/Protocol/Bind/Sasl/UsernameExtractor/SaslUsernameExtractorFactoryTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/UsernameExtractor/SaslUsernameExtractorFactoryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
+
+use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\PlainUsernameExtractor;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\SaslUsernameExtractorFactory;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\ScramUsernameExtractor;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\UsernameFieldExtractor;
+use PHPUnit\Framework\TestCase;
+
+final class SaslUsernameExtractorFactoryTest extends TestCase
+{
+    private SaslUsernameExtractorFactory $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new SaslUsernameExtractorFactory();
+    }
+
+    public function test_make_plain_returns_plain_extractor(): void
+    {
+        self::assertInstanceOf(
+            PlainUsernameExtractor::class,
+            $this->subject->make('PLAIN')
+        );
+    }
+
+    public function test_make_scram_sha256_returns_scram_extractor(): void
+    {
+        self::assertInstanceOf(
+            ScramUsernameExtractor::class,
+            $this->subject->make('SCRAM-SHA-256')
+        );
+    }
+
+    public function test_make_cram_md5_returns_username_field_extractor(): void
+    {
+        self::assertInstanceOf(
+            UsernameFieldExtractor::class,
+            $this->subject->make('CRAM-MD5')
+        );
+    }
+
+    public function test_make_digest_md5_returns_username_field_extractor(): void
+    {
+        self::assertInstanceOf(
+            UsernameFieldExtractor::class,
+            $this->subject->make('DIGEST-MD5')
+        );
+    }
+
+    public function test_make_unknown_mechanism_throws(): void
+    {
+        self::expectException(RuntimeException::class);
+
+        $this->subject->make('UNKNOWN');
+    }
+}

--- a/tests/unit/Protocol/Bind/Sasl/UsernameExtractor/ScramUsernameExtractorTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/UsernameExtractor/ScramUsernameExtractorTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\ScramUsernameExtractor;
+use FreeDSx\Sasl\Mechanism\ScramMechanism;
+use PHPUnit\Framework\TestCase;
+
+final class ScramUsernameExtractorTest extends TestCase
+{
+    private ScramUsernameExtractor $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new ScramUsernameExtractor();
+    }
+
+    public function test_it_supports_all_scram_variants(): void
+    {
+        foreach (ScramMechanism::VARIANTS as $variant) {
+            self::assertTrue(
+                $this->subject->supports($variant),
+                "Expected support for $variant"
+            );
+        }
+    }
+
+    public function test_it_does_not_support_non_scram_mechanisms(): void
+    {
+        self::assertFalse($this->subject->supports('PLAIN'));
+        self::assertFalse($this->subject->supports('CRAM-MD5'));
+        self::assertFalse($this->subject->supports('DIGEST-MD5'));
+    }
+
+    public function test_it_extracts_username_from_standard_client_first(): void
+    {
+        // n,, GS2 header (no channel binding)
+        self::assertSame(
+            'testuser',
+            $this->subject->extractUsername(
+                ScramMechanism::SHA256,
+                'n,,n=testuser,r=clientnonce',
+            )
+        );
+    }
+
+    public function test_it_extracts_username_from_channel_binding_client_first(): void
+    {
+        // p=tls-unique,, GS2 header
+        self::assertSame(
+            'testuser',
+            $this->subject->extractUsername(
+                ScramMechanism::SHA256_PLUS,
+                'p=tls-unique,,n=testuser,r=clientnonce'
+            ),
+        );
+    }
+
+    public function test_it_decodes_rfc5802_encoded_comma_in_username(): void
+    {
+        // ',' is encoded as '=2C'
+        self::assertSame(
+            'user,name',
+            $this->subject->extractUsername(
+                ScramMechanism::SHA256,
+                'n,,n=user=2Cname,r=nonce',
+            )
+        );
+    }
+
+    public function test_it_decodes_rfc5802_encoded_equals_in_username(): void
+    {
+        // '=' is encoded as '=3D'
+        self::assertSame(
+            'user=name',
+            $this->subject->extractUsername(
+                ScramMechanism::SHA256,
+                'n,,n=user=3Dname,r=nonce'
+            )
+        );
+    }
+
+    public function test_it_throws_protocol_error_when_username_field_is_missing(): void
+    {
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::PROTOCOL_ERROR);
+
+        // Malformed message with no n= field
+        $this->subject->extractUsername(
+            ScramMechanism::SHA256,
+            'n,,r=nonce'
+        );
+    }
+
+    public function test_it_extracts_username_when_credentials_have_no_gs2_header(): void
+    {
+        // No ',,' separator — the whole string is treated as the bare client-first-message.
+        self::assertSame(
+            'testuser',
+            $this->subject->extractUsername(
+                ScramMechanism::SHA256,
+                'n=testuser,r=nonce',
+            ),
+        );
+    }
+}

--- a/tests/unit/Protocol/Bind/Sasl/UsernameExtractor/UsernameFieldExtractorTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/UsernameExtractor/UsernameFieldExtractorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\UsernameFieldExtractor;
+use FreeDSx\Sasl\Encoder\EncoderInterface;
+use FreeDSx\Sasl\Mechanism\CramMD5Mechanism;
+use FreeDSx\Sasl\Mechanism\DigestMD5Mechanism;
+use FreeDSx\Sasl\Message;
+use FreeDSx\Sasl\SaslContext;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class UsernameFieldExtractorTest extends TestCase
+{
+    private EncoderInterface&MockObject $mockEncoder;
+
+    private UsernameFieldExtractor $subject;
+
+    protected function setUp(): void
+    {
+        $this->mockEncoder = $this->createMock(EncoderInterface::class);
+
+        $this->subject = new UsernameFieldExtractor([
+            CramMD5Mechanism::NAME => $this->mockEncoder,
+        ]);
+    }
+
+    public function test_it_supports_mechanisms_that_have_a_registered_encoder(): void
+    {
+        self::assertTrue($this->subject->supports(CramMD5Mechanism::NAME));
+    }
+
+    public function test_it_does_not_support_mechanisms_without_a_registered_encoder(): void
+    {
+        self::assertFalse($this->subject->supports('PLAIN'));
+    }
+
+    public function test_it_defaults_to_supporting_cram_md5_and_digest_md5(): void
+    {
+        $subject = new UsernameFieldExtractor();
+
+        self::assertTrue($subject->supports(CramMD5Mechanism::NAME));
+        self::assertTrue($subject->supports(DigestMD5Mechanism::NAME));
+    }
+
+    public function test_it_extracts_the_username_field_from_decoded_credentials(): void
+    {
+        $credentials = 'some-credential-bytes';
+
+        $this->mockEncoder
+            ->expects(self::once())
+            ->method('decode')
+            ->willReturn(new Message(['username' => 'cn=user,dc=foo,dc=bar']));
+
+        self::assertSame(
+            'cn=user,dc=foo,dc=bar',
+            $this->subject->extractUsername(CramMD5Mechanism::NAME, $credentials),
+        );
+    }
+
+    public function test_it_decodes_credentials_in_server_mode(): void
+    {
+        $this->mockEncoder
+            ->expects(self::once())
+            ->method('decode')
+            ->with(
+                self::anything(),
+                self::callback(fn (SaslContext $ctx): bool => $ctx->isServerMode()),
+            )
+            ->willReturn(new Message(['username' => 'user']));
+
+        $this->subject->extractUsername(CramMD5Mechanism::NAME, 'bytes');
+    }
+
+    public function test_it_throws_a_protocol_error_when_the_username_field_is_missing(): void
+    {
+        $this->mockEncoder
+            ->method('decode')
+            ->willReturn(new Message([]));
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::PROTOCOL_ERROR);
+
+        $this->subject->extractUsername(
+            CramMD5Mechanism::NAME,
+            'bytes'
+        );
+    }
+}

--- a/tests/unit/Protocol/Bind/SaslBindTest.php
+++ b/tests/unit/Protocol/Bind/SaslBindTest.php
@@ -1,0 +1,265 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Operation\Request\AnonBindRequest;
+use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
+use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Bind\SaslBind;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
+use FreeDSx\Ldap\Server\RequestHandler\SaslHandlerInterface;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use FreeDSx\Ldap\ServerOptions;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Combined interface so PHPUnit can mock both at once.
+ */
+interface SaslRequestHandlerInterface extends RequestHandlerInterface, SaslHandlerInterface {}
+
+final class SaslBindTest extends TestCase
+{
+    private SaslBind $subject;
+
+    private ServerQueue&MockObject $mockQueue;
+
+    private RequestHandlerInterface&MockObject $mockDispatcher;
+
+    protected function setUp(): void
+    {
+        $this->mockQueue = $this->createMock(ServerQueue::class);
+        $this->mockDispatcher = $this->createMock(RequestHandlerInterface::class);
+
+        $this->subject = new SaslBind(
+            queue: $this->mockQueue,
+            dispatcher: $this->mockDispatcher,
+            mechanisms: [ServerOptions::SASL_PLAIN],
+        );
+    }
+
+    public function test_it_supports_sasl_bind_requests(): void
+    {
+        self::assertTrue($this->subject->supports(new LdapMessageRequest(
+            1,
+            new SaslBindRequest('PLAIN'),
+        )));
+    }
+
+    public function test_it_does_not_support_other_bind_request_types(): void
+    {
+        self::assertFalse($this->subject->supports(new LdapMessageRequest(
+            1,
+            new AnonBindRequest(),
+        )));
+        self::assertFalse($this->subject->supports(new LdapMessageRequest(
+            1,
+            new SimpleBindRequest('foo', 'bar'),
+        )));
+    }
+
+    public function test_it_validates_the_ldap_version(): void
+    {
+        $this->mockQueue
+            ->expects(self::never())
+            ->method('sendMessage');
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::PROTOCOL_ERROR);
+
+        $this->subject->bind(new LdapMessageRequest(
+            1,
+            (new SaslBindRequest('PLAIN'))->setVersion(2),
+        ));
+    }
+
+    public function test_it_throws_for_an_unsupported_mechanism(): void
+    {
+        $this->mockQueue
+            ->expects(self::never())
+            ->method('sendMessage');
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::AUTH_METHOD_UNSUPPORTED);
+
+        $this->subject->bind(new LdapMessageRequest(
+            1,
+            new SaslBindRequest('GSSAPI'),
+        ));
+    }
+
+    public function test_it_throws_when_challenge_based_mechanism_is_used_without_sasl_handler(): void
+    {
+        $subject = new SaslBind(
+            queue: $this->mockQueue,
+            dispatcher: $this->mockDispatcher,
+            mechanisms: [ServerOptions::SASL_CRAM_MD5],
+        );
+
+        $this->mockQueue
+            ->expects(self::never())
+            ->method('sendMessage');
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::OTHER);
+
+        $subject->bind(new LdapMessageRequest(
+            1,
+            new SaslBindRequest('CRAM-MD5'),
+        ));
+    }
+
+    public function test_it_can_authenticate_with_plain(): void
+    {
+        // PLAIN credential format: "authzid\x00authcid\x00passwd" (all three parts must be non-empty)
+        $credentials = "user\x00cn=user,dc=foo,dc=bar\x0012345";
+
+        $this->mockDispatcher
+            ->expects(self::once())
+            ->method('bind')
+            ->with('cn=user,dc=foo,dc=bar', '12345')
+            ->willReturn(true);
+
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('sendMessage');
+
+        self::assertEquals(
+            new BindToken('cn=user,dc=foo,dc=bar', ''),
+            $this->subject->bind(new LdapMessageRequest(
+                1,
+                new SaslBindRequest('PLAIN', $credentials),
+            )),
+        );
+    }
+
+    public function test_it_throws_invalid_credentials_when_plain_authentication_fails(): void
+    {
+        $credentials = "user\x00cn=user,dc=foo,dc=bar\x00wrong";
+
+        $this->mockDispatcher
+            ->expects(self::once())
+            ->method('bind')
+            ->with('cn=user,dc=foo,dc=bar', 'wrong')
+            ->willReturn(false);
+
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('sendMessage');
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        $this->subject->bind(new LdapMessageRequest(
+            1,
+            new SaslBindRequest('PLAIN', $credentials),
+        ));
+    }
+
+    public function test_challenge_mechanism_sends_invalid_credentials_on_authentication_failure(): void
+    {
+        /** @var SaslRequestHandlerInterface&MockObject $mockSaslDispatcher */
+        $mockSaslDispatcher = $this->createMock(SaslRequestHandlerInterface::class);
+
+        $subject = new SaslBind(
+            queue: $this->mockQueue,
+            dispatcher: $mockSaslDispatcher,
+            mechanisms: [ServerOptions::SASL_CRAM_MD5],
+        );
+
+        // Return a real password so the HMAC callable runs; the client digest is wrong so
+        // the challenge will set isAuthenticated=false and isComplete=true.
+        $mockSaslDispatcher
+            ->method('getPassword')
+            ->willReturn('correctpassword');
+
+        // First sendMessage: SASL_BIND_IN_PROGRESS (the server challenge).
+        // Second sendMessage: INVALID_CREDENTIALS (the failure response).
+        $this->mockQueue
+            ->expects(self::exactly(2))
+            ->method('sendMessage');
+
+        // Client responds with a syntactically valid CRAM-MD5 response but the wrong HMAC.
+        // CRAM-MD5 response format: "<username> <32-char-hex-md5>"
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('getMessage')
+            ->willReturn(new LdapMessageRequest(
+                2,
+                new SaslBindRequest(
+                    'CRAM-MD5',
+                    'cn=user,dc=foo,dc=bar aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                ),
+            ));
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        $subject->bind(new LdapMessageRequest(
+            1,
+            new SaslBindRequest('CRAM-MD5'),
+        ));
+    }
+
+    public function test_it_throws_runtime_exception_when_bind_is_called_with_a_non_sasl_request(): void
+    {
+        $this->mockQueue->expects(self::never())->method('sendMessage');
+
+        self::expectException(RuntimeException::class);
+
+        $this->subject->bind(new LdapMessageRequest(
+            1,
+            new SimpleBindRequest('cn=user', 'pass'),
+        ));
+    }
+
+    public function test_it_throws_protocol_error_when_non_sasl_request_received_during_exchange(): void
+    {
+        /** @var SaslRequestHandlerInterface&MockObject $mockSaslDispatcher */
+        $mockSaslDispatcher = $this->createMock(SaslRequestHandlerInterface::class);
+
+        $subject = new SaslBind(
+            queue: $this->mockQueue,
+            dispatcher: $mockSaslDispatcher,
+            mechanisms: [ServerOptions::SASL_CRAM_MD5],
+        );
+
+        // First sendMessage is the SASL_BIND_IN_PROGRESS challenge; second is the error response.
+        $this->mockQueue
+            ->expects(self::exactly(2))
+            ->method('sendMessage');
+
+        // Client sends the wrong request type during the exchange
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('getMessage')
+            ->willReturn(new LdapMessageRequest(
+                2,
+                new SimpleBindRequest('foo', 'bar')
+            ));
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::PROTOCOL_ERROR);
+
+        $subject->bind(new LdapMessageRequest(
+            1,
+            new SaslBindRequest('CRAM-MD5'),
+        ));
+    }
+}

--- a/tests/unit/Protocol/ServerAuthorizationTest.php
+++ b/tests/unit/Protocol/ServerAuthorizationTest.php
@@ -22,6 +22,7 @@ use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
 use PHPUnit\Framework\TestCase;
 
 final class ServerAuthorizationTest extends TestCase
@@ -131,6 +132,37 @@ final class ServerAuthorizationTest extends TestCase
     {
         self::assertTrue($this->subject->isAuthenticationTypeSupported(
             Operations::bind('foo', 'bar')
+        ));
+    }
+
+    public function test_it_should_not_allow_sasl_bind_when_no_mechanisms_are_configured(): void
+    {
+        self::assertFalse($this->subject->isAuthenticationTypeSupported(
+            new SaslBindRequest(ServerOptions::SASL_PLAIN)
+        ));
+    }
+
+    public function test_it_should_allow_sasl_bind_when_the_mechanism_is_configured(): void
+    {
+        $this->subject = new ServerAuthorization(
+            (new ServerOptions())
+                ->setSaslMechanisms(ServerOptions::SASL_PLAIN),
+        );
+
+        self::assertTrue($this->subject->isAuthenticationTypeSupported(
+            new SaslBindRequest(ServerOptions::SASL_PLAIN)
+        ));
+    }
+
+    public function test_it_should_not_allow_sasl_bind_for_a_mechanism_that_is_not_configured(): void
+    {
+        $this->subject = new ServerAuthorization(
+            (new ServerOptions())
+                ->setSaslMechanisms(ServerOptions::SASL_PLAIN),
+        );
+
+        self::assertFalse($this->subject->isAuthenticationTypeSupported(
+            new SaslBindRequest(ServerOptions::SASL_CRAM_MD5)
         ));
     }
 

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerRootDseHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerRootDseHandlerTest.php
@@ -179,6 +179,41 @@ final class ServerRootDseHandlerTest extends TestCase
         );
     }
 
+    public function test_it_should_include_supported_sasl_mechanisms_when_configured(): void
+    {
+        $this->options
+            ->setSaslMechanisms(ServerOptions::SASL_PLAIN, ServerOptions::SASL_CRAM_MD5);
+
+        $search = new LdapMessageRequest(
+            1,
+            (new SearchRequest(Filters::present('objectClass')))->base('')->useBaseScope()
+        );
+
+        $this->mockQueue
+            ->expects($this->once())
+            ->method('sendMessage')
+            ->with(
+                self::callback(function (LdapMessageResponse $response) {
+                    /** @var SearchResultEntry $search */
+                    $search = $response->getResponse();
+                    $attribute = $search->getEntry()->get('supportedSaslMechanisms');
+
+                    return $attribute !== null
+                        && $attribute->has(ServerOptions::SASL_PLAIN)
+                        && $attribute->has(ServerOptions::SASL_CRAM_MD5);
+                }),
+                new LdapMessageResponse(
+                    1,
+                    new SearchResultDone(0)
+                ),
+            );
+
+        $this->subject->handleRequest(
+            $search,
+            $this->mockToken,
+        );
+    }
+
     public function test_it_should_only_return_attribute_names_from_the_RootDSE_if_requested(): void
     {
         $this->options

--- a/tests/unit/Server/ServerProtocolFactoryTest.php
+++ b/tests/unit/Server/ServerProtocolFactoryTest.php
@@ -54,4 +54,22 @@ final class ServerProtocolFactoryTest extends TestCase
 
         $this->subject->make($mockSocket);
     }
+
+    public function test_it_includes_sasl_when_mechanisms_are_configured(): void
+    {
+        $mockSocket = $this->createMock(Socket::class);
+
+        $this->mockHandlerFactory
+            ->expects($this->once())
+            ->method('makeRequestHandler')
+            ->willReturn(new GenericRequestHandler());
+
+        $subject = new ServerProtocolFactory(
+            $this->mockHandlerFactory,
+            (new ServerOptions())->setSaslMechanisms(ServerOptions::SASL_PLAIN),
+            $this->mockServerAuthorization,
+        );
+
+        $subject->make($mockSocket);
+    }
 }

--- a/tests/unit/ServerOptionsTest.php
+++ b/tests/unit/ServerOptionsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap;
+
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\ServerOptions;
+use PHPUnit\Framework\TestCase;
+
+final class ServerOptionsTest extends TestCase
+{
+    private ServerOptions $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new ServerOptions();
+    }
+
+    public function test_sasl_mechanisms_are_empty_by_default(): void
+    {
+        self::assertSame(
+            [],
+            $this->subject->getSaslMechanisms(),
+        );
+    }
+
+    public function test_it_can_set_supported_sasl_mechanisms(): void
+    {
+        $this->subject->setSaslMechanisms(
+            ServerOptions::SASL_PLAIN,
+            ServerOptions::SASL_CRAM_MD5,
+        );
+
+        self::assertSame(
+            [ServerOptions::SASL_PLAIN, ServerOptions::SASL_CRAM_MD5],
+            $this->subject->getSaslMechanisms(),
+        );
+    }
+
+    public function test_it_throws_for_an_unsupported_sasl_mechanism(): void
+    {
+        self::expectException(InvalidArgumentException::class);
+
+        $this->subject->setSaslMechanisms('GSSAPI');
+    }
+
+    public function test_it_throws_for_any_unsupported_mechanism_in_the_list(): void
+    {
+        self::expectException(InvalidArgumentException::class);
+
+        $this->subject->setSaslMechanisms(ServerOptions::SASL_PLAIN, 'GSSAPI');
+    }
+
+    public function test_it_accepts_all_defined_mechanism_constants(): void
+    {
+        $this->subject->setSaslMechanisms(
+            ServerOptions::SASL_PLAIN,
+            ServerOptions::SASL_CRAM_MD5,
+            ServerOptions::SASL_DIGEST_MD5,
+            ServerOptions::SASL_SCRAM_SHA_1,
+            ServerOptions::SASL_SCRAM_SHA_1_PLUS,
+            ServerOptions::SASL_SCRAM_SHA_224,
+            ServerOptions::SASL_SCRAM_SHA_224_PLUS,
+            ServerOptions::SASL_SCRAM_SHA_256,
+            ServerOptions::SASL_SCRAM_SHA_256_PLUS,
+            ServerOptions::SASL_SCRAM_SHA_384,
+            ServerOptions::SASL_SCRAM_SHA_384_PLUS,
+            ServerOptions::SASL_SCRAM_SHA_512,
+            ServerOptions::SASL_SCRAM_SHA_512_PLUS,
+            ServerOptions::SASL_SCRAM_SHA3_512,
+            ServerOptions::SASL_SCRAM_SHA3_512_PLUS,
+        );
+
+        self::assertCount(
+            15,
+            $this->subject->getSaslMechanisms(),
+        );
+    }
+}


### PR DESCRIPTION
This adds server side SASL support, as the client already supports it. Currently DIGEST-MD5 is busted, so the currently supported mechs aren't great. But DIGEST-MD5 is already deprecated and removed from most things. However, I have a separate PR I'm working on to add support for SCRAM in the SASL library. So once that's in I can support it here.

I largely leaned on claude to iterate through this to get it out fast. I will be going over it a bit myself more (already have looked it over a ton and modified some things), but most of this seems reasonable now.