### PR TITLE
[1.0.0] Optimizations, fixes, and load testing.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "symplify/easy-coding-standard": "^9.4",
     "phpstan/phpstan": "^2.1",
     "symfony/process": "^5.4",
+    "symfony/console": "^6.4",
     "squizlabs/php_codesniffer": "^3.7",
     "slevomat/coding-standard": "^7.2",
     "phpstan/phpstan-phpunit": "^2.0",

--- a/docs/Server/General-Usage.md
+++ b/docs/Server/General-Usage.md
@@ -413,10 +413,15 @@ Four storage implementations are included for common use cases. All are used via
 
 An in-memory, array-backed storage implementation. Suitable for:
 
-- **Swoole**: all connections share the same process memory.
+- **Swoole**: all connections share the same process memory, so reads and writes are visible to every client.
 - **PCNTL** with pre-seeded, read-only data: data seeded before `run()` is inherited by all forked child processes.
 
-**Note**: With PCNTL, write operations performed by one child process are not visible to other children.
+> **⚠️ PCNTL write caveat**
+>
+> Under the PCNTL runner, `InMemoryStorage` is **not safe for multi-client write workloads**. Each forked child receives
+> its own copy of the store at fork time. Written data is not propagated.
+>
+> Use one of `JsonFileStorage`, `SqliteStorage`, or `MysqlStorage` if you need write behavior and use PCNTL.
 
 ```php
 use FreeDSx\Ldap\Entry\Attribute;

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/NameResolver/DnBindNameResolver.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/NameResolver/DnBindNameResolver.php
@@ -18,8 +18,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 
 /**
- * The default bind-name resolver. Treats the bind name as a DN and delegates
- * to LdapBackendInterface::get().
+ * Default resolver: treats the bind name as a DN and delegates to LdapBackendInterface::get().
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticatableInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticatableInterface.php
@@ -23,9 +23,7 @@ use SensitiveParameter;
 interface PasswordAuthenticatableInterface
 {
     /**
-     * Return true if the supplied password is valid for the given bind name.
-     *
-     * The name is the raw value from the LDAP bind request — it need not be a DN.
+     * Return true if $password is valid for $name; $name is the raw LDAP bind name and need not be a DN.
      */
     public function verifyPassword(
         string $name,
@@ -34,16 +32,9 @@ interface PasswordAuthenticatableInterface
     ): bool;
 
     /**
-     * Return the plaintext password for the given username and SASL mechanism,
-     * or null if the user does not exist or should not authenticate.
+     * Return the plaintext password for $username (SCRAM/CRAM derive keys from plaintext), or null to reject the bind.
      *
-     * The $mechanism parameter receives the exact SASL mechanism name (e.g.
-     * 'SCRAM-SHA-256', 'CRAM-MD5'). For all currently supported SASL mechanisms
-     * the return value must be the user's plaintext password: the underlying SASL
-     * library derives the required keys (PBKDF2 for SCRAM, HMAC for CRAM-MD5)
-     * from plaintext at authentication time.
-     *
-     * RFC 5803 stored-key format (pre-computed StoredKey/ServerKey) is not currently supported.
+     * RFC 5803 pre-computed StoredKey/ServerKey is not supported.
      */
     public function getPassword(
         string $username,

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticator.php
@@ -18,11 +18,7 @@ use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use SensitiveParameter;
 
 /**
- * Default password authenticator. Resolves the bind name to an Entry via a
- * BindNameResolverInterface, then verifies the supplied password against the
- * entry's userPassword attribute.
- *
- * Supported storage schemes: {SHA}, {SSHA}, {MD5}, {SMD5}, and plain-text.
+ * Resolves the bind name to an Entry and verifies its userPassword; supports {SHA}, {SSHA}, {MD5}, {SMD5}, and plaintext.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -73,9 +69,7 @@ final class PasswordAuthenticator implements PasswordAuthenticatableInterface
     }
 
     /**
-     * Verify a plain-text password against a (possibly hashed) stored value.
-     *
-     * Supports {SHA}, {SSHA}, {MD5}, {SMD5}, and plain-text storage.
+     * Verify plaintext against the stored value, which may be {SHA}, {SSHA}, {MD5}, {SMD5}, or plaintext.
      */
     private function checkPassword(
         #[SensitiveParameter]

--- a/src/FreeDSx/Ldap/Server/Backend/GenericBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/GenericBackend.php
@@ -24,10 +24,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use Generator;
 
 /**
- * A no-op backend used when no backend has been configured via LdapServer::useBackend().
- *
- * Read operations return empty / false results. Write operations are handled by
- * an empty WriteOperationDispatcher, which returns UNWILLING_TO_PERFORM.
+ * No-op fallback backend: reads return empty, writes are rejected with UNWILLING_TO_PERFORM by the empty dispatcher.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/LdapBackendInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/LdapBackendInterface.php
@@ -22,30 +22,14 @@ use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 
 /**
- * The core contract for an LDAP backend storage implementation.
- *
- * Implement this interface to provide a read-only backend.
- *
- * For a writable backend (add, delete, modify, rename) implement WritableLdapBackendInterface.
- *
- * The search() method returns a Generator that yields Entry objects. This library applies its own FilterEvaluator as a
- * final pass, so the backend may pre-filter for efficiency (e.g. translate to a SQL WHERE clause) or yield all
- * candidates in scope and let the framework filter.
- *
- * Each generator is scoped to a single client connection and a single paging session. It is paused between pages and
- * garbage-collected when the session ends, so no external paging state management is needed.
+ * Read-only LDAP backend contract; implement WritableLdapBackendInterface for full CRUD.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 interface LdapBackendInterface
 {
     /**
-     * Return an EntryStream for the given search context.
-     *
-     * The result wraps a lazy generator of candidate entries and a flag indicating whether the backend has already
-     * applied the filter exactly. When EntryStream::$isPreFiltered is true, the caller may skip PHP-level
-     * FilterEvaluator evaluation. Otherwise, all yielded entries are passed through FilterEvaluator as a final
-     * correctness pass.
+     * Set EntryStream::$isPreFiltered to true when the backend has applied the filter exactly; otherwise FilterEvaluator re-checks each yielded entry.
      */
     public function search(
         SearchRequest $request,
@@ -58,10 +42,7 @@ interface LdapBackendInterface
     public function get(Dn $dn): ?Entry;
 
     /**
-     * Evaluate a compare assertion against an entry.
-     *
-     * Return true if the attribute-value assertion matches, false if it does not.
-     * Throw OperationException(NO_SUCH_OBJECT) if the entry does not exist.
+     * Evaluate a compare assertion; throws OperationException(NO_SUCH_OBJECT) when the entry is missing.
      *
      * @throws OperationException
      */

--- a/src/FreeDSx/Ldap/Server/Backend/ResettableInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/ResettableInterface.php
@@ -11,23 +11,14 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter;
-
-use PDO;
+namespace FreeDSx\Ldap\Server\Backend;
 
 /**
- * Resolves a PDO connection and its transaction state for the current execution context.
+ * Implemented by components whose cached state or connections should be discarded on demand (such as after forking).
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-interface PdoConnectionProviderInterface
+interface ResettableInterface
 {
-    public function get(): PDO;
-
-    public function txState(): PdoTxState;
-
-    /**
-     * Discard any cached connection and transaction state.
-     */
     public function reset(): void;
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/ArrayEntryStorageTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/ArrayEntryStorageTrait.php
@@ -19,11 +19,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
 use Generator;
 
 /**
- * Provides scope-filtered list helpers for array-backed EntryStorageInterface implementations.
- *
- * Includes DefaultHasChildrenTrait for the default hasChildren() implementation.
- * Use DefaultHasChildrenTrait directly if you only need the hasChildren() default
- * (e.g. for a database-backed adapter that handles list() natively).
+ * Scope-filtered list helpers for array-backed stores; composes DefaultHasChildrenTrait (use that directly for DB-backed adapters).
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/CoroutinePdoConnectionProvider.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/CoroutinePdoConnectionProvider.php
@@ -72,6 +72,13 @@ final class CoroutinePdoConnectionProvider implements PdoConnectionProviderInter
         return $this->txStates[$cid];
     }
 
+    /**
+     * No-op: connections are already isolated per coroutine, and coroutines do not cross fork boundaries.
+     */
+    public function reset(): void
+    {
+    }
+
     private function requireCoroutineId(): int
     {
         $cid = Coroutine::getCid();

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/DefaultHasChildrenTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/DefaultHasChildrenTrait.php
@@ -18,11 +18,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 
 /**
- * Provides a default hasChildren() implementation in terms of list().
- *
- * Suitable for any EntryStorageInterface implementation. Adapters that can
- * answer the question more efficiently (e.g. via an EXISTS query on a database)
- * should override hasChildren() directly.
+ * Default hasChildren() built on list(); override in adapters that can answer via an EXISTS query.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/MysqlDialect.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/MysqlDialect.php
@@ -14,9 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
 
 /**
- * MySQL/MariaDB-specific SQL for PdoStorage.
- *
- * Requires MySQL 8.0+ or MariaDB 10.6+.
+ * MySQL/MariaDB SQL for PdoStorage; requires MySQL 8.0+ or MariaDB 10.6+.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -25,7 +23,7 @@ final class MysqlDialect implements PdoDialectInterface
     use PdoDialectTrait;
 
     /**
-     * The 768-character DN columns are sized to the maximum that still fits InnoDB's index.
+     * DN columns are 768 chars — the maximum that still fits an InnoDB index.
      *
      * @TODO How to handle indexing on attributes?
      */
@@ -44,8 +42,7 @@ final class MysqlDialect implements PdoDialectInterface
     }
 
     /**
-     * Returns null because the index is already defined inline in ddlCreateTable().
-     * PdoStorage::initialize() skips execution when null is returned.
+     * Null: the index is defined inline in ddlCreateTable().
      */
     public function ddlCreateIndex(): ?string
     {
@@ -53,8 +50,7 @@ final class MysqlDialect implements PdoDialectInterface
     }
 
     /**
-     * @todo VALUES() in ON DUPLICATE KEY UPDATE is deprecated since MySQL 8.0.20 and removed in 9.0.
-     *       Replace with row alias syntax (AS new_entry) once MariaDB support for that is confirmed.
+     * @todo Replace VALUES() (deprecated in MySQL 8.0.20, removed in 9.0) with row alias syntax once MariaDB supports it.
      */
     public function queryUpsert(): string
     {

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
 
+use PDO;
+
 /**
  * Provides the database-specific SQL strings used by PdoStorage.
  *
@@ -20,6 +22,22 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
  */
 interface PdoDialectInterface
 {
+    /**
+     * Begin a write-capable transaction.
+     */
+    public function beginTransaction(PDO $pdo): void;
+
+    /**
+     * Commit the current transaction started by beginTransaction().
+     */
+    public function commit(PDO $pdo): void;
+
+    /**
+     * Roll back the current transaction started by beginTransaction().
+     */
+    public function rollBack(PDO $pdo): void;
+
+
     /**
      * DDL for the `entries` table. Required columns:
      *   lc_dn         — PK, lowercased DN

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectInterface.php
@@ -21,36 +21,26 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
 interface PdoDialectInterface
 {
     /**
-     * DDL to create the entries table if it does not already exist.
-     *
-     * Required columns:
-     *   lc_dn         — primary key, lowercased DN string
-     *   dn            — original-case DN string
-     *   lc_parent_dn  — lowercased parent DN string (empty string for root entries)
+     * DDL for the `entries` table. Required columns:
+     *   lc_dn         — PK, lowercased DN
+     *   dn            — original-case DN
+     *   lc_parent_dn  — lowercased parent DN ('' for root)
      *   attributes    — JSON object mapping lowercased attribute names to string-value arrays
      */
     public function ddlCreateTable(): string;
 
     /**
-     * DDL to create an index on lc_parent_dn if it does not already exist.
-     *
-     * Return null if the index is already defined inline in ddlCreateTable()
+     * DDL to create an index on lc_parent_dn; return null when already defined inline in ddlCreateTable().
      */
     public function ddlCreateIndex(): ?string;
 
     /**
-     * SELECT 1 WHERE lc_dn = ? LIMIT 1
-     *
-     * Lightweight existence check without fetching attributes.
-     *
-     * Parameters: [lc_dn]
+     * Existence check: `SELECT 1 FROM entries WHERE lc_dn = ? LIMIT 1`. Parameters: [lc_dn]
      */
     public function queryExists(): string;
 
     /**
-     * SELECT dn, attributes WHERE lc_dn = ?
-     *
-     * Parameters: [lc_dn]
+     * `SELECT dn, attributes FROM entries WHERE lc_dn = ?`. Parameters: [lc_dn]
      */
     public function queryFetchEntry(): string;
 
@@ -60,40 +50,27 @@ interface PdoDialectInterface
     public function queryFetchAll(): string;
 
     /**
-     * SELECT dn, attributes WHERE lc_parent_dn = ?
-     *
-     * Parameters: [lc_parent_dn]
+     * `SELECT dn, attributes FROM entries WHERE lc_parent_dn = ?`. Parameters: [lc_parent_dn]
      */
     public function queryFetchChildren(): string;
 
     /**
-     * Recursive CTE that returns the base entry and all its descendants.
-     *
-     * The outer SELECT returns (dn, attributes) from the CTE result set.
-     * PdoStorage appends `WHERE (filter)` when a translated filter is available.
-     *
-     * Parameters: [lc_dn]
+     * Recursive CTE returning (dn, attributes) for the base entry and its descendants; PdoStorage may append `WHERE (filter)`. Parameters: [lc_dn]
      */
     public function querySubtree(): string;
 
     /**
-     * Returns at least one row when children exist under lc_parent_dn, zero rows otherwise.
-     *
-     * Parameters: [lc_parent_dn]
+     * Returns a row when children exist under lc_parent_dn, none otherwise. Parameters: [lc_parent_dn]
      */
     public function queryHasChildren(): string;
 
     /**
-     * INSERT or UPDATE (upsert) a single entry.
-     *
-     * Parameters: [lc_dn, dn, lc_parent_dn, attributes]
+     * Upsert a single entry. Parameters: [lc_dn, dn, lc_parent_dn, attributes]
      */
     public function queryUpsert(): string;
 
     /**
-     * DELETE FROM entries WHERE lc_dn = ?
-     *
-     * Parameters: [lc_dn]
+     * `DELETE FROM entries WHERE lc_dn = ?`. Parameters: [lc_dn]
      */
     public function queryDelete(): string;
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
 
+use PDO;
+
 /**
  * Standard SQL that should be cross-platform across the adapters.
  *
@@ -20,6 +22,21 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
  */
 trait PdoDialectTrait
 {
+    public function beginTransaction(PDO $pdo): void
+    {
+        $pdo->beginTransaction();
+    }
+
+    public function commit(PDO $pdo): void
+    {
+        $pdo->commit();
+    }
+
+    public function rollBack(PDO $pdo): void
+    {
+        $pdo->rollBack();
+    }
+
     public function queryExists(): string
     {
         return <<<SQL

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SqliteDialect.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SqliteDialect.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
 
+use PDO;
+
 /**
  * SQLite-specific SQL for PdoStorage.
  *
@@ -21,6 +23,25 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
 final class SqliteDialect implements PdoDialectInterface
 {
     use PdoDialectTrait;
+
+    /**
+     * `BEGIN IMMEDIATE` acquires the reserved lock up front so concurrent writers wait (honoring `busy_timeout`)
+     * instead of racing, which returns SQLITE_BUSY immediately to avoid deadlock.
+     */
+    public function beginTransaction(PDO $pdo): void
+    {
+        $pdo->exec('BEGIN IMMEDIATE');
+    }
+
+    public function commit(PDO $pdo): void
+    {
+        $pdo->exec('COMMIT');
+    }
+
+    public function rollBack(PDO $pdo): void
+    {
+        $pdo->exec('ROLLBACK');
+    }
 
     public function ddlCreateTable(): string
     {

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
@@ -20,15 +20,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 
 /**
- * An in-memory storage implementation backed by a plain PHP array.
- *
- * Suitable for single-process use cases: the Swoole server runner (all
- * connections share the same process memory), or pre-seeded read-only
- * use with the PCNTL runner (data seeded before run() is inherited by
- * all forked child processes).
- *
- * With the PCNTL runner, write operations performed by one child process
- * are not visible to other children or the parent.
+ * Array-backed storage; safe under Swoole or as a pre-seeded read-only fixture under PCNTL (child writes are not shared).
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -37,16 +29,12 @@ final class InMemoryStorage implements EntryStorageInterface
     use ArrayEntryStorageTrait;
 
     /**
-     * Entries keyed by their normalised (lowercased) DN string.
-     *
-     * @var array<string, Entry>
+     * @var array<string, Entry> keyed by normalised DN string
      */
     private array $entries = [];
 
     /**
-     * Pre-populate the storage with a set of entries.
-     *
-     * @param Entry[] $entries
+     * @param Entry[] $entries pre-populated into the store
      */
     public function __construct(array $entries = [])
     {

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonEntryBuffer.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonEntryBuffer.php
@@ -23,11 +23,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 use Generator;
 
 /**
- * A transient EntryStorageInterface view over an in-flight JSON data buffer.
- *
- * Created by JsonFileStorage::atomic() for the duration of a single locked
- * read-modify-write cycle. Changes are held in memory and written back when
- * the atomic operation completes.
+ * Transient EntryStorageInterface view used by JsonFileStorage::atomic() for one locked read-modify-write cycle.
  *
  * @internal
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonFileStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonFileStorage.php
@@ -24,28 +24,9 @@ use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 
 /**
- * A file-backed storage implementation that persists entries as a JSON file.
+ * JSON-file storage; use forPcntl() / forSwoole() to pick a locking strategy. Reads are lock-free; writes go through atomic() which loads, mutates, and rewrites the file under lock.
  *
- * Use the named constructors to select the appropriate locking strategy:
- *
- *   JsonFileStorage::forPcntl('/path/to/file.json')
- *   JsonFileStorage::forSwoole('/path/to/file.json')
- *
- * Reads are non-transactional (no lock acquired). Write operations performed
- * through WritableStorageBackend are always routed through atomic(), which
- * acquires the lock, loads the entire file into an in-memory buffer, passes
- * that buffer to the operation, then writes the result back atomically.
- *
- * JSON format:
- * {
- *   "cn=admin,dc=example,dc=com": {
- *     "dn": "cn=admin,dc=example,dc=com",
- *     "attributes": {
- *       "cn": ["admin"],
- *       "userPassword": ["{SHA}..."]
- *     }
- *   }
- * }
+ * File format: { "cn=x,dc=y": { "dn": "cn=x,dc=y", "attributes": { "cn": ["x"] } } }
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/AtomicStorageLockTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/AtomicStorageLockTrait.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock;
+
+use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
+use Throwable;
+
+/**
+ * Shared atomic read-mutate-publish flow: serialize via the consumer's lock primitive, then stage + rename.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+trait AtomicStorageLockTrait
+{
+    public function __construct(private readonly string $filePath)
+    {
+    }
+
+    final public function withLock(callable $mutation): void
+    {
+        $this->acquireLock();
+
+        try {
+            $newContents = $mutation($this->readCurrentContents());
+            $this->publishAtomically($newContents);
+        } finally {
+            $this->releaseLock();
+        }
+    }
+
+    abstract private function acquireLock(): void;
+
+    abstract private function releaseLock(): void;
+
+    abstract private function readCurrentContents(): string;
+
+    abstract private function writeContentsToTemp(
+        string $tmpPath,
+        string $contents,
+    ): int;
+
+    private function publishAtomically(string $contents): void
+    {
+        $tmpPath = tempnam(
+            dirname($this->filePath),
+            'ldap-storage-',
+        );
+
+        if ($tmpPath === false) {
+            throw new StorageIoException('Unable to stage the storage update.');
+        }
+
+        try {
+            $bytesWritten = $this->writeContentsToTemp(
+                $tmpPath,
+                $contents,
+            );
+
+            if ($bytesWritten !== strlen($contents)) {
+                throw new StorageIoException('Unable to stage the storage update.');
+            }
+
+            if (!rename($tmpPath, $this->filePath)) {
+                throw new StorageIoException('Unable to publish the storage update.');
+            }
+        } catch (Throwable $e) {
+            if (file_exists($tmpPath)) {
+                unlink($tmpPath);
+            }
+
+            throw $e;
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/CoroutineLock.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/CoroutineLock.php
@@ -13,37 +13,56 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock;
 
-use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
 use Swoole\Coroutine;
 use Swoole\Coroutine\Channel;
 
 /**
- * Swoole coroutine lock backed by a Channel(1) mutex.
+ * Swoole coroutine lock: serializes writes on a Channel(1) mutex and publishes updates atomically via rename().
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 final class CoroutineLock implements StorageLockInterface
 {
+    use AtomicStorageLockTrait;
+
     /**
      * @var Channel<mixed>|null
      */
     private ?Channel $mutex = null;
 
-    public function __construct(private readonly string $filePath)
+    private function acquireLock(): void
     {
+        $this->getOrCreateMutex()->pop();
     }
 
-    public function withLock(callable $mutation): void
+    private function releaseLock(): void
     {
-        $mutex = $this->getOrCreateMutex();
-        $mutex->pop();
-
-        try {
-            $result = $mutation($this->read());
-            $this->write($result);
-        } finally {
-            $mutex->push(true);
+        if ($this->mutex === null) {
+            return;
         }
+
+        $this->mutex->push(true);
+    }
+
+    private function readCurrentContents(): string
+    {
+        $contents = Coroutine\System::readFile($this->filePath);
+
+        return $contents !== false ? $contents : '';
+    }
+
+    private function writeContentsToTemp(
+        string $tmpPath,
+        string $contents,
+    ): int {
+        $bytesWritten = Coroutine\System::writeFile($tmpPath, $contents);
+
+        if ($bytesWritten === false) {
+            throw new StorageIoException('Unable to stage the storage update.');
+        }
+
+        return $bytesWritten;
     }
 
     /**
@@ -67,27 +86,5 @@ final class CoroutineLock implements StorageLockInterface
         $mutex->push(true);
 
         return $mutex;
-    }
-
-    private function read(): string
-    {
-        $contents = Coroutine\System::readFile($this->filePath);
-
-        return ($contents !== false) ? $contents : '';
-    }
-
-    private function write(string $contents): void
-    {
-        $result = Coroutine\System::writeFile(
-            $this->filePath,
-            $contents
-        );
-
-        if ($result === false) {
-            throw new RuntimeException(sprintf(
-                'Unable to write to storage file: %s',
-                $this->filePath
-            ));
-        }
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/CoroutineLock.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/CoroutineLock.php
@@ -18,15 +18,15 @@ use Swoole\Coroutine;
 use Swoole\Coroutine\Channel;
 
 /**
- * Locking strategy for the Swoole server runner.
- *
- * Uses a Swoole\Coroutine\Channel(1) as a coroutine-safe mutex.
+ * Swoole coroutine lock backed by a Channel(1) mutex.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 final class CoroutineLock implements StorageLockInterface
 {
-    /** @var Channel<mixed>|null */
+    /**
+     * @var Channel<mixed>|null
+     */
     private ?Channel $mutex = null;
 
     public function __construct(private readonly string $filePath)
@@ -46,7 +46,9 @@ final class CoroutineLock implements StorageLockInterface
         }
     }
 
-    /** @return Channel<mixed> */
+    /**
+     * @return Channel<mixed>
+     */
     private function getOrCreateMutex(): Channel
     {
         if ($this->mutex === null) {
@@ -56,7 +58,9 @@ final class CoroutineLock implements StorageLockInterface
         return $this->mutex;
     }
 
-    /** @return Channel<mixed> */
+    /**
+     * @return Channel<mixed>
+     */
     private static function createMutex(): Channel
     {
         $mutex = new Channel(1);

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/FileLock.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/FileLock.php
@@ -13,83 +13,80 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock;
 
-use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
 
 /**
- * PCNTL-safe lock using flock(LOCK_EX) to serialize writes across forked children.
+ * PCNTL-safe lock: serializes writes on a sidecar `.lock` file and publishes updates atomically via rename().
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class FileLock implements StorageLockInterface
+final class FileLock implements StorageLockInterface
 {
-    public function __construct(private readonly string $filePath)
-    {
-    }
+    use AtomicStorageLockTrait;
 
-    public function withLock(callable $mutation): void
+    private const LOCK_SUFFIX = '.lock';
+
+    /**
+     * @var resource|null
+     */
+    private $lockHandle = null;
+
+    private function acquireLock(): void
     {
         $handle = fopen(
-            $this->filePath,
-            'c+'
+            $this->filePath . self::LOCK_SUFFIX,
+            'c',
         );
 
         if ($handle === false) {
-            throw new RuntimeException(sprintf(
-                'Unable to open storage file: %s',
-                $this->filePath
-            ));
+            throw new StorageIoException('Unable to open the storage backend lock.');
         }
 
         if (!flock($handle, LOCK_EX)) {
             fclose($handle);
 
-            throw new RuntimeException(sprintf(
-                'Unable to acquire exclusive lock on storage file: %s',
-                $this->filePath
-            ));
+            throw new StorageIoException('Unable to acquire exclusive lock on the storage backend.');
         }
 
-        try {
-            $result = $mutation($this->readFromHandle($handle));
-
-            $this->writeToHandle(
-                $handle,
-                $result
-            );
-        } finally {
-            flock($handle, LOCK_UN);
-            fclose($handle);
-        }
+        $this->lockHandle = $handle;
     }
 
-    /**
-     * @param resource $handle
-     */
-    private function readFromHandle(mixed $handle): string
+    private function releaseLock(): void
     {
-        $size = fstat($handle)['size'] ?? 0;
+        if ($this->lockHandle === null) {
+            return;
+        }
 
-        if ($size <= 0) {
+        flock($this->lockHandle, LOCK_UN);
+        fclose($this->lockHandle);
+        $this->lockHandle = null;
+    }
+
+    private function readCurrentContents(): string
+    {
+        if (!file_exists($this->filePath)) {
             return '';
         }
 
-        $contents = fread(
-            $handle,
-            $size
-        );
+        $contents = file_get_contents($this->filePath);
 
-        return $contents !== false ? $contents : '';
+        if ($contents === false) {
+            throw new StorageIoException('Unable to read the storage backend contents.');
+        }
+
+        return $contents;
     }
 
-    /**
-     * @param resource $handle
-     */
-    private function writeToHandle(
-        mixed $handle,
+    private function writeContentsToTemp(
+        string $tmpPath,
         string $contents,
-    ): void {
-        ftruncate($handle, 0);
-        rewind($handle);
-        fwrite($handle, $contents);
+    ): int {
+        $bytesWritten = file_put_contents($tmpPath, $contents);
+
+        if ($bytesWritten === false) {
+            throw new StorageIoException('Unable to stage the storage update.');
+        }
+
+        return $bytesWritten;
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/FileLock.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/FileLock.php
@@ -16,9 +16,7 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock;
 use FreeDSx\Ldap\Exception\RuntimeException;
 
 /**
- * Locking strategy for the PCNTL server runner.
- *
- * Uses fopen + flock(LOCK_EX) to serialize concurrent writes across forked child processes.
+ * PCNTL-safe lock using flock(LOCK_EX) to serialize writes across forked children.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -65,8 +63,6 @@ class FileLock implements StorageLockInterface
     }
 
     /**
-     * Read the raw file contents from an open file handle.
-     *
      * @param resource $handle
      */
     private function readFromHandle(mixed $handle): string
@@ -86,8 +82,6 @@ class FileLock implements StorageLockInterface
     }
 
     /**
-     * Write a string back to an open file handle, truncating first.
-     *
      * @param resource $handle
      */
     private function writeToHandle(

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/StorageLockInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/StorageLockInterface.php
@@ -21,8 +21,7 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock;
 interface StorageLockInterface
 {
     /**
-     * Acquire exclusive access to the storage, pass the raw contents to the mutation callable, then persist the
-     * returned string and release the lock.
+     * Lock exclusively, hand the raw contents to $mutation, persist its return value, and release the lock.
      *
      * @param callable(string): string $mutation
      */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/MysqlStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/MysqlStorage.php
@@ -20,14 +20,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\MysqlFilterTranslator;
 use PDO;
 
 /**
- * MySQL/MariaDB-specific factory for PdoStorage.
- *
- * Use the named constructors to select the appropriate runner:
- *
- *   MysqlStorage::forPcntl('mysql:host=localhost;dbname=ldap', 'user', 'pass')
- *   MysqlStorage::forSwoole('mysql:host=localhost;dbname=ldap', 'user', 'pass')
- *
- * Requires MySQL 8.0+ or MariaDB 10.6+.
+ * MySQL/MariaDB factory for PdoStorage; use forPcntl()/forSwoole() to select the runner. Requires MySQL 8.0+ or MariaDB 10.6+.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/MoveOperation.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/MoveOperation.php
@@ -19,8 +19,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Server\Backend\Write\Command\MoveCommand;
 
 /**
- * Constructs a new Entry from the given RDN / parent, handling old RDN
- * deletion and new RDN attribute assignment.
+ * Builds the renamed/moved Entry, handling old-RDN removal and new-RDN attribute assignment.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -24,6 +24,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
+use FreeDSx\Ldap\Server\Backend\ResettableInterface;
 use Generator;
 use JsonException;
 use PDO;
@@ -37,13 +38,18 @@ use Throwable;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final class PdoStorage implements EntryStorageInterface
+final class PdoStorage implements EntryStorageInterface, ResettableInterface
 {
     public function __construct(
         private readonly PdoConnectionProviderInterface $provider,
         private readonly FilterTranslatorInterface $translator,
         private readonly PdoDialectInterface $dialect,
     ) {
+    }
+
+    public function reset(): void
+    {
+        $this->provider->reset();
     }
 
     public static function initialize(
@@ -199,10 +205,12 @@ final class PdoStorage implements EntryStorageInterface
 
         $depth = $txState->depth++;
         $savepointCreated = false;
+        $transactionStarted = false;
 
         try {
             if ($depth === 0) {
-                $pdo->beginTransaction();
+                $this->dialect->beginTransaction($pdo);
+                $transactionStarted = true;
             } else {
                 $pdo->exec("SAVEPOINT {$this->savepointName($depth)}");
                 $savepointCreated = true;
@@ -211,16 +219,16 @@ final class PdoStorage implements EntryStorageInterface
             $operation($this);
 
             if ($depth === 0 && $txState->broken) {
-                $pdo->rollBack();
+                $this->dialect->rollBack($pdo);
             } elseif ($depth === 0) {
-                $pdo->commit();
+                $this->dialect->commit($pdo);
             } else {
                 $pdo->exec("RELEASE SAVEPOINT {$this->savepointName($depth)}");
             }
         } catch (Throwable $e) {
-            if ($depth === 0 && $pdo->inTransaction()) {
-                $pdo->rollBack();
-            } elseif ($depth > 0 && $savepointCreated) {
+            if ($transactionStarted) {
+                $this->dialect->rollBack($pdo);
+            } elseif ($savepointCreated) {
                 $pdo->exec("ROLLBACK TO SAVEPOINT {$this->savepointName($depth)}");
             } elseif ($depth > 0) {
                 // Savepoint creation itself failed; the outer transaction is now in an unknown state and must not be committed.

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -31,21 +31,9 @@ use PDOStatement;
 use Throwable;
 
 /**
- * A PDO-backed storage implementation that persists LDAP entries using a relational database.
+ * PDO-backed storage; pass a PdoDialectInterface + PdoConnectionProviderInterface, or use SqliteStorage / MysqlStorage factories.
  *
- * Pass a PdoDialectInterface to target the desired database engine and a PdoConnectionProviderInterface to resolve the
- * PDO connection for the current execution context.
- *
- * When injecting a pre-existing PDO (e.g. for testing), wrap it in a SharedPdoConnectionProvider and call initialize()
- * first:
- *
- *   $dialect = new SqliteDialect();
- *   PdoStorage::initialize($pdo, $dialect);
- *   $storage = new PdoStorage(
- *       new SharedPdoConnectionProvider($pdo),
- *       $translator,
- *       $dialect,
- *   );
+ * When injecting a pre-built PDO, wrap it in SharedPdoConnectionProvider and call PdoStorage::initialize($pdo, $dialect) first.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorageFactoryInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorageFactoryInterface.php
@@ -14,11 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter;
 
 /**
- * Constructs a configured PdoStorage instance for a specific database driver.
- *
- * Example:
- *
- *   $storage = SqliteStorage::forPcntl('/path/to/db.sqlite')
+ * Constructs a configured PdoStorage for a specific database driver (e.g. SqliteStorage::forPcntl('/path/to/db.sqlite')).
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorageFactoryTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorageFactoryTrait.php
@@ -38,9 +38,13 @@ trait PdoStorageFactoryTrait
     protected function createShared(): PdoStorage
     {
         $dialect = $this->dialect();
+        $factory = fn (): PDO => $this->openConnection($dialect);
 
         return new PdoStorage(
-            new SharedPdoConnectionProvider($this->openConnection($dialect)),
+            new SharedPdoConnectionProvider(
+                $factory(),
+                $factory,
+            ),
             $this->translator(),
             $dialect,
         );

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorageFactoryTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorageFactoryTrait.php
@@ -18,10 +18,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\FilterTranslatorInterf
 use PDO;
 
 /**
- * Shared factory wiring for PdoStorage.
- *
- * Concrete factories provide the dialect, translator, and connection opener;
- * this trait assembles the PdoStorage with the correct connection provider.
+ * Shared PdoStorage wiring: concrete factories provide dialect, translator, and connection opener; the trait picks the provider.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoTxState.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoTxState.php
@@ -23,7 +23,7 @@ final class PdoTxState
     public int $depth = 0;
 
     /**
-     * Set when a nested savepoint operation fails before establishing its savepoint.
+     * Set when a nested savepoint fails before it is established.
      */
     public bool $broken = false;
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SharedPdoConnectionProvider.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SharedPdoConnectionProvider.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter;
 
+use Closure;
+use FreeDSx\Ldap\Exception\RuntimeException;
 use PDO;
 
 /**
@@ -22,20 +24,46 @@ use PDO;
  */
 final class SharedPdoConnectionProvider implements PdoConnectionProviderInterface
 {
-    private readonly PdoTxState $txState;
+    private ?PDO $pdo;
 
-    public function __construct(private readonly PDO $pdo)
-    {
+    private PdoTxState $txState;
+
+    /**
+     * @param Closure(): PDO|null $reconnectFactory Invoked by reset() to open a fresh PDO (required for fork-safe use)
+     */
+    public function __construct(
+        ?PDO $pdo,
+        private readonly ?Closure $reconnectFactory = null,
+    ) {
+        $this->pdo = $pdo;
         $this->txState = new PdoTxState();
     }
 
     public function get(): PDO
     {
+        if ($this->pdo !== null) {
+            return $this->pdo;
+        }
+
+        if ($this->reconnectFactory === null) {
+            throw new RuntimeException(
+                'No PDO connection is available and no reconnect factory was provided.'
+            );
+        }
+
+        $this->pdo = ($this->reconnectFactory)();
+
         return $this->pdo;
     }
 
     public function txState(): PdoTxState
     {
         return $this->txState;
+    }
+
+    public function reset(): void
+    {
+        $this->pdo = null;
+        $this->txState = new PdoTxState();
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SharedPdoConnectionProvider.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SharedPdoConnectionProvider.php
@@ -16,9 +16,7 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter;
 use PDO;
 
 /**
- * Returns a single shared PDO connection and transaction state.
- *
- * Used by the PCNTL runner and by unit tests that inject a pre-built PDO.
+ * Single shared PDO connection and transaction state; used by the PCNTL runner and unit tests with a pre-built PDO.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/FilterTranslatorInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/FilterTranslatorInterface.php
@@ -16,16 +16,10 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter;
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
 
 /**
- * Translates an LDAP FilterInterface into a SQL fragment for use in a WHERE clause.
+ * Translates FilterInterface into a SQL WHERE fragment.
  *
- * Return values:
- *   - null                             — filter cannot be expressed in SQL; all in-scope
- *                                        entries are returned; PHP eval must run over the
- *                                        full candidate set.
- *   - SqlFilterResult (isExact: true)  — the SQL exactly captures the filter semantics;
- *                                        PHP eval can safely be skipped for these entries.
- *   - SqlFilterResult (isExact: false) — partial SQL (superset); PHP eval still runs
- *                                        but only over the already-reduced candidate set.
+ * Returns null when untranslatable (PHP eval runs over the full candidate set), an exact SqlFilterResult when PHP eval
+ * can be skipped, or a non-exact SqlFilterResult (superset) that still needs PHP eval over the reduced candidates.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/MysqlFilterTranslator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/MysqlFilterTranslator.php
@@ -14,9 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter;
 
 /**
- * Translates LDAP filters into MySQL-compatible SQL WHERE clause fragments.
- *
- * Requires MySQL 8.0+ or MariaDB 10.6+.
+ * MySQL/MariaDB SQL WHERE translator for LDAP filters; requires MySQL 8.0+ or MariaDB 10.6+.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
@@ -26,37 +26,26 @@ use FreeDSx\Ldap\Search\Filter\PresentFilter;
 use FreeDSx\Ldap\Search\Filter\SubstringFilter;
 
 /**
- * Provides a reusable LDAP-filter-to-SQL translation implementation.
+ * Reusable LDAP-filter-to-SQL translator; concrete classes supply buildPresenceCheck() and buildValueExists().
  *
- * Implementing classes must provide two driver-specific primitives:
- *   - buildPresenceCheck(string $attribute): SQL fragment testing whether an attribute key exists
- *   - buildValueExists(string $attribute, string $innerCondition): SQL fragment iterating attribute values
- *
- * All AND/OR/NOT composition, substring/LIKE handling, GTE/LTE comparisons,
- * and LIKE escaping are generic and provided here.
- *
- * Translation rules:
- *   - AND: translates only the translatable children; partial results are allowed
- *   - OR:  all children must be translatable; returns null if any child is not
- *   - NOT: translatable only if the child is. Honors RFC 4511 §4.5.1.7
- *   - MatchingRuleFilter: always null / not supported
+ * Composition rules: AND keeps translatable children, OR requires every child to translate, NOT honors RFC 4511 §4.5.1.7,
+ * MatchingRuleFilter is never translated.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 trait SqlFilterTranslatorTrait
 {
     /**
-     * Returns a SQL fragment that tests whether an attribute key is present.
+     * SQL fragment testing whether the attribute key is present.
      *
      * @param string $attribute Pre-validated and safe to embed in SQL.
      */
     abstract protected function buildPresenceCheck(string $attribute): string;
 
     /**
-     * Wraps an inner condition so that it is evaluated for each value of an attribute.
+     * Wraps $innerCondition so it is evaluated per attribute value, referencing the current value via {@see valueAlias()}.
      *
      * @param string $attribute Pre-validated and safe to embed in SQL.
-     * @param string $innerCondition References the current value via the alias returned by {@see valueAlias()}.
      */
     abstract protected function buildValueExists(
         string $attribute,
@@ -158,10 +147,7 @@ trait SqlFilterTranslatorTrait
     }
 
     /**
-     * GTE/LTE are exact only for ASCII non-digit filter values. PHP's
-     * compareOrdered switches to integer compare when both operands are
-     * ctype_digit (e.g. "99" < "100"); SQL stays byte-wise ("99" > "100"),
-     * so digit filter values must fall through to PHP re-evaluation.
+     * Exact only for ASCII non-digit values; PHP compareOrdered int-compares when both operands are digits, SQL does not.
      */
     private function isOrderedCompareExact(string $value): bool
     {

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
@@ -114,12 +114,15 @@ trait SqlFilterTranslatorTrait
         $attribute = $this->validateAttribute($filter->getAttribute());
 
         $alias = $this->valueAlias();
+        $value = $filter->getValue();
 
         // Approximate matching is implementation-defined (RFC 4511 §4.5.1.7.6).
+        // Both SQL and PHP implementations pick case-insensitive equality, so
+        // for ASCII values the result is exact and PHP re-eval can be skipped.
         return new SqlFilterResult(
             $this->buildValueExists($attribute, "lower($alias) = lower(?)"),
-            [$filter->getValue()],
-            isExact: false,
+            [$value],
+            isExact: SqlFilterUtility::isAscii($value),
             referencedAttributes: [$attribute],
         );
     }
@@ -129,11 +132,12 @@ trait SqlFilterTranslatorTrait
         $attribute = $this->validateAttribute($filter->getAttribute());
 
         $alias = $this->valueAlias();
+        $value = $filter->getValue();
 
         return new SqlFilterResult(
             $this->buildValueExists($attribute, "lower($alias) >= lower(?)"),
-            [$filter->getValue()],
-            isExact: false,
+            [$value],
+            isExact: $this->isOrderedCompareExact($value),
             referencedAttributes: [$attribute],
         );
     }
@@ -143,13 +147,26 @@ trait SqlFilterTranslatorTrait
         $attribute = $this->validateAttribute($filter->getAttribute());
 
         $alias = $this->valueAlias();
+        $value = $filter->getValue();
 
         return new SqlFilterResult(
             $this->buildValueExists($attribute, "lower($alias) <= lower(?)"),
-            [$filter->getValue()],
-            isExact: false,
+            [$value],
+            isExact: $this->isOrderedCompareExact($value),
             referencedAttributes: [$attribute],
         );
+    }
+
+    /**
+     * GTE/LTE are exact only for ASCII non-digit filter values. PHP's
+     * compareOrdered switches to integer compare when both operands are
+     * ctype_digit (e.g. "99" < "100"); SQL stays byte-wise ("99" > "100"),
+     * so digit filter values must fall through to PHP re-evaluation.
+     */
+    private function isOrderedCompareExact(string $value): bool
+    {
+        return SqlFilterUtility::isAscii($value)
+            && !ctype_digit($value);
     }
 
     private function translateSubstring(SubstringFilter $filter): ?SqlFilterResult
@@ -169,12 +186,12 @@ trait SqlFilterTranslatorTrait
         //   - startsWith only, endsWith only, or both without contains
         //   - a single contains without startsWith/endsWith
         // Any contains + anchor combination (or 2+ contains) needs PHP re-eval.
-        $hasContains = count($filter->getContains()) > 0;
+        $containsCount = count($filter->getContains());
         $hasAnchor = $filter->getStartsWith() !== null
             || $filter->getEndsWith() !== null;
 
-        $isExact = count($filter->getContains()) < 2
-            && !($hasContains && $hasAnchor)
+        $isExact = $containsCount < 2
+            && !($containsCount > 0 && $hasAnchor)
             && SqlFilterUtility::isAscii((string) $filter->getStartsWith())
             && SqlFilterUtility::isAscii((string) $filter->getEndsWith())
             && $this->areAllAscii($filter->getContains());
@@ -245,7 +262,7 @@ trait SqlFilterTranslatorTrait
                 $hasUntranslatable = true;
             }
             $parts[] = '(' . $result->sql . ')';
-            $params = array_merge($params, $result->params);
+            array_push($params, ...$result->params);
         }
 
         if ($parts === []) {
@@ -274,7 +291,7 @@ trait SqlFilterTranslatorTrait
                 $hasInexact = true;
             }
             $parts[] = '(' . $result->sql . ')';
-            $params = array_merge($params, $result->params);
+            array_push($params, ...$result->params);
         }
 
         if ($parts === []) {
@@ -314,7 +331,7 @@ trait SqlFilterTranslatorTrait
         if ($result->referencedAttributes !== []) {
             $guards = array_map(
                 fn (string $attribute): string => $this->buildPresenceCheck($attribute),
-                $result->referencedAttributes,
+                array_values(array_unique($result->referencedAttributes)),
             );
 
             return new SqlFilterResult(

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterUtility.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterUtility.php
@@ -33,10 +33,7 @@ final class SqlFilterUtility
     }
 
     /**
-     * Returns true if the value contains only 7-bit ASCII bytes.
-     *
-     * The SQL translator's case-insensitive comparisons use `lower()`, which
-     * is ASCII-only on SQLite and collation-dependent on MySQL.
+     * True when $value is 7-bit ASCII; the translator falls back to PHP eval otherwise because SQL `lower()` is ASCII-only on SQLite and collation-dependent on MySQL.
      */
     public static function isAscii(string $value): bool
     {

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqliteStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqliteStorage.php
@@ -20,12 +20,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqliteFilterTranslator
 use PDO;
 
 /**
- * SQLite-specific factory for PdoStorage.
- *
- * Use the named constructors to select the appropriate runner:
- *
- *   SqliteStorage::forPcntl('/path/to/db.sqlite')
- *   SqliteStorage::forSwoole('/path/to/db.sqlite')
+ * SQLite factory for PdoStorage; use SqliteStorage::forPcntl() or ::forSwoole() to select the runner.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqliteStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqliteStorage.php
@@ -34,6 +34,8 @@ final class SqliteStorage implements PdoStorageFactoryInterface
 
     private const PRAGMA_SYNCHRONOUS_NORMAL = 'PRAGMA synchronous = NORMAL';
 
+    private const PRAGMA_BUSY_TIMEOUT_MS = 'PRAGMA busy_timeout = 5000';
+
     public function __construct(private readonly string $dbPath)
     {
     }
@@ -66,8 +68,9 @@ final class SqliteStorage implements PdoStorageFactoryInterface
             null,
             [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION],
         );
-        $pdo->exec(self::PRAGMA_JOURNAL_MODE_WAL);
+        $pdo->exec(self::PRAGMA_BUSY_TIMEOUT_MS);
         $pdo->exec(self::PRAGMA_SYNCHRONOUS_NORMAL);
+        $pdo->exec(self::PRAGMA_JOURNAL_MODE_WAL);
 
         PdoStorage::initialize($pdo, $dialect);
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStorageInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStorageInterface.php
@@ -18,13 +18,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\DefaultHasChildrenTrait;
 
 /**
- * Primitive storage contract for directory entries.
- *
- * Implementations handle raw data persistence only — all LDAP semantics (validation, error codes, scope checking) are
- * handled by WritableStorageBackend.
- *
- * Where methods accept a Dn parameter, it is a normalised (lowercased) Dn as returned by Dn::normalize(). Use
- * $dn->toString() as the internal string key.
+ * Raw persistence contract; LDAP semantics live in WritableStorageBackend. Dn parameters are always normalised (lowercased).
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -41,31 +35,17 @@ interface EntryStorageInterface
     public function exists(Dn $dn): bool;
 
     /**
-     * Return true if the given normalised DN has any direct children.
-     *
-     * Implementations may use {@see DefaultHasChildrenTrait} for a default implementation built on top of list().
-     * Backends that can answer more efficiently (e.g. an EXISTS query on a database) should override it directly.
+     * Return true if the DN has any direct children; {@see DefaultHasChildrenTrait} supplies a list()-based default.
      */
     public function hasChildren(Dn $dn): bool;
 
     /**
-     * Yield entries according to the scope defined in $options.
-     *
-     * When $options->subtree is false: yield only direct children (base entry not included).
-     * When $options->subtree is true: yield all entries whose DN matches or is subordinate to $options->baseDn.
-     *
-     * Pass a Dn with an empty string as baseDn to list from the root of the tree.
-     *
-     * Implementations should stream entries lazily where possible to avoid
-     * loading the entire dataset into memory at once.
+     * Lazily yield entries per $options scope: direct children when subtree is false, descendants (including base) when true; empty baseDn lists from the tree root.
      */
     public function list(StorageListOptions $options): EntryStream;
 
     /**
-     * Persist the entry, replacing any existing entry at the same DN.
-     *
-     * The entry must be keyed by its normalised DN. Use $entry->getDn()->normalize()->toString() as the storage key,
-     * as the Entry's own DN may retain the original client-supplied casing.
+     * Persist the entry keyed by its normalised DN, replacing any existing entry at the same DN.
      */
     public function store(Entry $entry): void;
 
@@ -75,10 +55,7 @@ interface EntryStorageInterface
     public function remove(Dn $dn): void;
 
     /**
-     * Execute $operation as an atomic read-modify-write cycle.
-     *
-     * Implementations backed by a file, database, or any resource accessible to concurrent connections must acquire
-     * an appropriate lock or open a transaction before executing $operation, then commit or release on completion.
+     * Execute $operation as an atomic read-modify-write cycle; implementations must hold an exclusive lock or transaction.
      *
      * @param callable(EntryStorageInterface): void $operation
      */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStream.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStream.php
@@ -17,10 +17,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use Generator;
 
 /**
- * The result of a storage list() or backend search() call.
- *
- * Wraps the lazy entry generator together with a flag indicating whether the adapter has already applied the LDAP
- * filter exactly in its native query.
+ * Lazy entry generator returned by storage list() / backend search(); $isPreFiltered marks an exact native filter match.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Exception/StorageIoException.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Exception/StorageIoException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Exception;
+
+use FreeDSx\Ldap\Exception\RuntimeException;
+
+/**
+ * Thrown when a storage backend fails to read, lock, or atomically persist its state.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class StorageIoException extends RuntimeException
+{
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/FilterEvaluator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/FilterEvaluator.php
@@ -31,13 +31,7 @@ use FreeDSx\Ldap\Search\Filter\SubstringFilter;
 use WeakMap;
 
 /**
- * Pure-PHP implementation of FilterEvaluatorInterface.
- *
- * Evaluates LDAP filters against in-memory Entry objects using the three-valued logic (TRUE / FALSE / UNDEFINED)
- * required by RFC 4511 §4.5.1.
- *
- * Attribute name comparisons are always case-insensitive. Value comparisons default to case-insensitive string
- * comparison, matching the caseIgnoreMatch semantics used by the majority of LDAP schema attribute types.
+ * Pure-PHP FilterEvaluatorInterface using RFC 4511 §4.5.1 three-valued logic; names/values compare case-insensitively.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -448,8 +442,7 @@ final class FilterEvaluator implements FilterEvaluatorInterface
     }
 
     /**
-     * Fast attribute lookup. Defers to Entry::get() when the filter attribute has options,
-     * to preserve Attribute::equals() options-matching semantics.
+     * Defers to Entry::get() when the filter attribute has options, to preserve Attribute::equals() options-matching.
      */
     private function lookupAttribute(
         Entry $entry,

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/FilterEvaluator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/FilterEvaluator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage;
 
+use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
@@ -27,6 +28,7 @@ use FreeDSx\Ldap\Search\Filter\NotFilter;
 use FreeDSx\Ldap\Search\Filter\OrFilter;
 use FreeDSx\Ldap\Search\Filter\PresentFilter;
 use FreeDSx\Ldap\Search\Filter\SubstringFilter;
+use WeakMap;
 
 /**
  * Pure-PHP implementation of FilterEvaluatorInterface.
@@ -49,10 +51,49 @@ final class FilterEvaluator implements FilterEvaluatorInterface
 
     private const MATCHING_RULE_BIT_OR = '1.2.840.113556.1.4.804';
 
+    /**
+     * Flattened RDN components of the current entry's DN; scoped to one evaluate() call.
+     *
+     * @var array<\FreeDSx\Ldap\Entry\Rdn>|null
+     */
+    private ?array $cachedDnRdns = null;
+
+    /**
+     * Lowercased base name => first matching attribute; scoped to one evaluate() call.
+     *
+     * @var array<string, Attribute>|null
+     */
+    private ?array $attributeIndex = null;
+
+    /**
+     * @var WeakMap<object, string>
+     */
+    private WeakMap $loweredSingleValueCache;
+
+    /**
+     * @var WeakMap<object, array{startsWith: ?string, endsWith: ?string, contains: list<string>}>
+     */
+    private WeakMap $substringCache;
+
+    /**
+     * @var WeakMap<object, bool>
+     */
+    private WeakMap $orderedDigitCache;
+
+    public function __construct()
+    {
+        $this->loweredSingleValueCache = new WeakMap();
+        $this->substringCache = new WeakMap();
+        $this->orderedDigitCache = new WeakMap();
+    }
+
     public function evaluate(
         Entry $entry,
         FilterInterface $filter,
     ): bool {
+        $this->cachedDnRdns = null;
+        $this->attributeIndex = null;
+
         return $this->evaluateFilter($entry, $filter) === FilterResult::True;
     }
 
@@ -141,7 +182,7 @@ final class FilterEvaluator implements FilterEvaluatorInterface
         Entry $entry,
         PresentFilter $filter,
     ): FilterResult {
-        return $entry->has($filter->getAttribute())
+        return $this->lookupAttribute($entry, $filter->getAttribute()) !== null
             ? FilterResult::True
             : FilterResult::False;
     }
@@ -150,13 +191,13 @@ final class FilterEvaluator implements FilterEvaluatorInterface
         Entry $entry,
         EqualityFilter $filter,
     ): FilterResult {
-        $attribute = $entry->get($filter->getAttribute());
+        $attribute = $this->lookupAttribute($entry, $filter->getAttribute());
 
         if ($attribute === null) {
             return FilterResult::Undefined;
         }
 
-        $filterValue = strtolower($filter->getValue());
+        $filterValue = $this->lowerSingleValue($filter);
 
         foreach ($attribute->getValues() as $value) {
             if (strtolower($value) === $filterValue) {
@@ -171,22 +212,21 @@ final class FilterEvaluator implements FilterEvaluatorInterface
         Entry $entry,
         SubstringFilter $filter,
     ): FilterResult {
-        $attribute = $entry->get($filter->getAttribute());
+        $attribute = $this->lookupAttribute($entry, $filter->getAttribute());
 
         if ($attribute === null) {
             return FilterResult::Undefined;
         }
 
-        $startsWith = $filter->getStartsWith() !== null
-            ? strtolower($filter->getStartsWith())
-            : null;
-        $endsWith = $filter->getEndsWith() !== null
-            ? strtolower($filter->getEndsWith())
-            : null;
-        $contains = array_map('strtolower', $filter->getContains());
+        $compiled = $this->substringLowered($filter);
 
         foreach ($attribute->getValues() as $value) {
-            if ($this->substringMatches(strtolower($value), $startsWith, $endsWith, $contains)) {
+            if ($this->substringMatches(
+                strtolower($value),
+                $compiled['startsWith'],
+                $compiled['endsWith'],
+                $compiled['contains'],
+            )) {
                 return FilterResult::True;
             }
         }
@@ -230,16 +270,17 @@ final class FilterEvaluator implements FilterEvaluatorInterface
         Entry $entry,
         GreaterThanOrEqualFilter $filter,
     ): FilterResult {
-        $attribute = $entry->get($filter->getAttribute());
+        $attribute = $this->lookupAttribute($entry, $filter->getAttribute());
 
         if ($attribute === null) {
             return FilterResult::Undefined;
         }
 
         $filterValue = $filter->getValue();
+        $filterIsDigit = $this->orderedFilterValueIsDigit($filter);
 
         foreach ($attribute->getValues() as $value) {
-            if ($this->compareOrdered($value, $filterValue) >= 0) {
+            if ($this->compareOrdered($value, $filterValue, $filterIsDigit) >= 0) {
                 return FilterResult::True;
             }
         }
@@ -251,16 +292,17 @@ final class FilterEvaluator implements FilterEvaluatorInterface
         Entry $entry,
         LessThanOrEqualFilter $filter,
     ): FilterResult {
-        $attribute = $entry->get($filter->getAttribute());
+        $attribute = $this->lookupAttribute($entry, $filter->getAttribute());
 
         if ($attribute === null) {
             return FilterResult::Undefined;
         }
 
         $filterValue = $filter->getValue();
+        $filterIsDigit = $this->orderedFilterValueIsDigit($filter);
 
         foreach ($attribute->getValues() as $value) {
-            if ($this->compareOrdered($value, $filterValue) <= 0) {
+            if ($this->compareOrdered($value, $filterValue, $filterIsDigit) <= 0) {
                 return FilterResult::True;
             }
         }
@@ -271,8 +313,9 @@ final class FilterEvaluator implements FilterEvaluatorInterface
     private function compareOrdered(
         string $value,
         string $filterValue,
+        bool $filterValueIsDigit,
     ): int {
-        if (ctype_digit($value) && ctype_digit($filterValue)) {
+        if ($filterValueIsDigit && ctype_digit($value)) {
             return (int) $value <=> (int) $filterValue;
         }
 
@@ -283,13 +326,13 @@ final class FilterEvaluator implements FilterEvaluatorInterface
         Entry $entry,
         ApproximateFilter $filter,
     ): FilterResult {
-        $attribute = $entry->get($filter->getAttribute());
+        $attribute = $this->lookupAttribute($entry, $filter->getAttribute());
 
         if ($attribute === null) {
             return FilterResult::Undefined;
         }
 
-        $filterValue = strtolower($filter->getValue());
+        $filterValue = $this->lowerSingleValue($filter);
 
         foreach ($attribute->getValues() as $value) {
             if (strtolower($value) === $filterValue) {
@@ -331,15 +374,15 @@ final class FilterEvaluator implements FilterEvaluatorInterface
         $values = [];
 
         if ($filterAttributeName !== null) {
-            $attribute = $entry->get($filterAttributeName);
+            $attribute = $this->lookupAttribute($entry, $filterAttributeName);
             if ($attribute !== null) {
                 $values = $attribute->getValues();
             }
         } else {
             foreach ($entry->getAttributes() as $attribute) {
-                $values = array_merge(
+                array_push(
                     $values,
-                    $attribute->getValues(),
+                    ...$attribute->getValues(),
                 );
             }
         }
@@ -366,12 +409,13 @@ final class FilterEvaluator implements FilterEvaluatorInterface
         Entry $entry,
         ?string $filterAttributeName,
     ): array {
-        $components = array_merge(
-            ...array_map(
-                fn ($rdn) => $rdn->getAll(),
-                $entry->getDn()->toArray(),
-            ),
-        );
+        $components = $this->cachedDnRdns
+            ?? ($this->cachedDnRdns = array_merge(
+                ...array_map(
+                    fn ($rdn) => $rdn->getAll(),
+                    $entry->getDn()->toArray(),
+                ),
+            ));
 
         if ($filterAttributeName !== null) {
             $components = array_filter(
@@ -401,5 +445,56 @@ final class FilterEvaluator implements FilterEvaluatorInterface
                 ResultCode::INAPPROPRIATE_MATCHING,
             ),
         };
+    }
+
+    /**
+     * Fast attribute lookup. Defers to Entry::get() when the filter attribute has options,
+     * to preserve Attribute::equals() options-matching semantics.
+     */
+    private function lookupAttribute(
+        Entry $entry,
+        string $filterAttributeName,
+    ): ?Attribute {
+        if (str_contains($filterAttributeName, ';')) {
+            return $entry->get($filterAttributeName);
+        }
+
+        if ($this->attributeIndex === null) {
+            $index = [];
+            foreach ($entry->getAttributes() as $attr) {
+                $lc = strtolower($attr->getName());
+                $index[$lc] ??= $attr;
+            }
+            $this->attributeIndex = $index;
+        }
+
+        return $this->attributeIndex[strtolower($filterAttributeName)] ?? null;
+    }
+
+    private function lowerSingleValue(EqualityFilter|ApproximateFilter $filter): string
+    {
+        return $this->loweredSingleValueCache[$filter] ??= strtolower($filter->getValue());
+    }
+
+    /**
+     * @return array{startsWith: ?string, endsWith: ?string, contains: list<string>}
+     */
+    private function substringLowered(SubstringFilter $filter): array
+    {
+        return $this->substringCache[$filter] ??= [
+            'startsWith' => $filter->getStartsWith() !== null
+                ? strtolower($filter->getStartsWith())
+                : null,
+            'endsWith' => $filter->getEndsWith() !== null
+                ? strtolower($filter->getEndsWith())
+                : null,
+            'contains' => array_values(array_map('strtolower', $filter->getContains())),
+        ];
+    }
+
+    private function orderedFilterValueIsDigit(
+        GreaterThanOrEqualFilter|LessThanOrEqualFilter $filter,
+    ): bool {
+        return $this->orderedDigitCache[$filter] ??= ctype_digit($filter->getValue());
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/FilterEvaluatorInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/FilterEvaluatorInterface.php
@@ -17,11 +17,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
 
 /**
- * Evaluates an LDAP filter against an entry.
- *
- * Implementations may choose different strategies — pure-PHP evaluation,
- * SQL translation, etc. — without coupling the request handler to any
- * specific approach.
+ * Evaluates an LDAP filter against an entry; implementations pick their own strategy (pure-PHP, SQL translation, etc).
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
@@ -18,8 +18,7 @@ use FreeDSx\Ldap\Search\Filter\AndFilter;
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
 
 /**
- * A DTO encapsulating all parameters for a storage list operation, decoupled
- * from LDAP protocol objects.
+ * DTO for EntryStorageInterface::list(), decoupled from LDAP protocol objects.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -35,9 +34,7 @@ final class StorageListOptions
     }
 
     /**
-     * Create options that match all entries within the given scope.
-     *
-     * Convenient for internal operations (e.g. hasChildren) and tests that do not need a meaningful filter.
+     * Match-all options for internal callers (e.g. hasChildren) and tests that do not need a meaningful filter.
      */
     public static function matchAll(
         Dn $baseDn,

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -33,15 +33,7 @@ use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
 use Generator;
 
 /**
- * Orchestrates LDAP directory operations over a pluggable EntryStorageInterface.
- *
- * Handles all LDAP semantics — existence checks, subordinate checks, scope
- * filtering, DN normalisation, and entry transformation — so that storage
- * implementations only need to provide raw persistence primitives.
- *
- * All write operations are routed through EntryStorageInterface::atomic() to
- * ensure transactional consistency. See EntryStorageInterface::atomic() for the
- * contract each storage implementation must satisfy.
+ * Applies LDAP semantics over a pluggable EntryStorageInterface; writes are routed through EntryStorageInterface::atomic().
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -146,8 +138,7 @@ final class WritableStorageBackend implements WritableLdapBackendInterface
     }
 
     /**
-     * Wraps a storage generator and converts TimeLimitExceededException to an OperationException so the protocol layer
-     * receives a well-formed LDAP error.
+     * Converts TimeLimitExceededException from the storage generator into an LDAP OperationException.
      *
      * @param Generator<Entry> $generator
      * @return Generator<Entry>
@@ -253,8 +244,7 @@ final class WritableStorageBackend implements WritableLdapBackendInterface
     }
 
     /**
-     * Runs a write operation under the storage's atomic boundary and translates storage-layer exceptions into their
-     * corresponding LDAP OperationException result codes.
+     * Runs the operation under storage->atomic() and maps storage-layer exceptions to LDAP result codes.
      *
      * @param callable(EntryStorageInterface): void $operation
      * @throws OperationException

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -30,6 +30,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Exception\InvalidAttributeException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
 use FreeDSx\Ldap\Server\Backend\Write\WritableBackendTrait;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ResettableInterface;
 use Generator;
 
 /**
@@ -37,7 +38,7 @@ use Generator;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final class WritableStorageBackend implements WritableLdapBackendInterface
+final class WritableStorageBackend implements WritableLdapBackendInterface, ResettableInterface
 {
     use WritableBackendTrait;
 
@@ -45,6 +46,13 @@ final class WritableStorageBackend implements WritableLdapBackendInterface
         private readonly EntryStorageInterface $storage,
         private readonly WriteEntryOperationHandler $entryHandler = new WriteEntryOperationHandler(),
     ) {
+    }
+
+    public function reset(): void
+    {
+        if ($this->storage instanceof ResettableInterface) {
+            $this->storage->reset();
+        }
     }
 
     public function get(Dn $dn): ?Entry

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -27,6 +27,7 @@ use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\DnTooLongException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\InvalidAttributeException;
+use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
 use FreeDSx\Ldap\Server\Backend\Write\WritableBackendTrait;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
@@ -265,6 +266,12 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             throw new OperationException(
                 $e->getMessage(),
                 ResultCode::ADMIN_LIMIT_EXCEEDED,
+                $e,
+            );
+        } catch (StorageIoException $e) {
+            throw new OperationException(
+                'The backend storage is currently unavailable.',
+                ResultCode::UNAVAILABLE,
                 $e,
             );
         }

--- a/src/FreeDSx/Ldap/Server/Backend/Write/WritableBackendTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/WritableBackendTrait.php
@@ -19,9 +19,7 @@ use FreeDSx\Ldap\Server\Backend\Write\Command\MoveCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 
 /**
- * Use this trait in classes that implement WritableLdapBackendInterface and
- * want to handle all four write operations via distinct, methods
- * rather than a single handle() with instanceof checks.
+ * Splits WriteHandlerInterface::handle() into four typed methods (add/delete/update/move) for WritableLdapBackendInterface.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Write/WritableLdapBackendInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/WritableLdapBackendInterface.php
@@ -16,16 +16,8 @@ namespace FreeDSx\Ldap\Server\Backend\Write;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 
 /**
- * Marker interface for backends that support all LDAP write operations.
- *
- * Implementing this interface signals full CRUD capability. The optional
- * WritableBackendTrait bridges the WriteHandlerInterface contract (supports()
- * and handle()) to four typed methods (add, delete, update, move), which is
- * the recommended approach for full-CRUD backends.
- *
- * For partial write support — where a backend or standalone class handles only
- * a subset of write operations — implement WriteHandlerInterface directly and
- * register the handler via LdapServer::useWriteHandler().
+ * Marker for full-CRUD backends; pair with WritableBackendTrait for typed add/delete/update/move methods. For partial
+ * write support, implement WriteHandlerInterface directly and register via LdapServer::useWriteHandler().
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Write/WriteHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/WriteHandlerInterface.php
@@ -14,10 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Write;
 
 /**
- * Implemented by any class that handles one or more LDAP write operations.
- *
- * The framework calls supports() first and only calls handle() when it returns
- * true, so implementations never need no-op stubs for unsupported operations.
+ * Handles one or more LDAP write operations; the framework only calls handle() after supports() returns true.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Write/WriteOperationDispatcher.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/WriteOperationDispatcher.php
@@ -17,11 +17,7 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 
 /**
- * Holds an ordered list of write handlers and routes each write command to
- * the first handler that declares support for it.
- *
- * Handlers are tried in registration order. Explicitly registered handlers
- * take priority when the backend is appended last as a fallback.
+ * Routes a write command to the first registered handler that supports it; explicit handlers precede the fallback backend.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -199,7 +199,8 @@ class PcntlServerRunner implements ServerRunnerInterface
                     $socket
                 );
             }
-        } while ($this->server->isConnected());
+        // Use the shutdown flag, not the socket state (not reliable after forking)
+        } while (!$this->isShuttingDown);
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -17,6 +17,7 @@ use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Server\ChildProcess;
+use FreeDSx\Ldap\Server\Backend\ResettableInterface;
 use FreeDSx\Ldap\Server\ServerProtocolFactory;
 use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Socket\Socket;
@@ -346,6 +347,12 @@ class PcntlServerRunner implements ServerRunnerInterface
     ): never {
         $context = ['pid' => $pid];
         $this->isMainProcess = false;
+        $backend = $this->options->getBackend();
+
+        if ($backend instanceof ResettableInterface) {
+            $backend->reset();
+        }
+
         $serverProtocolHandler = $this->serverProtocolFactory->make($socket);
 
         $this->installChildSignalHandlers(

--- a/tests/bin/ldap-backend-storage.php
+++ b/tests/bin/ldap-backend-storage.php
@@ -25,6 +25,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\MysqlStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqliteStorage;
 use FreeDSx\Ldap\ServerOptions;
 
@@ -72,8 +73,8 @@ if ($storageOpt !== null || $runnerOpt !== null) {
     };
 }
 
-if (!in_array($storage, ['memory', 'json', 'sqlite'], true)) {
-    fwrite(STDERR, "Invalid --storage value: {$storage}. Expected one of: memory, json, sqlite." . PHP_EOL);
+if (!in_array($storage, ['memory', 'json', 'sqlite', 'mysql'], true)) {
+    fwrite(STDERR, "Invalid --storage value: {$storage}. Expected one of: memory, json, sqlite, mysql." . PHP_EOL);
     exit(2);
 }
 if (!in_array($runner, ['pcntl', 'swoole'], true)) {
@@ -153,7 +154,7 @@ if ($storage === 'memory') {
     }
 
     $server->useStorage($adapter);
-} else {
+} elseif ($storage === 'sqlite') {
     $dbPath = sys_get_temp_dir() . '/ldap_test_backend_storage.sqlite';
 
     foreach ([$dbPath, $dbPath . '-wal', $dbPath . '-shm'] as $path) {
@@ -165,6 +166,38 @@ if ($storage === 'memory') {
     $adapter = $runner === 'swoole'
         ? SqliteStorage::forSwoole($dbPath)
         : SqliteStorage::forPcntl($dbPath);
+
+    if ($runner === 'swoole') {
+        Swoole\Coroutine\run(function () use ($adapter, $entries): void {
+            foreach ($entries as $entry) {
+                $adapter->store($entry);
+            }
+        });
+    } else {
+        foreach ($entries as $entry) {
+            $adapter->store($entry);
+        }
+    }
+
+    $server->useStorage($adapter);
+} else {
+    $dsn = getenv('MYSQL_DSN') ?: 'mysql:host=127.0.0.1;port=3306;dbname=freedsx';
+    $user = getenv('MYSQL_USER') ?: 'root';
+    $password = getenv('MYSQL_PASSWORD') ?: 'root';
+
+    // Start each run from a known-empty table.
+    $cleanup = new PDO(
+        $dsn,
+        $user,
+        $password,
+        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION],
+    );
+    $cleanup->exec('DROP TABLE IF EXISTS entries');
+    unset($cleanup);
+
+    $adapter = $runner === 'swoole'
+        ? MysqlStorage::forSwoole($dsn, $user, $password)
+        : MysqlStorage::forPcntl($dsn, $user, $password);
 
     if ($runner === 'swoole') {
         Swoole\Coroutine\run(function () use ($adapter, $entries): void {

--- a/tests/bin/ldap-backend-storage.php
+++ b/tests/bin/ldap-backend-storage.php
@@ -45,6 +45,7 @@ $entries = [
         new Attribute('objectClass', 'inetOrgPerson'),
         new Attribute('sn', 'Smith'),
         new Attribute('mail', 'alice@foo.bar'),
+        new Attribute('uidNumber', '99'),
     ),
 ];
 

--- a/tests/bin/ldap-backend-storage.php
+++ b/tests/bin/ldap-backend-storage.php
@@ -3,7 +3,20 @@
 declare(strict_types=1);
 
 /**
- * Server bootstrap script for LdapBackendStorageTest.
+ * Server bootstrap script for LdapBackendStorageTest and ldap-load-test.
+ *
+ * Accepts two forms:
+ *
+ *   Legacy positional: php ldap-backend-storage.php <transport> [file|sqlite|swoole]
+ *     - `file`   -> JsonFileStorage (pcntl runner)
+ *     - `sqlite` -> SqliteStorage   (pcntl runner)
+ *     - `swoole` -> InMemoryStorage (swoole runner)
+ *     - omitted  -> InMemoryStorage (pcntl runner)
+ *
+ *   Named: php ldap-backend-storage.php <transport> --storage=<memory|json|sqlite|mysql> --runner=<pcntl|swoole>
+ *
+ *     `mysql` reads connection details from the MYSQL_DSN / MYSQL_USER / MYSQL_PASSWORD env vars,
+ *     defaulting to `mysql:host=127.0.0.1;port=3306;dbname=freedsx` / `root` / `root`.
  */
 
 use FreeDSx\Ldap\Entry\Attribute;
@@ -20,7 +33,53 @@ require __DIR__ . '/../../vendor/autoload.php';
 $passwordHash = '{SHA}' . base64_encode(sha1('12345', true));
 
 $transport = $argv[1] ?? 'tcp';
-$handler = $argv[2] ?? null;
+$legacyHandler = null;
+$storageOpt = null;
+$runnerOpt = null;
+$portOpt = null;
+$seedEntriesOpt = 0;
+
+for ($i = 2; isset($argv[$i]); $i++) {
+    $arg = $argv[$i];
+
+    if (str_starts_with($arg, '--storage=')) {
+        $storageOpt = substr($arg, strlen('--storage='));
+    } elseif (str_starts_with($arg, '--runner=')) {
+        $runnerOpt = substr($arg, strlen('--runner='));
+    } elseif (str_starts_with($arg, '--port=')) {
+        $portOpt = (int) substr($arg, strlen('--port='));
+    } elseif (str_starts_with($arg, '--seed-entries=')) {
+        $seedEntriesOpt = (int) substr($arg, strlen('--seed-entries='));
+    } elseif ($legacyHandler === null && !str_starts_with($arg, '--')) {
+        $legacyHandler = $arg;
+    }
+}
+
+if ($seedEntriesOpt < 0) {
+    fwrite(STDERR, "Invalid --seed-entries value: {$seedEntriesOpt}. Must be zero or greater." . PHP_EOL);
+    exit(2);
+}
+
+if ($storageOpt !== null || $runnerOpt !== null) {
+    $storage = $storageOpt ?? 'memory';
+    $runner = $runnerOpt ?? 'pcntl';
+} else {
+    [$storage, $runner] = match ($legacyHandler) {
+        'file' => ['json', 'pcntl'],
+        'sqlite' => ['sqlite', 'pcntl'],
+        'swoole' => ['memory', 'swoole'],
+        default => ['memory', 'pcntl'],
+    };
+}
+
+if (!in_array($storage, ['memory', 'json', 'sqlite'], true)) {
+    fwrite(STDERR, "Invalid --storage value: {$storage}. Expected one of: memory, json, sqlite." . PHP_EOL);
+    exit(2);
+}
+if (!in_array($runner, ['pcntl', 'swoole'], true)) {
+    fwrite(STDERR, "Invalid --runner value: {$runner}. Expected one of: pcntl, swoole." . PHP_EOL);
+    exit(2);
+}
 
 $entries = [
     new Entry(
@@ -49,29 +108,52 @@ $entries = [
     ),
 ];
 
+for ($i = 1; $i <= $seedEntriesOpt; $i++) {
+    $entries[] = new Entry(
+        new Dn("cn=seed-{$i},ou=people,dc=foo,dc=bar"),
+        new Attribute('cn', "seed-{$i}"),
+        new Attribute('objectClass', 'inetOrgPerson'),
+        new Attribute('sn', 'Seeded'),
+        new Attribute('mail', "seed-{$i}@foo.bar"),
+        new Attribute('uidNumber', (string) (1000 + $i)),
+    );
+}
+
 $server = new LdapServer(
     (new ServerOptions())
-        ->setPort(10389)
+        ->setPort($portOpt ?? 10389)
         ->setTransport($transport)
         ->setSocketAcceptTimeout(0.1)
-        ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL))
+        ->setOnServerReady(fn () => fwrite(STDOUT, 'server starting...' . PHP_EOL))
 );
 
-if ($handler === 'file') {
+if ($storage === 'memory') {
+    $server->useStorage(new InMemoryStorage($entries));
+} elseif ($storage === 'json') {
     $filePath = sys_get_temp_dir() . '/ldap_test_backend_storage.json';
 
     if (file_exists($filePath)) {
         unlink($filePath);
     }
 
-    $storage = JsonFileStorage::forPcntl($filePath);
+    $adapter = $runner === 'swoole'
+        ? JsonFileStorage::forSwoole($filePath)
+        : JsonFileStorage::forPcntl($filePath);
 
-    foreach ($entries as $entry) {
-        $storage->store($entry);
+    if ($runner === 'swoole') {
+        Swoole\Coroutine\run(function () use ($adapter, $entries): void {
+            foreach ($entries as $entry) {
+                $adapter->store($entry);
+            }
+        });
+    } else {
+        foreach ($entries as $entry) {
+            $adapter->store($entry);
+        }
     }
 
-    $server->useStorage($storage);
-} elseif ($handler === 'sqlite') {
+    $server->useStorage($adapter);
+} else {
     $dbPath = sys_get_temp_dir() . '/ldap_test_backend_storage.sqlite';
 
     foreach ([$dbPath, $dbPath . '-wal', $dbPath . '-shm'] as $path) {
@@ -80,18 +162,26 @@ if ($handler === 'file') {
         }
     }
 
-    $storage = SqliteStorage::forPcntl($dbPath);
+    $adapter = $runner === 'swoole'
+        ? SqliteStorage::forSwoole($dbPath)
+        : SqliteStorage::forPcntl($dbPath);
 
-    foreach ($entries as $entry) {
-        $storage->store($entry);
+    if ($runner === 'swoole') {
+        Swoole\Coroutine\run(function () use ($adapter, $entries): void {
+            foreach ($entries as $entry) {
+                $adapter->store($entry);
+            }
+        });
+    } else {
+        foreach ($entries as $entry) {
+            $adapter->store($entry);
+        }
     }
 
-    $server->useStorage($storage);
-} else {
-    $server->useStorage(new InMemoryStorage($entries));
+    $server->useStorage($adapter);
 }
 
-if ($handler === 'swoole') {
+if ($runner === 'swoole') {
     $server->useSwooleRunner();
 }
 

--- a/tests/bin/ldap-load-test.php
+++ b/tests/bin/ldap-load-test.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Load-test driver for the FreeDSx LDAP storage backends.
+ *
+ * Spawns an LDAP server with the chosen backend+runner, fires concurrent LDAP operations from a
+ * Swoole coroutine pool, then prints per-op latency/throughput/error stats. Run with --help to
+ * see the full option list.
+ */
+
+use Symfony\Component\Console\Application;
+use Tests\Performance\FreeDSx\Ldap\LoadTest\LoadTestCommand;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+require_once __DIR__ . '/../performance/Config.php';
+require_once __DIR__ . '/../performance/WorkloadMix.php';
+require_once __DIR__ . '/../performance/StatsCollector.php';
+require_once __DIR__ . '/../performance/StatsSnapshot.php';
+require_once __DIR__ . '/../performance/ServerManager.php';
+require_once __DIR__ . '/../performance/Worker.php';
+require_once __DIR__ . '/../performance/Report.php';
+require_once __DIR__ . '/../performance/Driver.php';
+require_once __DIR__ . '/../performance/LoadTestCommand.php';
+
+$command = new LoadTestCommand();
+$application = new Application('FreeDSx LDAP load test');
+$application->add($command);
+$application->setDefaultCommand((string) $command->getName(), true);
+$application->run();

--- a/tests/integration/Storage/LdapBackendSqliteStorageTest.php
+++ b/tests/integration/Storage/LdapBackendSqliteStorageTest.php
@@ -15,6 +15,7 @@ namespace Tests\Integration\FreeDSx\Ldap\Storage;
 
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\Search\Filter\ApproximateFilter;
 use FreeDSx\Ldap\Search\Filters;
 
 /**
@@ -107,6 +108,60 @@ final class LdapBackendSqliteStorageTest extends LdapBackendStorageTest
         );
         self::assertSame(
             'cn=persistent,dc=foo,dc=bar',
+            $entries->first()?->getDn()->toString()
+        );
+    }
+
+    public function testApproximateWithAsciiValueMatches(): void
+    {
+        $this->authenticateUser();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(new ApproximateFilter('cn', 'Alice'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope()
+        );
+
+        self::assertCount(1, $entries);
+        self::assertSame(
+            'cn=alice,ou=people,dc=foo,dc=bar',
+            $entries->first()?->getDn()->toString()
+        );
+    }
+
+    /**
+     * Canary for the GTE/LTE digit-value inexact rule: alice has uidNumber=99.
+     * A byte-wise SQL compare ("99" > "100") would incorrectly return her for
+     * (uidNumber>=100). PHP re-evaluation must kick in and integer-compare,
+     * excluding her. If this fails, translateGte was wrongly marked exact
+     * for a digit filter value.
+     */
+    public function testGteDigitFilterExcludesLowerNumericValueEvenThoughBytewiseCompareWouldMatch(): void
+    {
+        $this->authenticateUser();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::greaterThanOrEqual('uidNumber', '100'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope()
+        );
+
+        self::assertCount(0, $entries);
+    }
+
+    public function testGteAsciiNonDigitValueMatchesLexicographically(): void
+    {
+        $this->authenticateUser();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::greaterThanOrEqual('sn', 'Smith'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope()
+        );
+
+        self::assertCount(1, $entries);
+        self::assertSame(
+            'cn=alice,ou=people,dc=foo,dc=bar',
             $entries->first()?->getDn()->toString()
         );
     }

--- a/tests/integration/Storage/LdapBackendSqliteStorageTest.php
+++ b/tests/integration/Storage/LdapBackendSqliteStorageTest.php
@@ -130,11 +130,7 @@ final class LdapBackendSqliteStorageTest extends LdapBackendStorageTest
     }
 
     /**
-     * Canary for the GTE/LTE digit-value inexact rule: alice has uidNumber=99.
-     * A byte-wise SQL compare ("99" > "100") would incorrectly return her for
-     * (uidNumber>=100). PHP re-evaluation must kick in and integer-compare,
-     * excluding her. If this fails, translateGte was wrongly marked exact
-     * for a digit filter value.
+     * Canary: if translateGte is wrongly marked exact for a digit value, SQL byte-compare ("99">"100") returns alice.
      */
     public function testGteDigitFilterExcludesLowerNumericValueEvenThoughBytewiseCompareWouldMatch(): void
     {

--- a/tests/performance/Config.php
+++ b/tests/performance/Config.php
@@ -27,6 +27,7 @@ final class Config
         'memory',
         'json',
         'sqlite',
+        'mysql',
     ];
 
     /**

--- a/tests/performance/Config.php
+++ b/tests/performance/Config.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+
+use InvalidArgumentException;
+
+/**
+ * Immutable configuration for the load-test driver; built by LoadTestCommand from CLI input.
+ */
+final class Config
+{
+    /**
+     * @var list<string>
+     */
+    public const BACKENDS = [
+        'memory',
+        'json',
+        'sqlite',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    public const RUNNERS = [
+        'pcntl',
+        'swoole',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    public const SERVER_MODES = [
+        'spawn',
+        'external',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    public const OUTPUTS = [
+        'text',
+        'json',
+    ];
+
+    public const DEFAULT_MIX = 'bind=5,search-read=50,search-eq=25,search-sub=10,search-list=5,add=2,modify=2,delete=1';
+
+    public function __construct(
+        public readonly string $backend,
+        public readonly string $runner,
+        public readonly int $clients = 16,
+        public readonly ?int $duration = 10,
+        public readonly ?int $ops = null,
+        public readonly string $mix = self::DEFAULT_MIX,
+        public readonly string $host = '127.0.0.1',
+        public readonly int $port = 10389,
+        public readonly int $warmup = 2,
+        public readonly string $serverMode = 'spawn',
+        public readonly ?int $seed = null,
+        public readonly string $output = 'text',
+        public readonly int $seedEntries = 100,
+    ) {
+        $this->assertEnum('backend', $backend, self::BACKENDS);
+        $this->assertEnum('runner', $runner, self::RUNNERS);
+        $this->assertEnum('server', $serverMode, self::SERVER_MODES);
+        $this->assertEnum('output', $output, self::OUTPUTS);
+        $this->assertPositive('clients', $clients);
+        $this->assertPositive('port', $port);
+        $this->assertNonNegative('warmup', $warmup);
+        $this->assertNonNegative('seed-entries', $seedEntries);
+
+        if ($duration !== null) {
+            $this->assertPositive('duration', $duration);
+        }
+        if ($ops !== null) {
+            $this->assertPositive('ops', $ops);
+        }
+        if ($duration === null && $ops === null) {
+            throw new InvalidArgumentException('One of --duration or --ops must be set.');
+        }
+        if ($backend === 'memory' && $runner === 'pcntl') {
+            throw new InvalidArgumentException(
+                'InMemoryStorage requires the Swoole runner: pcntl fork children each hold their own copy '
+                . 'of the seed entries, so writes never propagate between connections.'
+            );
+        }
+    }
+
+    /**
+     * @param list<string> $allowed
+     */
+    private function assertEnum(string $name, string $value, array $allowed): void
+    {
+        if (in_array($value, $allowed, true)) {
+            return;
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Invalid --%s value "%s". Expected one of: %s.',
+            $name,
+            $value,
+            implode(', ', $allowed)
+        ));
+    }
+
+    private function assertPositive(string $name, int $value): void
+    {
+        if ($value > 0) {
+            return;
+        }
+
+        throw new InvalidArgumentException("--{$name} must be greater than zero, got {$value}.");
+    }
+
+    private function assertNonNegative(string $name, int $value): void
+    {
+        if ($value >= 0) {
+            return;
+        }
+
+        throw new InvalidArgumentException("--{$name} must be zero or greater, got {$value}.");
+    }
+}

--- a/tests/performance/Driver.php
+++ b/tests/performance/Driver.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+
+use RuntimeException;
+use Swoole\Coroutine;
+use Swoole\Coroutine\Channel;
+use Swoole\Coroutine\WaitGroup;
+use Swoole\Runtime;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+/**
+ * Orchestrates a load-test run end-to-end: server lifecycle, coroutine pool, warmup timer,
+ * barrier + deadline coordination, then a rendered report.
+ */
+final class Driver
+{
+    public function __construct(
+        private readonly Config $config,
+    ) {
+    }
+
+    public function run(OutputInterface $output): void
+    {
+        $this->assertSwooleAvailable();
+
+        if ($this->config->seed !== null) {
+            mt_srand($this->config->seed);
+        }
+
+        $progress = $this->progressChannel($output);
+        $mix = new WorkloadMix($this->config->mix);
+        $stats = new StatsCollector();
+        $serverManager = $this->config->serverMode === 'spawn'
+            ? new ServerManager($this->config)
+            : null;
+
+        if ($serverManager !== null) {
+            $progress->writeln($this->describeServerStart());
+            $serverManager->start();
+            $progress->writeln('Server ready.');
+        } else {
+            $progress->writeln(sprintf(
+                'Using external server at %s:%d.',
+                $this->config->host,
+                $this->config->port,
+            ));
+        }
+
+        $progress->writeln($this->describeRunStart());
+
+        try {
+            $snapshot = $this->runCoroutinePool($mix, $stats);
+        } finally {
+            $serverManager?->stop();
+        }
+
+        (new Report($this->config, $mix, $snapshot))->render($output);
+    }
+
+    private function progressChannel(OutputInterface $output): OutputInterface
+    {
+        if ($output instanceof ConsoleOutputInterface) {
+            return $output->getErrorOutput();
+        }
+
+        return $output;
+    }
+
+    private function describeServerStart(): string
+    {
+        $seedSuffix = $this->config->seedEntries > 0
+            ? sprintf(', seed-entries=%d', $this->config->seedEntries)
+            : '';
+
+        return sprintf(
+            'Starting server (backend=%s, runner=%s, port=%d%s)...',
+            $this->config->backend,
+            $this->config->runner,
+            $this->config->port,
+            $seedSuffix,
+        );
+    }
+
+    private function describeRunStart(): string
+    {
+        $budget = $this->config->duration !== null
+            ? sprintf('duration=%ds', $this->config->duration)
+            : sprintf('ops/client=%d', $this->config->ops);
+
+        return sprintf(
+            'Running load test: clients=%d, warmup=%ds, %s...',
+            $this->config->clients,
+            $this->config->warmup,
+            $budget,
+        );
+    }
+
+    private function runCoroutinePool(WorkloadMix $mix, StatsCollector $stats): StatsSnapshot
+    {
+        Runtime::enableCoroutine(SWOOLE_HOOK_ALL);
+
+        $elapsedSeconds = 0.0;
+        $workerErrors = [];
+
+        Coroutine\run(function () use ($mix, $stats, &$elapsedSeconds, &$workerErrors): void {
+            $clients = $this->config->clients;
+            $readyBarrier = new Channel($clients);
+            $startSignal = new Channel($clients);
+            $waitGroup = new WaitGroup();
+
+            for ($i = 0; $i < $clients; $i++) {
+                $waitGroup->add();
+                $workerId = $i;
+                Coroutine::create(function () use ($workerId, $mix, $stats, $readyBarrier, $startSignal, $waitGroup, &$workerErrors): void {
+                    try {
+                        (new Worker(
+                            workerId: $workerId,
+                            config: $this->config,
+                            mix: $mix,
+                            stats: $stats,
+                            readyBarrier: $readyBarrier,
+                            startSignal: $startSignal,
+                            opsCap: $this->config->ops,
+                        ))->run();
+                    } catch (Throwable $e) {
+                        $workerErrors[] = $e;
+                    } finally {
+                        $waitGroup->done();
+                    }
+                });
+            }
+
+            $allReady = $this->awaitReady($readyBarrier, $clients);
+
+            $deadline = $this->config->duration !== null
+                ? microtime(true) + $this->config->warmup + (float) $this->config->duration
+                : null;
+
+            for ($i = 0; $i < $clients; $i++) {
+                $startSignal->push($allReady ? $deadline : false);
+            }
+
+            if ($allReady) {
+                $elapsedSeconds = $this->driveWarmupAndRecord($stats, $waitGroup);
+            } else {
+                $waitGroup->wait();
+            }
+        });
+
+        if ($workerErrors !== []) {
+            $first = $workerErrors[0];
+            throw new RuntimeException(sprintf(
+                '%d of %d workers failed; first error: %s: %s',
+                count($workerErrors),
+                $this->config->clients,
+                $first::class,
+                $first->getMessage()
+            ), 0, $first);
+        }
+
+        return $stats->snapshot($elapsedSeconds);
+    }
+
+    private function awaitReady(Channel $readyBarrier, int $expected): bool
+    {
+        $allReady = true;
+
+        for ($i = 0; $i < $expected; $i++) {
+            $ready = $readyBarrier->pop();
+
+            if ($ready !== true) {
+                $allReady = false;
+            }
+        }
+
+        return $allReady;
+    }
+
+    private function driveWarmupAndRecord(StatsCollector $stats, WaitGroup $waitGroup): float
+    {
+        $recordingStart = 0.0;
+
+        Coroutine::create(function () use ($stats, &$recordingStart): void {
+            if ($this->config->warmup > 0) {
+                Coroutine::sleep((float) $this->config->warmup);
+            }
+
+            $recordingStart = microtime(true);
+            $stats->startRecording();
+        });
+
+        $waitGroup->wait();
+
+        $stats->stopRecording();
+
+        return $recordingStart > 0.0
+            ? microtime(true) - $recordingStart
+            : 0.0;
+    }
+
+    private function assertSwooleAvailable(): void
+    {
+        if (extension_loaded('swoole')) {
+            return;
+        }
+
+        throw new RuntimeException(
+            'The load-test driver requires ext-swoole for concurrent coroutine-based clients. '
+            . 'Install via PECL: pecl install swoole (^5.1 for PHP 8.3/8.4, ^6.0 for PHP 8.5+).'
+        );
+    }
+}

--- a/tests/performance/LoadTestCommand.php
+++ b/tests/performance/LoadTestCommand.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+
+use InvalidArgumentException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+/**
+ * Symfony Console entry point that parses CLI options, builds a Config, and runs the Driver.
+ */
+final class LoadTestCommand extends Command
+{
+    protected static $defaultName = 'load-test';
+
+    protected static $defaultDescription = 'Run a concurrent LDAP load test against a storage backend.';
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'backend',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Storage adapter: ' . implode(' | ', Config::BACKENDS),
+            )
+            ->addOption(
+                'runner',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Server runner: ' . implode(' | ', Config::RUNNERS) . ' (memory REQUIRES swoole)',
+            )
+            ->addOption(
+                'clients',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Concurrent coroutines',
+                '16',
+            )
+            ->addOption(
+                'duration',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Seconds to run (default 10 unless --ops is set)',
+            )
+            ->addOption(
+                'ops',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Total ops per client (alternative to --duration)',
+            )
+            ->addOption(
+                'mix',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Op mix, comma-separated weights',
+                Config::DEFAULT_MIX,
+            )
+            ->addOption(
+                'host',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Bind host',
+                '127.0.0.1',
+            )
+            ->addOption(
+                'port',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Listen port',
+                '10389',
+            )
+            ->addOption(
+                'warmup',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Warmup seconds before sampling',
+                '2',
+            )
+            ->addOption(
+                'server',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'spawn = script manages server; external = already running',
+                'spawn',
+            )
+            ->addOption(
+                'seed',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'RNG seed for reproducible workloads',
+            )
+            ->addOption(
+                'output',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Report format: ' . implode(' | ', Config::OUTPUTS),
+                'text',
+            )
+            ->addOption(
+                'seed-entries',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Extra fixture entries to pre-seed under ou=people before the run',
+                '100',
+            );
+    }
+
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output,
+    ): int {
+        try {
+            $config = $this->buildConfig($input);
+        } catch (InvalidArgumentException $e) {
+            $output->writeln('<error>Configuration error: ' . $e->getMessage() . '</error>');
+
+            return Command::INVALID;
+        }
+
+        try {
+            (new Driver($config))->run($output);
+        } catch (Throwable $e) {
+            $output->writeln('<error>Load test failed: ' . $e->getMessage() . '</error>');
+
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function buildConfig(InputInterface $input): Config
+    {
+        $backend = $this->requireString($input, 'backend');
+        $runner = $this->requireString($input, 'runner');
+
+        $opsOpt = $input->getOption('ops');
+        $durationOpt = $input->getOption('duration');
+        $ops = $this->parseInt($opsOpt, 'ops');
+
+        if ($durationOpt !== null) {
+            $duration = $this->parseInt($durationOpt, 'duration');
+        } elseif ($ops !== null) {
+            $duration = null;
+        } else {
+            $duration = 10;
+        }
+
+        return new Config(
+            backend: $backend,
+            runner: $runner,
+            clients: $this->requireInt($input, 'clients'),
+            duration: $duration,
+            ops: $ops,
+            mix: $this->requireString($input, 'mix'),
+            host: $this->requireString($input, 'host'),
+            port: $this->requireInt($input, 'port'),
+            warmup: $this->requireInt($input, 'warmup'),
+            serverMode: $this->requireString($input, 'server'),
+            seed: $this->parseInt($input->getOption('seed'), 'seed'),
+            output: $this->requireString($input, 'output'),
+            seedEntries: $this->requireInt($input, 'seed-entries'),
+        );
+    }
+
+    private function requireString(InputInterface $input, string $name): string
+    {
+        $value = $input->getOption($name);
+
+        if (!is_string($value) || $value === '') {
+            throw new InvalidArgumentException("--{$name} is required.");
+        }
+
+        return $value;
+    }
+
+    private function requireInt(InputInterface $input, string $name): int
+    {
+        $value = $this->parseInt($input->getOption($name), $name);
+
+        if ($value === null) {
+            throw new InvalidArgumentException("--{$name} is required.");
+        }
+
+        return $value;
+    }
+
+    private function parseInt(mixed $value, string $name): ?int
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_string($value) || !preg_match('/^-?\d+$/', $value)) {
+            $display = is_scalar($value)
+                ? (string) $value
+                : get_debug_type($value);
+
+            throw new InvalidArgumentException("--{$name} must be an integer, got \"{$display}\".");
+        }
+
+        return (int) $value;
+    }
+}

--- a/tests/performance/Report.php
+++ b/tests/performance/Report.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Formats a StatsSnapshot as either a human-readable table or machine-readable JSON.
+ */
+final class Report
+{
+    private const HEADERS = [
+        'Operation',
+        'Count',
+        'Errors',
+        'Ops/sec',
+        'Min',
+        'p50',
+        'p95',
+        'p99',
+        'Max',
+        'Mean',
+    ];
+
+    public function __construct(
+        private readonly Config $config,
+        private readonly WorkloadMix $mix,
+        private readonly StatsSnapshot $snapshot,
+    ) {
+    }
+
+    public function render(OutputInterface $output): void
+    {
+        if ($this->config->output === 'json') {
+            $output->writeln($this->renderJson());
+
+            return;
+        }
+
+        $this->renderText($output);
+    }
+
+    private function renderText(OutputInterface $output): void
+    {
+        $output->writeln($this->renderBanner());
+        $output->writeln('');
+
+        $table = new Table($output);
+        $table->setHeaders(self::HEADERS);
+        foreach ($this->snapshot->operations() as $op) {
+            $table->addRow($this->textRow($op));
+        }
+        $table->render();
+
+        $output->writeln('');
+        $output->writeln($this->renderTotals());
+
+        $substitutions = $this->renderSubstitutions();
+        if ($substitutions !== '') {
+            $output->writeln($substitutions);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function textRow(string $op): array
+    {
+        $stats = $this->snapshot->latencyStats($op);
+
+        return [
+            $op,
+            (string) $this->snapshot->successCount($op),
+            (string) $this->snapshot->errorCount($op),
+            number_format($this->snapshot->throughput($op), 2),
+            self::formatNanos($stats['min']),
+            self::formatNanos($stats['p50']),
+            self::formatNanos($stats['p95']),
+            self::formatNanos($stats['p99']),
+            self::formatNanos($stats['max']),
+            self::formatNanos($stats['mean']),
+        ];
+    }
+
+    private function renderBanner(): string
+    {
+        $duration = $this->config->duration !== null
+            ? sprintf('%ds', $this->config->duration)
+            : sprintf('%d ops/client', $this->config->ops);
+
+        $lines = [
+            'FreeDSx LDAP load test',
+            '======================',
+            sprintf(
+                'Backend: %s (%s runner)   Clients: %d   Duration: %s   Warmup: %ds   Elapsed: %.1fs',
+                $this->config->backend,
+                $this->config->runner,
+                $this->config->clients,
+                $duration,
+                $this->config->warmup,
+                $this->snapshot->elapsedSeconds,
+            ),
+            sprintf(
+                'Mix: %s',
+                $this->mix->describe(),
+            ),
+        ];
+
+        return implode(PHP_EOL, $lines);
+    }
+
+    private function renderTotals(): string
+    {
+        $total = $this->snapshot->totalSuccess();
+        $errors = $this->snapshot->totalErrors();
+        $attempted = $total + $errors;
+        $errPct = $attempted > 0 ? ($errors / $attempted) * 100 : 0.0;
+
+        $line = sprintf(
+            'Total: %d ops in %.1fs  |  Throughput: %s ops/sec  |  Errors: %d (%.3f%%)',
+            $total,
+            $this->snapshot->elapsedSeconds,
+            number_format($this->snapshot->overallThroughput(), 1),
+            $errors,
+            $errPct,
+        );
+
+        $topErrs = $this->snapshot->topErrorClasses();
+        if ($topErrs === []) {
+            return $line;
+        }
+
+        $parts = [];
+        foreach ($topErrs as $err) {
+            $short = self::shortClass($err['class']);
+            $parts[] = "{$short} ({$err['count']})";
+        }
+
+        return $line . PHP_EOL . 'Top errors: ' . implode(', ', $parts);
+    }
+
+    private function renderSubstitutions(): string
+    {
+        if ($this->snapshot->substituted === []) {
+            return '';
+        }
+
+        $parts = [];
+        foreach ($this->snapshot->substituted as $pair => $count) {
+            $parts[] = "{$pair} ({$count})";
+        }
+
+        return 'Substituted (write op converted when worker had no owned DNs): ' . implode(', ', $parts);
+    }
+
+    private function renderJson(): string
+    {
+        $ops = [];
+        foreach ($this->snapshot->operations() as $op) {
+            $stats = $this->snapshot->latencyStats($op);
+            $ops[$op] = [
+                'count' => $this->snapshot->successCount($op),
+                'errors' => $this->snapshot->errorCount($op),
+                'throughput' => $this->snapshot->throughput($op),
+                'latency_ns' => $stats,
+            ];
+        }
+
+        return json_encode([
+            'config' => [
+                'backend' => $this->config->backend,
+                'runner' => $this->config->runner,
+                'clients' => $this->config->clients,
+                'duration' => $this->config->duration,
+                'ops' => $this->config->ops,
+                'warmup' => $this->config->warmup,
+                'mix' => $this->mix->weights(),
+                'host' => $this->config->host,
+                'port' => $this->config->port,
+            ],
+            'elapsed_seconds' => $this->snapshot->elapsedSeconds,
+            'operations' => $ops,
+            'totals' => [
+                'success' => $this->snapshot->totalSuccess(),
+                'errors' => $this->snapshot->totalErrors(),
+                'throughput' => $this->snapshot->overallThroughput(),
+            ],
+            'top_error_classes' => $this->snapshot->topErrorClasses(),
+            'substituted' => $this->snapshot->substituted,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+    }
+
+    private static function formatNanos(int $nanos): string
+    {
+        if ($nanos === 0) {
+            return '-';
+        }
+
+        return sprintf('%.2fms', $nanos / 1_000_000);
+    }
+
+    private static function shortClass(string $fqcn): string
+    {
+        $pos = strrpos($fqcn, '\\');
+
+        return $pos === false ? $fqcn : substr($fqcn, $pos + 1);
+    }
+}

--- a/tests/performance/ServerManager.php
+++ b/tests/performance/ServerManager.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+/**
+ * Spawns ldap-backend-storage.php, waits for the readiness marker, and stops it on destruction.
+ */
+final class ServerManager
+{
+    private const READY_MARKER = 'server starting...';
+
+    private const POLL_INTERVAL_US = 15_000;
+
+    private const BOOTSTRAP_PATH = __DIR__ . '/../bin/ldap-backend-storage.php';
+
+    private ?Process $process = null;
+
+    public function __construct(
+        private readonly Config $config,
+        private readonly int $maxWaitSeconds = 10,
+    ) {
+    }
+
+    private function readyDeadlineSeconds(): int
+    {
+        return $this->maxWaitSeconds + (int) ceil($this->config->seedEntries / 100);
+    }
+
+    public function start(): void
+    {
+        if ($this->process !== null) {
+            throw new RuntimeException('ServerManager::start() called twice.');
+        }
+
+        $this->process = new Process([
+            'php',
+            '-dpcov.enabled=0',
+            self::BOOTSTRAP_PATH,
+            'tcp',
+            '--storage=' . $this->config->backend,
+            '--runner=' . $this->config->runner,
+            '--port=' . $this->config->port,
+            '--seed-entries=' . $this->config->seedEntries,
+        ]);
+
+        $this->process->start();
+
+        $this->awaitReady($this->process);
+    }
+
+    public function stop(): void
+    {
+        if ($this->process === null) {
+            return;
+        }
+
+        $this->process->stop();
+        $this->process = null;
+    }
+
+    public function __destruct()
+    {
+        $this->stop();
+    }
+
+    private function awaitReady(Process $process): void
+    {
+        $waitSeconds = $this->readyDeadlineSeconds();
+        $deadline = microtime(true) + $waitSeconds;
+
+        while ($process->isRunning()) {
+            $output = $process->getOutput();
+
+            if (str_contains($output, self::READY_MARKER)) {
+                $process->clearOutput();
+
+                return;
+            }
+
+            if (microtime(true) >= $deadline) {
+                break;
+            }
+
+            usleep(self::POLL_INTERVAL_US);
+        }
+
+        $process->stop();
+        throw new RuntimeException(sprintf(
+            "Server did not emit '%s' within %d seconds. Stderr: %s",
+            self::READY_MARKER,
+            $waitSeconds,
+            PHP_EOL . $process->getErrorOutput()
+        ));
+    }
+}

--- a/tests/performance/StatsCollector.php
+++ b/tests/performance/StatsCollector.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+
+/**
+ * Accumulates per-op latency samples and error counts while recording is enabled.
+ *
+ * Samples are capped per op via reservoir sampling to bound memory.
+ */
+final class StatsCollector
+{
+    public const SAMPLE_CAP = 10_000_000;
+
+    private bool $recording = false;
+
+    /**
+     * @var array<string, array<int, int>> op -> sampled nanosecond latencies (size <= SAMPLE_CAP).
+     *                                     Not typed as list<int> because reservoir overwrites break the list shape.
+     */
+    private array $samples = [];
+
+    /**
+     * @var array<string, int> op -> total successful ops observed while recording
+     */
+    private array $counts = [];
+
+    /**
+     * @var array<string, int> op -> error count while recording
+     */
+    private array $errors = [];
+
+    /**
+     * @var array<string, array<string, int>> op -> exception class -> count
+     */
+    private array $errorClasses = [];
+
+    /**
+     * @var array<string, int> "fromOp->toOp" -> count (e.g. "modify->add")
+     */
+    private array $substituted = [];
+
+    public function startRecording(): void
+    {
+        $this->recording = true;
+    }
+
+    public function stopRecording(): void
+    {
+        $this->recording = false;
+    }
+
+    public function isRecording(): bool
+    {
+        return $this->recording;
+    }
+
+    public function recordSuccess(string $op, int $nanos): void
+    {
+        if (!$this->recording) {
+            return;
+        }
+
+        $seen = ($this->counts[$op] ?? 0) + 1;
+        $this->counts[$op] = $seen;
+
+        if (!isset($this->samples[$op])) {
+            $this->samples[$op] = [];
+        }
+
+        if ($seen <= self::SAMPLE_CAP) {
+            $this->samples[$op][] = $nanos;
+
+            return;
+        }
+
+        $slot = mt_rand(0, $seen - 1);
+        if ($slot < self::SAMPLE_CAP) {
+            $this->samples[$op][$slot] = $nanos;
+        }
+    }
+
+    public function recordError(string $op, string $exceptionClass): void
+    {
+        if (!$this->recording) {
+            return;
+        }
+
+        $this->errors[$op] = ($this->errors[$op] ?? 0) + 1;
+        $this->errorClasses[$op][$exceptionClass] = ($this->errorClasses[$op][$exceptionClass] ?? 0) + 1;
+    }
+
+    public function recordSubstitution(string $fromOp, string $toOp): void
+    {
+        if (!$this->recording) {
+            return;
+        }
+
+        $key = "{$fromOp}->{$toOp}";
+        $this->substituted[$key] = ($this->substituted[$key] ?? 0) + 1;
+    }
+
+    public function snapshot(float $elapsedSeconds): StatsSnapshot
+    {
+        return new StatsSnapshot(
+            samples: $this->samples,
+            counts: $this->counts,
+            errors: $this->errors,
+            errorClasses: $this->errorClasses,
+            substituted: $this->substituted,
+            elapsedSeconds: max($elapsedSeconds, 0.000001),
+        );
+    }
+}

--- a/tests/performance/StatsSnapshot.php
+++ b/tests/performance/StatsSnapshot.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+
+/**
+ * Frozen result of a load run.
+ */
+final class StatsSnapshot
+{
+    /**
+     * @param array<string, array<int, int>> $samples op -> nanosecond latencies
+     * @param array<string, int> $counts op -> total successes
+     * @param array<string, int> $errors op -> total errors
+     * @param array<string, array<string, int>> $errorClasses op -> exception class -> count
+     * @param array<string, int> $substituted "fromOp->toOp" -> count
+     */
+    public function __construct(
+        public readonly array $samples,
+        public readonly array $counts,
+        public readonly array $errors,
+        public readonly array $errorClasses,
+        public readonly array $substituted,
+        public readonly float $elapsedSeconds,
+    ) {
+    }
+
+    /**
+     * @return list<string> ops ordered by total activity (successes + errors) descending
+     */
+    public function operations(): array
+    {
+        $allOps = array_unique(array_merge(
+            array_keys($this->counts),
+            array_keys($this->errors),
+        ));
+
+        usort($allOps, fn ($a, $b) => $this->activity($b) <=> $this->activity($a));
+
+        return $allOps;
+    }
+
+    public function successCount(string $op): int
+    {
+        return $this->counts[$op] ?? 0;
+    }
+
+    public function errorCount(string $op): int
+    {
+        return $this->errors[$op] ?? 0;
+    }
+
+    public function throughput(string $op): float
+    {
+        return $this->successCount($op) / $this->elapsedSeconds;
+    }
+
+    /**
+     * @return array{min: int, max: int, mean: int, p50: int, p95: int, p99: int}
+     */
+    public function latencyStats(string $op): array
+    {
+        $sorted = $this->samples[$op] ?? [];
+
+        if ($sorted === []) {
+            return ['min' => 0, 'max' => 0, 'mean' => 0, 'p50' => 0, 'p95' => 0, 'p99' => 0];
+        }
+
+        sort($sorted);
+        $n = count($sorted);
+
+        return [
+            'min' => $sorted[0],
+            'max' => $sorted[$n - 1],
+            'mean' => (int) (array_sum($sorted) / $n),
+            'p50' => self::percentile($sorted, 0.50),
+            'p95' => self::percentile($sorted, 0.95),
+            'p99' => self::percentile($sorted, 0.99),
+        ];
+    }
+
+    public function totalSuccess(): int
+    {
+        return array_sum($this->counts);
+    }
+
+    public function totalErrors(): int
+    {
+        return array_sum($this->errors);
+    }
+
+    public function overallThroughput(): float
+    {
+        return $this->totalSuccess() / $this->elapsedSeconds;
+    }
+
+    /**
+     * @return list<array{class: string, count: int}> top N exception classes across all ops
+     */
+    public function topErrorClasses(int $limit = 3): array
+    {
+        $totals = [];
+        foreach ($this->errorClasses as $classes) {
+            foreach ($classes as $class => $count) {
+                $totals[$class] = ($totals[$class] ?? 0) + $count;
+            }
+        }
+
+        arsort($totals);
+        $top = array_slice($totals, 0, $limit, true);
+
+        $result = [];
+        foreach ($top as $class => $count) {
+            $result[] = ['class' => $class, 'count' => $count];
+        }
+
+        return $result;
+    }
+
+    private function activity(string $op): int
+    {
+        return ($this->counts[$op] ?? 0) + ($this->errors[$op] ?? 0);
+    }
+
+    /**
+     * @param array<int, int> $sorted values in ascending order, keyed 0..n-1
+     */
+    private static function percentile(
+        array $sorted,
+        float $p
+    ): int {
+        $n = count($sorted);
+        $idx = (int) floor($p * ($n - 1));
+
+        return $sorted[$idx];
+    }
+}

--- a/tests/performance/Worker.php
+++ b/tests/performance/Worker.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+
+use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Change;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\Search\Filter\FilterInterface;
+use FreeDSx\Ldap\Search\Filters;
+use LogicException;
+use Swoole\Coroutine\Channel;
+use Throwable;
+
+/**
+ * Generates load in a single Swoole coroutine.
+ */
+final class Worker
+{
+    private const BIND_DN = 'cn=user,dc=foo,dc=bar';
+
+    private const BIND_PASSWORD = '12345';
+
+    private const SEARCH_BASE = 'dc=foo,dc=bar';
+
+    private const WRITE_BASE = 'ou=people,dc=foo,dc=bar';
+
+    private const COMPARE_DN = 'cn=alice,ou=people,dc=foo,dc=bar';
+
+    /**
+     * @var list<string> DNs known to exist at startup; used by search-read / search-eq.
+     */
+    private const FIXED_READ_DNS = [
+        'dc=foo,dc=bar',
+        'cn=user,dc=foo,dc=bar',
+        'ou=people,dc=foo,dc=bar',
+        'cn=alice,ou=people,dc=foo,dc=bar',
+    ];
+
+    /**
+     * @var list<string> DNs this worker added and has not yet deleted; modify/delete pick from here.
+     */
+    private array $ownedDns = [];
+
+    private int $addSeq = 0;
+
+    public function __construct(
+        private readonly int $workerId,
+        private readonly Config $config,
+        private readonly WorkloadMix $mix,
+        private readonly StatsCollector $stats,
+        private readonly Channel $readyBarrier,
+        private readonly Channel $startSignal,
+        private readonly ?int $opsCap,
+    ) {
+    }
+
+    public function run(): void
+    {
+        $client = $this->buildClient();
+
+        try {
+            $client->bind(self::BIND_DN, self::BIND_PASSWORD);
+        } catch (Throwable $e) {
+            $this->readyBarrier->push(false);
+
+            throw $e;
+        }
+
+        $this->readyBarrier->push(true);
+
+        $signal = $this->startSignal->pop();
+        if ($signal === false) {
+            $this->cleanup($client);
+
+            return;
+        }
+
+        $deadline = is_float($signal) ? $signal : null;
+
+        $iterations = 0;
+        while ($this->shouldContinue($deadline, $iterations)) {
+            $this->runOne($client);
+            $iterations++;
+        }
+
+        $this->cleanup($client);
+    }
+
+    private function shouldContinue(?float $deadline, int $iterations): bool
+    {
+        if ($deadline !== null && microtime(true) >= $deadline) {
+            return false;
+        }
+
+        if ($this->opsCap !== null && $iterations >= $this->opsCap) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function runOne(LdapClient $client): void
+    {
+        $op = $this->mix->pick();
+        $effective = $this->resolveEffectiveOp($op);
+
+        $start = hrtime(true);
+
+        try {
+            $this->dispatch($client, $effective);
+            $this->stats->recordSuccess($op, hrtime(true) - $start);
+        } catch (Throwable $e) {
+            $this->stats->recordError($op, $e::class);
+        }
+    }
+
+    private function resolveEffectiveOp(string $op): string
+    {
+        if (($op === 'modify' || $op === 'delete') && $this->ownedDns === []) {
+            $this->stats->recordSubstitution($op, 'add');
+
+            return 'add';
+        }
+
+        return $op;
+    }
+
+    private function dispatch(LdapClient $client, string $op): void
+    {
+        match ($op) {
+            'bind' => $this->doBind($client),
+            'search-read' => $this->doSearchRead($client),
+            'search-eq' => $this->doSearchEq($client),
+            'search-sub' => $this->doSearchSub($client),
+            'search-list' => $this->doSearchList($client),
+            'compare' => $this->doCompare($client),
+            'add' => $this->doAdd($client),
+            'modify' => $this->doModify($client),
+            'delete' => $this->doDelete($client),
+            default => throw new LogicException("Unknown load-test op: {$op}"),
+        };
+    }
+
+    private function doBind(LdapClient $client): void
+    {
+        $client->bind(self::BIND_DN, self::BIND_PASSWORD);
+    }
+
+    private function doSearchRead(LdapClient $client): void
+    {
+        $request = Operations::search(Filters::present('objectClass'))
+            ->base($this->randomReadDn())
+            ->useBaseScope();
+
+        $client->search($request);
+    }
+
+    private function doSearchEq(LdapClient $client): void
+    {
+        $request = Operations::search($this->randomEqualityFilter())
+            ->base(self::SEARCH_BASE)
+            ->useSubtreeScope();
+
+        $client->search($request);
+    }
+
+    private function doSearchSub(LdapClient $client): void
+    {
+        $filter = $this->config->seedEntries > 0
+            ? Filters::startsWith('cn', 'seed-')
+            : Filters::startsWith('cn', '');
+
+        $request = Operations::search($filter)
+            ->base(self::SEARCH_BASE)
+            ->useSubtreeScope();
+
+        $client->search($request);
+    }
+
+    private function doSearchList(LdapClient $client): void
+    {
+        $request = Operations::search(Filters::equal('objectClass', 'inetOrgPerson'))
+            ->base(self::WRITE_BASE)
+            ->useSubtreeScope();
+
+        $client->search($request);
+    }
+
+    private function randomReadDn(): string
+    {
+        if ($this->config->seedEntries > 0 && mt_rand(1, 100) <= 80) {
+            $idx = mt_rand(1, $this->config->seedEntries);
+
+            return "cn=seed-{$idx},ou=people,dc=foo,dc=bar";
+        }
+
+        return self::FIXED_READ_DNS[array_rand(self::FIXED_READ_DNS)];
+    }
+
+    private function randomEqualityFilter(): FilterInterface
+    {
+        if ($this->config->seedEntries > 0 && mt_rand(1, 100) <= 80) {
+            $idx = mt_rand(1, $this->config->seedEntries);
+
+            return mt_rand(0, 1) === 0
+                ? Filters::equal('cn', "seed-{$idx}")
+                : Filters::equal('mail', "seed-{$idx}@foo.bar");
+        }
+
+        return mt_rand(0, 1) === 0
+            ? Filters::equal('cn', 'alice')
+            : Filters::equal('mail', 'alice@foo.bar');
+    }
+
+    private function doCompare(LdapClient $client): void
+    {
+        $client->compare(self::COMPARE_DN, 'mail', 'alice@foo.bar');
+    }
+
+    private function doAdd(LdapClient $client): void
+    {
+        $seq = ++$this->addSeq;
+        $cn = "load-w{$this->workerId}-{$seq}";
+        $dn = "cn={$cn}," . self::WRITE_BASE;
+
+        $client->create(new Entry(
+            $dn,
+            new Attribute('cn', $cn),
+            new Attribute('objectClass', 'inetOrgPerson'),
+            new Attribute('sn', 'Load'),
+            new Attribute('uidNumber', (string) $seq),
+        ));
+
+        $this->ownedDns[] = $dn;
+    }
+
+    private function doModify(LdapClient $client): void
+    {
+        $dn = $this->ownedDns[array_rand($this->ownedDns)];
+
+        $request = Operations::modify(
+            $dn,
+            Change::replace('uidNumber', (string) mt_rand(1, 1_000_000))
+        );
+
+        $client->send($request);
+    }
+
+    private function doDelete(LdapClient $client): void
+    {
+        $idx = array_rand($this->ownedDns);
+        $dn = $this->ownedDns[$idx];
+
+        $client->delete($dn);
+
+        array_splice($this->ownedDns, $idx, 1);
+    }
+
+    private function cleanup(LdapClient $client): void
+    {
+        try {
+            $client->unbind();
+        } catch (Throwable) {
+        }
+    }
+
+    private function buildClient(): LdapClient
+    {
+        return new LdapClient(
+            (new ClientOptions())
+                ->setServers([$this->config->host])
+                ->setPort($this->config->port)
+                ->setTransport('tcp')
+                ->setTimeoutConnect(5)
+                ->setTimeoutRead(30)
+        );
+    }
+}

--- a/tests/performance/WorkloadMix.php
+++ b/tests/performance/WorkloadMix.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+
+use InvalidArgumentException;
+
+/**
+ * Weighted op picker. Parses a "bind=5,search=90,add=2" spec and returns ops in proportion.
+ */
+final class WorkloadMix
+{
+    public const SUPPORTED_OPS = [
+        'bind',
+        'search-read',
+        'search-eq',
+        'search-sub',
+        'search-list',
+        'compare',
+        'add',
+        'modify',
+        'delete',
+    ];
+
+    /**
+     * @var array<string, int> op name -> declared weight
+     */
+    private readonly array $weights;
+
+    /**
+     * @var list<string> ops indexed in order matching $cumulative
+     */
+    private readonly array $ops;
+
+    /**
+     * @var list<int> cumulative weights (strictly increasing)
+     */
+    private readonly array $cumulative;
+
+    private readonly int $total;
+
+    public function __construct(string $spec)
+    {
+        $weights = [];
+
+        foreach (explode(',', $spec) as $part) {
+            $part = trim($part);
+
+            if ($part === '') {
+                continue;
+            }
+
+            $weights[] = $this->parsePair($part);
+        }
+
+        if ($weights === []) {
+            throw new InvalidArgumentException('Workload mix spec is empty.');
+        }
+
+        $combined = [];
+        foreach ($weights as [$op, $w]) {
+            $combined[$op] = ($combined[$op] ?? 0) + $w;
+        }
+
+        $ops = [];
+        $cumulative = [];
+        $running = 0;
+
+        foreach ($combined as $op => $w) {
+            $running += $w;
+            $ops[] = $op;
+            $cumulative[] = $running;
+        }
+
+        if ($running <= 0) {
+            throw new InvalidArgumentException('Workload mix weights must sum to a positive value.');
+        }
+
+        $this->weights = $combined;
+        $this->ops = $ops;
+        $this->cumulative = $cumulative;
+        $this->total = $running;
+    }
+
+    public function pick(): string
+    {
+        $roll = mt_rand(1, $this->total);
+
+        foreach ($this->cumulative as $idx => $bound) {
+            if ($roll <= $bound) {
+                return $this->ops[$idx];
+            }
+        }
+
+        return $this->ops[count($this->ops) - 1];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function weights(): array
+    {
+        return $this->weights;
+    }
+
+    public function describe(): string
+    {
+        $parts = [];
+        foreach ($this->weights as $op => $w) {
+            $parts[] = "{$op}={$w}";
+        }
+
+        return implode(', ', $parts);
+    }
+
+    /**
+     * @return array{string, int}
+     */
+    private function parsePair(string $pair): array
+    {
+        $eq = strpos($pair, '=');
+        if ($eq === false) {
+            throw new InvalidArgumentException("Invalid mix entry \"{$pair}\": expected op=weight.");
+        }
+
+        $op = strtolower(trim(substr($pair, 0, $eq)));
+        $weight = (int) trim(substr($pair, $eq + 1));
+
+        if (!in_array($op, self::SUPPORTED_OPS, true)) {
+            throw new InvalidArgumentException(sprintf(
+                'Unsupported op "%s" in mix. Supported: %s.',
+                $op,
+                implode(', ', self::SUPPORTED_OPS)
+            ));
+        }
+        if ($weight <= 0) {
+            throw new InvalidArgumentException("Mix weight for \"{$op}\" must be positive, got {$weight}.");
+        }
+
+        return [$op, $weight];
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Adapter/Lock/FileLockTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Lock/FileLockTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock;
+
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock\FileLock;
+use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
+use PHPUnit\Framework\TestCase;
+
+final class FileLockTest extends TestCase
+{
+    private string $tempFile;
+
+    protected function setUp(): void
+    {
+        $this->tempFile = sys_get_temp_dir() . '/ldap_test_filelock_' . uniqid() . '.dat';
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ([$this->tempFile, $this->tempFile . '.lock'] as $path) {
+            if (file_exists($path)) {
+                unlink($path);
+            }
+        }
+    }
+
+    public function test_reads_empty_string_when_main_file_does_not_exist(): void
+    {
+        $lock = new FileLock($this->tempFile);
+        $observed = null;
+
+        $lock->withLock(function (string $contents) use (&$observed): string {
+            $observed = $contents;
+
+            return 'initial';
+        });
+
+        self::assertSame(
+            '',
+            $observed,
+        );
+    }
+
+    public function test_passes_existing_file_contents_to_mutation(): void
+    {
+        file_put_contents($this->tempFile, 'existing payload');
+        $lock = new FileLock($this->tempFile);
+        $observed = null;
+
+        $lock->withLock(function (string $contents) use (&$observed): string {
+            $observed = $contents;
+
+            return $contents;
+        });
+
+        self::assertSame(
+            'existing payload',
+            $observed,
+        );
+    }
+
+    public function test_publishes_mutation_result_to_main_file(): void
+    {
+        $lock = new FileLock($this->tempFile);
+
+        $lock->withLock(fn (string $_): string => 'first');
+        $lock->withLock(fn (string $contents): string => $contents . '|second');
+
+        self::assertSame(
+            'first|second',
+            file_get_contents($this->tempFile),
+        );
+    }
+
+    public function test_creates_sidecar_lock_file_alongside_main_file(): void
+    {
+        $lock = new FileLock($this->tempFile);
+        $lock->withLock(fn (string $_): string => 'payload');
+
+        self::assertFileExists($this->tempFile . '.lock');
+    }
+
+    public function test_main_file_is_never_left_empty_after_publish(): void
+    {
+        $lock = new FileLock($this->tempFile);
+
+        $lock->withLock(fn (string $_): string => 'v1');
+        self::assertSame(
+            'v1',
+            file_get_contents($this->tempFile),
+        );
+
+        $lock->withLock(fn (string $_): string => 'v2 (larger payload)');
+        self::assertSame(
+            'v2 (larger payload)',
+            file_get_contents($this->tempFile),
+        );
+    }
+
+    public function test_throws_storage_io_exception_when_lock_directory_is_unwritable(): void
+    {
+        $lock = new FileLock('/nonexistent-ldap-test-dir/storage.dat');
+
+        self::expectException(StorageIoException::class);
+
+        set_error_handler(static fn (): bool => true);
+
+        try {
+            $lock->withLock(fn (string $_): string => 'payload');
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    public function test_releases_lock_and_rethrows_when_mutation_throws(): void
+    {
+        file_put_contents($this->tempFile, 'original');
+        $lock = new FileLock($this->tempFile);
+
+        try {
+            $lock->withLock(function (string $_): string {
+                throw new \RuntimeException('mutation failed');
+            });
+            self::fail('Expected exception was not thrown.');
+        } catch (\RuntimeException $e) {
+            self::assertSame(
+                'mutation failed',
+                $e->getMessage(),
+            );
+        }
+
+        self::assertSame(
+            'original',
+            file_get_contents($this->tempFile),
+        );
+
+        $second = new FileLock($this->tempFile);
+        $second->withLock(fn (string $contents): string => $contents . '|recovered');
+
+        self::assertSame(
+            'original|recovered',
+            file_get_contents($this->tempFile),
+        );
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Adapter/MysqlFilterTranslatorTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/MysqlFilterTranslatorTest.php
@@ -112,11 +112,22 @@ final class MysqlFilterTranslatorTest extends TestCase
         );
     }
 
-    public function test_approximate_filter_is_marked_inexact(): void
+    public function test_approximate_filter_with_ascii_value_is_exact(): void
     {
         $result = $this->subject->translate(new ApproximateFilter(
             'cn',
             'Alice',
+        ));
+
+        self::assertNotNull($result);
+        self::assertTrue($result->isExact);
+    }
+
+    public function test_approximate_filter_with_non_ascii_value_is_inexact(): void
+    {
+        $result = $this->subject->translate(new ApproximateFilter(
+            'cn',
+            'Café',
         ));
 
         self::assertNotNull($result);
@@ -165,6 +176,38 @@ final class MysqlFilterTranslatorTest extends TestCase
             ['30'],
             $result->params,
         );
+    }
+
+    public function test_gte_filter_with_digit_value_is_inexact(): void
+    {
+        $result = $this->subject->translate(new GreaterThanOrEqualFilter(
+            'uidNumber',
+            '100',
+        ));
+
+        self::assertNotNull($result);
+        self::assertFalse($result->isExact);
+    }
+
+    public function test_gte_filter_with_ascii_non_digit_value_is_exact(): void
+    {
+        $result = $this->subject->translate(new GreaterThanOrEqualFilter(
+            'sn',
+            'Smith',
+        ));
+
+        self::assertNotNull($result);
+        self::assertTrue($result->isExact);
+    }
+
+    public function test_gte_filter_with_non_ascii_value_is_inexact(): void
+    {
+        $result = $this->subject->translate(new GreaterThanOrEqualFilter(
+            'sn',
+            'Smíth',
+        ));
+
+        self::assertNotNull($result);
         self::assertFalse($result->isExact);
     }
 
@@ -188,6 +231,38 @@ final class MysqlFilterTranslatorTest extends TestCase
             ['50'],
             $result->params,
         );
+    }
+
+    public function test_lte_filter_with_digit_value_is_inexact(): void
+    {
+        $result = $this->subject->translate(new LessThanOrEqualFilter(
+            'uidNumber',
+            '100',
+        ));
+
+        self::assertNotNull($result);
+        self::assertFalse($result->isExact);
+    }
+
+    public function test_lte_filter_with_ascii_non_digit_value_is_exact(): void
+    {
+        $result = $this->subject->translate(new LessThanOrEqualFilter(
+            'sn',
+            'Smith',
+        ));
+
+        self::assertNotNull($result);
+        self::assertTrue($result->isExact);
+    }
+
+    public function test_lte_filter_with_non_ascii_value_is_inexact(): void
+    {
+        $result = $this->subject->translate(new LessThanOrEqualFilter(
+            'sn',
+            'Smíth',
+        ));
+
+        self::assertNotNull($result);
         self::assertFalse($result->isExact);
     }
 

--- a/tests/unit/Server/Backend/Storage/Adapter/SqliteFilterTranslatorTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/SqliteFilterTranslatorTest.php
@@ -98,11 +98,22 @@ final class SqliteFilterTranslatorTest extends TestCase
         );
     }
 
-    public function test_approximate_filter_is_marked_inexact(): void
+    public function test_approximate_filter_with_ascii_value_is_exact(): void
     {
         $result = $this->subject->translate(new ApproximateFilter(
             'cn',
             'Alice',
+        ));
+
+        self::assertNotNull($result);
+        self::assertTrue($result->isExact);
+    }
+
+    public function test_approximate_filter_with_non_ascii_value_is_inexact(): void
+    {
+        $result = $this->subject->translate(new ApproximateFilter(
+            'cn',
+            'Café',
         ));
 
         self::assertNotNull($result);
@@ -158,6 +169,40 @@ final class SqliteFilterTranslatorTest extends TestCase
             ['30'],
             $result->params,
         );
+    }
+
+    public function test_gte_filter_with_digit_value_is_inexact(): void
+    {
+        // Critical: PHP compareOrdered does integer compare when both sides
+        // are ctype_digit, so SQL byte compare would diverge. Must stay inexact.
+        $result = $this->subject->translate(new GreaterThanOrEqualFilter(
+            'uidNumber',
+            '100',
+        ));
+
+        self::assertNotNull($result);
+        self::assertFalse($result->isExact);
+    }
+
+    public function test_gte_filter_with_ascii_non_digit_value_is_exact(): void
+    {
+        $result = $this->subject->translate(new GreaterThanOrEqualFilter(
+            'sn',
+            'Smith',
+        ));
+
+        self::assertNotNull($result);
+        self::assertTrue($result->isExact);
+    }
+
+    public function test_gte_filter_with_non_ascii_value_is_inexact(): void
+    {
+        $result = $this->subject->translate(new GreaterThanOrEqualFilter(
+            'sn',
+            'Smíth',
+        ));
+
+        self::assertNotNull($result);
         self::assertFalse($result->isExact);
     }
 
@@ -177,6 +222,38 @@ final class SqliteFilterTranslatorTest extends TestCase
             ['50'],
             $result->params,
         );
+    }
+
+    public function test_lte_filter_with_digit_value_is_inexact(): void
+    {
+        $result = $this->subject->translate(new LessThanOrEqualFilter(
+            'uidNumber',
+            '100',
+        ));
+
+        self::assertNotNull($result);
+        self::assertFalse($result->isExact);
+    }
+
+    public function test_lte_filter_with_ascii_non_digit_value_is_exact(): void
+    {
+        $result = $this->subject->translate(new LessThanOrEqualFilter(
+            'sn',
+            'Smith',
+        ));
+
+        self::assertNotNull($result);
+        self::assertTrue($result->isExact);
+    }
+
+    public function test_lte_filter_with_non_ascii_value_is_inexact(): void
+    {
+        $result = $this->subject->translate(new LessThanOrEqualFilter(
+            'sn',
+            'Smíth',
+        ));
+
+        self::assertNotNull($result);
         self::assertFalse($result->isExact);
     }
 

--- a/tests/unit/Server/Backend/Storage/Adapter/SqliteStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/SqliteStorageTest.php
@@ -239,17 +239,16 @@ final class SqliteStorageTest extends TestCase
         $mockPdo = $this->createMock(PDO::class);
 
         $beginTransactionCalls = 0;
-        $mockPdo->method('beginTransaction')
-            ->willReturnCallback(static function () use (&$beginTransactionCalls): bool {
-                if (++$beginTransactionCalls === 1) {
-                    throw new RuntimeException('DB connection error');
+        $mockPdo->method('exec')
+            ->willReturnCallback(static function (string $sql) use (&$beginTransactionCalls): int {
+                if ($sql === 'BEGIN IMMEDIATE') {
+                    if (++$beginTransactionCalls === 1) {
+                        throw new RuntimeException('DB connection error');
+                    }
                 }
 
-                return true;
+                return 0;
             });
-
-        $mockPdo->method('inTransaction')->willReturn(false);
-        $mockPdo->method('commit')->willReturn(true);
 
         $storage = new PdoStorage(
             new SharedPdoConnectionProvider($mockPdo),
@@ -257,7 +256,7 @@ final class SqliteStorageTest extends TestCase
             new SqliteDialect(),
         );
 
-        // First call: beginTransaction throws; txDepth must recover to 0.
+        // First call: BEGIN IMMEDIATE throws; txDepth must recover to 0.
         try {
             $storage->atomic(fn() => null);
             self::fail('Expected RuntimeException was not thrown.');
@@ -265,7 +264,7 @@ final class SqliteStorageTest extends TestCase
             self::assertSame('DB connection error', $e->getMessage());
         }
 
-        // Second call: txDepth is 0, so beginTransaction must be called again (not SAVEPOINT).
+        // Second call: txDepth is 0, so BEGIN IMMEDIATE must be issued again (not SAVEPOINT).
         // A corrupted txDepth of 1 would issue SAVEPOINT sp_1 here instead.
         $storage->atomic(fn() => null);
 
@@ -319,27 +318,16 @@ final class SqliteStorageTest extends TestCase
     {
         /** @var PDO&MockObject $mockPdo */
         $mockPdo = $this->createMock(PDO::class);
-        $mockPdo->method('beginTransaction')->willReturn(true);
-        $mockPdo->method('inTransaction')->willReturn(true);
 
         $commitCalls = 0;
         $rollBackCalls = 0;
-        $mockPdo->method('commit')
-            ->willReturnCallback(static function () use (&$commitCalls): bool {
-                $commitCalls++;
-
-                return true;
-            });
-        $mockPdo->method('rollBack')
-            ->willReturnCallback(static function () use (&$rollBackCalls): bool {
-                $rollBackCalls++;
-
-                return true;
-            });
-
         $mockPdo->method('exec')
-            ->willReturnCallback(static function (string $sql): int {
-                if (str_contains($sql, 'SAVEPOINT sp_1') && !str_contains($sql, 'ROLLBACK') && !str_contains($sql, 'RELEASE')) {
+            ->willReturnCallback(static function (string $sql) use (&$commitCalls, &$rollBackCalls): int {
+                if ($sql === 'COMMIT') {
+                    $commitCalls++;
+                } elseif ($sql === 'ROLLBACK') {
+                    $rollBackCalls++;
+                } elseif (str_contains($sql, 'SAVEPOINT sp_1') && !str_contains($sql, 'ROLLBACK') && !str_contains($sql, 'RELEASE')) {
                     throw new RuntimeException('savepoint error');
                 }
 
@@ -376,15 +364,8 @@ final class SqliteStorageTest extends TestCase
     {
         /** @var PDO&MockObject $mockPdo */
         $mockPdo = $this->createMock(PDO::class);
-        $mockPdo->method('beginTransaction')->willReturn(true);
-        $mockPdo->method('inTransaction')->willReturn(true);
-        $mockPdo->method('commit')->willReturn(true);
-        $mockPdo->method('rollBack')->willReturn(true);
-
-        $callCount = 0;
         $mockPdo->method('exec')
-            ->willReturnCallback(static function (string $sql) use (&$callCount): int {
-                $callCount++;
+            ->willReturnCallback(static function (string $sql): int {
                 if (str_contains($sql, 'SAVEPOINT sp_1') && !str_contains($sql, 'ROLLBACK') && !str_contains($sql, 'RELEASE')) {
                     throw new RuntimeException('savepoint error');
                 }
@@ -407,13 +388,13 @@ final class SqliteStorageTest extends TestCase
 
         $commitCalls = 0;
         $mockPdo = $this->createMock(PDO::class);
-        $mockPdo->method('beginTransaction')->willReturn(true);
-        $mockPdo->method('inTransaction')->willReturn(true);
-        $mockPdo->method('commit')
-            ->willReturnCallback(static function () use (&$commitCalls): bool {
-                $commitCalls++;
+        $mockPdo->method('exec')
+            ->willReturnCallback(static function (string $sql) use (&$commitCalls): int {
+                if ($sql === 'COMMIT') {
+                    $commitCalls++;
+                }
 
-                return true;
+                return 0;
             });
 
         $storage = new PdoStorage(

--- a/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
@@ -25,6 +25,7 @@ use FreeDSx\Ldap\Search\Filter\PresentFilter;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
+use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use Generator;
@@ -487,6 +488,94 @@ final class WritableStorageBackendTest extends TestCase
     {
         yield new Entry(new Dn('dc=example,dc=com'));
         throw new TimeLimitExceededException();
+    }
+
+    public function test_add_converts_storage_io_exception_to_unavailable_operation_exception(): void
+    {
+        $ioException = new StorageIoException('Unable to publish the storage update.');
+        /** @var EntryStorageInterface&MockObject $storage */
+        $storage = $this->createMock(EntryStorageInterface::class);
+        $storage->method('atomic')
+            ->willThrowException($ioException);
+
+        $subject = new WritableStorageBackend($storage);
+
+        try {
+            $subject->add(new AddCommand(new Entry(
+                new Dn('cn=New,dc=example,dc=com'),
+                new Attribute('cn', 'New'),
+            )));
+            self::fail('Expected OperationException was not thrown.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::UNAVAILABLE,
+                $e->getCode(),
+            );
+            self::assertSame(
+                'The backend storage is currently unavailable.',
+                $e->getMessage(),
+            );
+            self::assertSame(
+                $ioException,
+                $e->getPrevious(),
+            );
+        }
+    }
+
+    public function test_delete_converts_storage_io_exception_to_unavailable_operation_exception(): void
+    {
+        /** @var EntryStorageInterface&MockObject $storage */
+        $storage = $this->createMock(EntryStorageInterface::class);
+        $storage->method('atomic')
+            ->willThrowException(new StorageIoException('Unable to acquire exclusive lock on the storage backend.'));
+
+        $subject = new WritableStorageBackend($storage);
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::UNAVAILABLE);
+        self::expectExceptionMessage('The backend storage is currently unavailable.');
+
+        $subject->delete(new DeleteCommand(new Dn('cn=Alice,dc=example,dc=com')));
+    }
+
+    public function test_update_converts_storage_io_exception_to_unavailable_operation_exception(): void
+    {
+        /** @var EntryStorageInterface&MockObject $storage */
+        $storage = $this->createMock(EntryStorageInterface::class);
+        $storage->method('atomic')
+            ->willThrowException(new StorageIoException('Unable to stage the storage update.'));
+
+        $subject = new WritableStorageBackend($storage);
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::UNAVAILABLE);
+        self::expectExceptionMessage('The backend storage is currently unavailable.');
+
+        $subject->update(new UpdateCommand(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            [new Change(Change::TYPE_REPLACE, 'cn', 'Alicia')],
+        ));
+    }
+
+    public function test_move_converts_storage_io_exception_to_unavailable_operation_exception(): void
+    {
+        /** @var EntryStorageInterface&MockObject $storage */
+        $storage = $this->createMock(EntryStorageInterface::class);
+        $storage->method('atomic')
+            ->willThrowException(new StorageIoException('Unable to publish the storage update.'));
+
+        $subject = new WritableStorageBackend($storage);
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::UNAVAILABLE);
+        self::expectExceptionMessage('The backend storage is currently unavailable.');
+
+        $subject->move(new MoveCommand(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            Rdn::create('cn=Alicia'),
+            true,
+            null,
+        ));
     }
 
     public function test_supports_returns_false_for_unknown_request(): void

--- a/tests/unit/Server/Backend/Storage/FilterEvaluatorTest.php
+++ b/tests/unit/Server/Backend/Storage/FilterEvaluatorTest.php
@@ -821,10 +821,7 @@ final class FilterEvaluatorTest extends TestCase
     }
 
     /**
-     * Guards against evaluate() stashing compiled state directly on the filter
-     * (e.g. a cached lowerValue property). Such a cache must live outside the
-     * filter — serialize catches any structural mutation, including in nested
-     * children of composite filters.
+     * Guards against evaluate() stashing compiled state on the filter; serialize catches nested composite mutations too.
      */
     public function test_filter_is_not_mutated_by_evaluation(): void
     {

--- a/tests/unit/Server/Backend/Storage/FilterEvaluatorTest.php
+++ b/tests/unit/Server/Backend/Storage/FilterEvaluatorTest.php
@@ -656,4 +656,210 @@ final class FilterEvaluatorTest extends TestCase
             $this->createMock(FilterInterface::class),
         );
     }
+
+    public function test_equality_matches_attribute_with_mixed_case_name_on_entry(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Bob,dc=example,dc=com'),
+            new Attribute('CN', 'Bob'),
+        );
+
+        self::assertTrue($this->subject->evaluate(
+            $entry,
+            Filters::equal('cn', 'Bob'),
+        ));
+    }
+
+    public function test_equality_with_attribute_options_in_filter_matches_same_options_on_entry(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Bob,dc=example,dc=com'),
+            new Attribute('cn;lang-en', 'Hello'),
+            new Attribute('cn;lang-de', 'Hallo'),
+        );
+
+        self::assertTrue($this->subject->evaluate(
+            $entry,
+            Filters::equal('cn;lang-en', 'Hello'),
+        ));
+        self::assertFalse($this->subject->evaluate(
+            $entry,
+            Filters::equal('cn;lang-en', 'Hallo'),
+        ));
+    }
+
+    public function test_equality_with_attribute_options_in_filter_does_not_match_base_only_entry(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Bob,dc=example,dc=com'),
+            new Attribute('cn', 'Hello'),
+        );
+
+        self::assertFalse($this->subject->evaluate(
+            $entry,
+            Filters::equal('cn;lang-en', 'Hello'),
+        ));
+    }
+
+    public function test_equality_filter_without_options_matches_any_option_variant_on_entry(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Bob,dc=example,dc=com'),
+            new Attribute('cn;lang-en', 'Hello'),
+        );
+
+        self::assertTrue($this->subject->evaluate(
+            $entry,
+            Filters::equal('cn', 'Hello'),
+        ));
+    }
+
+    public function test_equality_multi_valued_attribute_matches_second_value(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Multi,dc=example,dc=com'),
+            new Attribute('mailAlias', 'a@foo.bar', 'b@foo.bar', 'c@foo.bar'),
+        );
+
+        self::assertTrue($this->subject->evaluate(
+            $entry,
+            Filters::equal('mailAlias', 'b@foo.bar'),
+        ));
+    }
+
+    public function test_substring_present_absent_and_options_conformance(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Ann,dc=example,dc=com'),
+            new Attribute('cn;lang-en', 'Annabelle'),
+        );
+
+        $filter = (new SubstringFilter('cn'))->setStartsWith('Ann');
+        self::assertTrue($this->subject->evaluate($entry, $filter));
+
+        $filterMiss = (new SubstringFilter('sn'))->setStartsWith('Ann');
+        self::assertFalse($this->subject->evaluate($entry, $filterMiss));
+    }
+
+    public function test_gte_undefined_when_attribute_absent(): void
+    {
+        self::assertFalse($this->subject->evaluate(
+            $this->entry,
+            Filters::greaterThanOrEqual('employeeNumber', '1'),
+        ));
+    }
+
+    public function test_lte_undefined_when_attribute_absent(): void
+    {
+        self::assertFalse($this->subject->evaluate(
+            $this->entry,
+            Filters::lessThanOrEqual('employeeNumber', '1'),
+        ));
+    }
+
+    public function test_approximate_undefined_when_attribute_absent(): void
+    {
+        self::assertFalse($this->subject->evaluate(
+            $this->entry,
+            new ApproximateFilter('employeeNumber', '1'),
+        ));
+    }
+
+    public function test_same_filter_against_many_entries_produces_consistent_results(): void
+    {
+        $filter = Filters::equal('cn', 'Alice');
+
+        $matching = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('cn', 'Alice'),
+        );
+        $nonMatching = new Entry(
+            new Dn('cn=Bob,dc=example,dc=com'),
+            new Attribute('cn', 'Bob'),
+        );
+
+        for ($i = 0; $i < 50; $i++) {
+            self::assertTrue($this->subject->evaluate($matching, $filter));
+            self::assertFalse($this->subject->evaluate($nonMatching, $filter));
+        }
+    }
+
+    public function test_same_substring_filter_against_many_entries_is_stable(): void
+    {
+        $filter = (new SubstringFilter('mail'))
+            ->setStartsWith('alice')
+            ->setContains('example')
+            ->setEndsWith('com');
+
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('mail', 'alice@example.com'),
+        );
+
+        for ($i = 0; $i < 25; $i++) {
+            self::assertTrue($this->subject->evaluate($entry, $filter));
+        }
+    }
+
+    public function test_same_gte_filter_against_digit_and_non_digit_entries_is_stable(): void
+    {
+        $filter = Filters::greaterThanOrEqual('uidNumber', '100');
+
+        $digitMatches = new Entry(
+            new Dn('cn=One,dc=example,dc=com'),
+            new Attribute('uidNumber', '500'),
+        );
+        $digitMisses = new Entry(
+            new Dn('cn=Two,dc=example,dc=com'),
+            new Attribute('uidNumber', '99'),
+        );
+
+        for ($i = 0; $i < 25; $i++) {
+            self::assertTrue($this->subject->evaluate($digitMatches, $filter));
+            self::assertFalse($this->subject->evaluate($digitMisses, $filter));
+        }
+    }
+
+    /**
+     * Guards against evaluate() stashing compiled state directly on the filter
+     * (e.g. a cached lowerValue property). Such a cache must live outside the
+     * filter — serialize catches any structural mutation, including in nested
+     * children of composite filters.
+     */
+    public function test_filter_is_not_mutated_by_evaluation(): void
+    {
+        $filter = Filters::and(
+            Filters::equal('cn', 'Alice'),
+            Filters::or(
+                Filters::equal('sn', 'Smith'),
+                Filters::greaterThanOrEqual('uidNumber', '100'),
+            ),
+        );
+        $snapshot = serialize($filter);
+
+        $this->subject->evaluate($this->entry, $filter);
+        $this->subject->evaluate($this->entry, $filter);
+
+        self::assertSame(
+            $snapshot,
+            serialize($filter),
+        );
+    }
+
+    public function test_substring_filter_is_not_mutated_by_evaluation(): void
+    {
+        $filter = (new SubstringFilter('mail'))
+            ->setStartsWith('alice')
+            ->setContains('example')
+            ->setEndsWith('com');
+        $snapshot = serialize($filter);
+
+        $this->subject->evaluate($this->entry, $filter);
+        $this->subject->evaluate($this->entry, $filter);
+
+        self::assertSame(
+            $snapshot,
+            serialize($filter),
+        );
+    }
 }


### PR DESCRIPTION
This PR is a follow-up to all the work needed to implement storage adapters for the backend. It is focused on a few different areas:

1. Many optimizations needed in various spots (sql filters, RDN handling, lower-case cache maps in various spots).
2. Fixes SQLite transaction handling, which was an issue only surfaced when I went to load test how the server handled many concurrent connections.
3. Fixes PCNTL concurrent traffic handling. This silently broke ages ago when I implemented child process clean up. This was also surfaced by the load testing script I'm adding here.
4. Fixing MySQL storage when used with PCNTL. Forking borks the resource. So we need a way to reset it.
5. Fixing JSON storage with concurrent reads + writes. Load testing revealed a flaw in the atomic nature of the writes on both Wwoole and PCNTL.

I really need a way to have these concurrent load tests baked into CI to prevent regressions like this. So I think I will try to focus on that next. One of these issues isn't even something that was introduced with this backend / storage work.

However, with these changes I can verify that MySQL / SQLite / memory / JSON backends all function as expected under concurrent load.