### PR TITLE
[1.0.0] Lock dependencies to prepare for a 1.0 release.

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
 
       - name: Cache Dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest]
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.2']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
       - name: Checkout
@@ -38,15 +38,10 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Install Composer dependencies
-        if: ${{ matrix.php-versions != '8.1' }}
         run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
 
-      - name: Install Composer dependencies (8.1)
-        if: ${{ matrix.php-versions == '8.1' }}
-        run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader --ignore-platform-reqs
-
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+0.8.1 (2026-04-25)
+------------------
+* Lock FreeDSx dependencies to prepare for a 1.0 release. This will be the final 0.x release.
+
 0.8.0 (2022-05-21)
 ------------------
 * Properly handle and reap child processes in the LDAP server.

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
   ],
   "require": {
     "php": ">=7.1",
-    "freedsx/asn1": ">=0.4.0",
-    "freedsx/socket": ">=0.5.0",
-    "freedsx/sasl": ">=0.1.0",
-    "psr/log": "^1|^2|^3"
+    "freedsx/asn1": ">=0.4,<1.0",
+    "freedsx/socket": ">=0.5,<1.0",
+    "freedsx/sasl": ">=0.1,<1.0",
+    "psr/log": "^1||^2||^3"
   },
   "require-dev": {
     "phpspec/phpspec": "^7.2|^7.1|^6.1|^5.1",

--- a/src/FreeDSx/Ldap/Operation/Response/SearchResultEntry.php
+++ b/src/FreeDSx/Ldap/Operation/Response/SearchResultEntry.php
@@ -82,7 +82,12 @@ class SearchResultEntry implements ResponseInterface
                     }
                 }
 
-                $attributes[] = new Attribute($partialAttribute->getChild(0)->getValue(), ...$values);
+                $attrType = $partialAttribute->getChild(0);
+                if ($attrType === null) {
+                    throw new ProtocolException('The search result entry is malformed.');
+                }
+
+                $attributes[] = new Attribute($attrType->getValue(), ...$values);
             }
         }
 


### PR DESCRIPTION
This tightens the dependencies to prepare for the 1.0 release. All dependencies will have the same tightening done so I can properly modernize + cut a 1.0 release on them that this project will use. I don't want pre-1.0 dep changes breaking people who don't plan on / want to upgrade.