### PR TITLE
Add a separate table for indexed lc attribute value comparisons.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
   ],
   "require": {
     "php": ">=8.1",
-    "freedsx/asn1": ">=0.4.0",
-    "freedsx/socket": ">=0.6.2",
-    "freedsx/sasl": ">=0.2.1",
+    "freedsx/asn1": "^0.4.0",
+    "freedsx/socket": "^0.6.2",
+    "freedsx/sasl": "^0.2.1",
     "psr/log": "^3"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -56,21 +56,21 @@
   },
   "scripts": {
     "test-coverage": [
-      "phpunit --testsuite unit --coverage-clover=coverage-unit.xml",
-      "phpunit --testsuite integration --coverage-clover=coverage-integration.xml"
+      "XDEBUG_MODE=coverage phpunit --testsuite unit --coverage-clover=coverage-unit.xml",
+      "XDEBUG_MODE=coverage phpunit --testsuite integration --coverage-clover=coverage-integration.xml"
     ],
     "test-unit": [
-      "phpunit --testsuite unit"
+      "XDEBUG_MODE=off phpunit --testsuite unit"
     ],
     "test-integration": [
-      "phpunit --testsuite integration"
+      "XDEBUG_MODE=off phpunit --testsuite integration"
     ],
     "test-integration-local": [
       "docker compose -f tests/resources/openldap/docker-compose.yml down --rmi local",
       "docker compose -f tests/resources/openldap/docker-compose.yml up -d --build --wait",
       "@test-integration"
     ],
-    "test-load": "php tests/bin/ldap-load-test.php --backend=sqlite --runner=swoole --duration=10 --warmup=2 --clients=8 --output=text",
+    "test-load": "XDEBUG_MODE=off php tests/bin/ldap-load-test.php --backend=sqlite --runner=swoole --duration=10 --warmup=2 --clients=8 --output=text",
     "analyse": [
       "phpstan --memory-limit=-1 analyse"
     ],

--- a/composer.json
+++ b/composer.json
@@ -56,21 +56,22 @@
   },
   "scripts": {
     "test-coverage": [
-      "XDEBUG_MODE=coverage phpunit --testsuite unit --coverage-clover=coverage-unit.xml",
-      "XDEBUG_MODE=coverage phpunit --testsuite integration --coverage-clover=coverage-integration.xml"
+      "@php -d xdebug.mode=coverage vendor/bin/phpunit --testsuite unit --coverage-clover=coverage-unit.xml",
+      "@php -d xdebug.mode=coverage vendor/bin/phpunit --testsuite integration --coverage-clover=coverage-integration.xml"
     ],
     "test-unit": [
-      "XDEBUG_MODE=off phpunit --testsuite unit"
+      "@php -d xdebug.mode=off vendor/bin/phpunit --testsuite unit"
     ],
     "test-integration": [
-      "XDEBUG_MODE=off phpunit --testsuite integration"
+      "@php -d xdebug.mode=off vendor/bin/phpunit --testsuite integration"
     ],
     "test-integration-local": [
       "docker compose -f tests/resources/openldap/docker-compose.yml down --rmi local",
       "docker compose -f tests/resources/openldap/docker-compose.yml up -d --build --wait",
       "@test-integration"
     ],
-    "test-load": "XDEBUG_MODE=off php tests/bin/ldap-load-test.php --backend=sqlite --runner=swoole --duration=10 --warmup=2 --clients=8 --output=text",
+    "test-load": "@php -d xdebug.mode=off tests/bin/ldap-load-test.php --backend=sqlite --runner=swoole --duration=10 --warmup=2 --clients=8 --output=text",
+    "test-load-compare": "@php -d xdebug.mode=off tests/bin/ldap-bench-compare.php",
     "analyse": [
       "phpstan --memory-limit=-1 analyse"
     ],

--- a/src/FreeDSx/Ldap/Protocol/Queue/ClientQueue.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/ClientQueue.php
@@ -26,7 +26,6 @@ use FreeDSx\Ldap\Protocol\LdapQueue;
 use FreeDSx\Socket\Exception\ConnectionException;
 use FreeDSx\Socket\Queue\Message;
 use FreeDSx\Socket\SocketPool;
-use Generator;
 
 /**
  * The LDAP Queue class for sending and receiving messages for clients.
@@ -68,17 +67,6 @@ class ClientQueue extends LdapQueue
         }
 
         return $message;
-    }
-
-    /**
-     * @return Generator<LdapMessageResponse>
-     * @throws ConnectionException
-     */
-    public function getMessages(?int $id = null): Generator
-    {
-        $this->initSocket();
-
-        return parent::getMessages($id);
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/MysqlDialect.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/MysqlDialect.php
@@ -24,8 +24,6 @@ final class MysqlDialect implements PdoDialectInterface
 
     /**
      * DN columns are 768 chars — the maximum that still fits an InnoDB index.
-     *
-     * @TODO How to handle indexing on attributes?
      */
     public function ddlCreateTable(): string
     {
@@ -42,7 +40,7 @@ final class MysqlDialect implements PdoDialectInterface
     }
 
     /**
-     * Null: the index is defined inline in ddlCreateTable().
+     * @inheritDoc Inline with ddlCreateTable().
      */
     public function ddlCreateIndex(): ?string
     {
@@ -50,7 +48,34 @@ final class MysqlDialect implements PdoDialectInterface
     }
 
     /**
-     * @todo Replace VALUES() (deprecated in MySQL 8.0.20, removed in 9.0) with row alias syntax once MariaDB supports it.
+     * entry_lc_dn collation matches entries.lc_dn (FK requirement); value_lower uses utf8mb4_bin so pre-lowered values compare byte-wise.
+     */
+    public function ddlCreateSidecarTable(): string
+    {
+        return <<<SQL
+            CREATE TABLE IF NOT EXISTS entry_attribute_values (
+                entry_lc_dn      VARCHAR(768) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+                attr_name_lower  VARCHAR(255) NOT NULL,
+                value_lower      VARCHAR(255) NOT NULL,
+                value_original   TEXT NOT NULL,
+                INDEX idx_eav_attr_value (attr_name_lower, value_lower),
+                INDEX idx_eav_entry (entry_lc_dn),
+                CONSTRAINT fk_eav_entry FOREIGN KEY (entry_lc_dn)
+                    REFERENCES entries(lc_dn) ON DELETE CASCADE
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+        SQL;
+    }
+
+    /**
+     * @inheritDoc Inline with ddlCreateSidecarTable().
+     */
+    public function ddlCreateSidecarIndexes(): array
+    {
+        return [];
+    }
+
+    /**
+     * @todo Replace VALUES() with row alias syntax once MariaDB supports it.
      */
     public function queryUpsert(): string
     {

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectInterface.php
@@ -53,6 +53,22 @@ interface PdoDialectInterface
     public function ddlCreateIndex(): ?string;
 
     /**
+     * DDL for the `entry_attribute_values` sidecar index table. Required columns:
+     *   entry_lc_dn      — FK to entries.lc_dn ON DELETE CASCADE
+     *   attr_name_lower  — lowercased attribute description (stripped of options)
+     *   value_lower      — lowercased value, truncated to 255 chars (indexed)
+     *   value_original   — original-case full value (not indexed; retained for debugging)
+     */
+    public function ddlCreateSidecarTable(): string;
+
+    /**
+     * DDL statements creating sidecar indexes; empty when indexes are defined inline in ddlCreateSidecarTable().
+     *
+     * @return list<string>
+     */
+    public function ddlCreateSidecarIndexes(): array;
+
+    /**
      * Existence check: `SELECT 1 FROM entries WHERE lc_dn = ? LIMIT 1`. Parameters: [lc_dn]
      */
     public function queryExists(): string;
@@ -91,6 +107,16 @@ interface PdoDialectInterface
      * `DELETE FROM entries WHERE lc_dn = ?`. Parameters: [lc_dn]
      */
     public function queryDelete(): string;
+
+    /**
+     * `DELETE FROM entry_attribute_values WHERE entry_lc_dn = ?`. Parameters: [entry_lc_dn]
+     */
+    public function querySidecarDelete(): string;
+
+    /**
+     * INSERT prefix for the sidecar; caller appends `(?, ?, ?, ?)` tuples for (entry_lc_dn, attr_name_lower, value_lower, value_original).
+     */
+    public function querySidecarInsertPrefix(): string;
 
     /**
      * Maximum DN byte-length allowed by the storage backend, or null if there is no practical limit.

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
@@ -106,4 +106,17 @@ trait PdoDialectTrait
             WHERE lc_dn = ?
         SQL;
     }
+
+    public function querySidecarDelete(): string
+    {
+        return <<<SQL
+            DELETE FROM entry_attribute_values
+            WHERE entry_lc_dn = ?
+        SQL;
+    }
+
+    public function querySidecarInsertPrefix(): string
+    {
+        return 'INSERT INTO entry_attribute_values (entry_lc_dn, attr_name_lower, value_lower, value_original) VALUES ';
+    }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SqliteDialect.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SqliteDialect.php
@@ -62,6 +62,27 @@ final class SqliteDialect implements PdoDialectInterface
         SQL;
     }
 
+    public function ddlCreateSidecarTable(): string
+    {
+        return <<<SQL
+            CREATE TABLE IF NOT EXISTS entry_attribute_values (
+                entry_lc_dn      TEXT NOT NULL,
+                attr_name_lower  TEXT NOT NULL,
+                value_lower      TEXT NOT NULL,
+                value_original   TEXT NOT NULL,
+                FOREIGN KEY (entry_lc_dn) REFERENCES entries(lc_dn) ON DELETE CASCADE
+            )
+        SQL;
+    }
+
+    public function ddlCreateSidecarIndexes(): array
+    {
+        return [
+            'CREATE INDEX IF NOT EXISTS idx_eav_attr_value ON entry_attribute_values (attr_name_lower, value_lower)',
+            'CREATE INDEX IF NOT EXISTS idx_eav_entry ON entry_attribute_values (entry_lc_dn)',
+        ];
+    }
+
     public function queryUpsert(): string
     {
         return <<<SQL

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\DnTooLongException;
+use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\FilterTranslatorInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterResult;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterUtility;
@@ -31,6 +32,7 @@ use JsonException;
 use PDO;
 use PDOStatement;
 use Throwable;
+use WeakMap;
 
 /**
  * PDO-backed storage; pass a PdoDialectInterface + PdoConnectionProviderInterface, or use SqliteStorage / MysqlStorage factories.
@@ -41,16 +43,25 @@ use Throwable;
  */
 final class PdoStorage implements EntryStorageInterface, ResettableInterface
 {
+    private const STATEMENT_CACHE_MAX = 64;
+
+    /**
+     * @var WeakMap<PDO, array<string, list<PDOStatement>>>
+     */
+    private WeakMap $statementCache;
+
     public function __construct(
         private readonly PdoConnectionProviderInterface $provider,
         private readonly FilterTranslatorInterface $translator,
         private readonly PdoDialectInterface $dialect,
     ) {
+        $this->statementCache = new WeakMap();
     }
 
     public function reset(): void
     {
         $this->provider->reset();
+        $this->statementCache = new WeakMap();
     }
 
     public static function initialize(
@@ -133,7 +144,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
      * @return Generator<Entry>
      */
     private function generateRows(
-        PDOStatement $stmt,
+        PooledStatement $stmt,
         ?float $deadline,
     ): Generator {
         while (($row = $stmt->fetch()) !== false) {
@@ -337,7 +348,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
         bool $subtree,
         ?SqlFilterResult $filterResult,
         ?int $sizeLimit,
-    ): PDOStatement {
+    ): PooledStatement {
         if (!$subtree) {
             return $this->buildChildQuery(
                 $base,
@@ -364,7 +375,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
         string $base,
         ?SqlFilterResult $filterResult,
         ?int $sizeLimit,
-    ): PDOStatement {
+    ): PooledStatement {
         $sql = $this->dialect->queryFetchChildren();
         $params = [$base];
 
@@ -385,7 +396,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
     private function buildRootQuery(
         ?SqlFilterResult $filterResult,
         ?int $sizeLimit,
-    ): PDOStatement {
+    ): PooledStatement {
         $sql = $this->dialect->queryFetchAll();
         $params = [];
 
@@ -404,7 +415,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
         string $base,
         ?SqlFilterResult $filterResult,
         ?int $sizeLimit,
-    ): PDOStatement {
+    ): PooledStatement {
         if ($filterResult !== null) {
             return $this->buildFilteredSubtreeQuery(
                 $base,
@@ -426,7 +437,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
         string $base,
         SqlFilterResult $filterResult,
         ?int $sizeLimit,
-    ): PDOStatement {
+    ): PooledStatement {
         $fetchAll = $this->dialect->queryFetchAll();
         $filterSql = $filterResult->sql;
         $sql = <<<SQL
@@ -522,11 +533,59 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
     private function prepareAndExecute(
         string $query,
         array $params = [],
-    ): PDOStatement {
-        $stmt = $this->provider->get()->prepare($query);
+    ): PooledStatement {
+        $pdo = $this->provider->get();
+        $pools = $this->statementCache[$pdo] ?? [];
+
+        if (isset($pools[$query]) && $pools[$query] !== []) {
+            $pool = $pools[$query];
+            $stmt = array_pop($pool);
+            $pools[$query] = $pool;
+        } else {
+            if (!isset($pools[$query]) && count($pools) >= self::STATEMENT_CACHE_MAX) {
+                array_shift($pools);
+            }
+
+            $stmt = $pdo->prepare($query);
+            if ($stmt === false) {
+                throw new StorageIoException('Failed to prepare SQL statement.');
+            }
+
+            if (!isset($pools[$query])) {
+                $pools[$query] = [];
+            }
+        }
+
+        $this->statementCache[$pdo] = $pools;
+
         $stmt->execute($params);
 
-        return $stmt;
+        return new PooledStatement(
+            $stmt,
+            function (PDOStatement $released) use ($pdo, $query): void {
+                $this->returnToPool($pdo, $query, $released);
+            },
+        );
+    }
+
+    private function returnToPool(
+        PDO $pdo,
+        string $query,
+        PDOStatement $stmt,
+    ): void {
+        try {
+            $stmt->closeCursor();
+        } catch (Throwable) {
+            return;
+        }
+
+        $pools = $this->statementCache[$pdo] ?? [];
+        if (!isset($pools[$query])) {
+            return;
+        }
+
+        $pools[$query][] = $stmt;
+        $this->statementCache[$pdo] = $pools;
     }
 
     private function savepointName(int $depth): string

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\DnTooLongException;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\FilterTranslatorInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterResult;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterUtility;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
@@ -70,6 +71,12 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
         $indexDdl = $dialect->ddlCreateIndex();
         if ($indexDdl !== null) {
             $pdo->exec($indexDdl);
+        }
+
+        $pdo->exec($dialect->ddlCreateSidecarTable());
+
+        foreach ($dialect->ddlCreateSidecarIndexes() as $indexSql) {
+            $pdo->exec($indexSql);
         }
     }
 
@@ -148,12 +155,93 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
 
         $this->assertDnFits($dnString);
 
-        $this->prepareAndExecute($this->dialect->queryUpsert(), [
-            $normDn->toString(),
-            $dnString,
-            $normDn->getParent()?->toString() ?? '',
-            $this->encodeAttributes($entry),
-        ]);
+        $lcDn = $normDn->toString();
+
+        $this->atomic(function () use ($entry, $lcDn, $dnString, $normDn): void {
+            $this->prepareAndExecute($this->dialect->queryUpsert(), [
+                $lcDn,
+                $dnString,
+                $normDn->getParent()?->toString() ?? '',
+                $this->encodeAttributes($entry),
+            ]);
+
+            $this->prepareAndExecute(
+                $this->dialect->querySidecarDelete(),
+                [$lcDn],
+            );
+
+            $this->insertSidecarRows(
+                $lcDn,
+                $entry,
+            );
+        });
+    }
+
+    private function insertSidecarRows(
+        string $lcDn,
+        Entry $entry,
+    ): void {
+        $rows = $this->buildSidecarRows($lcDn, $entry);
+        if ($rows === []) {
+            return;
+        }
+
+        $tuple = '(?, ?, ?, ?)';
+        $placeholders = implode(
+            ', ',
+            array_fill(0, count($rows), $tuple),
+        );
+        $params = [];
+        foreach ($rows as $row) {
+            $params[] = $row[0];
+            $params[] = $row[1];
+            $params[] = $row[2];
+            $params[] = $row[3];
+        }
+
+        $this->prepareAndExecute(
+            $this->dialect->querySidecarInsertPrefix() . $placeholders,
+            $params,
+        );
+    }
+
+    /**
+     * @return list<array{string, string, string, string}> (entry_lc_dn, attr_name_lower, value_lower, value_original)
+     */
+    private function buildSidecarRows(
+        string $lcDn,
+        Entry $entry,
+    ): array {
+        $rows = [];
+
+        foreach ($entry->getAttributes() as $attribute) {
+            $attrNameLower = strtolower($attribute->getName());
+
+            foreach ($attribute->getValues() as $value) {
+                $rows[] = [
+                    $lcDn,
+                    $attrNameLower,
+                    $this->buildSidecarValueLower($value),
+                    $value,
+                ];
+            }
+        }
+
+        return $rows;
+    }
+
+    private function buildSidecarValueLower(string $value): string
+    {
+        if (!mb_check_encoding($value, 'UTF-8')) {
+            return '';
+        }
+
+        return mb_substr(
+            mb_strtolower($value, 'UTF-8'),
+            0,
+            SqlFilterUtility::MAX_INDEXED_VALUE_CHARS,
+            'UTF-8',
+        );
     }
 
     /**
@@ -317,13 +405,38 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
         ?SqlFilterResult $filterResult,
         ?int $sizeLimit,
     ): PDOStatement {
-        $params = [$base];
-        $sql = $this->dialect->querySubtree();
-
         if ($filterResult !== null) {
-            $sql .= ' WHERE (' . $filterResult->sql . ')';
-            $params = array_merge($params, $filterResult->params);
+            return $this->buildFilteredSubtreeQuery(
+                $base,
+                $filterResult,
+                $sizeLimit,
+            );
         }
+
+        return $this->prepareAndExecute(
+            $this->dialect->querySubtree() . $this->buildLimitClause($sizeLimit),
+            [$base],
+        );
+    }
+
+    /**
+     * Filter drives via the sidecar index; scope suffix is LIKE-checked per candidate.
+     */
+    private function buildFilteredSubtreeQuery(
+        string $base,
+        SqlFilterResult $filterResult,
+        ?int $sizeLimit,
+    ): PDOStatement {
+        $fetchAll = $this->dialect->queryFetchAll();
+        $filterSql = $filterResult->sql;
+        $sql = <<<SQL
+            $fetchAll WHERE ($filterSql)
+            AND (lc_dn = ? OR lc_dn LIKE ? ESCAPE '!')
+            SQL;
+
+        $params = $filterResult->params;
+        $params[] = $base;
+        $params[] = '%,' . SqlFilterUtility::escape($base);
 
         return $this->prepareAndExecute(
             $sql . $this->buildLimitClause($sizeLimit),
@@ -345,10 +458,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
         $attributes = [];
 
         foreach ($entry->getAttributes() as $attribute) {
-            $attributes[strtolower($attribute->getName())] = [
-                'name' => $attribute->getName(),
-                'values' => array_values($attribute->getValues()),
-            ];
+            $attributes[$attribute->getName()] = array_values($attribute->getValues());
         }
 
         return json_encode(
@@ -386,23 +496,16 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
 
         $attributes = [];
 
-        foreach ($raw as $lcName => $slot) {
-            if (!is_string($lcName) || !is_array($slot)) {
+        foreach ($raw as $name => $values) {
+            if (!is_string($name) || !is_array($values)) {
                 continue;
             }
-
-            $displayName = isset($slot['name']) && is_string($slot['name'])
-                ? $slot['name']
-                : $lcName;
-            $values = isset($slot['values']) && is_array($slot['values'])
-                ? $slot['values']
-                : [];
 
             $stringValues = array_values(
                 array_filter($values, fn($v) => is_string($v)),
             );
             $attributes[] = new Attribute(
-                $displayName,
+                $name,
                 ...$stringValues
             );
         }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PooledStatement.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PooledStatement.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter;
+
+use Closure;
+use PDOStatement;
+use Throwable;
+
+/**
+ * RAII wrapper around a PDOStatement leased from a per-query pool; returns it on destruction.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class PooledStatement
+{
+    private ?Closure $release;
+
+    public function __construct(
+        private readonly PDOStatement $statement,
+        Closure $release,
+    ) {
+        $this->release = $release;
+    }
+
+    public function fetch(): mixed
+    {
+        return $this->statement->fetch();
+    }
+
+    public function __destruct()
+    {
+        if ($this->release === null) {
+            return;
+        }
+
+        $release = $this->release;
+        $this->release = null;
+
+        try {
+            $release($this->statement);
+        } catch (Throwable) {
+            // Drop the statement rather than recycling a poisoned one into the pool.
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/MysqlFilterTranslator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/MysqlFilterTranslator.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter;
 
 /**
- * MySQL/MariaDB SQL WHERE translator for LDAP filters; requires MySQL 8.0+ or MariaDB 10.6+.
+ * MySQL/MariaDB SQL WHERE translator for LDAP filters; targets the `entry_attribute_values` sidecar index.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -22,32 +22,26 @@ final class MysqlFilterTranslator implements FilterTranslatorInterface
 {
     use SqlFilterTranslatorTrait;
 
-    protected function buildPresenceCheck(string $attribute): string
+    private function buildPresenceCheck(string $attribute): string
     {
-        return "JSON_CONTAINS_PATH(attributes, 'one', '$.\"{$attribute}\"')";
+        return <<<SQL
+            lc_dn IN (SELECT s.entry_lc_dn FROM entry_attribute_values s
+                WHERE s.attr_name_lower = '$attribute')
+            SQL;
     }
 
-    protected function buildValueExists(
+    private function buildValueExists(
         string $attribute,
         string $innerCondition,
     ): string {
-        // NO_SEMIJOIN is required: MySQL 8.0 silently rewrites the correlated JSON_TABLE
-        // subquery into an unconditional hash join that loses the outer `attributes` reference,
-        // producing zero rows for every filter.
         return <<<SQL
-            EXISTS (
-                SELECT /*+ NO_SEMIJOIN() */ 1
-                FROM JSON_TABLE(
-                    attributes,
-                    '$."{$attribute}".values[*]' COLUMNS (val TEXT PATH '$')
-                ) AS _jt
-                WHERE $innerCondition
-            )
-        SQL;
+            lc_dn IN (SELECT s.entry_lc_dn FROM entry_attribute_values s
+                WHERE s.attr_name_lower = '$attribute' AND $innerCondition)
+            SQL;
     }
 
-    protected function valueAlias(): string
+    private function valueAlias(): string
     {
-        return 'val';
+        return 's.value_lower';
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
@@ -26,36 +26,26 @@ use FreeDSx\Ldap\Search\Filter\PresentFilter;
 use FreeDSx\Ldap\Search\Filter\SubstringFilter;
 
 /**
- * Reusable LDAP-filter-to-SQL translator; concrete classes supply buildPresenceCheck() and buildValueExists().
- *
- * Composition rules: AND keeps translatable children, OR requires every child to translate, NOT honors RFC 4511 §4.5.1.7,
- * MatchingRuleFilter is never translated.
+ * Translates LDAP filters to SQL against the `entry_attribute_values` sidecar index.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 trait SqlFilterTranslatorTrait
 {
     /**
-     * SQL fragment testing whether the attribute key is present.
-     *
-     * @param string $attribute Pre-validated and safe to embed in SQL.
+     * @param string $attribute Pre-validated; safe to embed in SQL.
      */
-    abstract protected function buildPresenceCheck(string $attribute): string;
+    abstract private function buildPresenceCheck(string $attribute): string;
 
     /**
-     * Wraps $innerCondition so it is evaluated per attribute value, referencing the current value via {@see valueAlias()}.
-     *
-     * @param string $attribute Pre-validated and safe to embed in SQL.
+     * @param string $attribute Pre-validated; safe to embed in SQL.
      */
-    abstract protected function buildValueExists(
+    abstract private function buildValueExists(
         string $attribute,
         string $innerCondition,
     ): string;
 
-    /**
-     * Returns the column alias used by the value-iteration function.
-     */
-    abstract protected function valueAlias(): string;
+    abstract private function valueAlias(): string;
 
     public function translate(FilterInterface $filter): ?SqlFilterResult
     {
@@ -91,9 +81,9 @@ trait SqlFilterTranslatorTrait
         $value = $filter->getValue();
 
         return new SqlFilterResult(
-            $this->buildValueExists($attribute, "lower($alias) = lower(?)"),
-            [$value],
-            isExact: SqlFilterUtility::isAscii($value),
+            $this->buildValueExists($attribute, "$alias = ?"),
+            [$this->prepareMatchValue($value)],
+            isExact: $this->isExactEquality($value),
             referencedAttributes: [$attribute],
         );
     }
@@ -105,13 +95,11 @@ trait SqlFilterTranslatorTrait
         $alias = $this->valueAlias();
         $value = $filter->getValue();
 
-        // Approximate matching is implementation-defined (RFC 4511 §4.5.1.7.6).
-        // Both SQL and PHP implementations pick case-insensitive equality, so
-        // for ASCII values the result is exact and PHP re-eval can be skipped.
+        // Implementation-defined (RFC 4511 §4.5.1.7.6); mirror FilterEvaluator's case-insensitive equality.
         return new SqlFilterResult(
-            $this->buildValueExists($attribute, "lower($alias) = lower(?)"),
-            [$value],
-            isExact: SqlFilterUtility::isAscii($value),
+            $this->buildValueExists($attribute, "$alias = ?"),
+            [$this->prepareMatchValue($value)],
+            isExact: $this->isExactEquality($value),
             referencedAttributes: [$attribute],
         );
     }
@@ -123,10 +111,11 @@ trait SqlFilterTranslatorTrait
         $alias = $this->valueAlias();
         $value = $filter->getValue();
 
+        // Truncation preserves GTE when query <= 255 chars: full >= query implies its prefix >= query.
         return new SqlFilterResult(
-            $this->buildValueExists($attribute, "lower($alias) >= lower(?)"),
-            [$value],
-            isExact: $this->isOrderedCompareExact($value),
+            $this->buildValueExists($attribute, "$alias >= ?"),
+            [$this->prepareMatchValue($value)],
+            isExact: $this->isExactOrdered($value),
             referencedAttributes: [$attribute],
         );
     }
@@ -138,98 +127,110 @@ trait SqlFilterTranslatorTrait
         $alias = $this->valueAlias();
         $value = $filter->getValue();
 
+        // LTE under truncation admits false positives (stored value > 255 whose prefix equals query); always inexact.
         return new SqlFilterResult(
-            $this->buildValueExists($attribute, "lower($alias) <= lower(?)"),
-            [$value],
-            isExact: $this->isOrderedCompareExact($value),
+            $this->buildValueExists($attribute, "$alias <= ?"),
+            [$this->prepareMatchValue($value)],
+            isExact: false,
             referencedAttributes: [$attribute],
         );
-    }
-
-    /**
-     * Exact only for ASCII non-digit values; PHP compareOrdered int-compares when both operands are digits, SQL does not.
-     */
-    private function isOrderedCompareExact(string $value): bool
-    {
-        return SqlFilterUtility::isAscii($value)
-            && !ctype_digit($value);
     }
 
     private function translateSubstring(SubstringFilter $filter): ?SqlFilterResult
     {
         $attribute = $this->validateAttribute($filter->getAttribute());
 
-        [$conditions, $params] = $this->buildSubstringParts($filter);
+        $startsWith = $filter->getStartsWith();
+        $contains = $filter->getContains();
+        $endsWith = $filter->getEndsWith();
 
-        if ($conditions === []) {
+        if ($startsWith === null && $contains === [] && $endsWith === null) {
             return null;
         }
 
-        // LDAP substring ordering (RFC 4511 §4.5.1.7.2) requires each fragment
-        // to appear strictly after the previous one. Independent AND'd LIKE
-        // clauses cannot preserve that ordering, so we can only mark the result
-        // exact when each part is independently anchored:
-        //   - startsWith only, endsWith only, or both without contains
-        //   - a single contains without startsWith/endsWith
-        // Any contains + anchor combination (or 2+ contains) needs PHP re-eval.
-        $containsCount = count($filter->getContains());
-        $hasAnchor = $filter->getStartsWith() !== null
-            || $filter->getEndsWith() !== null;
+        // Prefix-anchored LIKE is the only valid superset under truncation; other fragments fall back to presence + PHP re-eval.
+        $alias = $this->valueAlias();
 
-        $isExact = $containsCount < 2
-            && !($containsCount > 0 && $hasAnchor)
-            && SqlFilterUtility::isAscii((string) $filter->getStartsWith())
-            && SqlFilterUtility::isAscii((string) $filter->getEndsWith())
-            && $this->areAllAscii($filter->getContains());
+        if ($startsWith !== null) {
+            $prefix = $this->prepareMatchValue($startsWith);
+            $sql = $this->buildValueExists(
+                $attribute,
+                "$alias LIKE ? ESCAPE '!'",
+            );
+            $params = [SqlFilterUtility::escape($prefix) . '%'];
+        } else {
+            $sql = $this->buildPresenceCheck($attribute);
+            $params = [];
+        }
+
+        $isExact = $this->isExactSubstring(
+            $startsWith,
+            $contains,
+            $endsWith,
+        );
 
         return new SqlFilterResult(
-            $this->buildValueExists($attribute, implode(' AND ', $conditions)),
+            $sql,
             $params,
             isExact: $isExact,
             referencedAttributes: [$attribute],
         );
     }
 
-    /**
-     * @param array<int|string, string> $values
-     */
-    private function areAllAscii(array $values): bool
+    private function isExactEquality(string $value): bool
     {
-        foreach ($values as $value) {
-            if (!SqlFilterUtility::isAscii($value)) {
-                return false;
-            }
-        }
-
-        return true;
+        return SqlFilterUtility::isAscii($value)
+            && mb_check_encoding($value, 'UTF-8')
+            && mb_strlen($value, 'UTF-8') <= SqlFilterUtility::MAX_INDEXED_VALUE_CHARS;
     }
 
     /**
-     * @return array{list<string>, list<string>}
+     * ASCII non-digit within truncation; digit-only values compare numerically in PHP but lexically in SQL.
      */
-    private function buildSubstringParts(SubstringFilter $filter): array
+    private function isExactOrdered(string $value): bool
     {
-        $conditions = [];
-        $params = [];
-        $alias = $this->valueAlias();
-        $likeClause = "lower($alias) LIKE lower(?) ESCAPE '!'";
+        return SqlFilterUtility::isAscii($value)
+            && !ctype_digit($value)
+            && mb_check_encoding($value, 'UTF-8')
+            && mb_strlen($value, 'UTF-8') <= SqlFilterUtility::MAX_INDEXED_VALUE_CHARS;
+    }
 
-        if ($filter->getStartsWith() !== null) {
-            $conditions[] = $likeClause;
-            $params[] = SqlFilterUtility::escape($filter->getStartsWith()) . '%';
+    /**
+     * @param array<string> $contains
+     */
+    private function isExactSubstring(
+        ?string $startsWith,
+        array $contains,
+        ?string $endsWith,
+    ): bool {
+        if ($startsWith === null) {
+            return false;
         }
 
-        foreach ($filter->getContains() as $contains) {
-            $conditions[] = $likeClause;
-            $params[] = '%' . SqlFilterUtility::escape($contains) . '%';
+        if ($contains !== [] || $endsWith !== null) {
+            return false;
         }
 
-        if ($filter->getEndsWith() !== null) {
-            $conditions[] = $likeClause;
-            $params[] = '%' . SqlFilterUtility::escape($filter->getEndsWith());
+        return SqlFilterUtility::isAscii($startsWith)
+            && mb_check_encoding($startsWith, 'UTF-8')
+            && mb_strlen($startsWith, 'UTF-8') <= SqlFilterUtility::MAX_INDEXED_VALUE_CHARS;
+    }
+
+    /**
+     * Pre-lower + truncate to match sidecar's value_lower; non-UTF-8 returns '' (matches binary-syntax rows only).
+     */
+    private function prepareMatchValue(string $value): string
+    {
+        if (!mb_check_encoding($value, 'UTF-8')) {
+            return '';
         }
 
-        return [$conditions, $params];
+        return mb_substr(
+            mb_strtolower($value, 'UTF-8'),
+            0,
+            SqlFilterUtility::MAX_INDEXED_VALUE_CHARS,
+            'UTF-8',
+        );
     }
 
     private function translateAnd(AndFilter $filter): ?SqlFilterResult

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterUtility.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterUtility.php
@@ -21,7 +21,12 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter;
 final class SqlFilterUtility
 {
     /**
-     * Escapes LIKE special characters using `!` as the escape character.
+     * Char limit for sidecar `value_lower`; queries longer than this can't match exactly.
+     */
+    public const MAX_INDEXED_VALUE_CHARS = 255;
+
+    /**
+     * Escape LIKE specials using `!` as the escape char.
      */
     public static function escape(string $value): string
     {
@@ -33,7 +38,7 @@ final class SqlFilterUtility
     }
 
     /**
-     * True when $value is 7-bit ASCII; the translator falls back to PHP eval otherwise because SQL `lower()` is ASCII-only on SQLite and collation-dependent on MySQL.
+     * True when $value is 7-bit ASCII.
      */
     public static function isAscii(string $value): bool
     {

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqliteFilterTranslator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqliteFilterTranslator.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter;
 
 /**
- * Translates LDAP filters into SQLite-compatible SQL WHERE clause fragments.
+ * SQLite SQL WHERE translator for LDAP filters; targets the `entry_attribute_values` sidecar index.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -22,20 +22,26 @@ final class SqliteFilterTranslator implements FilterTranslatorInterface
 {
     use SqlFilterTranslatorTrait;
 
-    protected function buildPresenceCheck(string $attribute): string
+    private function buildPresenceCheck(string $attribute): string
     {
-        return "json_type(attributes, '$.\"{$attribute}\"') IS NOT NULL";
+        return <<<SQL
+            lc_dn IN (SELECT s.entry_lc_dn FROM entry_attribute_values s
+                WHERE s.attr_name_lower = '$attribute')
+            SQL;
     }
 
-    protected function buildValueExists(
+    private function buildValueExists(
         string $attribute,
         string $innerCondition,
     ): string {
-        return "EXISTS (SELECT 1 FROM json_each(attributes, '$.\"{$attribute}\".values') WHERE {$innerCondition})";
+        return <<<SQL
+            lc_dn IN (SELECT s.entry_lc_dn FROM entry_attribute_values s
+                WHERE s.attr_name_lower = '$attribute' AND $innerCondition)
+            SQL;
     }
 
-    protected function valueAlias(): string
+    private function valueAlias(): string
     {
-        return 'value';
+        return 's.value_lower';
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqliteStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqliteStorage.php
@@ -36,6 +36,8 @@ final class SqliteStorage implements PdoStorageFactoryInterface
 
     private const PRAGMA_BUSY_TIMEOUT_MS = 'PRAGMA busy_timeout = 5000';
 
+    private const PRAGMA_FOREIGN_KEYS_ON = 'PRAGMA foreign_keys = ON';
+
     public function __construct(private readonly string $dbPath)
     {
     }
@@ -71,6 +73,7 @@ final class SqliteStorage implements PdoStorageFactoryInterface
         $pdo->exec(self::PRAGMA_BUSY_TIMEOUT_MS);
         $pdo->exec(self::PRAGMA_SYNCHRONOUS_NORMAL);
         $pdo->exec(self::PRAGMA_JOURNAL_MODE_WAL);
+        $pdo->exec(self::PRAGMA_FOREIGN_KEYS_ON);
 
         PdoStorage::initialize($pdo, $dialect);
 

--- a/tests/bin/ldap-backend-storage.php
+++ b/tests/bin/ldap-backend-storage.php
@@ -185,6 +185,7 @@ if ($storage === 'memory') {
         $password,
         [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION],
     );
+    $cleanup->exec('DROP TABLE IF EXISTS entry_attribute_values');
     $cleanup->exec('DROP TABLE IF EXISTS entries');
     unset($cleanup);
 

--- a/tests/bin/ldap-bench-compare.php
+++ b/tests/bin/ldap-bench-compare.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Side-by-side benchmark driver: runs the FreeDSx load test workload against an external LDAP
+ * target and against a spawned FreeDSx server at identical parameters, then prints a comparison.
+ *
+ * Defaults point at a local OpenLDAP; override `--target-*` to aim at another server.
+ *
+ * Run with --help to see options.
+ */
+
+use Symfony\Component\Console\Application;
+use Tests\Performance\FreeDSx\Ldap\Compare\BenchCompareCommand;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$command = new BenchCompareCommand();
+$application = new Application('FreeDSx LDAP bench-compare');
+$application->add($command);
+$application->setDefaultCommand(
+    (string) $command->getName(),
+    true,
+);
+$application->run();

--- a/tests/integration/Storage/LdapBackendStorageTest.php
+++ b/tests/integration/Storage/LdapBackendStorageTest.php
@@ -338,4 +338,107 @@ class LdapBackendStorageTest extends ServerTestCase
         // After abandonment, hasEntries() must return false
         self::assertFalse($paging->hasEntries());
     }
+
+    public function testSubstringStartsWithMatches(): void
+    {
+        $this->authenticateUser();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::startsWith('cn', 'al'))
+                ->base('ou=people,dc=foo,dc=bar')
+                ->useSubtreeScope()
+        );
+
+        self::assertCount(1, $entries);
+        self::assertSame(
+            'cn=alice,ou=people,dc=foo,dc=bar',
+            $entries->first()?->getDn()->toString(),
+        );
+    }
+
+    public function testSubstringContainsMatches(): void
+    {
+        $this->authenticateUser();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::contains('cn', 'lic'))
+                ->base('ou=people,dc=foo,dc=bar')
+                ->useSubtreeScope()
+        );
+
+        self::assertCount(1, $entries);
+        self::assertSame(
+            'cn=alice,ou=people,dc=foo,dc=bar',
+            $entries->first()?->getDn()->toString(),
+        );
+    }
+
+    public function testSubstringEndsWithMatches(): void
+    {
+        $this->authenticateUser();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::endsWith('cn', 'ice'))
+                ->base('ou=people,dc=foo,dc=bar')
+                ->useSubtreeScope()
+        );
+
+        self::assertCount(1, $entries);
+        self::assertSame(
+            'cn=alice,ou=people,dc=foo,dc=bar',
+            $entries->first()?->getDn()->toString(),
+        );
+    }
+
+    public function testGteAsciiExcludesLowerValue(): void
+    {
+        $this->authenticateUser();
+
+        // Scope to ou=people so cn=user (which would match cn >= 'alicf') is excluded.
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::gte('cn', 'alicf'))
+                ->base('ou=people,dc=foo,dc=bar')
+                ->useSubtreeScope()
+        );
+
+        // 'alice' < 'alicf' lexicographically
+        self::assertCount(0, $entries);
+    }
+
+    public function testLteAsciiIncludesMatchingValue(): void
+    {
+        $this->authenticateUser();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::and(
+                Filters::present('cn'),
+                Filters::lte('cn', 'alice'),
+            ))
+                ->base('ou=people,dc=foo,dc=bar')
+                ->useSubtreeScope()
+        );
+
+        self::assertCount(1, $entries);
+        self::assertSame(
+            'cn=alice,ou=people,dc=foo,dc=bar',
+            $entries->first()?->getDn()->toString(),
+        );
+    }
+
+    public function testNotEqualityExcludesMatches(): void
+    {
+        $this->authenticateUser();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::and(
+                Filters::present('cn'),
+                Filters::not(Filters::equal('cn', 'alice')),
+            ))
+                ->base('ou=people,dc=foo,dc=bar')
+                ->useSubtreeScope()
+        );
+
+        // Under ou=people only alice exists in the seed; NOT-equal alice leaves zero matches.
+        self::assertCount(0, $entries);
+    }
 }

--- a/tests/performance/Compare/BenchCompareCommand.php
+++ b/tests/performance/Compare/BenchCompareCommand.php
@@ -1,0 +1,507 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\Compare;
+
+use InvalidArgumentException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Tests\Performance\FreeDSx\Ldap\Config;
+use Tests\Performance\FreeDSx\Ldap\Driver;
+use Tests\Performance\FreeDSx\Ldap\Report\Report;
+use Tests\Performance\FreeDSx\Ldap\Stats\StatsSnapshot;
+use Tests\Performance\FreeDSx\Ldap\Workload\WorkloadMix;
+use Throwable;
+
+/**
+ * Runs the load test against an external LDAP target and FreeDSx (spawned) with
+ * identical workload parameters, then prints a side-by-side comparison. Target defaults
+ * assume a local OpenLDAP; override `--target-*` to point at another server (389 DS,
+ * OpenDJ, ApacheDS, etc). Active Directory is not supported — the seeder uses
+ * `inetOrgPerson + extensibleObject`.
+ */
+final class BenchCompareCommand extends Command
+{
+    protected static $defaultName = 'load-compare';
+
+    protected static $defaultDescription = 'Benchmark FreeDSx vs an external LDAP target under identical workload parameters.';
+
+    private const DEFAULT_TARGET_BASE_DN = 'dc=example,dc=com';
+
+    private const DEFAULT_TARGET_BIND_DN = 'cn=admin,dc=example,dc=com';
+
+    private const DEFAULT_TARGET_BIND_PASSWORD = 'P@ssword12345';
+
+    private const DEFAULT_FREEDSX_PORT = 10389;
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'clients',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Concurrent coroutines',
+                '16',
+            )
+            ->addOption(
+                'duration',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Seconds per run (default 15 unless --ops is set)',
+            )
+            ->addOption(
+                'ops',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Total ops per client (alternative to --duration)',
+            )
+            ->addOption(
+                'warmup',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Warmup seconds before sampling',
+                '3',
+            )
+            ->addOption(
+                'mix',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Op mix, comma-separated weights',
+                'search-eq=100',
+            )
+            ->addOption(
+                'seed-entries',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Fixture entries to pre-seed under the write base',
+                '5000',
+            )
+            ->addOption(
+                'rng-seed',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'RNG seed for reproducible workloads (applied to both runs)',
+            )
+            ->addOption(
+                'freedsx-backend',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'FreeDSx backend: ' . implode(' | ', Config::BACKENDS),
+                'sqlite',
+            )
+            ->addOption(
+                'freedsx-runner',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'FreeDSx runner: ' . implode(' | ', Config::RUNNERS),
+                'swoole',
+            )
+            ->addOption(
+                'freedsx-port',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Port to spawn FreeDSx on',
+                (string) self::DEFAULT_FREEDSX_PORT,
+            )
+            ->addOption(
+                'target-host',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'External LDAP target host',
+                '127.0.0.1',
+            )
+            ->addOption(
+                'target-port',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'External LDAP target port',
+                '389',
+            )
+            ->addOption(
+                'target-bind-dn',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'DN to bind to the target for seeding + workload',
+                self::DEFAULT_TARGET_BIND_DN,
+            )
+            ->addOption(
+                'target-bind-password',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Password paired with --target-bind-dn',
+                self::DEFAULT_TARGET_BIND_PASSWORD,
+            )
+            ->addOption(
+                'target-base-dn',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Target base DN below which the bench subtree is created',
+                self::DEFAULT_TARGET_BASE_DN,
+            )
+            ->addOption(
+                'skip-target',
+                null,
+                InputOption::VALUE_NONE,
+                'Skip the target run (FreeDSx-only)',
+            )
+            ->addOption(
+                'skip-freedsx',
+                null,
+                InputOption::VALUE_NONE,
+                'Skip the FreeDSx run (target-only)',
+            )
+            ->addOption(
+                'no-cleanup',
+                null,
+                InputOption::VALUE_NONE,
+                'Leave the target bench subtree in place after the run',
+            )
+            ->addOption(
+                'output',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Report format: ' . implode(' | ', Config::OUTPUTS),
+                'text',
+            );
+    }
+
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output,
+    ): int {
+        $progress = $this->progressChannel($output);
+        $skipTarget = (bool) $input->getOption('skip-target');
+        $skipFreedsx = (bool) $input->getOption('skip-freedsx');
+
+        if ($skipTarget && $skipFreedsx) {
+            $output->writeln('<error>Both --skip-target and --skip-freedsx are set; nothing to run.</error>');
+
+            return Command::INVALID;
+        }
+
+        try {
+            $params = $this->resolveParams($input);
+        } catch (InvalidArgumentException $e) {
+            $output->writeln('<error>Configuration error: ' . $e->getMessage() . '</error>');
+
+            return Command::INVALID;
+        }
+
+        $targetSnapshot = null;
+        $freedsxSnapshot = null;
+
+        $bench = $skipTarget
+            ? null
+            : $this->makeBench($input);
+
+        try {
+            if ($bench !== null) {
+                $this->seedTarget(
+                    $progress,
+                    $bench,
+                    $params['seedEntries'],
+                );
+
+                $targetSnapshot = $this->runAgainstTarget(
+                    $output,
+                    $progress,
+                    $input,
+                    $bench,
+                    $params,
+                );
+                $this->renderSingleRun(
+                    $output,
+                    'Target',
+                    $targetSnapshot,
+                    $this->buildTargetConfig(
+                        $input,
+                        $bench,
+                        $params,
+                    ),
+                );
+            }
+
+            if (!$skipFreedsx) {
+                $freedsxSnapshot = $this->runAgainstFreedsx(
+                    $output,
+                    $progress,
+                    $input,
+                    $params,
+                );
+                $this->renderSingleRun(
+                    $output,
+                    'FreeDSx',
+                    $freedsxSnapshot,
+                    $this->buildFreedsxConfig(
+                        $input,
+                        $params,
+                    ),
+                );
+            }
+        } catch (Throwable $e) {
+            $output->writeln('<error>Benchmark failed: ' . $e->getMessage() . '</error>');
+
+            return Command::FAILURE;
+        } finally {
+            if ($bench !== null) {
+                if (!$input->getOption('no-cleanup')) {
+                    $progress->writeln(sprintf(
+                        'Cleaning up target bench subtree at %s...',
+                        $bench->benchBaseDn,
+                    ));
+                    try {
+                        $bench->cleanup();
+                    } catch (Throwable $e) {
+                        $progress->writeln('<comment>Cleanup warning: ' . $e->getMessage() . '</comment>');
+                    }
+                }
+                $bench->close();
+            }
+        }
+
+        $format = $this->requireString($input, 'output');
+        (new ComparisonReport(
+            target: $targetSnapshot,
+            freedsx: $freedsxSnapshot,
+            format: $format,
+        ))->render($output);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int}
+     */
+    private function resolveParams(InputInterface $input): array
+    {
+        $opsOpt = $input->getOption('ops');
+        $durationOpt = $input->getOption('duration');
+        $ops = $this->parseInt($opsOpt, 'ops');
+
+        if ($durationOpt !== null) {
+            $duration = $this->parseInt($durationOpt, 'duration');
+        } elseif ($ops !== null) {
+            $duration = null;
+        } else {
+            $duration = 15;
+        }
+
+        return [
+            'duration' => $duration,
+            'ops' => $ops,
+            'mix' => $this->requireString($input, 'mix'),
+            'clients' => $this->requireInt($input, 'clients'),
+            'warmup' => $this->requireInt($input, 'warmup'),
+            'rngSeed' => $this->parseInt($input->getOption('rng-seed'), 'rng-seed'),
+            'seedEntries' => $this->requireInt($input, 'seed-entries'),
+        ];
+    }
+
+    private function makeBench(InputInterface $input): TargetBench
+    {
+        return new TargetBench(
+            host: $this->requireString($input, 'target-host'),
+            port: $this->requireInt($input, 'target-port'),
+            bindDn: $this->requireString($input, 'target-bind-dn'),
+            bindPassword: $this->requireString($input, 'target-bind-password'),
+            rootBaseDn: $this->requireString($input, 'target-base-dn'),
+        );
+    }
+
+    private function seedTarget(
+        OutputInterface $progress,
+        TargetBench $bench,
+        int $seedEntries,
+    ): void {
+        $progress->writeln(sprintf(
+            'Seeding target bench subtree %s with %d entries (+ cn=alice)...',
+            $bench->benchBaseDn,
+            $seedEntries,
+        ));
+
+        $start = microtime(true);
+        $bench->seed($seedEntries);
+        $elapsed = microtime(true) - $start;
+
+        $progress->writeln(sprintf(
+            'Target seed complete in %.1fs.',
+            $elapsed,
+        ));
+    }
+
+    /**
+     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int} $params
+     */
+    private function runAgainstTarget(
+        OutputInterface $output,
+        OutputInterface $progress,
+        InputInterface $input,
+        TargetBench $bench,
+        array $params,
+    ): StatsSnapshot {
+        $progress->writeln('Running workload against target...');
+
+        $config = $this->buildTargetConfig(
+            $input,
+            $bench,
+            $params,
+        );
+
+        return (new Driver($config))->run($output);
+    }
+
+    /**
+     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int} $params
+     */
+    private function runAgainstFreedsx(
+        OutputInterface $output,
+        OutputInterface $progress,
+        InputInterface $input,
+        array $params,
+    ): StatsSnapshot {
+        $progress->writeln('Running workload against FreeDSx...');
+
+        $config = $this->buildFreedsxConfig(
+            $input,
+            $params,
+        );
+
+        return (new Driver($config))->run($output);
+    }
+
+    /**
+     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int} $params
+     */
+    private function buildTargetConfig(
+        InputInterface $input,
+        TargetBench $bench,
+        array $params,
+    ): Config {
+        return new Config(
+            backend: $this->requireString($input, 'freedsx-backend'),
+            runner: $this->requireString($input, 'freedsx-runner'),
+            clients: $params['clients'],
+            duration: $params['duration'],
+            ops: $params['ops'],
+            mix: $params['mix'],
+            host: $this->requireString($input, 'target-host'),
+            port: $this->requireInt($input, 'target-port'),
+            warmup: $params['warmup'],
+            serverMode: 'external',
+            rngSeed: $params['rngSeed'],
+            output: 'text',
+            seedEntries: 0,
+            bindDn: $this->requireString($input, 'target-bind-dn'),
+            bindPassword: $this->requireString($input, 'target-bind-password'),
+            baseDn: $bench->benchBaseDn,
+            writeBase: $bench->writeBaseDn,
+        );
+    }
+
+    /**
+     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int} $params
+     */
+    private function buildFreedsxConfig(
+        InputInterface $input,
+        array $params,
+    ): Config {
+        return new Config(
+            backend: $this->requireString($input, 'freedsx-backend'),
+            runner: $this->requireString($input, 'freedsx-runner'),
+            clients: $params['clients'],
+            duration: $params['duration'],
+            ops: $params['ops'],
+            mix: $params['mix'],
+            host: '127.0.0.1',
+            port: $this->requireInt($input, 'freedsx-port'),
+            warmup: $params['warmup'],
+            serverMode: 'spawn',
+            rngSeed: $params['rngSeed'],
+            output: 'text',
+            seedEntries: $params['seedEntries'],
+        );
+    }
+
+    private function renderSingleRun(
+        OutputInterface $output,
+        string $label,
+        StatsSnapshot $snapshot,
+        Config $config,
+    ): void {
+        $output->writeln('');
+        $output->writeln(sprintf('--- %s results ---', $label));
+        (new Report(
+            $config,
+            new WorkloadMix($config->mix),
+            $snapshot,
+        ))->render($output);
+    }
+
+    private function progressChannel(OutputInterface $output): OutputInterface
+    {
+        if ($output instanceof ConsoleOutputInterface) {
+            return $output->getErrorOutput();
+        }
+
+        return $output;
+    }
+
+    private function requireString(
+        InputInterface $input,
+        string $name,
+    ): string {
+        $value = $input->getOption($name);
+
+        if (!is_string($value) || $value === '') {
+            throw new InvalidArgumentException("--{$name} is required.");
+        }
+
+        return $value;
+    }
+
+    private function requireInt(
+        InputInterface $input,
+        string $name,
+    ): int {
+        $value = $this->parseInt($input->getOption($name), $name);
+
+        if ($value === null) {
+            throw new InvalidArgumentException("--{$name} is required.");
+        }
+
+        return $value;
+    }
+
+    private function parseInt(
+        mixed $value,
+        string $name,
+    ): ?int {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_string($value) || !preg_match('/^-?\d+$/', $value)) {
+            $display = is_scalar($value)
+                ? (string) $value
+                : get_debug_type($value);
+
+            throw new InvalidArgumentException("--{$name} must be an integer, got \"{$display}\".");
+        }
+
+        return (int) $value;
+    }
+}

--- a/tests/performance/Compare/ComparisonReport.php
+++ b/tests/performance/Compare/ComparisonReport.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\Compare;
+
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Output\OutputInterface;
+use Tests\Performance\FreeDSx\Ldap\Stats\StatsSnapshot;
+
+/**
+ * Side-by-side renderer for an external LDAP target vs FreeDSx benchmark run.
+ */
+final class ComparisonReport
+{
+    private const HEADERS = [
+        'Operation',
+        'Target ops/s',
+        'FreeDSx ops/s',
+        'Ratio (FreeDSx/Target)',
+        'Target p99',
+        'FreeDSx p99',
+        'Target err',
+        'FD err',
+    ];
+
+    public function __construct(
+        private readonly ?StatsSnapshot $target,
+        private readonly ?StatsSnapshot $freedsx,
+        private readonly string $format,
+    ) {
+    }
+
+    public function render(OutputInterface $output): void
+    {
+        if ($this->format === 'json') {
+            $output->writeln($this->renderJson());
+
+            return;
+        }
+
+        $this->renderText($output);
+    }
+
+    private function renderText(OutputInterface $output): void
+    {
+        $output->writeln('');
+        $output->writeln('Side-by-side comparison');
+        $output->writeln('=======================');
+
+        if ($this->target === null) {
+            $output->writeln('Target run was skipped.');
+        }
+        if ($this->freedsx === null) {
+            $output->writeln('FreeDSx run was skipped.');
+        }
+
+        if ($this->target === null || $this->freedsx === null) {
+            return;
+        }
+
+        $table = new Table($output);
+        $table->setHeaders(self::HEADERS);
+
+        foreach ($this->unionOps() as $op) {
+            $table->addRow($this->buildRow($op));
+        }
+
+        $table->render();
+
+        $targetTotal = $this->target->overallThroughput();
+        $fdTotal = $this->freedsx->overallThroughput();
+
+        $output->writeln('');
+        $output->writeln(sprintf(
+            'Overall throughput: Target %s ops/s  |  FreeDSx %s ops/s  |  ratio %s',
+            number_format($targetTotal, 1),
+            number_format($fdTotal, 1),
+            $this->formatRatio($fdTotal, $targetTotal),
+        ));
+        $output->writeln(sprintf(
+            'Errors: Target %d  |  FreeDSx %d',
+            $this->target->totalErrors(),
+            $this->freedsx->totalErrors(),
+        ));
+        $output->writeln(sprintf(
+            'Elapsed: Target %.1fs  |  FreeDSx %.1fs',
+            $this->target->elapsedSeconds,
+            $this->freedsx->elapsedSeconds,
+        ));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildRow(string $op): array
+    {
+        $targetThr = $this->target?->throughput($op) ?? 0.0;
+        $fdThr = $this->freedsx?->throughput($op) ?? 0.0;
+
+        $targetStats = $this->target?->latencyStats($op) ?? ['p99' => 0];
+        $fdStats = $this->freedsx?->latencyStats($op) ?? ['p99' => 0];
+
+        return [
+            $op,
+            number_format($targetThr, 2),
+            number_format($fdThr, 2),
+            $this->formatRatio($fdThr, $targetThr),
+            self::formatNanos($targetStats['p99']),
+            self::formatNanos($fdStats['p99']),
+            (string) ($this->target?->errorCount($op) ?? 0),
+            (string) ($this->freedsx?->errorCount($op) ?? 0),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function unionOps(): array
+    {
+        $ops = array_merge(
+            $this->target?->operations() ?? [],
+            $this->freedsx?->operations() ?? [],
+        );
+
+        return array_values(array_unique($ops));
+    }
+
+    private function renderJson(): string
+    {
+        return json_encode(
+            [
+                'target' => $this->snapshotToArray($this->target),
+                'freedsx' => $this->snapshotToArray($this->freedsx),
+            ],
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function snapshotToArray(?StatsSnapshot $snapshot): ?array
+    {
+        if ($snapshot === null) {
+            return null;
+        }
+
+        $ops = [];
+        foreach ($snapshot->operations() as $op) {
+            $ops[$op] = [
+                'count' => $snapshot->successCount($op),
+                'errors' => $snapshot->errorCount($op),
+                'throughput' => $snapshot->throughput($op),
+                'latency_ns' => $snapshot->latencyStats($op),
+            ];
+        }
+
+        return [
+            'elapsed_seconds' => $snapshot->elapsedSeconds,
+            'operations' => $ops,
+            'totals' => [
+                'success' => $snapshot->totalSuccess(),
+                'errors' => $snapshot->totalErrors(),
+                'throughput' => $snapshot->overallThroughput(),
+            ],
+        ];
+    }
+
+    private function formatRatio(
+        float $numerator,
+        float $denominator,
+    ): string {
+        if ($denominator <= 0.0) {
+            return '-';
+        }
+
+        return sprintf('%.2fx', $numerator / $denominator);
+    }
+
+    private static function formatNanos(int $nanos): string
+    {
+        if ($nanos === 0) {
+            return '-';
+        }
+
+        return sprintf('%.2fms', $nanos / 1_000_000);
+    }
+}

--- a/tests/performance/Compare/TargetBench.php
+++ b/tests/performance/Compare/TargetBench.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\Compare;
+
+use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\Search\Filters;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Seeds and cleans up a throwaway bench subtree in a live external LDAP target.
+ *
+ * Note: Active Directory needs a different schema and is not supported here.
+ */
+final class TargetBench
+{
+    public readonly string $benchBaseDn;
+
+    public readonly string $writeBaseDn;
+
+    private readonly LdapClient $client;
+
+    private bool $bound = false;
+
+    public function __construct(
+        private readonly string $host,
+        private readonly int $port,
+        private readonly string $bindDn,
+        private readonly string $bindPassword,
+        private readonly string $rootBaseDn,
+        private readonly string $benchOu = 'freedsx-bench',
+        private readonly string $peopleOu = 'people',
+    ) {
+        $this->benchBaseDn = "ou={$this->benchOu},{$this->rootBaseDn}";
+        $this->writeBaseDn = "ou={$this->peopleOu},{$this->benchBaseDn}";
+        $this->client = new LdapClient(
+            (new ClientOptions())
+                ->setServers([$this->host])
+                ->setPort($this->port)
+                ->setTransport('tcp')
+                ->setTimeoutConnect(5)
+                ->setTimeoutRead(30)
+        );
+    }
+
+    public function compareDn(): string
+    {
+        return "cn=alice,{$this->writeBaseDn}";
+    }
+
+    public function mailDomain(): string
+    {
+        if (preg_match_all('/dc=([^,]+)/i', $this->rootBaseDn, $matches) === 0) {
+            return 'example.com';
+        }
+
+        return implode(
+            '.',
+            array_map('strtolower', $matches[1]),
+        );
+    }
+
+    public function seed(int $seedEntries): void
+    {
+        $this->bindIfNeeded();
+
+        $mailDomain = $this->mailDomain();
+
+        $this->ensureOrganizationalUnit(
+            $this->benchBaseDn,
+            $this->benchOu,
+        );
+        $this->ensureOrganizationalUnit(
+            $this->writeBaseDn,
+            $this->peopleOu,
+        );
+
+        $this->ensurePerson(
+            $this->compareDn(),
+            'alice',
+            'Alice',
+            "alice@{$mailDomain}",
+            '1',
+        );
+
+        for ($i = 1; $i <= $seedEntries; $i++) {
+            $this->ensurePerson(
+                "cn=seed-{$i},{$this->writeBaseDn}",
+                "seed-{$i}",
+                'Seed',
+                "seed-{$i}@{$mailDomain}",
+                (string) $i,
+            );
+        }
+    }
+
+    public function cleanup(): void
+    {
+        $this->bindIfNeeded();
+
+        try {
+            $entries = $this->client->search(
+                Operations::search(
+                    Filters::present('objectClass'),
+                )
+                    ->base($this->benchBaseDn)
+                    ->useSubtreeScope()
+            );
+        } catch (OperationException $e) {
+            if ($e->getCode() === ResultCode::NO_SUCH_OBJECT) {
+                return;
+            }
+
+            throw $e;
+        }
+
+        $dns = [];
+        foreach ($entries as $entry) {
+            $dns[] = (string) $entry->getDn();
+        }
+
+        usort(
+            $dns,
+            fn (string $a, string $b) => substr_count($b, ',') <=> substr_count($a, ',')
+        );
+
+        foreach ($dns as $dn) {
+            try {
+                $this->client->delete($dn);
+            } catch (Throwable) {
+            }
+        }
+    }
+
+    public function close(): void
+    {
+        if (!$this->bound) {
+            return;
+        }
+
+        try {
+            $this->client->unbind();
+        } catch (Throwable) {
+        }
+
+        $this->bound = false;
+    }
+
+    private function bindIfNeeded(): void
+    {
+        if ($this->bound) {
+            return;
+        }
+
+        try {
+            $this->client->bind($this->bindDn, $this->bindPassword);
+        } catch (Throwable $e) {
+            throw new RuntimeException(sprintf(
+                'Unable to bind to LDAP target at %s:%d as %s: %s',
+                $this->host,
+                $this->port,
+                $this->bindDn,
+                $e->getMessage(),
+            ), 0, $e);
+        }
+
+        $this->bound = true;
+    }
+
+    private function ensureOrganizationalUnit(
+        string $dn,
+        string $ou,
+    ): void {
+        $entry = new Entry(
+            $dn,
+            new Attribute('objectClass', 'organizationalUnit'),
+            new Attribute('ou', $ou),
+        );
+
+        $this->createOrIgnoreExists($entry);
+    }
+
+    private function ensurePerson(
+        string $dn,
+        string $cn,
+        string $sn,
+        string $mail,
+        string $uidNumber,
+    ): void {
+        $entry = new Entry(
+            $dn,
+            new Attribute('objectClass', 'inetOrgPerson', 'extensibleObject'),
+            new Attribute('cn', $cn),
+            new Attribute('sn', $sn),
+            new Attribute('mail', $mail),
+            new Attribute('uidNumber', $uidNumber),
+        );
+
+        $this->createOrIgnoreExists($entry);
+    }
+
+    private function createOrIgnoreExists(Entry $entry): void
+    {
+        try {
+            $this->client->create($entry);
+        } catch (OperationException $e) {
+            if ($e->getCode() === ResultCode::ENTRY_ALREADY_EXISTS) {
+                return;
+            }
+
+            throw $e;
+        }
+    }
+}

--- a/tests/performance/Config.php
+++ b/tests/performance/Config.php
@@ -56,6 +56,14 @@ final class Config
 
     public const DEFAULT_MIX = 'bind=5,search-read=50,search-eq=25,search-sub=10,search-list=5,add=2,modify=2,delete=1';
 
+    public const DEFAULT_BIND_DN = 'cn=user,dc=foo,dc=bar';
+
+    public const DEFAULT_BIND_PASSWORD = '12345';
+
+    public const DEFAULT_BASE_DN = 'dc=foo,dc=bar';
+
+    public const DEFAULT_WRITE_BASE = 'ou=people,dc=foo,dc=bar';
+
     public function __construct(
         public readonly string $backend,
         public readonly string $runner,
@@ -70,6 +78,10 @@ final class Config
         public readonly ?int $rngSeed = null,
         public readonly string $output = 'text',
         public readonly int $seedEntries = 100,
+        public readonly string $bindDn = self::DEFAULT_BIND_DN,
+        public readonly string $bindPassword = self::DEFAULT_BIND_PASSWORD,
+        public readonly string $baseDn = self::DEFAULT_BASE_DN,
+        public readonly string $writeBase = self::DEFAULT_WRITE_BASE,
     ) {
         $this->assertEnum('backend', $backend, self::BACKENDS);
         $this->assertEnum('runner', $runner, self::RUNNERS);

--- a/tests/performance/LoadTestCommand.php
+++ b/tests/performance/LoadTestCommand.php
@@ -125,6 +125,34 @@ final class LoadTestCommand extends Command
                 '100',
             )
             ->addOption(
+                'bind-dn',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'DN used to bind each worker client',
+                Config::DEFAULT_BIND_DN,
+            )
+            ->addOption(
+                'bind-password',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Password paired with --bind-dn',
+                Config::DEFAULT_BIND_PASSWORD,
+            )
+            ->addOption(
+                'base-dn',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Search base for read/eq/sub operations',
+                Config::DEFAULT_BASE_DN,
+            )
+            ->addOption(
+                'write-base',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Parent DN for add/modify/delete + seed-N entries',
+                Config::DEFAULT_WRITE_BASE,
+            )
+            ->addOption(
                 'ci-profile',
                 null,
                 InputOption::VALUE_REQUIRED,
@@ -243,6 +271,10 @@ final class LoadTestCommand extends Command
             rngSeed: $this->parseInt($input->getOption('rng-seed'), 'rng-seed'),
             output: $this->requireString($input, 'output'),
             seedEntries: $this->requireInt($input, 'seed-entries'),
+            bindDn: $this->requireString($input, 'bind-dn'),
+            bindPassword: $this->requireString($input, 'bind-password'),
+            baseDn: $this->requireString($input, 'base-dn'),
+            writeBase: $this->requireString($input, 'write-base'),
         );
     }
 

--- a/tests/performance/Workload/Worker.php
+++ b/tests/performance/Workload/Worker.php
@@ -32,25 +32,14 @@ use Throwable;
  */
 final class Worker
 {
-    private const BIND_DN = 'cn=user,dc=foo,dc=bar';
+    private readonly string $compareDn;
 
-    private const BIND_PASSWORD = '12345';
-
-    private const SEARCH_BASE = 'dc=foo,dc=bar';
-
-    private const WRITE_BASE = 'ou=people,dc=foo,dc=bar';
-
-    private const COMPARE_DN = 'cn=alice,ou=people,dc=foo,dc=bar';
+    private readonly string $mailDomain;
 
     /**
      * @var list<string> DNs known to exist at startup; used by search-read / search-eq.
      */
-    private const FIXED_READ_DNS = [
-        'dc=foo,dc=bar',
-        'cn=user,dc=foo,dc=bar',
-        'ou=people,dc=foo,dc=bar',
-        'cn=alice,ou=people,dc=foo,dc=bar',
-    ];
+    private readonly array $fixedReadDns;
 
     /**
      * @var list<string> DNs this worker added and has not yet deleted; modify/delete pick from here.
@@ -68,6 +57,23 @@ final class Worker
         private readonly Channel $startSignal,
         private readonly ?int $opsCap,
     ) {
+        $this->compareDn = 'cn=alice,' . $this->config->writeBase;
+        $this->mailDomain = $this->deriveMailDomain($this->config->baseDn);
+        $this->fixedReadDns = [
+            $this->config->baseDn,
+            $this->config->bindDn,
+            $this->config->writeBase,
+            $this->compareDn,
+        ];
+    }
+
+    private function deriveMailDomain(string $baseDn): string
+    {
+        if (preg_match_all('/dc=([^,]+)/i', $baseDn, $matches) === 0) {
+            return 'example.com';
+        }
+
+        return implode('.', array_map('strtolower', $matches[1]));
     }
 
     public function run(): void
@@ -75,7 +81,10 @@ final class Worker
         $client = $this->buildClient();
 
         try {
-            $client->bind(self::BIND_DN, self::BIND_PASSWORD);
+            $client->bind(
+                $this->config->bindDn,
+                $this->config->bindPassword,
+            );
         } catch (Throwable $e) {
             $this->readyBarrier->push(false);
 
@@ -159,7 +168,10 @@ final class Worker
 
     private function doBind(LdapClient $client): void
     {
-        $client->bind(self::BIND_DN, self::BIND_PASSWORD);
+        $client->bind(
+            $this->config->bindDn,
+            $this->config->bindPassword,
+        );
     }
 
     private function doSearchRead(LdapClient $client): void
@@ -174,7 +186,7 @@ final class Worker
     private function doSearchEq(LdapClient $client): void
     {
         $request = Operations::search($this->randomEqualityFilter())
-            ->base(self::SEARCH_BASE)
+            ->base($this->config->baseDn)
             ->useSubtreeScope();
 
         $client->search($request);
@@ -187,7 +199,7 @@ final class Worker
             : Filters::startsWith('cn', '');
 
         $request = Operations::search($filter)
-            ->base(self::SEARCH_BASE)
+            ->base($this->config->baseDn)
             ->useSubtreeScope();
 
         $client->search($request);
@@ -196,7 +208,7 @@ final class Worker
     private function doSearchList(LdapClient $client): void
     {
         $request = Operations::search(Filters::equal('objectClass', 'inetOrgPerson'))
-            ->base(self::WRITE_BASE)
+            ->base($this->config->writeBase)
             ->useSubtreeScope();
 
         $client->search($request);
@@ -207,10 +219,10 @@ final class Worker
         if ($this->config->seedEntries > 0 && mt_rand(1, 100) <= 80) {
             $idx = mt_rand(1, $this->config->seedEntries);
 
-            return "cn=seed-{$idx},ou=people,dc=foo,dc=bar";
+            return "cn=seed-{$idx}," . $this->config->writeBase;
         }
 
-        return self::FIXED_READ_DNS[array_rand(self::FIXED_READ_DNS)];
+        return $this->fixedReadDns[array_rand($this->fixedReadDns)];
     }
 
     private function randomEqualityFilter(): FilterInterface
@@ -220,29 +232,29 @@ final class Worker
 
             return mt_rand(0, 1) === 0
                 ? Filters::equal('cn', "seed-{$idx}")
-                : Filters::equal('mail', "seed-{$idx}@foo.bar");
+                : Filters::equal('mail', "seed-{$idx}@{$this->mailDomain}");
         }
 
         return mt_rand(0, 1) === 0
             ? Filters::equal('cn', 'alice')
-            : Filters::equal('mail', 'alice@foo.bar');
+            : Filters::equal('mail', "alice@{$this->mailDomain}");
     }
 
     private function doCompare(LdapClient $client): void
     {
-        $client->compare(self::COMPARE_DN, 'mail', 'alice@foo.bar');
+        $client->compare($this->compareDn, 'mail', "alice@{$this->mailDomain}");
     }
 
     private function doAdd(LdapClient $client): void
     {
         $seq = ++$this->addSeq;
         $cn = "load-w{$this->workerId}-{$seq}";
-        $dn = "cn={$cn}," . self::WRITE_BASE;
+        $dn = "cn={$cn}," . $this->config->writeBase;
 
         $client->create(new Entry(
             $dn,
             new Attribute('cn', $cn),
-            new Attribute('objectClass', 'inetOrgPerson'),
+            new Attribute('objectClass', 'inetOrgPerson', 'extensibleObject'),
             new Attribute('sn', 'Load'),
             new Attribute('uidNumber', (string) $seq),
         ));

--- a/tests/unit/Server/Backend/Storage/Adapter/MysqlFilterTranslatorTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/MysqlFilterTranslatorTest.php
@@ -16,7 +16,6 @@ namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Adapter;
 use FreeDSx\Ldap\Search\Filter\AndFilter;
 use FreeDSx\Ldap\Search\Filter\ApproximateFilter;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
-use FreeDSx\Ldap\Search\Filter\FilterInterface;
 use FreeDSx\Ldap\Search\Filter\GreaterThanOrEqualFilter;
 use FreeDSx\Ldap\Search\Filter\LessThanOrEqualFilter;
 use FreeDSx\Ldap\Search\Filter\MatchingRuleFilter;
@@ -37,13 +36,21 @@ final class MysqlFilterTranslatorTest extends TestCase
         $this->subject = new MysqlFilterTranslator();
     }
 
-    public function test_present_filter_returns_json_contains_path(): void
+    public function test_present_filter_returns_sidecar_presence_exists(): void
     {
         $result = $this->subject->translate(new PresentFilter('cn'));
 
         self::assertNotNull($result);
-        self::assertSame(
-            "JSON_CONTAINS_PATH(attributes, 'one', '$.\"cn\"')",
+        self::assertStringContainsString(
+            'FROM entry_attribute_values s',
+            $result->sql,
+        );
+        self::assertStringContainsString(
+            "s.attr_name_lower = 'cn'",
+            $result->sql,
+        );
+        self::assertStringStartsWith(
+            'lc_dn IN (SELECT s.entry_lc_dn',
             $result->sql,
         );
         self::assertSame(
@@ -59,16 +66,12 @@ final class MysqlFilterTranslatorTest extends TestCase
 
         self::assertNotNull($result);
         self::assertStringContainsString(
-            '$."objectclass"',
-            $result->sql,
-        );
-        self::assertStringNotContainsString(
-            '$."objectClass"',
+            "s.attr_name_lower = 'objectclass'",
             $result->sql,
         );
     }
 
-    public function test_equality_filter_returns_json_table_exists(): void
+    public function test_equality_filter_emits_sidecar_value_equality(): void
     {
         $result = $this->subject->translate(new EqualityFilter(
             'cn',
@@ -77,15 +80,15 @@ final class MysqlFilterTranslatorTest extends TestCase
 
         self::assertNotNull($result);
         self::assertStringContainsString(
-            '$."cn".values[*]',
+            "s.attr_name_lower = 'cn'",
             $result->sql,
         );
         self::assertStringContainsString(
-            'lower(val) = lower(?)',
+            's.value_lower = ?',
             $result->sql,
         );
         self::assertSame(
-            ['Alice'],
+            ['alice'],
             $result->params,
         );
         self::assertTrue($result->isExact);
@@ -100,15 +103,11 @@ final class MysqlFilterTranslatorTest extends TestCase
 
         self::assertNotNull($result);
         self::assertStringContainsString(
-            'JSON_TABLE',
-            $result->sql,
-        );
-        self::assertStringContainsString(
-            'lower(val) = lower(?)',
+            's.value_lower = ?',
             $result->sql,
         );
         self::assertSame(
-            ['Alice'],
+            ['alice'],
             $result->params,
         );
     }
@@ -146,6 +145,31 @@ final class MysqlFilterTranslatorTest extends TestCase
         self::assertFalse($result->isExact);
     }
 
+    public function test_equality_with_long_value_is_inexact(): void
+    {
+        $result = $this->subject->translate(new EqualityFilter(
+            'cn',
+            str_repeat('a', 256),
+        ));
+
+        self::assertNotNull($result);
+        self::assertFalse($result->isExact);
+    }
+
+    public function test_equality_lowercased_query_value_is_truncated_to_255_chars(): void
+    {
+        $result = $this->subject->translate(new EqualityFilter(
+            'cn',
+            str_repeat('A', 300),
+        ));
+
+        self::assertNotNull($result);
+        self::assertSame(
+            [str_repeat('a', 255)],
+            $result->params,
+        );
+    }
+
     public function test_substring_with_non_ascii_fragment_is_inexact(): void
     {
         $result = $this->subject->translate(new SubstringFilter(
@@ -157,7 +181,7 @@ final class MysqlFilterTranslatorTest extends TestCase
         self::assertFalse($result->isExact);
     }
 
-    public function test_gte_filter_returns_json_table_gte(): void
+    public function test_gte_filter_emits_sidecar_value_gte(): void
     {
         $result = $this->subject->translate(new GreaterThanOrEqualFilter(
             'age',
@@ -166,11 +190,11 @@ final class MysqlFilterTranslatorTest extends TestCase
 
         self::assertNotNull($result);
         self::assertStringContainsString(
-            '$."age".values[*]',
+            "s.attr_name_lower = 'age'",
             $result->sql,
         );
         self::assertStringContainsString(
-            'lower(val) >= lower(?)',
+            's.value_lower >= ?',
             $result->sql,
         );
         self::assertSame(
@@ -212,7 +236,7 @@ final class MysqlFilterTranslatorTest extends TestCase
         self::assertFalse($result->isExact);
     }
 
-    public function test_lte_filter_returns_json_table_lte(): void
+    public function test_lte_filter_emits_sidecar_value_lte(): void
     {
         $result = $this->subject->translate(new LessThanOrEqualFilter(
             'age',
@@ -221,11 +245,11 @@ final class MysqlFilterTranslatorTest extends TestCase
 
         self::assertNotNull($result);
         self::assertStringContainsString(
-            '$."age".values[*]',
+            "s.attr_name_lower = 'age'",
             $result->sql,
         );
         self::assertStringContainsString(
-            'lower(val) <= lower(?)',
+            's.value_lower <= ?',
             $result->sql,
         );
         self::assertSame(
@@ -234,18 +258,7 @@ final class MysqlFilterTranslatorTest extends TestCase
         );
     }
 
-    public function test_lte_filter_with_digit_value_is_inexact(): void
-    {
-        $result = $this->subject->translate(new LessThanOrEqualFilter(
-            'uidNumber',
-            '100',
-        ));
-
-        self::assertNotNull($result);
-        self::assertFalse($result->isExact);
-    }
-
-    public function test_lte_filter_with_ascii_non_digit_value_is_exact(): void
+    public function test_lte_filter_is_always_inexact_under_sidecar_truncation(): void
     {
         $result = $this->subject->translate(new LessThanOrEqualFilter(
             'sn',
@@ -253,21 +266,10 @@ final class MysqlFilterTranslatorTest extends TestCase
         ));
 
         self::assertNotNull($result);
-        self::assertTrue($result->isExact);
-    }
-
-    public function test_lte_filter_with_non_ascii_value_is_inexact(): void
-    {
-        $result = $this->subject->translate(new LessThanOrEqualFilter(
-            'sn',
-            'Smíth',
-        ));
-
-        self::assertNotNull($result);
         self::assertFalse($result->isExact);
     }
 
-    public function test_attribute_with_option_strips_option_from_json_path(): void
+    public function test_attribute_with_option_strips_option_from_sql(): void
     {
         $result = $this->subject->translate(new EqualityFilter(
             'userCertificate;binary',
@@ -276,7 +278,7 @@ final class MysqlFilterTranslatorTest extends TestCase
 
         self::assertNotNull($result);
         self::assertStringContainsString(
-            '$."usercertificate"',
+            "s.attr_name_lower = 'usercertificate'",
             $result->sql,
         );
         self::assertStringNotContainsString(
@@ -291,7 +293,7 @@ final class MysqlFilterTranslatorTest extends TestCase
 
         self::assertNotNull($result);
         self::assertStringContainsString(
-            '$."cn"',
+            "s.attr_name_lower = 'cn'",
             $result->sql,
         );
         self::assertStringNotContainsString(
@@ -300,18 +302,18 @@ final class MysqlFilterTranslatorTest extends TestCase
         );
     }
 
-    public function test_numericoid_attribute_translates_with_quoted_path(): void
+    public function test_numericoid_attribute_translates(): void
     {
         $result = $this->subject->translate(new PresentFilter('2.5.4.3'));
 
         self::assertNotNull($result);
-        self::assertSame(
-            "JSON_CONTAINS_PATH(attributes, 'one', '$.\"2.5.4.3\"')",
+        self::assertStringContainsString(
+            "s.attr_name_lower = '2.5.4.3'",
             $result->sql,
         );
     }
 
-    public function test_numericoid_equality_translates_with_quoted_path(): void
+    public function test_numericoid_equality_translates(): void
     {
         $result = $this->subject->translate(new EqualityFilter(
             '2.5.4.3',
@@ -320,11 +322,11 @@ final class MysqlFilterTranslatorTest extends TestCase
 
         self::assertNotNull($result);
         self::assertStringContainsString(
-            '$."2.5.4.3".values[*]',
+            "s.attr_name_lower = '2.5.4.3'",
             $result->sql,
         );
         self::assertSame(
-            ['Alice'],
+            ['alice'],
             $result->params,
         );
     }
@@ -371,7 +373,7 @@ final class MysqlFilterTranslatorTest extends TestCase
         self::assertNull($result);
     }
 
-    public function test_substring_with_starts_with_only(): void
+    public function test_substring_with_starts_with_only_emits_prefix_like(): void
     {
         $result = $this->subject->translate(new SubstringFilter(
             'cn',
@@ -380,115 +382,76 @@ final class MysqlFilterTranslatorTest extends TestCase
 
         self::assertNotNull($result);
         self::assertStringContainsString(
-            'JSON_TABLE',
-            $result->sql,
-        );
-        self::assertStringContainsString(
-            '$."cn".values[*]',
+            "s.value_lower LIKE ? ESCAPE '!'",
             $result->sql,
         );
         self::assertSame(
-            ['Al%'],
+            ['al%'],
             $result->params,
         );
-    }
-
-    public function test_substring_with_contains_and_anchors_is_not_exact(): void
-    {
-        $result = $this->subject->translate(new SubstringFilter(
-            'cn',
-            'A',
-            'e',
-            'lic',
-        ));
-
-        self::assertNotNull($result);
-        self::assertFalse($result->isExact);
-    }
-
-    public function test_substring_with_contains_and_starts_with_is_not_exact(): void
-    {
-        $result = $this->subject->translate(new SubstringFilter(
-            'cn',
-            'Alice',
-            null,
-            'lic',
-        ));
-
-        self::assertNotNull($result);
-        self::assertFalse($result->isExact);
-    }
-
-    public function test_substring_with_contains_and_ends_with_is_not_exact(): void
-    {
-        $result = $this->subject->translate(new SubstringFilter(
-            'cn',
-            null,
-            'ice',
-            'lic',
-        ));
-
-        self::assertNotNull($result);
-        self::assertFalse($result->isExact);
-    }
-
-    public function test_substring_with_single_contains_only_is_exact(): void
-    {
-        $result = $this->subject->translate(new SubstringFilter(
-            'cn',
-            null,
-            null,
-            'lic',
-        ));
-
-        self::assertNotNull($result);
         self::assertTrue($result->isExact);
     }
 
-    public function test_substring_with_starts_and_ends_without_contains_is_exact(): void
+    public function test_substring_with_ends_with_only_falls_back_to_presence(): void
     {
         $result = $this->subject->translate(new SubstringFilter(
             'cn',
-            'A',
-            'e',
+            null,
+            'ce',
         ));
 
         self::assertNotNull($result);
-        self::assertTrue($result->isExact);
-    }
-
-    public function test_substring_with_multiple_contains_is_not_exact(): void
-    {
-        $result = $this->subject->translate(new SubstringFilter(
-            'cn',
-            'a',
-            'd',
-            'b',
-            'c',
-        ));
-
-        self::assertNotNull($result);
-        self::assertFalse($result->isExact);
-    }
-
-    public function test_substring_with_all_components(): void
-    {
-        $result = $this->subject->translate(new SubstringFilter(
-            'cn',
-            'A',
-            'e',
-            'lic',
-        ));
-
-        self::assertNotNull($result);
-        self::assertSame(
-            ['A%', '%lic%', '%e'],
-            $result->params,
-        );
-        self::assertStringContainsString(
-            'AND',
+        self::assertStringNotContainsString(
+            'LIKE',
             $result->sql,
         );
+        self::assertStringContainsString(
+            "s.attr_name_lower = 'cn'",
+            $result->sql,
+        );
+        self::assertSame(
+            [],
+            $result->params,
+        );
+        self::assertFalse($result->isExact);
+    }
+
+    public function test_substring_with_single_contains_falls_back_to_presence(): void
+    {
+        $result = $this->subject->translate(new SubstringFilter(
+            'cn',
+            null,
+            null,
+            'lic',
+        ));
+
+        self::assertNotNull($result);
+        self::assertStringNotContainsString(
+            'LIKE',
+            $result->sql,
+        );
+        self::assertFalse($result->isExact);
+    }
+
+    public function test_substring_with_all_fragments_uses_prefix_only(): void
+    {
+        $result = $this->subject->translate(new SubstringFilter(
+            'cn',
+            'A',
+            'e',
+            'lic',
+        ));
+
+        self::assertNotNull($result);
+        self::assertStringContainsString(
+            "s.value_lower LIKE ? ESCAPE '!'",
+            $result->sql,
+        );
+        self::assertSame(
+            ['a%'],
+            $result->params,
+        );
+        self::assertFalse($result->isExact);
     }
 
     public function test_substring_escapes_special_like_characters(): void
@@ -616,8 +579,12 @@ final class MysqlFilterTranslatorTest extends TestCase
         );
 
         self::assertNotNull($result);
-        self::assertSame(
-            "NOT (JSON_CONTAINS_PATH(attributes, 'one', '$.\"cn\"'))",
+        self::assertStringStartsWith(
+            'NOT (lc_dn IN (',
+            $result->sql,
+        );
+        self::assertStringContainsString(
+            "s.attr_name_lower = 'cn'",
             $result->sql,
         );
     }
@@ -637,11 +604,11 @@ final class MysqlFilterTranslatorTest extends TestCase
             $result->sql,
         );
         self::assertStringContainsString(
-            "JSON_CONTAINS_PATH(attributes, 'one', '$.\"cn\"')",
+            "s.attr_name_lower = 'cn'",
             $result->sql,
         );
         self::assertSame(
-            ['Alice'],
+            ['alice'],
             $result->params,
         );
         self::assertTrue($result->isExact);
@@ -724,41 +691,8 @@ final class MysqlFilterTranslatorTest extends TestCase
 
         self::assertNotNull($result);
         self::assertSame(
-            ['Alice', 'person'],
+            ['alice', 'person'],
             $result->params,
-        );
-    }
-
-    /**
-     * @return iterable<string, array{0: FilterInterface}>
-     */
-    public static function valueBearingFilterProvider(): iterable
-    {
-        yield 'equality' => [new EqualityFilter('cn', 'Alice')];
-        yield 'approximate' => [new ApproximateFilter('cn', 'Alice')];
-        yield 'substring' => [
-            new SubstringFilter(
-                'cn',
-                'Al',
-                'ce',
-                'i',
-            ),
-        ];
-        yield 'gte' => [new GreaterThanOrEqualFilter('uidNumber', '100')];
-        yield 'lte' => [new LessThanOrEqualFilter('uidNumber', '100')];
-    }
-
-    /**
-     * @dataProvider valueBearingFilterProvider
-     */
-    public function test_value_bearing_filters_include_no_semijoin_hint(FilterInterface $filter): void
-    {
-        $result = $this->subject->translate($filter);
-
-        self::assertNotNull($result);
-        self::assertStringContainsString(
-            'NO_SEMIJOIN()',
-            $result->sql,
         );
     }
 }

--- a/tests/unit/Server/Backend/Storage/Adapter/SqliteFilterTranslatorTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/SqliteFilterTranslatorTest.php
@@ -36,13 +36,17 @@ final class SqliteFilterTranslatorTest extends TestCase
         $this->subject = new SqliteFilterTranslator();
     }
 
-    public function test_present_filter_returns_json_type_check(): void
+    public function test_present_emits_sidecar_presence_exists(): void
     {
         $result = $this->subject->translate(new PresentFilter('cn'));
 
         self::assertNotNull($result);
-        self::assertSame(
-            "json_type(attributes, '$.\"cn\"') IS NOT NULL",
+        self::assertStringContainsString(
+            'FROM entry_attribute_values s',
+            $result->sql,
+        );
+        self::assertStringContainsString(
+            "s.attr_name_lower = 'cn'",
             $result->sql,
         );
         self::assertSame(
@@ -51,18 +55,18 @@ final class SqliteFilterTranslatorTest extends TestCase
         );
     }
 
-    public function test_present_filter_lowercases_attribute_name(): void
+    public function test_present_lowercases_attribute_name(): void
     {
         $result = $this->subject->translate(new PresentFilter('objectClass'));
 
         self::assertNotNull($result);
         self::assertStringContainsString(
-            '$."objectclass"',
+            "s.attr_name_lower = 'objectclass'",
             $result->sql,
         );
     }
 
-    public function test_equality_filter_returns_exists_lower_equals(): void
+    public function test_equality_emits_sidecar_value_equality(): void
     {
         $result = $this->subject->translate(new EqualityFilter(
             'cn',
@@ -70,17 +74,17 @@ final class SqliteFilterTranslatorTest extends TestCase
         ));
 
         self::assertNotNull($result);
-        self::assertSame(
-            "EXISTS (SELECT 1 FROM json_each(attributes, '$.\"cn\".values') WHERE lower(value) = lower(?))",
+        self::assertStringContainsString(
+            's.value_lower = ?',
             $result->sql,
         );
         self::assertSame(
-            ['Alice'],
+            ['alice'],
             $result->params,
         );
     }
 
-    public function test_approximate_filter_translates_same_as_equality(): void
+    public function test_approximate_translates_same_as_equality(): void
     {
         $result = $this->subject->translate(new ApproximateFilter(
             'cn',
@@ -88,17 +92,17 @@ final class SqliteFilterTranslatorTest extends TestCase
         ));
 
         self::assertNotNull($result);
-        self::assertSame(
-            "EXISTS (SELECT 1 FROM json_each(attributes, '$.\"cn\".values') WHERE lower(value) = lower(?))",
+        self::assertStringContainsString(
+            's.value_lower = ?',
             $result->sql,
         );
         self::assertSame(
-            ['Alice'],
+            ['alice'],
             $result->params,
         );
     }
 
-    public function test_approximate_filter_with_ascii_value_is_exact(): void
+    public function test_approximate_with_ascii_value_is_exact(): void
     {
         $result = $this->subject->translate(new ApproximateFilter(
             'cn',
@@ -109,7 +113,7 @@ final class SqliteFilterTranslatorTest extends TestCase
         self::assertTrue($result->isExact);
     }
 
-    public function test_approximate_filter_with_non_ascii_value_is_inexact(): void
+    public function test_approximate_with_non_ascii_value_is_inexact(): void
     {
         $result = $this->subject->translate(new ApproximateFilter(
             'cn',
@@ -120,7 +124,7 @@ final class SqliteFilterTranslatorTest extends TestCase
         self::assertFalse($result->isExact);
     }
 
-    public function test_equality_filter_with_ascii_value_is_exact(): void
+    public function test_equality_with_ascii_value_is_exact(): void
     {
         $result = $this->subject->translate(new EqualityFilter(
             'cn',
@@ -131,7 +135,7 @@ final class SqliteFilterTranslatorTest extends TestCase
         self::assertTrue($result->isExact);
     }
 
-    public function test_equality_filter_with_non_ascii_value_is_inexact(): void
+    public function test_equality_with_non_ascii_value_is_inexact(): void
     {
         $result = $this->subject->translate(new EqualityFilter(
             'cn',
@@ -142,18 +146,32 @@ final class SqliteFilterTranslatorTest extends TestCase
         self::assertFalse($result->isExact);
     }
 
-    public function test_substring_with_non_ascii_fragment_is_inexact(): void
+    public function test_equality_with_long_value_is_inexact(): void
     {
-        $result = $this->subject->translate(new SubstringFilter(
+        $result = $this->subject->translate(new EqualityFilter(
             'cn',
-            'Café',
+            str_repeat('a', 256),
         ));
 
         self::assertNotNull($result);
         self::assertFalse($result->isExact);
     }
 
-    public function test_gte_filter_returns_exists_lower_gte(): void
+    public function test_equality_value_is_lowercased_and_truncated(): void
+    {
+        $result = $this->subject->translate(new EqualityFilter(
+            'cn',
+            str_repeat('A', 300),
+        ));
+
+        self::assertNotNull($result);
+        self::assertSame(
+            [str_repeat('a', 255)],
+            $result->params,
+        );
+    }
+
+    public function test_gte_emits_sidecar_value_gte(): void
     {
         $result = $this->subject->translate(new GreaterThanOrEqualFilter(
             'age',
@@ -161,8 +179,8 @@ final class SqliteFilterTranslatorTest extends TestCase
         ));
 
         self::assertNotNull($result);
-        self::assertSame(
-            "EXISTS (SELECT 1 FROM json_each(attributes, '$.\"age\".values') WHERE lower(value) >= lower(?))",
+        self::assertStringContainsString(
+            's.value_lower >= ?',
             $result->sql,
         );
         self::assertSame(
@@ -171,7 +189,7 @@ final class SqliteFilterTranslatorTest extends TestCase
         );
     }
 
-    public function test_gte_filter_with_digit_value_is_inexact(): void
+    public function test_gte_with_digit_value_is_inexact(): void
     {
         // Critical: PHP compareOrdered does integer compare when both sides
         // are ctype_digit, so SQL byte compare would diverge. Must stay inexact.
@@ -184,7 +202,7 @@ final class SqliteFilterTranslatorTest extends TestCase
         self::assertFalse($result->isExact);
     }
 
-    public function test_gte_filter_with_ascii_non_digit_value_is_exact(): void
+    public function test_gte_with_ascii_non_digit_value_is_exact(): void
     {
         $result = $this->subject->translate(new GreaterThanOrEqualFilter(
             'sn',
@@ -195,7 +213,7 @@ final class SqliteFilterTranslatorTest extends TestCase
         self::assertTrue($result->isExact);
     }
 
-    public function test_gte_filter_with_non_ascii_value_is_inexact(): void
+    public function test_gte_with_non_ascii_value_is_inexact(): void
     {
         $result = $this->subject->translate(new GreaterThanOrEqualFilter(
             'sn',
@@ -206,7 +224,7 @@ final class SqliteFilterTranslatorTest extends TestCase
         self::assertFalse($result->isExact);
     }
 
-    public function test_lte_filter_returns_exists_lower_lte(): void
+    public function test_lte_emits_sidecar_value_lte(): void
     {
         $result = $this->subject->translate(new LessThanOrEqualFilter(
             'age',
@@ -214,8 +232,8 @@ final class SqliteFilterTranslatorTest extends TestCase
         ));
 
         self::assertNotNull($result);
-        self::assertSame(
-            "EXISTS (SELECT 1 FROM json_each(attributes, '$.\"age\".values') WHERE lower(value) <= lower(?))",
+        self::assertStringContainsString(
+            's.value_lower <= ?',
             $result->sql,
         );
         self::assertSame(
@@ -224,18 +242,7 @@ final class SqliteFilterTranslatorTest extends TestCase
         );
     }
 
-    public function test_lte_filter_with_digit_value_is_inexact(): void
-    {
-        $result = $this->subject->translate(new LessThanOrEqualFilter(
-            'uidNumber',
-            '100',
-        ));
-
-        self::assertNotNull($result);
-        self::assertFalse($result->isExact);
-    }
-
-    public function test_lte_filter_with_ascii_non_digit_value_is_exact(): void
+    public function test_lte_is_always_inexact(): void
     {
         $result = $this->subject->translate(new LessThanOrEqualFilter(
             'sn',
@@ -243,21 +250,10 @@ final class SqliteFilterTranslatorTest extends TestCase
         ));
 
         self::assertNotNull($result);
-        self::assertTrue($result->isExact);
-    }
-
-    public function test_lte_filter_with_non_ascii_value_is_inexact(): void
-    {
-        $result = $this->subject->translate(new LessThanOrEqualFilter(
-            'sn',
-            'Smíth',
-        ));
-
-        self::assertNotNull($result);
         self::assertFalse($result->isExact);
     }
 
-    public function test_attribute_with_option_strips_option_from_json_path(): void
+    public function test_attribute_with_option_strips_option(): void
     {
         $result = $this->subject->translate(new EqualityFilter(
             'userCertificate;binary',
@@ -266,7 +262,7 @@ final class SqliteFilterTranslatorTest extends TestCase
 
         self::assertNotNull($result);
         self::assertStringContainsString(
-            '$."usercertificate"',
+            "s.attr_name_lower = 'usercertificate'",
             $result->sql,
         );
         self::assertStringNotContainsString(
@@ -281,7 +277,7 @@ final class SqliteFilterTranslatorTest extends TestCase
 
         self::assertNotNull($result);
         self::assertStringContainsString(
-            '$."cn"',
+            "s.attr_name_lower = 'cn'",
             $result->sql,
         );
         self::assertStringNotContainsString(
@@ -290,18 +286,18 @@ final class SqliteFilterTranslatorTest extends TestCase
         );
     }
 
-    public function test_numericoid_attribute_translates_with_quoted_path(): void
+    public function test_numericoid_attribute_translates(): void
     {
         $result = $this->subject->translate(new PresentFilter('2.5.4.3'));
 
         self::assertNotNull($result);
-        self::assertSame(
-            "json_type(attributes, '$.\"2.5.4.3\"') IS NOT NULL",
+        self::assertStringContainsString(
+            "s.attr_name_lower = '2.5.4.3'",
             $result->sql,
         );
     }
 
-    public function test_numericoid_equality_attribute_translates_with_quoted_path(): void
+    public function test_numericoid_equality_translates(): void
     {
         $result = $this->subject->translate(new EqualityFilter(
             '2.5.4.3',
@@ -310,11 +306,11 @@ final class SqliteFilterTranslatorTest extends TestCase
 
         self::assertNotNull($result);
         self::assertStringContainsString(
-            '$."2.5.4.3"',
+            "s.attr_name_lower = '2.5.4.3'",
             $result->sql,
         );
         self::assertSame(
-            ['Alice'],
+            ['alice'],
             $result->params,
         );
     }
@@ -361,7 +357,7 @@ final class SqliteFilterTranslatorTest extends TestCase
         self::assertNull($result);
     }
 
-    public function test_substring_with_starts_with_only(): void
+    public function test_substring_starts_with_only_emits_prefix_like(): void
     {
         $result = $this->subject->translate(new SubstringFilter(
             'cn',
@@ -370,31 +366,37 @@ final class SqliteFilterTranslatorTest extends TestCase
 
         self::assertNotNull($result);
         self::assertStringContainsString(
-            'json_each',
+            "s.value_lower LIKE ? ESCAPE '!'",
             $result->sql,
         );
         self::assertSame(
-            ['Al%'],
+            ['al%'],
             $result->params,
         );
+        self::assertTrue($result->isExact);
     }
 
-    public function test_substring_with_ends_with_only(): void
+    public function test_substring_ends_with_only_falls_back_to_presence_inexact(): void
     {
         $result = $this->subject->translate(new SubstringFilter(
             'cn',
             null,
-            'ice',
+            'ce',
         ));
 
         self::assertNotNull($result);
+        self::assertStringNotContainsString(
+            'LIKE',
+            $result->sql,
+        );
+        self::assertFalse($result->isExact);
         self::assertSame(
-            ['%ice'],
+            [],
             $result->params,
         );
     }
 
-    public function test_substring_with_contains_only(): void
+    public function test_substring_single_contains_falls_back_to_presence_inexact(): void
     {
         $result = $this->subject->translate(new SubstringFilter(
             'cn',
@@ -404,13 +406,14 @@ final class SqliteFilterTranslatorTest extends TestCase
         ));
 
         self::assertNotNull($result);
-        self::assertSame(
-            ['%lic%'],
-            $result->params,
+        self::assertStringNotContainsString(
+            'LIKE',
+            $result->sql,
         );
+        self::assertFalse($result->isExact);
     }
 
-    public function test_substring_with_all_components(): void
+    public function test_substring_with_all_fragments_uses_prefix_only(): void
     {
         $result = $this->subject->translate(new SubstringFilter(
             'cn',
@@ -420,14 +423,15 @@ final class SqliteFilterTranslatorTest extends TestCase
         ));
 
         self::assertNotNull($result);
-        self::assertSame(
-            ['A%', '%lic%', '%e'],
-            $result->params,
-        );
         self::assertStringContainsString(
-            'AND',
+            "s.value_lower LIKE ? ESCAPE '!'",
             $result->sql,
         );
+        self::assertSame(
+            ['a%'],
+            $result->params,
+        );
+        self::assertFalse($result->isExact);
     }
 
     public function test_substring_escapes_special_like_characters(): void
@@ -444,85 +448,7 @@ final class SqliteFilterTranslatorTest extends TestCase
         );
     }
 
-    public function test_substring_with_contains_and_anchors_is_not_exact(): void
-    {
-        $result = $this->subject->translate(new SubstringFilter(
-            'cn',
-            'A',
-            'e',
-            'lic',
-        ));
-
-        self::assertNotNull($result);
-        self::assertFalse($result->isExact);
-    }
-
-    public function test_substring_with_contains_and_starts_with_is_not_exact(): void
-    {
-        $result = $this->subject->translate(new SubstringFilter(
-            'cn',
-            'Alice',
-            null,
-            'lic',
-        ));
-
-        self::assertNotNull($result);
-        self::assertFalse($result->isExact);
-    }
-
-    public function test_substring_with_contains_and_ends_with_is_not_exact(): void
-    {
-        $result = $this->subject->translate(new SubstringFilter(
-            'cn',
-            null,
-            'ice',
-            'lic',
-        ));
-
-        self::assertNotNull($result);
-        self::assertFalse($result->isExact);
-    }
-
-    public function test_substring_with_single_contains_only_is_exact(): void
-    {
-        $result = $this->subject->translate(new SubstringFilter(
-            'cn',
-            null,
-            null,
-            'lic',
-        ));
-
-        self::assertNotNull($result);
-        self::assertTrue($result->isExact);
-    }
-
-    public function test_substring_with_starts_and_ends_without_contains_is_exact(): void
-    {
-        $result = $this->subject->translate(new SubstringFilter(
-            'cn',
-            'A',
-            'e',
-        ));
-
-        self::assertNotNull($result);
-        self::assertTrue($result->isExact);
-    }
-
-    public function test_substring_with_multiple_contains_is_not_exact(): void
-    {
-        $result = $this->subject->translate(new SubstringFilter(
-            'cn',
-            'a',
-            'd',
-            'b',
-            'c',
-        ));
-
-        self::assertNotNull($result);
-        self::assertFalse($result->isExact);
-    }
-
-    public function test_and_filter_all_translatable_returns_combined(): void
+    public function test_and_of_translatable_is_exact(): void
     {
         $result = $this->subject->translate(new AndFilter(
             new PresentFilter('cn'),
@@ -544,7 +470,7 @@ final class SqliteFilterTranslatorTest extends TestCase
         self::assertTrue($result->isExact);
     }
 
-    public function test_and_filter_partial_translatable_returns_translatable_children_only(): void
+    public function test_and_partial_translatable_is_inexact(): void
     {
         $result = $this->subject->translate(new AndFilter(
             new PresentFilter('cn'),
@@ -556,18 +482,14 @@ final class SqliteFilterTranslatorTest extends TestCase
         ));
 
         self::assertNotNull($result);
-        self::assertStringContainsString(
-            'json_type',
-            $result->sql,
-        );
+        self::assertFalse($result->isExact);
         self::assertSame(
             [],
             $result->params,
         );
-        self::assertFalse($result->isExact);
     }
 
-    public function test_and_filter_with_no_translatable_children_returns_null(): void
+    public function test_and_with_no_translatable_children_returns_null(): void
     {
         $result = $this->subject->translate(new AndFilter(
             new MatchingRuleFilter(
@@ -580,7 +502,7 @@ final class SqliteFilterTranslatorTest extends TestCase
         self::assertNull($result);
     }
 
-    public function test_or_filter_all_translatable_returns_combined(): void
+    public function test_or_of_translatable_is_exact(): void
     {
         $result = $this->subject->translate(new OrFilter(
             new PresentFilter('cn'),
@@ -595,27 +517,24 @@ final class SqliteFilterTranslatorTest extends TestCase
             ' OR ',
             $result->sql,
         );
-        self::assertSame(
-            ['person'],
-            $result->params,
-        );
-    }
-
-    public function test_or_filter_all_translatable_is_exact(): void
-    {
-        $result = $this->subject->translate(new OrFilter(
-            new PresentFilter('cn'),
-            new EqualityFilter(
-                'objectClass',
-                'person',
-            ),
-        ));
-
-        self::assertNotNull($result);
         self::assertTrue($result->isExact);
     }
 
-    public function test_or_filter_with_inexact_child_is_not_exact(): void
+    public function test_or_with_one_untranslatable_child_returns_null(): void
+    {
+        $result = $this->subject->translate(new OrFilter(
+            new PresentFilter('cn'),
+            new MatchingRuleFilter(
+                '1.2.840.113556.1.4.803',
+                'memberOf',
+                '2',
+            ),
+        ));
+
+        self::assertNull($result);
+    }
+
+    public function test_or_with_inexact_child_is_inexact(): void
     {
         $result = $this->subject->translate(new OrFilter(
             new AndFilter(
@@ -636,48 +555,18 @@ final class SqliteFilterTranslatorTest extends TestCase
         self::assertFalse($result->isExact);
     }
 
-    public function test_or_filter_with_one_untranslatable_child_returns_null(): void
-    {
-        $result = $this->subject->translate(new OrFilter(
-            new PresentFilter('cn'),
-            new MatchingRuleFilter(
-                '1.2.840.113556.1.4.803',
-                'memberOf',
-                '2',
-            ),
-        ));
-
-        self::assertNull($result);
-    }
-
-    public function test_not_filter_with_translatable_child_returns_not_sql(): void
+    public function test_not_present_emits_plain_not(): void
     {
         $result = $this->subject->translate(
             new NotFilter(new PresentFilter('cn')),
         );
 
         self::assertNotNull($result);
-        self::assertStringContainsString(
-            'NOT (',
+        self::assertStringStartsWith(
+            'NOT (lc_dn IN (',
             $result->sql,
         );
-        self::assertSame(
-            [],
-            $result->params,
-        );
-    }
-
-    public function test_not_present_emits_plain_not_without_presence_guard(): void
-    {
-        $result = $this->subject->translate(
-            new NotFilter(new PresentFilter('cn')),
-        );
-
-        self::assertNotNull($result);
-        self::assertSame(
-            "NOT (json_type(attributes, '$.\"cn\"') IS NOT NULL)",
-            $result->sql,
-        );
+        self::assertTrue($result->isExact);
     }
 
     public function test_not_equality_adds_presence_guard(): void
@@ -690,12 +579,16 @@ final class SqliteFilterTranslatorTest extends TestCase
         );
 
         self::assertNotNull($result);
-        self::assertSame(
-            "(NOT (EXISTS (SELECT 1 FROM json_each(attributes, '$.\"cn\".values') WHERE lower(value) = lower(?))) AND json_type(attributes, '$.\"cn\"') IS NOT NULL)",
+        self::assertStringStartsWith(
+            '(NOT (',
+            $result->sql,
+        );
+        self::assertStringContainsString(
+            "s.attr_name_lower = 'cn'",
             $result->sql,
         );
         self::assertSame(
-            ['Alice'],
+            ['alice'],
             $result->params,
         );
         self::assertTrue($result->isExact);
@@ -712,43 +605,9 @@ final class SqliteFilterTranslatorTest extends TestCase
 
         self::assertNotNull($result);
         self::assertFalse($result->isExact);
-        self::assertStringContainsString(
-            "json_type(attributes, '$.\"cn\"') IS NOT NULL",
-            $result->sql,
-        );
     }
 
-    public function test_not_substring_adds_presence_guard(): void
-    {
-        $result = $this->subject->translate(
-            new NotFilter(new SubstringFilter(
-                'cn',
-                'A',
-            )),
-        );
-
-        self::assertNotNull($result);
-        self::assertStringContainsString(
-            'NOT (',
-            $result->sql,
-        );
-        self::assertStringContainsString(
-            "json_type(attributes, '$.\"cn\"') IS NOT NULL",
-            $result->sql,
-        );
-    }
-
-    public function test_not_filter_with_exact_child_is_exact(): void
-    {
-        $result = $this->subject->translate(
-            new NotFilter(new PresentFilter('cn')),
-        );
-
-        self::assertNotNull($result);
-        self::assertTrue($result->isExact);
-    }
-
-    public function test_not_filter_with_inexact_child_is_not_exact(): void
+    public function test_not_composite_inner_is_inexact(): void
     {
         $result = $this->subject->translate(
             new NotFilter(new AndFilter(
@@ -765,7 +624,7 @@ final class SqliteFilterTranslatorTest extends TestCase
         self::assertFalse($result->isExact);
     }
 
-    public function test_not_filter_with_untranslatable_child_returns_null(): void
+    public function test_not_with_untranslatable_child_returns_null(): void
     {
         $result = $this->subject->translate(
             new NotFilter(new MatchingRuleFilter(
@@ -791,24 +650,6 @@ final class SqliteFilterTranslatorTest extends TestCase
         self::assertNull($result);
     }
 
-    public function test_attribute_name_is_lowercased_in_sql(): void
-    {
-        $result = $this->subject->translate(new EqualityFilter(
-            'objectClass',
-            'person',
-        ));
-
-        self::assertNotNull($result);
-        self::assertStringContainsString(
-            '$."objectclass"',
-            $result->sql,
-        );
-        self::assertStringNotContainsString(
-            '$."objectClass"',
-            $result->sql,
-        );
-    }
-
     public function test_and_params_are_merged_in_order(): void
     {
         $result = $this->subject->translate(new AndFilter(
@@ -824,7 +665,7 @@ final class SqliteFilterTranslatorTest extends TestCase
 
         self::assertNotNull($result);
         self::assertSame(
-            ['Alice', 'person'],
+            ['alice', 'person'],
             $result->params,
         );
     }

--- a/tests/unit/Server/Backend/Storage/Adapter/SqliteStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/SqliteStorageTest.php
@@ -584,6 +584,10 @@ final class SqliteStorageTest extends TestCase
             ->willReturn($sqlite->ddlCreateTable());
         $dialect->method('ddlCreateIndex')
             ->willReturn($sqlite->ddlCreateIndex());
+        $dialect->method('ddlCreateSidecarTable')
+            ->willReturn($sqlite->ddlCreateSidecarTable());
+        $dialect->method('ddlCreateSidecarIndexes')
+            ->willReturn($sqlite->ddlCreateSidecarIndexes());
         $dialect->method('queryUpsert')
             ->willReturn($sqlite->queryUpsert());
         $dialect->method('queryExists')

--- a/tests/unit/Server/Backend/Storage/Adapter/SqliteStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/SqliteStorageTest.php
@@ -146,6 +146,39 @@ final class SqliteStorageTest extends TestCase
         self::assertCount(2, $results);
     }
 
+    public function test_interleaved_lists_do_not_share_cursor_state(): void
+    {
+        $this->subject->add(new AddCommand(
+            new Entry(new Dn('cn=Bob,dc=example,dc=com'), new Attribute('cn', 'Bob')),
+        ));
+        $this->subject->add(new AddCommand(
+            new Entry(new Dn('cn=Carol,dc=example,dc=com'), new Attribute('cn', 'Carol')),
+        ));
+
+        $outerIterator = $this->storage->list(StorageListOptions::matchAll(
+            new Dn('dc=example,dc=com'),
+            true,
+        ))->entries;
+
+        $outerIterator->current();
+        $outerIterator->next();
+
+        $inner = iterator_to_array($this->storage->list(StorageListOptions::matchAll(
+            new Dn('dc=example,dc=com'),
+            true,
+        ))->entries);
+
+        $remaining = [];
+        while ($outerIterator->valid()) {
+            $remaining[] = $outerIterator->current();
+            $outerIterator->next();
+        }
+
+        self::assertCount(4, $inner);
+        // Outer yielded 1 entry before the inner list; the remaining 3 must still come through.
+        self::assertCount(3, $remaining);
+    }
+
     public function test_has_children_returns_true_when_children_exist(): void
     {
         self::assertTrue($this->storage->hasChildren(new Dn('dc=example,dc=com')));


### PR DESCRIPTION
The storage backend is now actually quite performant under load with a large number of entries loaded. But there are some remaining optimizations to be done to close some of the larger gaps:

1. indexed lowercase attribute value lookups. The current structure is just not efficient. And the only cross platform way to address it is with a separate table (I don't want to rely on specific versions of MySQL or PostgreSQL). This is by far the biggest optimization.
2. Adding a PDOStatement cache. This shaves off another 10% or so.

The remaining slowdowns with the only substantial savings are:

1. The socket calls to read / peek the data. this can actually be optimized, but needs changes in the socket library + a new release.
2. The BER encoding / decoding. However, this is already heavily optimized. Whatever is done here would like be quite ugly or would require a lot of weird sacrifices to code sanity. So I will likely pass on it.

Even minus the above optimizations the library is quite fast compared to OpenLDAP when used with PDO storage.

Separately: Added a quick and dirty way to run a performance comparison against another LDAP.