### PR TITLE
[1.0.0] Storage adapter imports + Naming Context Operations

### DIFF
--- a/docs/Server/General-Usage.md
+++ b/docs/Server/General-Usage.md
@@ -603,6 +603,38 @@ final class PostgresStorage implements PdoStorageFactoryInterface
 }
 ```
 
+#### Seeding Initial Entries
+
+`LdapImporter` writes a batch of entries in one atomic transaction. Use it to populate a persistent storage backend
+before `$server->run()`. The same pattern works for every adapter.
+
+```php
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqliteStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
+
+$storage = SqliteStorage::forPcntl('/var/lib/myapp/ldap.sqlite');
+
+(new LdapImporter($storage))->importEntries([
+    new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example')),
+    new Entry(
+        new Dn('cn=admin,dc=example,dc=com'),
+        new Attribute('cn', 'admin'),
+    ),
+]);
+
+(new LdapServer())->useStorage($storage)->run();
+```
+
+`importEntries()` is an upsert: existing entries at the same DN are replaced. Re-running is safe, but any changes made
+between imports are overwritten — guard the call yourself if you only want to seed on first run.
+
+For Swoole factories (`::forSwoole()`), wrap the `importEntries()` call in `Swoole\Coroutine\run()` so the adapter's
+coroutine-scoped connection is available during import.
+
 ### Proxy Backend
 
 `ProxyBackend` implements `WritableLdapBackendInterface` by forwarding all operations to an upstream LDAP server.

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -72,7 +72,10 @@ class LdapServer
      */
     public function useStorage(EntryStorageInterface $storage): self
     {
-        return $this->useBackend(new WritableStorageBackend($storage));
+        return $this->useBackend(new WritableStorageBackend(
+            storage: $storage,
+            namingContexts: $this->options->getDseNamingContexts(),
+        ));
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/LdapImporter.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/LdapImporter.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+
+/**
+ * Bulk-imports entries into an EntryStorageInterface under a single atomic write.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class LdapImporter
+{
+    public function __construct(
+        private readonly EntryStorageInterface $storage,
+    ) {
+    }
+
+    /**
+     * Persist all entries in one atomic batch; no-op when the list is empty.
+     *
+     * @param Entry[] $entries
+     * @param bool $ignoreValidation when true, skips basic validation. only do this if you know what you're doing.
+     * @throws InvalidArgumentException when a non-top-level entry's parent is not present in storage yet
+     */
+    public function importEntries(
+        array $entries,
+        bool $ignoreValidation = false,
+    ): void {
+        if ($entries === []) {
+            return;
+        }
+
+        if (!$ignoreValidation) {
+            $entries = $this->sortByDepth($entries);
+        }
+
+        $this->storage->atomic(function (EntryStorageInterface $storage) use ($entries, $ignoreValidation): void {
+            foreach ($entries as $entry) {
+                if (!$ignoreValidation) {
+                    $this->assertParentExists($storage, $entry->getDn());
+                }
+
+                $storage->store($entry);
+            }
+        });
+    }
+
+    /**
+     * @param Entry[] $entries
+     * @return Entry[]
+     */
+    private function sortByDepth(array $entries): array
+    {
+        usort(
+            $entries,
+            static fn (Entry $a, Entry $b): int => $a->getDn()->count() <=> $b->getDn()->count(),
+        );
+
+        return $entries;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    private function assertParentExists(
+        EntryStorageInterface $storage,
+        Dn $dn,
+    ): void {
+        $parent = $dn->normalize()->getParent();
+
+        if ($parent === null || $parent->getParent() === null) {
+            return;
+        }
+
+        if ($storage->exists($parent)) {
+            return;
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Parent entry "%s" does not exist for "%s".',
+            $parent->toString(),
+            $dn->toString(),
+        ));
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -43,10 +43,24 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
 {
     use WritableBackendTrait;
 
+    /**
+     * @var array<string, true> normalised DN strings of protected naming contexts.
+     */
+    private readonly array $namingContexts;
+
+    /**
+     * @param string[] $namingContexts DN strings that may not be deleted.
+     */
     public function __construct(
         private readonly EntryStorageInterface $storage,
         private readonly WriteEntryOperationHandler $entryHandler = new WriteEntryOperationHandler(),
+        array $namingContexts = [],
     ) {
+        $normalised = [];
+        foreach ($namingContexts as $namingContext) {
+            $normalised[(new Dn($namingContext))->normalize()->toString()] = true;
+        }
+        $this->namingContexts = $normalised;
     }
 
     public function reset(): void
@@ -189,6 +203,8 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
      */
     public function delete(DeleteCommand $command): void
     {
+        $this->assertNotNamingContext($command->dn);
+
         $this->writeAtomic(function (EntryStorageInterface $storage) use ($command): void {
             $dn = $command->dn->normalize();
             $this->findOrFail($storage, $dn);
@@ -227,6 +243,8 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
      */
     public function move(MoveCommand $command): void
     {
+        $this->assertNotNamingContext($command->dn);
+
         $this->writeAtomic(function (EntryStorageInterface $storage) use ($command): void {
             $normOld = $command->dn->normalize();
             $entry = $this->findOrFail($storage, $normOld);
@@ -323,6 +341,24 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         if ($normNewParent->getParent() !== null && !$storage->exists($normNewParent)) {
             $this->throwNoSuchObject($command->newParent);
         }
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function assertNotNamingContext(Dn $dn): void
+    {
+        if (!isset($this->namingContexts[$dn->normalize()->toString()])) {
+            return;
+        }
+
+        throw new OperationException(
+            sprintf(
+                'Entry "%s" is a naming context and cannot be deleted or renamed.',
+                $dn->toString()
+            ),
+            ResultCode::UNWILLING_TO_PERFORM,
+        );
     }
 
     /**

--- a/tests/bin/ldap-backend-storage.php
+++ b/tests/bin/ldap-backend-storage.php
@@ -27,6 +27,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\MysqlStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqliteStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
 use FreeDSx\Ldap\ServerOptions;
 
 require __DIR__ . '/../../vendor/autoload.php';
@@ -141,16 +142,12 @@ if ($storage === 'memory') {
         ? JsonFileStorage::forSwoole($filePath)
         : JsonFileStorage::forPcntl($filePath);
 
+    $importer = new LdapImporter($adapter);
+
     if ($runner === 'swoole') {
-        Swoole\Coroutine\run(function () use ($adapter, $entries): void {
-            foreach ($entries as $entry) {
-                $adapter->store($entry);
-            }
-        });
+        Swoole\Coroutine\run(fn () => $importer->importEntries($entries));
     } else {
-        foreach ($entries as $entry) {
-            $adapter->store($entry);
-        }
+        $importer->importEntries($entries);
     }
 
     $server->useStorage($adapter);
@@ -167,16 +164,12 @@ if ($storage === 'memory') {
         ? SqliteStorage::forSwoole($dbPath)
         : SqliteStorage::forPcntl($dbPath);
 
+    $importer = new LdapImporter($adapter);
+
     if ($runner === 'swoole') {
-        Swoole\Coroutine\run(function () use ($adapter, $entries): void {
-            foreach ($entries as $entry) {
-                $adapter->store($entry);
-            }
-        });
+        Swoole\Coroutine\run(fn () => $importer->importEntries($entries));
     } else {
-        foreach ($entries as $entry) {
-            $adapter->store($entry);
-        }
+        $importer->importEntries($entries);
     }
 
     $server->useStorage($adapter);
@@ -199,16 +192,12 @@ if ($storage === 'memory') {
         ? MysqlStorage::forSwoole($dsn, $user, $password)
         : MysqlStorage::forPcntl($dsn, $user, $password);
 
+    $importer = new LdapImporter($adapter);
+
     if ($runner === 'swoole') {
-        Swoole\Coroutine\run(function () use ($adapter, $entries): void {
-            foreach ($entries as $entry) {
-                $adapter->store($entry);
-            }
-        });
+        Swoole\Coroutine\run(fn () => $importer->importEntries($entries));
     } else {
-        foreach ($entries as $entry) {
-            $adapter->store($entry);
-        }
+        $importer->importEntries($entries);
     }
 
     $server->useStorage($adapter);

--- a/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
@@ -233,6 +233,82 @@ final class WritableStorageBackendTest extends TestCase
         $this->subject->delete(new DeleteCommand(new Dn('dc=example,dc=com')));
     }
 
+    public function test_delete_throws_unwilling_to_perform_for_configured_naming_context(): void
+    {
+        $leaf = new Entry(
+            new Dn('dc=example,dc=com'),
+            new Attribute('dc', 'example'),
+        );
+        $backend = new WritableStorageBackend(
+            storage: new InMemoryStorage([$leaf]),
+            namingContexts: ['dc=example,dc=com'],
+        );
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
+
+        $backend->delete(new DeleteCommand(new Dn('dc=example,dc=com')));
+    }
+
+    public function test_delete_naming_context_check_is_case_insensitive(): void
+    {
+        $leaf = new Entry(
+            new Dn('dc=example,dc=com'),
+            new Attribute('dc', 'example'),
+        );
+        $backend = new WritableStorageBackend(
+            storage: new InMemoryStorage([$leaf]),
+            namingContexts: ['DC=Example,DC=Com'],
+        );
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
+
+        $backend->delete(new DeleteCommand(new Dn('dc=example,dc=com')));
+    }
+
+    public function test_move_throws_unwilling_to_perform_when_renaming_naming_context(): void
+    {
+        $leaf = new Entry(
+            new Dn('dc=example,dc=com'),
+            new Attribute('dc', 'example'),
+        );
+        $backend = new WritableStorageBackend(
+            storage: new InMemoryStorage([$leaf]),
+            namingContexts: ['dc=example,dc=com'],
+        );
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
+
+        $backend->move(new MoveCommand(
+            new Dn('dc=example,dc=com'),
+            Rdn::create('dc=renamed'),
+            true,
+            null,
+        ));
+    }
+
+    public function test_delete_allows_non_naming_context_entries_when_naming_context_configured(): void
+    {
+        $base = new Entry(
+            new Dn('dc=example,dc=com'),
+            new Attribute('dc', 'example'),
+        );
+        $leaf = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('cn', 'Alice'),
+        );
+        $backend = new WritableStorageBackend(
+            storage: new InMemoryStorage([$base, $leaf]),
+            namingContexts: ['dc=example,dc=com'],
+        );
+
+        $backend->delete(new DeleteCommand(new Dn('cn=Alice,dc=example,dc=com')));
+
+        self::assertNull($backend->get(new Dn('cn=Alice,dc=example,dc=com')));
+    }
+
     public function test_update_add_attribute_value(): void
     {
         $this->subject->update(new UpdateCommand(

--- a/tests/unit/Server/Backend/Storage/LdapImporterTest.php
+++ b/tests/unit/Server/Backend/Storage/LdapImporterTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage;
+
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
+use PHPUnit\Framework\TestCase;
+
+final class LdapImporterTest extends TestCase
+{
+    public function test_importEntries_persists_all_entries(): void
+    {
+        $storage = new InMemoryStorage();
+        $importer = new LdapImporter($storage);
+
+        $importer->importEntries([
+            new Entry(
+                new Dn('dc=example,dc=com'),
+                new Attribute('dc', 'example'),
+            ),
+            new Entry(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                new Attribute('cn', 'Alice'),
+            ),
+        ]);
+
+        self::assertNotNull($storage->find(new Dn('dc=example,dc=com')));
+        self::assertNotNull($storage->find(new Dn('cn=alice,dc=example,dc=com')));
+    }
+
+    public function test_importEntries_is_noop_when_empty(): void
+    {
+        $storage = $this->createMock(EntryStorageInterface::class);
+        $storage
+            ->expects(self::never())
+            ->method('atomic');
+
+        (new LdapImporter($storage))->importEntries([]);
+    }
+
+    public function test_importEntries_runs_in_single_atomic_call(): void
+    {
+        $storage = $this->createMock(EntryStorageInterface::class);
+        $storage
+            ->expects(self::once())
+            ->method('atomic');
+
+        (new LdapImporter($storage))->importEntries([
+            new Entry(new Dn('dc=example,dc=com')),
+            new Entry(new Dn('cn=Alice,dc=example,dc=com')),
+        ]);
+    }
+
+    public function test_importEntries_sorts_by_depth_so_input_order_does_not_matter(): void
+    {
+        $storage = new InMemoryStorage();
+
+        (new LdapImporter($storage))->importEntries([
+            new Entry(new Dn('cn=Alice,dc=example,dc=com'), new Attribute('cn', 'Alice')),
+            new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example')),
+        ]);
+
+        self::assertNotNull($storage->find(new Dn('dc=example,dc=com')));
+        self::assertNotNull($storage->find(new Dn('cn=alice,dc=example,dc=com')));
+    }
+
+    public function test_importEntries_throws_when_parent_is_missing(): void
+    {
+        $storage = new InMemoryStorage();
+
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('Parent entry "dc=example,dc=com" does not exist for "cn=Alice,dc=example,dc=com".');
+
+        (new LdapImporter($storage))->importEntries([
+            new Entry(new Dn('cn=Alice,dc=example,dc=com'), new Attribute('cn', 'Alice')),
+        ]);
+    }
+
+    public function test_importEntries_accepts_existing_parent_in_pre_seeded_storage(): void
+    {
+        $storage = new InMemoryStorage([
+            new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example')),
+        ]);
+
+        (new LdapImporter($storage))->importEntries([
+            new Entry(new Dn('cn=Alice,dc=example,dc=com'), new Attribute('cn', 'Alice')),
+        ]);
+
+        self::assertNotNull($storage->find(new Dn('cn=alice,dc=example,dc=com')));
+    }
+
+    public function test_importEntries_ignoreValidation_skips_parent_check(): void
+    {
+        $storage = new InMemoryStorage();
+
+        (new LdapImporter($storage))->importEntries(
+            entries: [
+                new Entry(new Dn('cn=Alice,dc=example,dc=com'), new Attribute('cn', 'Alice')),
+            ],
+            ignoreValidation: true,
+        );
+
+        self::assertNotNull($storage->find(new Dn('cn=alice,dc=example,dc=com')));
+    }
+}


### PR DESCRIPTION
Two smaller items:

1. Adding a small utility to import entries for a storage adapter on the server and document it as the way to pre-populate. This helps make it obvious what the process is to get initial entries in place.
2. Adding security around the configured naming contexts so they can't be deleted or moved via the storage adapter / writable backend system.