### PR TITLE
[1.0.0] Add a load testing workflow to CI for the server.

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,0 +1,154 @@
+name: Load Test
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/performance/**'
+      - 'tests/bin/ldap-*.php'
+      - 'composer.json'
+      - 'composer.lock'
+      - '.github/workflows/load-test.yml'
+  push:
+    branches: [master, '1.0']
+  workflow_dispatch:
+
+concurrency:
+  group: load-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  load-test:
+    runs-on: ubuntu-latest
+    name: ${{ matrix.backend }} + ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { backend: memory, runner: swoole, profile: 'memory:swoole' }
+          - { backend: json,   runner: pcntl,  profile: 'json:pcntl' }
+          - { backend: json,   runner: swoole, profile: 'json:swoole' }
+          - { backend: sqlite, runner: pcntl,  profile: 'sqlite:pcntl' }
+          - { backend: sqlite, runner: swoole, profile: 'sqlite:swoole' }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup extension cache environment
+        id: extcache
+        uses: shivammathur/cache-extensions@v1
+        with:
+          php-version: '8.5'
+          extensions: swoole, pdo_sqlite, pcntl
+          key: load-test-ext-v1
+
+      - name: Cache extensions
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.extcache.outputs.dir }}
+          key: ${{ steps.extcache.outputs.key }}
+          restore-keys: ${{ steps.extcache.outputs.key }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: swoole, pdo_sqlite, pcntl
+          coverage: none
+          tools: composer:2.9
+
+      - name: Install Composer dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Run load test
+        run: |
+          php tests/bin/ldap-load-test.php \
+            --backend=${{ matrix.backend }} \
+            --runner=${{ matrix.runner }} \
+            --ci-profile=${{ matrix.profile }} \
+            --duration=15 --warmup=3 --clients=16 --rng-seed=1 \
+            --output=json \
+            --threshold-report=threshold-${{ matrix.backend }}-${{ matrix.runner }}.json \
+            > raw-${{ matrix.backend }}-${{ matrix.runner }}.json
+
+      - name: Upload load-test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: load-test-${{ matrix.backend }}-${{ matrix.runner }}
+          path: |
+            raw-*.json
+            threshold-*.json
+
+  load-test-mysql:
+    runs-on: ubuntu-latest
+    name: mysql + ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [pcntl, swoole]
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: freedsx
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -proot"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup extension cache environment
+        id: extcache
+        uses: shivammathur/cache-extensions@v1
+        with:
+          php-version: '8.5'
+          extensions: swoole, pdo_mysql, pcntl
+          key: load-test-mysql-ext-v1
+
+      - name: Cache extensions
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.extcache.outputs.dir }}
+          key: ${{ steps.extcache.outputs.key }}
+          restore-keys: ${{ steps.extcache.outputs.key }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          extensions: swoole, pdo_mysql, pcntl
+          coverage: none
+          tools: composer:2.9
+
+      - name: Install Composer dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Run load test
+        env:
+          MYSQL_DSN: 'mysql:host=127.0.0.1;port=3306;dbname=freedsx'
+          MYSQL_USER: root
+          MYSQL_PASSWORD: root
+        run: |
+          php tests/bin/ldap-load-test.php \
+            --backend=mysql \
+            --runner=${{ matrix.runner }} \
+            --ci-profile=mysql:${{ matrix.runner }} \
+            --duration=15 --warmup=3 --clients=16 --rng-seed=1 \
+            --output=json \
+            --threshold-report=threshold-mysql-${{ matrix.runner }}.json \
+            > raw-mysql-${{ matrix.runner }}.json
+
+      - name: Upload load-test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: load-test-mysql-${{ matrix.runner }}
+          path: |
+            raw-*.json
+            threshold-*.json

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
   "autoload-dev": {
     "psr-4": {
       "Tests\\Integration\\FreeDSx\\Ldap\\": "tests/integration",
-      "Tests\\Unit\\FreeDSx\\Ldap\\": "tests/unit"
+      "Tests\\Unit\\FreeDSx\\Ldap\\": "tests/unit",
+      "Tests\\Performance\\FreeDSx\\Ldap\\": "tests/performance"
     }
   },
   "config": {
@@ -69,6 +70,7 @@
       "docker compose -f tests/resources/openldap/docker-compose.yml up -d --build --wait",
       "@test-integration"
     ],
+    "test-load": "php tests/bin/ldap-load-test.php --backend=sqlite --runner=swoole --duration=10 --warmup=2 --clients=8 --output=text",
     "analyse": [
       "phpstan --memory-limit=-1 analyse"
     ],

--- a/tests/bin/ldap-load-test.php
+++ b/tests/bin/ldap-load-test.php
@@ -11,22 +11,15 @@ declare(strict_types=1);
  */
 
 use Symfony\Component\Console\Application;
-use Tests\Performance\FreeDSx\Ldap\LoadTest\LoadTestCommand;
+use Tests\Performance\FreeDSx\Ldap\LoadTestCommand;
 
 require __DIR__ . '/../../vendor/autoload.php';
-
-require_once __DIR__ . '/../performance/Config.php';
-require_once __DIR__ . '/../performance/WorkloadMix.php';
-require_once __DIR__ . '/../performance/StatsCollector.php';
-require_once __DIR__ . '/../performance/StatsSnapshot.php';
-require_once __DIR__ . '/../performance/ServerManager.php';
-require_once __DIR__ . '/../performance/Worker.php';
-require_once __DIR__ . '/../performance/Report.php';
-require_once __DIR__ . '/../performance/Driver.php';
-require_once __DIR__ . '/../performance/LoadTestCommand.php';
 
 $command = new LoadTestCommand();
 $application = new Application('FreeDSx LDAP load test');
 $application->add($command);
-$application->setDefaultCommand((string) $command->getName(), true);
+$application->setDefaultCommand(
+    (string) $command->getName(),
+    true,
+);
 $application->run();

--- a/tests/performance/Config.php
+++ b/tests/performance/Config.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+namespace Tests\Performance\FreeDSx\Ldap;
 
 use InvalidArgumentException;
 
@@ -67,7 +67,7 @@ final class Config
         public readonly int $port = 10389,
         public readonly int $warmup = 2,
         public readonly string $serverMode = 'spawn',
-        public readonly ?int $seed = null,
+        public readonly ?int $rngSeed = null,
         public readonly string $output = 'text',
         public readonly int $seedEntries = 100,
     ) {

--- a/tests/performance/Driver.php
+++ b/tests/performance/Driver.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+namespace Tests\Performance\FreeDSx\Ldap;
 
 use RuntimeException;
 use Swoole\Coroutine;
@@ -20,6 +20,11 @@ use Swoole\Coroutine\WaitGroup;
 use Swoole\Runtime;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Tests\Performance\FreeDSx\Ldap\Server\ServerManager;
+use Tests\Performance\FreeDSx\Ldap\Stats\StatsCollector;
+use Tests\Performance\FreeDSx\Ldap\Stats\StatsSnapshot;
+use Tests\Performance\FreeDSx\Ldap\Workload\Worker;
+use Tests\Performance\FreeDSx\Ldap\Workload\WorkloadMix;
 use Throwable;
 
 /**
@@ -33,12 +38,12 @@ final class Driver
     ) {
     }
 
-    public function run(OutputInterface $output): void
+    public function run(OutputInterface $output): StatsSnapshot
     {
         $this->assertSwooleAvailable();
 
-        if ($this->config->seed !== null) {
-            mt_srand($this->config->seed);
+        if ($this->config->rngSeed !== null) {
+            mt_srand($this->config->rngSeed);
         }
 
         $progress = $this->progressChannel($output);
@@ -63,12 +68,13 @@ final class Driver
         $progress->writeln($this->describeRunStart());
 
         try {
-            $snapshot = $this->runCoroutinePool($mix, $stats);
+            return $this->runCoroutinePool(
+                $mix,
+                $stats,
+            );
         } finally {
             $serverManager?->stop();
         }
-
-        (new Report($this->config, $mix, $snapshot))->render($output);
     }
 
     private function progressChannel(OutputInterface $output): OutputInterface

--- a/tests/performance/LoadTestCommand.php
+++ b/tests/performance/LoadTestCommand.php
@@ -11,13 +11,19 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+namespace Tests\Performance\FreeDSx\Ldap;
 
 use InvalidArgumentException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Tests\Performance\FreeDSx\Ldap\Report\Report;
+use Tests\Performance\FreeDSx\Ldap\Threshold\CiThresholds;
+use Tests\Performance\FreeDSx\Ldap\Threshold\ThresholdEvaluator;
+use Tests\Performance\FreeDSx\Ldap\Threshold\ThresholdResult;
+use Tests\Performance\FreeDSx\Ldap\Threshold\ThresholdSet;
+use Tests\Performance\FreeDSx\Ldap\Workload\WorkloadMix;
 use Throwable;
 
 /**
@@ -99,7 +105,7 @@ final class LoadTestCommand extends Command
                 'spawn',
             )
             ->addOption(
-                'seed',
+                'rng-seed',
                 null,
                 InputOption::VALUE_REQUIRED,
                 'RNG seed for reproducible workloads',
@@ -117,6 +123,42 @@ final class LoadTestCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Extra fixture entries to pre-seed under ou=people before the run',
                 '100',
+            )
+            ->addOption(
+                'ci-profile',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Apply built-in CI thresholds for combo: ' . implode(' | ', CiThresholds::KNOWN_PROFILES),
+            )
+            ->addOption(
+                'max-error-rate',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Fail if error rate exceeds this fraction (e.g. 0.001 = 0.1%); overrides --ci-profile',
+            )
+            ->addOption(
+                'max-errors',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Fail if total errors exceed this count; overrides --ci-profile',
+            )
+            ->addOption(
+                'min-throughput',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Fail if overall ops/sec falls below this floor; overrides --ci-profile',
+            )
+            ->addOption(
+                'max-p99-ms',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Fail if any op\'s p99 latency exceeds this ceiling (ms); overrides --ci-profile',
+            )
+            ->addOption(
+                'threshold-report',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Path to write per-gate pass/fail JSON report (for CI artifact upload)',
             );
     }
 
@@ -126,6 +168,7 @@ final class LoadTestCommand extends Command
     ): int {
         try {
             $config = $this->buildConfig($input);
+            $thresholds = $this->buildThresholds($input);
         } catch (InvalidArgumentException $e) {
             $output->writeln('<error>Configuration error: ' . $e->getMessage() . '</error>');
 
@@ -133,14 +176,40 @@ final class LoadTestCommand extends Command
         }
 
         try {
-            (new Driver($config))->run($output);
+            $snapshot = (new Driver($config))->run($output);
         } catch (Throwable $e) {
             $output->writeln('<error>Load test failed: ' . $e->getMessage() . '</error>');
 
             return Command::FAILURE;
         }
 
-        return Command::SUCCESS;
+        $mix = new WorkloadMix($config->mix);
+        (new Report($config, $mix, $snapshot))->render($output);
+
+        if ($thresholds->isEmpty()) {
+            return Command::SUCCESS;
+        }
+
+        $result = (new ThresholdEvaluator())->evaluate($snapshot, $thresholds);
+
+        $reportPath = $input->getOption('threshold-report');
+        if (is_string($reportPath) && $reportPath !== '') {
+            $this->writeThresholdReport(
+                $reportPath,
+                $result,
+            );
+        }
+
+        if ($result->passed) {
+            return Command::SUCCESS;
+        }
+
+        $this->renderThresholdFailure(
+            $output,
+            $result,
+        );
+
+        return Command::FAILURE;
     }
 
     private function buildConfig(InputInterface $input): Config
@@ -171,7 +240,7 @@ final class LoadTestCommand extends Command
             port: $this->requireInt($input, 'port'),
             warmup: $this->requireInt($input, 'warmup'),
             serverMode: $this->requireString($input, 'server'),
-            seed: $this->parseInt($input->getOption('seed'), 'seed'),
+            rngSeed: $this->parseInt($input->getOption('rng-seed'), 'rng-seed'),
             output: $this->requireString($input, 'output'),
             seedEntries: $this->requireInt($input, 'seed-entries'),
         );
@@ -214,5 +283,71 @@ final class LoadTestCommand extends Command
         }
 
         return (int) $value;
+    }
+
+    private function parseFloat(mixed $value, string $name): ?float
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_string($value) || !preg_match('/^-?\d+(\.\d+)?$/', $value)) {
+            $display = is_scalar($value)
+                ? (string) $value
+                : get_debug_type($value);
+
+            throw new InvalidArgumentException("--{$name} must be a number, got \"{$display}\".");
+        }
+
+        return (float) $value;
+    }
+
+    private function buildThresholds(InputInterface $input): ThresholdSet
+    {
+        $profile = $input->getOption('ci-profile');
+        $base = is_string($profile) && $profile !== ''
+            ? CiThresholds::forProfile($profile)
+            : new ThresholdSet();
+
+        $overrides = new ThresholdSet(
+            maxErrorRate: $this->parseFloat($input->getOption('max-error-rate'), 'max-error-rate'),
+            maxErrors: $this->parseInt($input->getOption('max-errors'), 'max-errors'),
+            minThroughput: $this->parseFloat($input->getOption('min-throughput'), 'min-throughput'),
+            maxP99Ms: $this->parseFloat($input->getOption('max-p99-ms'), 'max-p99-ms'),
+        );
+
+        return $base->withOverrides($overrides);
+    }
+
+    private function writeThresholdReport(
+        string $path,
+        ThresholdResult $result,
+    ): void {
+        $payload = [
+            'passed' => $result->passed,
+            'gates' => $result->gates,
+        ];
+
+        file_put_contents(
+            $path,
+            json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR),
+        );
+    }
+
+    private function renderThresholdFailure(
+        OutputInterface $output,
+        ThresholdResult $result,
+    ): void {
+        $output->writeln('');
+        $output->writeln('<error>Threshold check failed:</error>');
+
+        foreach ($result->failedGates() as $gate) {
+            $output->writeln(sprintf(
+                '  - %s: expected %s, got %s',
+                $gate['gate'],
+                $gate['expected'],
+                $gate['actual'],
+            ));
+        }
     }
 }

--- a/tests/performance/Report/Report.php
+++ b/tests/performance/Report/Report.php
@@ -11,10 +11,13 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+namespace Tests\Performance\FreeDSx\Ldap\Report;
 
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\OutputInterface;
+use Tests\Performance\FreeDSx\Ldap\Config;
+use Tests\Performance\FreeDSx\Ldap\Stats\StatsSnapshot;
+use Tests\Performance\FreeDSx\Ldap\Workload\WorkloadMix;
 
 /**
  * Formats a StatsSnapshot as either a human-readable table or machine-readable JSON.

--- a/tests/performance/Server/ServerManager.php
+++ b/tests/performance/Server/ServerManager.php
@@ -11,10 +11,11 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+namespace Tests\Performance\FreeDSx\Ldap\Server;
 
 use RuntimeException;
 use Symfony\Component\Process\Process;
+use Tests\Performance\FreeDSx\Ldap\Config;
 
 /**
  * Spawns ldap-backend-storage.php, waits for the readiness marker, and stops it on destruction.
@@ -25,7 +26,7 @@ final class ServerManager
 
     private const POLL_INTERVAL_US = 15_000;
 
-    private const BOOTSTRAP_PATH = __DIR__ . '/../bin/ldap-backend-storage.php';
+    private const BOOTSTRAP_PATH = __DIR__ . '/../../bin/ldap-backend-storage.php';
 
     private ?Process $process = null;
 

--- a/tests/performance/Stats/StatsCollector.php
+++ b/tests/performance/Stats/StatsCollector.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+namespace Tests\Performance\FreeDSx\Ldap\Stats;
 
 /**
  * Accumulates per-op latency samples and error counts while recording is enabled.

--- a/tests/performance/Stats/StatsSnapshot.php
+++ b/tests/performance/Stats/StatsSnapshot.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+namespace Tests\Performance\FreeDSx\Ldap\Stats;
 
 /**
  * Frozen result of a load run.

--- a/tests/performance/Threshold/CiThresholds.php
+++ b/tests/performance/Threshold/CiThresholds.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\Threshold;
+
+use InvalidArgumentException;
+
+/**
+ * Built-in CI threshold defaults for each (backend, runner) profile.
+ */
+final class CiThresholds
+{
+    /**
+     * @var list<string>
+     */
+    public const KNOWN_PROFILES = [
+        'memory:swoole',
+        'json:pcntl',
+        'json:swoole',
+        'sqlite:pcntl',
+        'sqlite:swoole',
+        'mysql:pcntl',
+        'mysql:swoole',
+    ];
+
+    public static function forProfile(string $key): ThresholdSet
+    {
+        return match ($key) {
+            'memory:swoole' => new ThresholdSet(
+                maxErrors: 0,
+                minThroughput: 400.0,
+                maxP99Ms: 200.0,
+            ),
+            'json:pcntl' => new ThresholdSet(
+                maxErrors: 0,
+                minThroughput: 100.0,
+                maxP99Ms: 800.0,
+            ),
+            'json:swoole' => new ThresholdSet(
+                maxErrors: 0,
+                minThroughput: 200.0,
+                maxP99Ms: 500.0,
+            ),
+            'sqlite:pcntl' => new ThresholdSet(
+                maxErrors: 0,
+                minThroughput: 100.0,
+                maxP99Ms: 800.0,
+            ),
+            'sqlite:swoole' => new ThresholdSet(
+                maxErrors: 0,
+                minThroughput: 200.0,
+                maxP99Ms: 500.0,
+            ),
+            'mysql:pcntl' => new ThresholdSet(
+                maxErrors: 0,
+                minThroughput: 50.0,
+                maxP99Ms: 1500.0,
+            ),
+            'mysql:swoole' => new ThresholdSet(
+                maxErrors: 0,
+                minThroughput: 100.0,
+                maxP99Ms: 1000.0,
+            ),
+            default => throw new InvalidArgumentException(sprintf(
+                'Unknown CI profile "%s". Known: %s.',
+                $key,
+                implode(', ', self::KNOWN_PROFILES),
+            )),
+        };
+    }
+}

--- a/tests/performance/Threshold/ThresholdEvaluator.php
+++ b/tests/performance/Threshold/ThresholdEvaluator.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\Threshold;
+
+use Tests\Performance\FreeDSx\Ldap\Stats\StatsSnapshot;
+
+/**
+ * Compares a StatsSnapshot against a ThresholdSet and reports pass/fail per gate.
+ */
+final class ThresholdEvaluator
+{
+    public function evaluate(
+        StatsSnapshot $snapshot,
+        ThresholdSet $thresholds,
+    ): ThresholdResult {
+        $gates = [];
+
+        if ($thresholds->maxErrors !== null) {
+            $gates[] = $this->evaluateMaxErrors(
+                $snapshot,
+                $thresholds->maxErrors,
+            );
+        }
+
+        if ($thresholds->maxErrorRate !== null) {
+            $gates[] = $this->evaluateMaxErrorRate(
+                $snapshot,
+                $thresholds->maxErrorRate,
+            );
+        }
+
+        if ($thresholds->minThroughput !== null) {
+            $gates[] = $this->evaluateMinThroughput(
+                $snapshot,
+                $thresholds->minThroughput,
+            );
+        }
+
+        if ($thresholds->maxP99Ms !== null) {
+            $gates[] = $this->evaluateMaxP99(
+                $snapshot,
+                $thresholds->maxP99Ms,
+            );
+        }
+
+        $passed = true;
+        foreach ($gates as $gate) {
+            if ($gate['passed']) {
+                continue;
+            }
+
+            $passed = false;
+            break;
+        }
+
+        return new ThresholdResult($passed, $gates);
+    }
+
+    /**
+     * @return array{gate: string, passed: bool, expected: string, actual: string}
+     */
+    private function evaluateMaxErrors(
+        StatsSnapshot $snapshot,
+        int $maxErrors,
+    ): array {
+        $errors = $snapshot->totalErrors();
+
+        return [
+            'gate' => 'max-errors',
+            'passed' => $errors <= $maxErrors,
+            'expected' => sprintf('<= %d', $maxErrors),
+            'actual' => (string) $errors,
+        ];
+    }
+
+    /**
+     * @return array{gate: string, passed: bool, expected: string, actual: string}
+     */
+    private function evaluateMaxErrorRate(
+        StatsSnapshot $snapshot,
+        float $maxRate,
+    ): array {
+        $attempts = $snapshot->totalSuccess() + $snapshot->totalErrors();
+        $rate = $attempts > 0
+            ? $snapshot->totalErrors() / $attempts
+            : 0.0;
+
+        return [
+            'gate' => 'max-error-rate',
+            'passed' => $rate <= $maxRate,
+            'expected' => sprintf('<= %.6f', $maxRate),
+            'actual' => sprintf('%.6f', $rate),
+        ];
+    }
+
+    /**
+     * @return array{gate: string, passed: bool, expected: string, actual: string}
+     */
+    private function evaluateMinThroughput(
+        StatsSnapshot $snapshot,
+        float $minOps,
+    ): array {
+        $tput = $snapshot->overallThroughput();
+
+        return [
+            'gate' => 'min-throughput',
+            'passed' => $tput >= $minOps,
+            'expected' => sprintf('>= %.2f ops/s', $minOps),
+            'actual' => sprintf('%.2f ops/s', $tput),
+        ];
+    }
+
+    /**
+     * @return array{gate: string, passed: bool, expected: string, actual: string}
+     */
+    private function evaluateMaxP99(
+        StatsSnapshot $snapshot,
+        float $maxMs,
+    ): array {
+        $worstOp = null;
+        $worstP99Ns = 0;
+
+        foreach ($snapshot->operations() as $op) {
+            $p99 = $snapshot->latencyStats($op)['p99'];
+
+            if ($p99 <= $worstP99Ns) {
+                continue;
+            }
+
+            $worstP99Ns = $p99;
+            $worstOp = $op;
+        }
+
+        $worstP99Ms = $worstP99Ns / 1_000_000;
+
+        return [
+            'gate' => 'max-p99-ms',
+            'passed' => $worstP99Ms <= $maxMs,
+            'expected' => sprintf('<= %.2f ms', $maxMs),
+            'actual' => $worstOp !== null
+                ? sprintf('%.2f ms (%s)', $worstP99Ms, $worstOp)
+                : 'no data',
+        ];
+    }
+}

--- a/tests/performance/Threshold/ThresholdResult.php
+++ b/tests/performance/Threshold/ThresholdResult.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\Threshold;
+
+/**
+ * Outcome of evaluating a StatsSnapshot against a ThresholdSet.
+ */
+final class ThresholdResult
+{
+    /**
+     * @param list<array{gate: string, passed: bool, expected: string, actual: string}> $gates
+     */
+    public function __construct(
+        public readonly bool $passed,
+        public readonly array $gates,
+    ) {
+    }
+
+    /**
+     * @return list<array{gate: string, expected: string, actual: string}>
+     */
+    public function failedGates(): array
+    {
+        $failed = [];
+
+        foreach ($this->gates as $gate) {
+            if ($gate['passed']) {
+                continue;
+            }
+
+            $failed[] = [
+                'gate' => $gate['gate'],
+                'expected' => $gate['expected'],
+                'actual' => $gate['actual'],
+            ];
+        }
+
+        return $failed;
+    }
+}

--- a/tests/performance/Threshold/ThresholdSet.php
+++ b/tests/performance/Threshold/ThresholdSet.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\Threshold;
+
+/**
+ * CI gating thresholds for a load-test run. Null members mean "no gate."
+ */
+final class ThresholdSet
+{
+    public function __construct(
+        public readonly ?float $maxErrorRate = null,
+        public readonly ?int $maxErrors = null,
+        public readonly ?float $minThroughput = null,
+        public readonly ?float $maxP99Ms = null,
+    ) {
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->maxErrorRate === null
+            && $this->maxErrors === null
+            && $this->minThroughput === null
+            && $this->maxP99Ms === null;
+    }
+
+    /**
+     * Returns a new set where any non-null field on $overrides replaces this set's value.
+     */
+    public function withOverrides(self $overrides): self
+    {
+        return new self(
+            maxErrorRate: $overrides->maxErrorRate ?? $this->maxErrorRate,
+            maxErrors: $overrides->maxErrors ?? $this->maxErrors,
+            minThroughput: $overrides->minThroughput ?? $this->minThroughput,
+            maxP99Ms: $overrides->maxP99Ms ?? $this->maxP99Ms,
+        );
+    }
+}

--- a/tests/performance/Workload/Worker.php
+++ b/tests/performance/Workload/Worker.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+namespace Tests\Performance\FreeDSx\Ldap\Workload;
 
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Entry\Attribute;
@@ -23,6 +23,8 @@ use FreeDSx\Ldap\Search\Filter\FilterInterface;
 use FreeDSx\Ldap\Search\Filters;
 use LogicException;
 use Swoole\Coroutine\Channel;
+use Tests\Performance\FreeDSx\Ldap\Config;
+use Tests\Performance\FreeDSx\Ldap\Stats\StatsCollector;
 use Throwable;
 
 /**

--- a/tests/performance/Workload/WorkloadMix.php
+++ b/tests/performance/Workload/WorkloadMix.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Performance\FreeDSx\Ldap\LoadTest;
+namespace Tests\Performance\FreeDSx\Ldap\Workload;
 
 use InvalidArgumentException;
 


### PR DESCRIPTION
This adds a load testing workflow that covers each combo of runner + storage adapter. This will help catch regressions / bugs that are not easily caught by unit and integration tests along, as the server can just react different with concurrent connections / reads / writes.