### PR TITLE
[1.0.0] Bump minimum PHP version to 8.2.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest]
-        php-versions: ['8.1', '8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.2', '8.3', '8.4', '8.5']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
       - name: Checkout

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -9,7 +9,7 @@ on:
       - 'composer.lock'
       - '.github/workflows/load-test.yml'
   push:
-    branches: [master, '1.0']
+    branches: [main, '1.0']
   workflow_dispatch:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FreeDSx LDAP ![](https://github.com/FreeDSx/LDAP/workflows/Analysis/badge.svg) ![](https://github.com/FreeDSx/LDAP/workflows/Build/badge.svg) [![codecov](https://codecov.io/gh/FreeDSx/LDAP/branch/master/graph/badge.svg)](https://codecov.io/gh/FreeDSx/LDAP)
+# FreeDSx LDAP ![](https://github.com/FreeDSx/LDAP/workflows/Analysis/badge.svg) ![](https://github.com/FreeDSx/LDAP/workflows/Build/badge.svg) [![codecov](https://codecov.io/gh/FreeDSx/LDAP/branch/main/graph/badge.svg)](https://codecov.io/gh/FreeDSx/LDAP)
 FreeDSx LDAP is a pure PHP LDAP library. It has no requirement on the core PHP LDAP extension. This library currently implements
 most client functionality described in [RFC 4511](https://tools.ietf.org/html/rfc4511) and some very limited LDAP server
 functionality. It also implements some other client features from various RFCs:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.2",
     "freedsx/asn1": "^0.4.0",
     "freedsx/socket": "^0.6.2",
     "freedsx/sasl": "^0.2.1",

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
   ],
   "require": {
     "php": ">=8.2",
-    "freedsx/asn1": "^0.4.0",
-    "freedsx/socket": "^0.6.2",
-    "freedsx/sasl": "^0.2.1",
+    "freedsx/asn1": "dev-main",
+    "freedsx/socket": "dev-main",
+    "freedsx/sasl": "dev-main",
     "psr/log": "^3"
   },
   "require-dev": {


### PR DESCRIPTION
I started to upgrade this library to a 1.0 version a while back. At the time, PHP 8.1 as the minimum made sense. It to no longer does. Bumping this to PHP 8.2. Also temporarily adjusting the version references on the other FreeDSx libraries until I cut a 1.0 version for them.