### PR TITLE
[1.0.0] Add a fluid query builder that also supports streaming results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Use the LdapClient class and the helper classes:
 ```php
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\LdapClient;
-use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Search\Filters;
 
 $ldap = new LdapClient(
@@ -65,30 +64,19 @@ $ldap->bind(
     password: '12345'
 );
 
-# Build up an LDAP filter using the helper methods
-$filter = Filters::and(
-    Filters::equal('objectClass', 'user'),
-    Filters::startsWith('cn', 'S'),
-    # Add a filter object based off a raw string filter...
-    Filters::raw('(telephoneNumber=*)')
-);
-# Create a search operation to be used based on the above filter
-$search = Operations::search(
-    $filter,
-    'cn'
-);
-
-# Create a paged search, 100 results at a time
-$paging = $ldap->paging(
-    $search,
-    100
-);
+# Use the query builder to construct and execute a paged search, 100 results at a time
+$paging = $ldap->query()
+    ->select('cn')
+    ->andWhere(Filters::equal('objectClass', 'user'))
+    ->andWhere(Filters::startsWith('cn', 'S'))
+    ->andWhere(Filters::raw('(telephoneNumber=*)'))
+    ->paging(100);
 
 while ($paging->hasEntries()) {
     $entries = $paging->getEntries();
 
     var_dump(count($entries));
-    
+
     foreach ($entries as $entry) {
         echo "Entry: " . $entry->getDn() . PHP_EOL;
     }

--- a/docs/Client/Searching-and-Filters.md
+++ b/docs/Client/Searching-and-Filters.md
@@ -1,5 +1,14 @@
 # Searching and Filters
 
+* [Query Builder](#query-builder)
+  * [Configuring the Search](#configuring-the-search)
+  * [Building Filters](#building-filters)
+  * [Executing the Search](#executing-the-search)
+    * [Get All Entries](#get-all-entries)
+    * [Get First Entry](#get-first-entry)
+    * [Paging](#query-builder-paging)
+    * [Streaming](#streaming)
+  * [Advanced Usage](#advanced-usage)
 * [Standard Searches](#standard-searches)
   * [Read Search](#read-search)
   * [List Search](#list-search)
@@ -26,8 +35,166 @@
   * [Construction Using String Filters](#construction-using-string-filters)
   * [String Representation](#string-representation)
 
-To search LDAP you can use standard searching, paging, or VLV. Each of these has their own use. The client class has 
+To search LDAP you can use standard searching, paging, or VLV. Each of these has their own use. The client class has
 helper methods for making each of these easier to work with.
+
+## Query Builder
+
+The query builder is the preferred way to construct and execute searches. Obtain one via `$ldap->query()` and
+chain calls to configure the search before executing it with one of the execution methods.
+
+```php
+use FreeDSx\Ldap\Search\Filters;
+
+$entries = $ldap->query()
+    ->from('dc=example,dc=local')
+    ->select('cn', 'mail')
+    ->andWhere(Filters::equal('objectClass', 'user'))
+    ->andWhere(Filters::present('telephoneNumber'))
+    ->get();
+
+foreach ($entries as $entry) {
+    echo $entry->getDn() . PHP_EOL;
+}
+```
+
+### Configuring the Search
+
+| Method | Description |
+|--------|-------------|
+| `from(string\|Dn $baseDn)` | Set the base DN to search from. |
+| `select(string\|Attribute ...$attrs)` | Attributes to return. Returns all attributes if not called. |
+| `useSubtreeScope()` | Search the entire subtree under the base DN *(default)*. |
+| `useSingleLevelScope()` | Search only direct children of the base DN. |
+| `useBaseScope()` | Search only the base DN object itself. |
+| `sizeLimit(int $limit)` | Maximum number of entries the server should return. |
+| `timeLimit(int $seconds)` | Maximum time in seconds the server should spend on the search. |
+
+### Building Filters
+
+Filters are accumulated using `andWhere()` and `orWhere()`. The first call to either method sets the filter directly
+with no wrapper. Subsequent calls append to an existing `AndFilter` / `OrFilter`, or wrap the current filter in one.
+
+```php
+use FreeDSx\Ldap\Search\Filters;
+
+# All conditions AND'd together: (&(objectClass=user)(telephoneNumber=*)(cn=S*))
+$ldap->query()
+    ->andWhere(Filters::equal('objectClass', 'user'))
+    ->andWhere(Filters::present('telephoneNumber'))
+    ->andWhere(Filters::startsWith('cn', 'S'))
+    ->get();
+
+# All conditions OR'd together: (|(objectClass=user)(objectClass=group))
+$ldap->query()
+    ->orWhere(Filters::equal('objectClass', 'user'))
+    ->orWhere(Filters::equal('objectClass', 'group'))
+    ->get();
+
+# Combine using nested Filters for complex logic:
+# (&(objectClass=user)(|(department=IT)(department=HR)))
+$ldap->query()
+    ->andWhere(Filters::equal('objectClass', 'user'))
+    ->andWhere(
+        Filters::or(
+            Filters::equal('department', 'IT'),
+            Filters::equal('department', 'HR'),
+        )
+    )
+    ->get();
+```
+
+Use `where()` to replace the entire filter at once when you have already constructed a complete `FilterInterface`:
+
+```php
+$filter = Filters::raw('(&(objectClass=user)(title=*Manager*))');
+
+$entries = $ldap->query()
+    ->from('dc=example,dc=local')
+    ->where($filter)
+    ->get();
+```
+
+### Executing the Search
+
+#### Get All Entries
+
+Execute the search and return all matching entries as an `Entries` collection:
+
+```php
+$entries = $ldap->query()
+    ->andWhere(Filters::equal('objectClass', 'user'))
+    ->get();
+```
+
+#### Get First Entry
+
+Execute the search and return the first matching entry, or `null` if none exists. Automatically applies a server-side
+`sizeLimit` of `1` unless you have already configured one yourself:
+
+```php
+$entry = $ldap->query()
+    ->from('dc=example,dc=local')
+    ->andWhere(Filters::equal('cn', 'jsmith'))
+    ->first();
+
+if ($entry) {
+    echo $entry->getDn() . PHP_EOL;
+}
+```
+
+#### Query Builder Paging
+
+Execute the search as a paged operation, returning a `Paging` helper to iterate through results in chunks:
+
+```php
+$paging = $ldap->query()
+    ->select('cn', 'mail')
+    ->andWhere(Filters::equal('objectClass', 'user'))
+    ->paging(100);   # 100 entries per page
+
+while ($paging->hasEntries()) {
+    foreach ($paging->getEntries() as $entry) {
+        echo $entry->getDn() . PHP_EOL;
+    }
+}
+```
+
+#### Streaming
+
+Execute the search as a lazy generator, yielding one result at a time as entries arrive from the server. Each yielded
+value is an `EntryResult`, which exposes both the entry and any per-entry response controls:
+
+```php
+use FreeDSx\Ldap\Search\Result\EntryResult;
+
+$query = $ldap->query()
+    ->select('cn', 'mail')
+    ->andWhere(Filters::equal('objectClass', 'user'));
+
+foreach ($query->stream() as $result) {
+    $entry = $result->getEntry();
+    $controls = $result->getMessage()->getControls();
+
+    echo $entry->getDn() . PHP_EOL;
+}
+```
+
+### Advanced Usage
+
+Use `toSearchRequest()` to obtain the underlying `SearchRequest` when you need options not exposed by the builder
+(such as VLV searches or custom controls):
+
+```php
+$search = $ldap->query()
+    ->from('dc=example,dc=local')
+    ->select('cn')
+    ->andWhere(Filters::equal('objectClass', 'user'))
+    ->toSearchRequest();
+
+# Pass the request directly to VLV or other client methods
+$vlv = $ldap->vlv($search, 'cn', 100);
+```
  
 ## Standard Searches
 

--- a/src/FreeDSx/Ldap/LdapClient.php
+++ b/src/FreeDSx/Ldap/LdapClient.php
@@ -33,6 +33,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ClientQueueInstantiator;
 use FreeDSx\Ldap\Search\DirSync;
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
+use FreeDSx\Ldap\Search\LdapQuery;
 use FreeDSx\Ldap\Search\Paging;
 use FreeDSx\Ldap\Search\RangeRetrieval;
 use FreeDSx\Ldap\Search\Vlv;
@@ -264,6 +265,14 @@ class LdapClient
             $newRdn,
             $deleteOldRdn
         ));
+    }
+
+    /**
+     * Create a fluent query builder for constructing and executing a search.
+     */
+    public function query(): LdapQuery
+    {
+        return new LdapQuery($this);
     }
 
     /**

--- a/src/FreeDSx/Ldap/Search/LdapQuery.php
+++ b/src/FreeDSx/Ldap/Search/LdapQuery.php
@@ -1,0 +1,290 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Search;
+
+use Fiber;
+use Generator;
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entries;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Search\Filter\AndFilter;
+use FreeDSx\Ldap\Search\Filter\FilterInterface;
+use FreeDSx\Ldap\Search\Filter\OrFilter;
+use FreeDSx\Ldap\Search\Result\EntryResult;
+
+/**
+ * A fluent builder for constructing and executing LDAP search operations.
+ *
+ * Obtain an instance via {@see LdapClient::query()}.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class LdapQuery
+{
+    private ?FilterInterface $filter = null;
+
+    private ?string $baseDn = null;
+
+    private int $scope = SearchRequest::SCOPE_WHOLE_SUBTREE;
+
+    /**
+     * @var Attribute[]
+     */
+    private array $attributes = [];
+
+    private ?int $sizeLimit = null;
+
+    private ?int $timeLimit = null;
+
+    public function __construct(private readonly LdapClient $client)
+    {
+    }
+
+    /**
+     * Set the base DN to search from.
+     */
+    public function from(string|Dn $baseDn): self
+    {
+        $this->baseDn = (string) $baseDn;
+
+        return $this;
+    }
+
+    /**
+     * Search the entire subtree under the base DN (default).
+     */
+    public function useSubtreeScope(): self
+    {
+        $this->scope = SearchRequest::SCOPE_WHOLE_SUBTREE;
+
+        return $this;
+    }
+
+    /**
+     * Search only direct children of the base DN.
+     */
+    public function useSingleLevelScope(): self
+    {
+        $this->scope = SearchRequest::SCOPE_SINGLE_LEVEL;
+
+        return $this;
+    }
+
+    /**
+     * Search only the base DN object itself.
+     */
+    public function useBaseScope(): self
+    {
+        $this->scope = SearchRequest::SCOPE_BASE_OBJECT;
+
+        return $this;
+    }
+
+    /**
+     * Set the attributes to return. Replaces any previously selected attributes.
+     */
+    public function select(Attribute|string ...$attributes): self
+    {
+        $this->attributes = array_map(
+            fn (Attribute|string $attr) => $attr instanceof Attribute
+                ? $attr
+                : new Attribute($attr),
+            $attributes,
+        );
+
+        return $this;
+    }
+
+    /**
+     * Replace the current filter entirely with the one specified.
+     */
+    public function where(FilterInterface $filter): self
+    {
+        $this->filter = $filter;
+
+        return $this;
+    }
+
+    /**
+     * Add a filter condition using logical AND.
+     *
+     * - First call: sets the filter directly (no wrapper).
+     * - Subsequent calls: appends to an existing {@see AndFilter} or wraps the existing filter in one.
+     */
+    public function andWhere(FilterInterface $filter): self
+    {
+        match (true) {
+            $this->filter === null => $this->filter = $filter,
+            $this->filter instanceof AndFilter => $this->filter->add($filter),
+            default => $this->filter = new AndFilter($this->filter, $filter),
+        };
+
+        return $this;
+    }
+
+    /**
+     * Add a filter condition using logical OR.
+     *
+     * - First call: sets the filter directly (no wrapper).
+     * - Subsequent calls: appends to an existing {@see OrFilter} or wraps the existing filter in one.
+     */
+    public function orWhere(FilterInterface $filter): self
+    {
+        match (true) {
+            $this->filter === null => $this->filter = $filter,
+            $this->filter instanceof OrFilter => $this->filter->add($filter),
+            default => $this->filter = new OrFilter($this->filter, $filter),
+        };
+
+        return $this;
+    }
+
+    /**
+     * Limit the number of entries the server should return.
+     */
+    public function sizeLimit(int $sizeLimit): self
+    {
+        $this->sizeLimit = $sizeLimit;
+
+        return $this;
+    }
+
+    /**
+     * Limit the time (in seconds) the server should spend on the search.
+     */
+    public function timeLimit(int $timeLimit): self
+    {
+        $this->timeLimit = $timeLimit;
+
+        return $this;
+    }
+
+    /**
+     * Execute the search and return all matching entries.
+     *
+     * @return Entries<Entry>
+     */
+    public function get(Control ...$controls): Entries
+    {
+        return $this->client->search(
+            $this->toSearchRequest(),
+            ...$controls,
+        );
+    }
+
+    /**
+     * Execute the search and return the first matching entry, or null if none exists.
+     *
+     * Automatically applies a server-side size limit of 1 unless a limit was already configured.
+     */
+    public function first(Control ...$controls): ?Entry
+    {
+        $request = $this->toSearchRequest();
+
+        if ($request->getSizeLimit() === 0) {
+            $request->sizeLimit(1);
+        }
+
+        return $this->client
+            ->search(
+                $request,
+                ...$controls,
+            )->first();
+    }
+
+    /**
+     * Return a paging helper for iterating through results in pages.
+     */
+    public function paging(?int $pageSize = null): Paging
+    {
+        return $this->client->paging(
+            $this->toSearchRequest(),
+            $pageSize,
+        );
+    }
+
+    /**
+     * Execute the search as a lazy generator, yielding one {@see EntryResult} at a time.
+     *
+     * Each result exposes both the entry via {@see EntryResult::getEntry()} and the raw
+     * protocol message (including any per-entry controls) via {@see EntryResult::getMessage()}.
+     *
+     * @return Generator<EntryResult>
+     */
+    public function stream(Control ...$controls): Generator
+    {
+        /** @var Fiber<mixed, null, void, EntryResult> $fiber */
+        $fiber = new Fiber($this->executeSearch(...));
+
+        $result = $fiber->start(...$controls);
+        while ($fiber->isSuspended()) {
+            if ($result !== null) {
+                yield $result;
+            }
+            $result = $fiber->resume();
+        }
+    }
+
+    /**
+     * Build and return the underlying {@see SearchRequest}.
+     *
+     * Useful as an escape hatch when you need access to options not exposed by this builder,
+     * or when passing the request to other client methods such as {@see LdapClient::vlv()}.
+     */
+    public function toSearchRequest(): SearchRequest
+    {
+        $request = new SearchRequest(
+            $this->buildFilter(),
+            ...$this->attributes,
+        );
+
+        if ($this->baseDn !== null) {
+            $request->base($this->baseDn);
+        }
+
+        $request->setScope($this->scope);
+
+        if ($this->sizeLimit !== null) {
+            $request->sizeLimit($this->sizeLimit);
+        }
+
+        if ($this->timeLimit !== null) {
+            $request->timeLimit($this->timeLimit);
+        }
+
+        return $request;
+    }
+
+    private function buildFilter(): FilterInterface
+    {
+        return $this->filter ?? Filters::present('objectClass');
+    }
+
+    private function executeSearch(Control ...$controls): void
+    {
+        $this->client->search(
+            $this->toSearchRequest()->useEntryHandler($this->suspendWithResult(...)),
+            ...$controls,
+        );
+    }
+
+    private function suspendWithResult(EntryResult $result): void
+    {
+        Fiber::suspend($result);
+    }
+}

--- a/tests/integration/Search/LdapQueryTest.php
+++ b/tests/integration/Search/LdapQueryTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Search;
+
+use FreeDSx\Ldap\Entry\Entries;
+use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Search\LdapQuery;
+use FreeDSx\Ldap\Search\Result\EntryResult;
+use Tests\Integration\FreeDSx\Ldap\LdapTestCase;
+use Throwable;
+
+final class LdapQueryTest extends LdapTestCase
+{
+    private const BASE_DN = 'ou=FreeDSx-Test,dc=example,dc=com';
+
+    private LdapClient $client;
+
+    private LdapQuery $subject;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->getClient();
+        $this->bindClient($this->client);
+        $this->subject = $this->client
+            ->query()
+            ->from(self::BASE_DN);
+    }
+
+    protected function tearDown(): void
+    {
+        try {
+            $this->client->unbind();
+        } catch (Throwable) {
+        }
+    }
+
+    public function testGetReturnsAllMatchingEntries(): void
+    {
+        $entries = $this->subject
+            ->select('ou')
+            ->andWhere(Filters::equal('objectClass', 'organizationalUnit'))
+            ->get();
+
+        $this->assertCount(12, $entries);
+    }
+
+    public function testGetWithAndWhereAccumulatesFilters(): void
+    {
+        $entries = $this->subject
+            ->select('cn')
+            ->andWhere(Filters::equal('objectClass', 'inetOrgPerson'))
+            ->andWhere(Filters::startsWith('cn', 'A'))
+            ->get();
+
+        $this->assertCount(
+            843,
+            $entries,
+        );
+    }
+
+    public function testGetWithOrWhereReturnsUnionOfResults(): void
+    {
+        $entries = $this->subject
+            ->select('cn')
+            ->orWhere(Filters::equal('cn', 'Birgit Pankhurst'))
+            ->orWhere(Filters::equal('cn', 'Carmelina Esposito'))
+            ->get();
+
+        $this->assertCount(
+            2,
+            $entries,
+        );
+    }
+
+    public function testSelectLimitsReturnedAttributes(): void
+    {
+        $entry = $this->subject
+            ->select('cn')
+            ->andWhere(Filters::equal('cn', 'Birgit Pankhurst'))
+            ->first();
+
+        $this->assertNotNull($entry);
+        $this->assertNotNull($entry->get('cn'));
+        $this->assertNull($entry->get('sn'));
+    }
+
+    public function testUseSingleLevelScopeSearchesDirectChildrenOnly(): void
+    {
+        $payrollDn = 'ou=Payroll,' . self::BASE_DN;
+
+        $entries = $this->subject
+            ->from($payrollDn)
+            ->useSingleLevelScope()
+            ->select('cn')
+            ->andWhere(Filters::equal('objectClass', 'inetOrgPerson'))
+            ->get();
+
+        $this->assertNotEmpty($entries);
+
+        foreach ($entries as $entry) {
+            $this->assertSame(
+                strtolower($payrollDn),
+                strtolower((string) $entry->getDn()->getParent()?->toString()),
+            );
+        }
+    }
+
+    public function testFirstReturnsFirstMatchingEntry(): void
+    {
+        $entry = $this->subject
+            ->select('cn')
+            ->andWhere(Filters::equal('cn', 'Birgit Pankhurst'))
+            ->first();
+
+        $this->assertNotNull($entry);
+        $this->assertSame(
+            strtolower('cn=Birgit Pankhurst,ou=Janitorial,' . self::BASE_DN),
+            strtolower($entry->getDn()->toString()),
+        );
+    }
+
+    public function testFirstReturnsNullWhenNoEntryMatches(): void
+    {
+        $entry = $this->subject
+            ->andWhere(Filters::equal('cn', 'ThisPersonDoesNotExist12345'))
+            ->first();
+
+        $this->assertNull($entry);
+    }
+
+    public function testPagingReturnsAllResultsAcrossPages(): void
+    {
+        $paging = $this->subject
+            ->select('ou')
+            ->andWhere(Filters::equal('objectClass', 'organizationalUnit'))
+            ->paging(4);
+
+        $entries = new Entries();
+        while ($paging->hasEntries()) {
+            $entries->add(...$paging->getEntries()->toArray());
+        }
+
+        $this->assertCount(
+            12,
+            $entries,
+        );
+    }
+
+    public function testStreamYieldsAllMatchingResults(): void
+    {
+        $subject = $this->subject
+            ->select('ou')
+            ->andWhere(Filters::equal('objectClass', 'organizationalUnit'));
+
+        $count = 0;
+        foreach ($subject->stream() as $result) {
+            $this->assertInstanceOf(EntryResult::class, $result);
+            $this->assertNotNull($result->getEntry()->get('ou'));
+            $count++;
+        }
+
+        $this->assertSame(12, $count);
+    }
+
+    public function testStreamYieldsResultsWithAccessibleMessageControls(): void
+    {
+        $subject = $this->subject
+            ->select('cn')
+            ->andWhere(Filters::equal('cn', 'Birgit Pankhurst'));
+
+        foreach ($subject->stream() as $result) {
+            $this->assertNotNull($result->getEntry());
+            $this->assertNotNull($result->getMessage());
+        }
+    }
+}

--- a/tests/unit/Search/LdapQueryTest.php
+++ b/tests/unit/Search/LdapQueryTest.php
@@ -1,0 +1,501 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Search;
+
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entries;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Search\Filter\AndFilter;
+use FreeDSx\Ldap\Search\Filter\EqualityFilter;
+use FreeDSx\Ldap\Search\Filter\OrFilter;
+use FreeDSx\Ldap\Search\Filter\PresentFilter;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Search\LdapQuery;
+use FreeDSx\Ldap\Search\Paging;
+use FreeDSx\Ldap\Search\Result\EntryResult;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class LdapQueryTest extends TestCase
+{
+    private LdapClient&MockObject $client;
+
+    private LdapQuery $subject;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createMock(LdapClient::class);
+        $this->subject = new LdapQuery($this->client);
+    }
+
+    // -------------------------------------------------------------------------
+    // toSearchRequest
+    // -------------------------------------------------------------------------
+
+    public function test_to_search_request_uses_present_objectClass_filter_by_default(): void
+    {
+        $request = $this->subject->toSearchRequest();
+
+        self::assertEquals(
+            new PresentFilter('objectClass'),
+            $request->getFilter(),
+        );
+    }
+
+    public function test_to_search_request_uses_whole_subtree_scope_by_default(): void
+    {
+        $request = $this->subject->toSearchRequest();
+
+        self::assertSame(SearchRequest::SCOPE_WHOLE_SUBTREE, $request->getScope());
+    }
+
+    public function test_to_search_request_sets_base_dn(): void
+    {
+        $request = $this->subject
+            ->from('dc=example,dc=local')
+            ->toSearchRequest();
+
+        self::assertEquals(new Dn('dc=example,dc=local'), $request->getBaseDn());
+    }
+
+    public function test_to_search_request_sets_base_dn_from_dn_object(): void
+    {
+        $request = $this->subject
+            ->from(new Dn('dc=example,dc=local'))
+            ->toSearchRequest();
+
+        self::assertEquals(new Dn('dc=example,dc=local'), $request->getBaseDn());
+    }
+
+    public function test_to_search_request_base_dn_is_null_when_not_set(): void
+    {
+        $request = $this->subject->toSearchRequest();
+
+        self::assertNull($request->getBaseDn());
+    }
+
+    public function test_to_search_request_sets_subtree_scope(): void
+    {
+        $request = $this->subject
+            ->useSubtreeScope()
+            ->toSearchRequest();
+
+        self::assertSame(SearchRequest::SCOPE_WHOLE_SUBTREE, $request->getScope());
+    }
+
+    public function test_to_search_request_sets_single_level_scope(): void
+    {
+        $request = $this->subject
+            ->useSingleLevelScope()
+            ->toSearchRequest();
+
+        self::assertSame(SearchRequest::SCOPE_SINGLE_LEVEL, $request->getScope());
+    }
+
+    public function test_to_search_request_sets_base_scope(): void
+    {
+        $request = $this->subject
+            ->useBaseScope()
+            ->toSearchRequest();
+
+        self::assertSame(SearchRequest::SCOPE_BASE_OBJECT, $request->getScope());
+    }
+
+    public function test_to_search_request_sets_attributes_from_strings(): void
+    {
+        $request = $this->subject
+            ->select('cn', 'mail')
+            ->toSearchRequest();
+
+        self::assertEquals(
+            [new Attribute('cn'), new Attribute('mail')],
+            $request->getAttributes(),
+        );
+    }
+
+    public function test_to_search_request_sets_attributes_from_attribute_objects(): void
+    {
+        $cn = new Attribute('cn');
+        $mail = new Attribute('mail');
+
+        $request = $this->subject
+            ->select($cn, $mail)
+            ->toSearchRequest();
+
+        self::assertEquals([$cn, $mail], $request->getAttributes());
+    }
+
+    public function test_to_search_request_sets_size_limit(): void
+    {
+        $request = $this->subject
+            ->sizeLimit(50)
+            ->toSearchRequest();
+
+        self::assertSame(50, $request->getSizeLimit());
+    }
+
+    public function test_to_search_request_does_not_set_size_limit_when_not_configured(): void
+    {
+        $request = $this->subject->toSearchRequest();
+
+        self::assertSame(0, $request->getSizeLimit());
+    }
+
+    public function test_to_search_request_sets_time_limit(): void
+    {
+        $request = $this->subject
+            ->timeLimit(30)
+            ->toSearchRequest();
+
+        self::assertSame(30, $request->getTimeLimit());
+    }
+
+    public function test_to_search_request_does_not_set_time_limit_when_not_configured(): void
+    {
+        $request = $this->subject->toSearchRequest();
+
+        self::assertSame(0, $request->getTimeLimit());
+    }
+
+    // -------------------------------------------------------------------------
+    // where / andWhere / orWhere
+    // -------------------------------------------------------------------------
+
+    public function test_where_replaces_the_filter(): void
+    {
+        $filter = Filters::equal('cn', 'foo');
+
+        $request = $this->subject
+            ->where($filter)
+            ->toSearchRequest();
+
+        self::assertSame($filter, $request->getFilter());
+    }
+
+    public function test_where_replaces_an_existing_filter(): void
+    {
+        $original = Filters::equal('cn', 'foo');
+        $replacement = Filters::equal('sn', 'bar');
+
+        $request = $this->subject
+            ->where($original)
+            ->where($replacement)
+            ->toSearchRequest();
+
+        self::assertSame($replacement, $request->getFilter());
+    }
+
+    public function test_and_where_sets_filter_directly_on_first_call(): void
+    {
+        $filter = Filters::equal('cn', 'foo');
+
+        $request = $this->subject
+            ->andWhere($filter)
+            ->toSearchRequest();
+
+        self::assertSame($filter, $request->getFilter());
+    }
+
+    public function test_and_where_wraps_in_and_filter_on_second_call(): void
+    {
+        $first = Filters::equal('objectClass', 'user');
+        $second = Filters::present('telephoneNumber');
+
+        $request = $this->subject
+            ->andWhere($first)
+            ->andWhere($second)
+            ->toSearchRequest();
+
+        $filter = $request->getFilter();
+        self::assertInstanceOf(AndFilter::class, $filter);
+        self::assertSame([$first, $second], $filter->get());
+    }
+
+    public function test_and_where_appends_to_existing_and_filter(): void
+    {
+        $first = Filters::equal('objectClass', 'user');
+        $second = Filters::present('telephoneNumber');
+        $third = Filters::startsWith('cn', 'A');
+
+        $request = $this->subject
+            ->andWhere($first)
+            ->andWhere($second)
+            ->andWhere($third)
+            ->toSearchRequest();
+
+        $filter = $request->getFilter();
+        self::assertInstanceOf(AndFilter::class, $filter);
+        self::assertSame([$first, $second, $third], $filter->get());
+    }
+
+    public function test_and_where_wraps_non_and_filter_in_and(): void
+    {
+        $existing = Filters::or(
+            Filters::equal('objectClass', 'user'),
+            Filters::equal('objectClass', 'group'),
+        );
+        $additional = Filters::present('cn');
+
+        $request = $this->subject
+            ->where($existing)
+            ->andWhere($additional)
+            ->toSearchRequest();
+
+        $filter = $request->getFilter();
+        self::assertInstanceOf(AndFilter::class, $filter);
+        self::assertSame([$existing, $additional], $filter->get());
+    }
+
+    public function test_or_where_sets_filter_directly_on_first_call(): void
+    {
+        $filter = Filters::equal('cn', 'foo');
+
+        $request = $this->subject
+            ->orWhere($filter)
+            ->toSearchRequest();
+
+        self::assertSame($filter, $request->getFilter());
+    }
+
+    public function test_or_where_wraps_in_or_filter_on_second_call(): void
+    {
+        $first = Filters::equal('objectClass', 'user');
+        $second = Filters::equal('objectClass', 'group');
+
+        $request = $this->subject
+            ->orWhere($first)
+            ->orWhere($second)
+            ->toSearchRequest();
+
+        $filter = $request->getFilter();
+        self::assertInstanceOf(OrFilter::class, $filter);
+        self::assertSame([$first, $second], $filter->get());
+    }
+
+    public function test_or_where_appends_to_existing_or_filter(): void
+    {
+        $first = Filters::equal('objectClass', 'user');
+        $second = Filters::equal('objectClass', 'group');
+        $third = Filters::equal('objectClass', 'contact');
+
+        $request = $this->subject
+            ->orWhere($first)
+            ->orWhere($second)
+            ->orWhere($third)
+            ->toSearchRequest();
+
+        $filter = $request->getFilter();
+        self::assertInstanceOf(OrFilter::class, $filter);
+        self::assertSame([$first, $second, $third], $filter->get());
+    }
+
+    public function test_or_where_wraps_non_or_filter_in_or(): void
+    {
+        $existing = new EqualityFilter('objectClass', 'user');
+        $additional = new EqualityFilter('objectClass', 'group');
+
+        $request = $this->subject
+            ->where($existing)
+            ->orWhere($additional)
+            ->toSearchRequest();
+
+        $filter = $request->getFilter();
+        self::assertInstanceOf(OrFilter::class, $filter);
+        self::assertSame([$existing, $additional], $filter->get());
+    }
+
+    // -------------------------------------------------------------------------
+    // get
+    // -------------------------------------------------------------------------
+
+    public function test_get_delegates_to_client_search(): void
+    {
+        $expected = new Entries(Entry::create('cn=foo,dc=example,dc=local'));
+
+        $this->client
+            ->expects(self::once())
+            ->method('search')
+            ->willReturn($expected);
+
+        $result = $this->subject
+            ->from('dc=example,dc=local')
+            ->andWhere(Filters::equal('objectClass', 'user'))
+            ->get();
+
+        self::assertSame($expected, $result);
+    }
+
+    // -------------------------------------------------------------------------
+    // first
+    // -------------------------------------------------------------------------
+
+    public function test_first_returns_the_first_entry(): void
+    {
+        $entry = Entry::create('cn=foo,dc=example,dc=local');
+
+        $this->client
+            ->method('search')
+            ->willReturn(new Entries($entry));
+
+        $result = $this->subject
+            ->andWhere(Filters::equal('cn', 'foo'))
+            ->first();
+
+        self::assertSame($entry, $result);
+    }
+
+    public function test_first_returns_null_when_no_entries_found(): void
+    {
+        $this->client
+            ->method('search')
+            ->willReturn(new Entries());
+
+        $result = $this->subject
+            ->andWhere(Filters::equal('cn', 'nobody'))
+            ->first();
+
+        self::assertNull($result);
+    }
+
+    public function test_first_sets_size_limit_to_one_when_not_configured(): void
+    {
+        $this->client
+            ->expects(self::once())
+            ->method('search')
+            ->with(self::callback(
+                fn (SearchRequest $r) => $r->getSizeLimit() === 1
+            ))
+            ->willReturn(new Entries());
+
+        $this->subject->first();
+    }
+
+    public function test_first_does_not_override_an_explicitly_configured_size_limit(): void
+    {
+        $this->client
+            ->expects(self::once())
+            ->method('search')
+            ->with(self::callback(
+                fn (SearchRequest $r) => $r->getSizeLimit() === 10
+            ))
+            ->willReturn(new Entries());
+
+        $this->subject->sizeLimit(10)->first();
+    }
+
+    // -------------------------------------------------------------------------
+    // paging
+    // -------------------------------------------------------------------------
+
+    public function test_paging_delegates_to_client_paging(): void
+    {
+        $paging = $this->createMock(Paging::class);
+
+        $this->client
+            ->expects(self::once())
+            ->method('paging')
+            ->with(
+                self::isInstanceOf(SearchRequest::class),
+                100,
+            )
+            ->willReturn($paging);
+
+        $result = $this->subject->paging(100);
+
+        self::assertSame($paging, $result);
+    }
+
+    public function test_paging_passes_null_page_size_by_default(): void
+    {
+        $paging = $this->createMock(Paging::class);
+
+        $this->client
+            ->expects(self::once())
+            ->method('paging')
+            ->with(
+                self::isInstanceOf(SearchRequest::class),
+                null,
+            )
+            ->willReturn($paging);
+
+        $this->subject->paging();
+    }
+
+    // -------------------------------------------------------------------------
+    // stream
+    // -------------------------------------------------------------------------
+
+    public function test_stream_yields_entry_results(): void
+    {
+        $result1 = new EntryResult(new LdapMessageResponse(
+            1,
+            new SearchResultEntry(Entry::create('cn=foo,dc=example,dc=local')),
+        ));
+        $result2 = new EntryResult(new LdapMessageResponse(
+            1,
+            new SearchResultEntry(Entry::create('cn=bar,dc=example,dc=local')),
+        ));
+
+        $this->client
+            ->method('search')
+            ->willReturnCallback(function (SearchRequest $request) use ($result1, $result2): Entries {
+                $handler = $request->getEntryHandler();
+                self::assertNotNull($handler);
+                $handler($result1);
+                $handler($result2);
+
+                return new Entries();
+            });
+
+        $results = iterator_to_array(
+            $this->subject
+                ->andWhere(Filters::equal('objectClass', 'user'))
+                ->stream()
+        );
+
+        self::assertSame([$result1, $result2], $results);
+    }
+
+    public function test_stream_yields_nothing_when_no_entries_found(): void
+    {
+        $this->client
+            ->method('search')
+            ->willReturn(new Entries());
+
+        $results = iterator_to_array($this->subject->stream());
+
+        self::assertSame([], $results);
+    }
+
+    public function test_stream_passes_controls_to_search(): void
+    {
+        $control = $this->createMock(\FreeDSx\Ldap\Control\Control::class);
+
+        $this->client
+            ->expects(self::once())
+            ->method('search')
+            ->with(
+                self::isInstanceOf(SearchRequest::class),
+                $control,
+            )
+            ->willReturn(new Entries());
+
+        iterator_to_array($this->subject->stream($control));
+    }
+}


### PR DESCRIPTION
This adds a more fluid query builder to reduce the awkwardness of the current methods. It adds convenience methods for paging / streaming  (this was made possible by some other work I did with SyncRepl) / getting all results / etc.

Updating the docs to note this as the preferred query building pattern along with examples.