### PR TITLE
[1.0.0] Change RequestHandlerInterface::search() to return SearchResult instead of Entries.

### DIFF
--- a/UPGRADE-1.0.md
+++ b/UPGRADE-1.0.md
@@ -7,6 +7,7 @@ Upgrading from 0.x to 1.0
     * [Server Options](#server-options)
     * [Constructing a Proxy Server](#constructing-a-proxy-server)
     * [Using a Custom ServerRunner](#using-a-custom-serverrunner)
+    * [Request Handler Search Return Type](#request-handler-search-return-type)
 
 ## Client Changes
 
@@ -175,4 +176,37 @@ $server = new LdapServer(
         ->setRequestHandler(new LdapProxyHandler())
 );
 $server->run();
+```
+
+## Request Handler Search Return Type
+
+The `search()` method of `RequestHandlerInterface` now returns `SearchResult` instead of `Entries`. Wrap your returned
+entries in `SearchResult::make()`. The new return type also allows returning response controls and non-success result
+codes (e.g. for partial results).
+
+**Before**:
+
+```php
+use FreeDSx\Ldap\Entry\Entries;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Server\RequestContext;
+
+public function search(RequestContext $context, SearchRequest $search): Entries
+{
+    return new Entries(/* ... */);
+}
+```
+
+**After**:
+
+```php
+use FreeDSx\Ldap\Entry\Entries;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Server\RequestContext;
+use FreeDSx\Ldap\Server\RequestHandler\SearchResult;
+
+public function search(RequestContext $context, SearchRequest $search): SearchResult
+{
+    return SearchResult::make(new Entries(/* ... */));
+}
 ```

--- a/docs/Server/General-Usage.md
+++ b/docs/Server/General-Usage.md
@@ -83,7 +83,7 @@ The interface has the following methods:
 
     public function modifyDn(RequestContext $context, ModifyDnRequest $modifyDn);
 
-    public function search(RequestContext $context, SearchRequest $search) : Entries;
+    public function search(RequestContext $context, SearchRequest $search) : SearchResult;
     
     public function bind(string $username, string $password) : bool;
 ```
@@ -149,6 +149,7 @@ should extend this class and override the methods for the requests you want to s
 namespace Foo;
 
 use FreeDSx\Ldap\Server\RequestHandler\GenericRequestHandler;
+use FreeDSx\Ldap\Server\RequestHandler\SearchResult;
 
 class LdapRequestHandler extends GenericRequestHandler
 {
@@ -172,25 +173,27 @@ class LdapRequestHandler extends GenericRequestHandler
     }
 
     /**
-     * Override the search request. This must send back an entries object.
+     * Override the search request. Return a SearchResult with the entries to send back.
      *
      * @param RequestContext $context
      * @param SearchRequest $search
-     * @return Entries
+     * @return SearchResult
      */
-    public function search(RequestContext $context, SearchRequest $search): Entries
+    public function search(RequestContext $context, SearchRequest $search): SearchResult
     {
-        return new Entries(
-            Entry::fromArray('cn=Foo,dc=FreeDSx,dc=local', [
-                'cn' => 'Foo',
-                'sn' => 'Bar',
-                'givenName' => 'Foo',
-            ]),
-            Entry::fromArray('cn=Chad,dc=FreeDSx,dc=local', [
-                'cn' => 'Chad',
-                'sn' => 'Sikorra',
-                'givenName' => 'Chad',
-            ])
+        return SearchResult::make(
+            new Entries(
+                Entry::fromArray('cn=Foo,dc=FreeDSx,dc=local', [
+                    'cn' => 'Foo',
+                    'sn' => 'Bar',
+                    'givenName' => 'Foo',
+                ]),
+                Entry::fromArray('cn=Chad,dc=FreeDSx,dc=local', [
+                    'cn' => 'Chad',
+                    'sn' => 'Sikorra',
+                    'givenName' => 'Chad',
+                ])
+            )
         );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandler.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestContext;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
+use FreeDSx\Ldap\Server\RequestHandler\SearchResult as HandlerSearchResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -65,14 +66,27 @@ class ServerPagingUnsupportedHandler implements ServerProtocolHandlerInterface
             );
         }
 
+        $handlerResult = null;
+
         try {
-            $searchResult = SearchResult::makeSuccessResult(
-                $this->dispatcher->search(
-                    $context,
-                    $request
-                ),
-                (string) $request->getBaseDn()
+            $handlerResult = $this->dispatcher->search(
+                $context,
+                $request,
             );
+            $baseDn = (string) $request->getBaseDn();
+
+            $searchResult = $handlerResult->getResultCode() === ResultCode::SUCCESS
+                ? SearchResult::makeSuccessResult(
+                    $handlerResult->getEntries(),
+                    $baseDn,
+                    $handlerResult->getDiagnosticMessage(),
+                )
+                : SearchResult::makeErrorResult(
+                    $handlerResult->getResultCode(),
+                    $baseDn,
+                    $handlerResult->getDiagnosticMessage(),
+                    $handlerResult->getEntries(),
+                );
         } catch (OperationException $e) {
             $searchResult = SearchResult::makeErrorResult(
                 $e->getCode(),
@@ -84,7 +98,8 @@ class ServerPagingUnsupportedHandler implements ServerProtocolHandlerInterface
         $this->sendEntriesToClient(
             $searchResult,
             $message,
-            $this->queue
+            $this->queue,
+            ...($handlerResult instanceof HandlerSearchResult ? $handlerResult->getControls() : []),
         );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -14,10 +14,12 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\RequestContext;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
+use FreeDSx\Ldap\Server\RequestHandler\SearchResult as HandlerSearchResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -48,14 +50,24 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         );
         $request = $this->getSearchRequestFromMessage($message);
 
+        $handlerResult = null;
+
         try {
-            $searchResult = SearchResult::makeSuccessResult(
-                $this->dispatcher->search(
-                    $context,
-                    $request
-                ),
-                (string) $request->getBaseDn()
-            );
+            $handlerResult = $this->dispatcher->search($context, $request);
+            $baseDn = (string) $request->getBaseDn();
+
+            $searchResult = $handlerResult->getResultCode() === ResultCode::SUCCESS
+                ? SearchResult::makeSuccessResult(
+                    $handlerResult->getEntries(),
+                    $baseDn,
+                    $handlerResult->getDiagnosticMessage(),
+                )
+                : SearchResult::makeErrorResult(
+                    $handlerResult->getResultCode(),
+                    $baseDn,
+                    $handlerResult->getDiagnosticMessage(),
+                    $handlerResult->getEntries(),
+                );
         } catch (OperationException $e) {
             $searchResult = SearchResult::makeErrorResult(
                 $e->getCode(),
@@ -67,7 +79,8 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         $this->sendEntriesToClient(
             $searchResult,
             $message,
-            $this->queue
+            $this->queue,
+            ...($handlerResult instanceof HandlerSearchResult ? $handlerResult->getControls() : []),
         );
     }
 }

--- a/src/FreeDSx/Ldap/Server/RequestHandler/GenericRequestHandler.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/GenericRequestHandler.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\RequestHandler;
 
-use FreeDSx\Ldap\Entry\Entries;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Operation\Request\CompareRequest;
@@ -110,7 +109,7 @@ class GenericRequestHandler implements RequestHandlerInterface
     public function search(
         RequestContext $context,
         SearchRequest $search
-    ): Entries {
+    ): SearchResult {
         throw new OperationException('The search operation is not supported.');
     }
 }

--- a/src/FreeDSx/Ldap/Server/RequestHandler/ProxyRequestHandler.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/ProxyRequestHandler.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\RequestHandler;
 
 use FreeDSx\Ldap\ClientOptions;
-use FreeDSx\Ldap\Entry\Entries;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\LdapClient;
@@ -26,6 +25,7 @@ use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\Response\SearchResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\RequestContext;
 use SensitiveParameter;
@@ -108,8 +108,24 @@ class ProxyRequestHandler implements RequestHandlerInterface
     public function search(
         RequestContext $context,
         SearchRequest $search
-    ): Entries {
-        return $this->ldap()->search($search, ...$context->controls()->toArray());
+    ): SearchResult {
+        /** @var SearchResponse $response */
+        $response = $this->ldap()
+            ->sendAndReceive(
+                $search,
+                ...$context->controls()->toArray()
+            )
+            ->getResponse();
+
+        if ($response->getResultCode() === ResultCode::SUCCESS) {
+            return SearchResult::make($response->getEntries());
+        }
+
+        return SearchResult::makeWithResultCode(
+            $response->getEntries(),
+            $response->getResultCode(),
+            $response->getDiagnosticMessage(),
+        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/RequestHandler/RequestHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/RequestHandlerInterface.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\RequestHandler;
 
-use FreeDSx\Ldap\Entry\Entries;
-use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Operation\Request\CompareRequest;
@@ -94,16 +92,14 @@ interface RequestHandlerInterface
     ): void;
 
     /**
-     * A search request. This should return an entries collection object.
-     *
-     * @return Entries<Entry>
+     * A search request. This should return a SearchResult object.
      *
      * @throws OperationException
      */
     public function search(
         RequestContext $context,
         SearchRequest $search,
-    ): Entries;
+    ): SearchResult;
 
     /**
      * A simple username/password bind. It should simply return true or false for whether the username and password is

--- a/src/FreeDSx/Ldap/Server/RequestHandler/SearchResult.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/SearchResult.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\RequestHandler;
+
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Entry\Entries;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Operation\ResultCode;
+
+/**
+ * Represents the search result to be returned from a request handler search.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class SearchResult
+{
+    /**
+     * @param Entries<Entry> $entries
+     * @param Control[] $controls
+     */
+    private function __construct(
+        private readonly Entries $entries,
+        private readonly int $resultCode,
+        private readonly string $diagnosticMessage,
+        private readonly array $controls,
+    ) {
+    }
+
+    /**
+     * Make a successful search result — the common case.
+     *
+     * @param Entries<Entry> $entries
+     */
+    public static function make(
+        Entries $entries,
+        Control ...$controls,
+    ): self {
+        return new self(
+            $entries,
+            ResultCode::SUCCESS,
+            '',
+            $controls,
+        );
+    }
+
+    /**
+     * Make a search result with an explicit result code. Use for partial results, size/time limit exceeded, referrals,
+     * etc. Entries are still returned to the client before the SearchResultDone.
+     *
+     * @param Entries<Entry> $entries
+     */
+    public static function makeWithResultCode(
+        Entries $entries,
+        int $resultCode,
+        string $diagnosticMessage = '',
+        Control ...$controls,
+    ): self {
+        return new self(
+            $entries,
+            $resultCode,
+            $diagnosticMessage,
+            $controls,
+        );
+    }
+
+    /**
+     * @return Entries<Entry>
+     */
+    public function getEntries(): Entries
+    {
+        return $this->entries;
+    }
+
+    public function getResultCode(): int
+    {
+        return $this->resultCode;
+    }
+
+    public function getDiagnosticMessage(): string
+    {
+        return $this->diagnosticMessage;
+    }
+
+    /**
+     * @return Control[]
+     */
+    public function getControls(): array
+    {
+        return $this->controls;
+    }
+}

--- a/tests/bin/ldapserver.php
+++ b/tests/bin/ldapserver.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Server\RequestContext;
 use FreeDSx\Ldap\Server\RequestHandler\GenericRequestHandler;
 use FreeDSx\Ldap\Server\RequestHandler\PagingHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\SaslHandlerInterface;
+use FreeDSx\Ldap\Server\RequestHandler\SearchResult;
 use FreeDSx\Ldap\ServerOptions;
 
 require __DIR__ . '/../../vendor/autoload.php';
@@ -175,19 +176,21 @@ class LdapServerRequestHandler extends GenericRequestHandler implements SaslHand
         );
     }
 
-    public function search(RequestContext $context, SearchRequest $search): Entries
+    public function search(RequestContext $context, SearchRequest $search): SearchResult
     {
         $this->logRequest(
             'search',
             "base-dn => {$search->getBaseDn()?->toString()}, filter => {$search->getFilter()->toString()}"
         );
 
-        return new Entries(
-            Entry::fromArray(
-                'cn=user,dc=foo,dc=bar',
-                [
-                    'name' => 'user',
-                ]
+        return SearchResult::make(
+            new Entries(
+                Entry::fromArray(
+                    'cn=user,dc=foo,dc=bar',
+                    [
+                        'name' => 'user',
+                    ]
+                )
             )
         );
     }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPagingUnsupportedHandlerTest.php
@@ -27,6 +27,7 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerPagingUnsupportedHandler;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
+use FreeDSx\Ldap\Server\RequestHandler\SearchResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -75,7 +76,7 @@ final class ServerPagingUnsupportedHandlerTest extends TestCase
             ->expects($this->once())
             ->method('search')
             ->with(self::anything(), $search->getRequest())
-            ->willReturn($entries);
+            ->willReturn(SearchResult::make($entries));
 
         $this->mockQueue
             ->expects($this->once())

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
+use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Entry\Entries;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -26,6 +27,7 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerSearchHandler;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
+use FreeDSx\Ldap\Server\RequestHandler\SearchResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -67,7 +69,7 @@ final class ServerSearchHandlerTest extends TestCase
             ->expects($this->once())
             ->method('search')
             ->with(self::anything(), $search->getRequest())
-            ->willReturn($entries);
+            ->willReturn(SearchResult::make($entries));
 
         $this->mockQueue
             ->expects($this->once())
@@ -117,6 +119,78 @@ final class ServerSearchHandlerTest extends TestCase
                     "Fail"
                 )
             )));
+
+        $this->subject->handleRequest(
+            $search,
+            $this->mockToken,
+        );
+    }
+
+    public function test_it_should_use_the_result_code_from_a_non_success_handler_result(): void
+    {
+        $search = new LdapMessageRequest(
+            2,
+            (new SearchRequest(Filters::equal('foo', 'bar')))->base('dc=foo,dc=bar')
+        );
+
+        $entries = new Entries(Entry::create('dc=foo,dc=bar', ['cn' => 'foo']));
+        $resultEntry = new LdapMessageResponse(2, new SearchResultEntry(Entry::create('dc=foo,dc=bar', ['cn' => 'foo'])));
+
+        $this->mockRequestHandler
+            ->expects($this->once())
+            ->method('search')
+            ->willReturn(SearchResult::makeWithResultCode(
+                $entries,
+                ResultCode::SIZE_LIMIT_EXCEEDED,
+                'Result set truncated.',
+            ));
+
+        $this->mockQueue
+            ->expects($this->once())
+            ->method('sendMessage')
+            ->with(
+                $resultEntry,
+                new LdapMessageResponse(
+                    2,
+                    new SearchResultDone(
+                        ResultCode::SIZE_LIMIT_EXCEEDED,
+                        'dc=foo,dc=bar',
+                        'Result set truncated.',
+                    ),
+                ),
+            );
+
+        $this->subject->handleRequest(
+            $search,
+            $this->mockToken,
+        );
+    }
+
+    public function test_it_should_pass_response_controls_from_the_handler_result_to_the_client(): void
+    {
+        $search = new LdapMessageRequest(
+            2,
+            (new SearchRequest(Filters::equal('foo', 'bar')))->base('dc=foo,dc=bar')
+        );
+
+        $entries = new Entries();
+        $control = new Control('1.2.3.4');
+
+        $this->mockRequestHandler
+            ->expects($this->once())
+            ->method('search')
+            ->willReturn(SearchResult::make($entries, $control));
+
+        $this->mockQueue
+            ->expects($this->once())
+            ->method('sendMessage')
+            ->with(
+                new LdapMessageResponse(
+                    2,
+                    new SearchResultDone(0, 'dc=foo,dc=bar'),
+                    $control,
+                ),
+            );
 
         $this->subject->handleRequest(
             $search,

--- a/tests/unit/Server/RequestHandler/ProxyRequestHandlerTest.php
+++ b/tests/unit/Server/RequestHandler/ProxyRequestHandlerTest.php
@@ -24,12 +24,16 @@ use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Response\BindResponse;
 use FreeDSx\Ldap\Operation\Response\CompareResponse;
+use FreeDSx\Ldap\Operation\Response\SearchResponse;
+use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Search\Result\EntryResult;
 use FreeDSx\Ldap\Server\RequestContext;
 use FreeDSx\Ldap\Server\RequestHandler\ProxyRequestHandler;
+use FreeDSx\Ldap\Server\RequestHandler\SearchResult;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -125,15 +129,54 @@ final class ProxyRequestHandlerTest extends TestCase
             Filters::present('objectClass'),
             'cn'
         )->base('dc=foo');
-        $entries = new Entries(Entry::create('dc=foo'));
+        $entry = Entry::create('dc=foo');
+        $entries = new Entries($entry);
 
         $this->mockClient
             ->expects($this->once())
-            ->method('search')
-            ->willReturn($entries);
+            ->method('sendAndReceive')
+            ->with($search)
+            ->willReturn(new LdapMessageResponse(
+                1,
+                new SearchResponse(
+                    new LdapResult(ResultCode::SUCCESS),
+                    [new EntryResult(new LdapMessageResponse(1, new SearchResultEntry($entry)))],
+                )
+            ));
 
         self::assertEquals(
-            $entries,
+            SearchResult::make($entries),
+            $this->subject->search($this->mockContext, $search),
+        );
+    }
+
+    public function test_it_should_pass_through_a_non_success_result_code_from_the_proxied_search(): void
+    {
+        $search = Operations::search(
+            Filters::present('objectClass'),
+            'cn'
+        )->base('dc=foo');
+        $entry = Entry::create('dc=foo');
+        $entries = new Entries($entry);
+
+        $this->mockClient
+            ->expects($this->once())
+            ->method('sendAndReceive')
+            ->with($search)
+            ->willReturn(new LdapMessageResponse(
+                1,
+                new SearchResponse(
+                    new LdapResult(ResultCode::SIZE_LIMIT_EXCEEDED, '', 'Result set truncated.'),
+                    [new EntryResult(new LdapMessageResponse(1, new SearchResultEntry($entry)))],
+                )
+            ));
+
+        self::assertEquals(
+            SearchResult::makeWithResultCode(
+                $entries,
+                ResultCode::SIZE_LIMIT_EXCEEDED,
+                'Result set truncated.',
+            ),
             $this->subject->search($this->mockContext, $search),
         );
     }


### PR DESCRIPTION
This lets servers return custom response codes and controls. This also fixes the ldap proxy server instance so it can handle certain edge cases. Documenting as a BC break in the upgrade guide (with the simple before / after changes) and updating the docs.