### PR TITLE
[1.0.0] Upgrade SASL library and refactor.

### DIFF
--- a/UPGRADE-1.0.md
+++ b/UPGRADE-1.0.md
@@ -11,6 +11,27 @@ Upgrading from 0.x to 1.0
 
 ## Client Changes
 
+### SASL Bind
+
+`LdapClient::bindSasl()` and `Operations::bindSasl()` now take `?MechanismName` instead of `string` for the mechanism
+parameter. Pass `null` (or omit it) to auto-select from the server's advertised mechanisms.
+
+**Before**:
+
+```php
+$client->bindSasl($options, 'DIGEST-MD5');
+$client->bindSasl($options); // auto-select
+```
+
+**After**:
+
+```php
+use FreeDSx\Sasl\Mechanism\MechanismName;
+
+$client->bindSasl($options, MechanismName::DIGEST_MD5);
+$client->bindSasl($options); // auto-select (null)
+```
+
 ### Client Options
 
 When instantiating the `LdapClient`, options are now an options object instead of an associative array.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": ">=8.2",
     "freedsx/asn1": "dev-main#46900759ae89b9e709356a86c1d84056c2e7ff67",
     "freedsx/socket": "dev-main#0e43af8f6af64de9ef3a730d3128e6c12134bc5e",
-    "freedsx/sasl": "dev-main#8dfa6e105f101960d9fa5f9c57d9c461d2c20593",
+    "freedsx/sasl": "dev-main#85e1ef9",
     "psr/log": "^3"
   },
   "require-dev": {

--- a/docs/Client/SASL-Bind-Authentication.md
+++ b/docs/Client/SASL-Bind-Authentication.md
@@ -58,6 +58,10 @@ $ldap->bindSasl(
 
 Each mechanism has its own options class from the `FreeDSx\Sasl\Options` namespace.
 
+> **Prefer SCRAM for new deployments.** The `SCRAM-SHA-256` (or higher) family offers modern cryptographic
+> guarantees and mutual authentication. `DIGEST-MD5` and `CRAM-MD5` are included for compatibility with
+> legacy servers only and should be avoided where the server supports SCRAM.
+
 ### PLAIN
 
 ```php

--- a/docs/Client/SASL-Bind-Authentication.md
+++ b/docs/Client/SASL-Bind-Authentication.md
@@ -3,15 +3,18 @@ SASL Bind Authentication
 
 * [Mechanisms](#mechanisms)
 * [Options](#options)
-    
-SASL support is provided via the [FreeDSx SASL](https://github.com/FreeDSx/SASL) library. You can initiate a SASL bind
-using the client methods.
 
-An example of letting it auto-detect a mechanism:
+SASL support is provided via the [FreeDSx SASL](https://github.com/FreeDSx/SASL) library. You can initiate a SASL bind
+using the `bindSasl()` method on the client.
+
+## Auto-selecting a Mechanism
+
+Omit the mechanism to let the library select the strongest one advertised by the server:
 
 ```php
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Sasl\Options\DigestMD5Options;
 
 $ldap = new LdapClient(
     (new ClientOptions)
@@ -19,19 +22,22 @@ $ldap = new LdapClient(
         ->setBaseDn('dc=example,dc=local')
 );
 
-# Bind using SASL, let it automatically detect an available supported mechanism.
-# The first parameter to bindSasl is an array of options for SASL to use.
-$ldap->bindSasl([
-    'username' => 'user',
-    'password' => '12345',
-]);
+$ldap->bindSasl(
+    (new DigestMD5Options)
+        ->setUsername('user')
+        ->setPassword('12345'),
+);
 ```
 
-An example of specifying a mechanism:
+## Specifying a Mechanism
+
+Pass a `MechanismName` enum value as the second argument to target a specific mechanism:
 
 ```php
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\DigestMD5Options;
 
 $ldap = new LdapClient(
     (new ClientOptions)
@@ -39,34 +45,92 @@ $ldap = new LdapClient(
         ->setBaseDn('dc=example,dc=local')
 );
 
-# Use the second parameter of bindSasl to specify a mechanism.
-$ldap->bindSasl([
-    'username' => 'user',
-    'password' => '12345',
-    # Also tell it to install an integrity security layer for further communications...
-    'use_integrity' => true,
-], 'DIGEST-MD5');
+$ldap->bindSasl(
+    (new DigestMD5Options)
+        ->setUsername('user')
+        ->setPassword('12345')
+        ->setUseIntegrity(true),
+    MechanismName::DIGEST_MD5,
+);
 ```
 
 ## Mechanisms
 
-The following table details mechanisms / options that are recognized when doing a SASL bind:
+Each mechanism has its own options class from the `FreeDSx\Sasl\Options` namespace.
 
-|                 | `DIGEST-MD5` | `CRAM-MD5` | `SCRAM-*` | `PLAIN` | `ANONYMOUS` |
-|-----------------|:------------:|:----------:|:---------:|:-------:|:-----------:|
-| `username`      |      X       |     X      |     X     |    X    |      X      |
-| `password`      |      X       |     X      |     X     |    X    |             |
-| `use_integrity` |      X       |            |           |         |             |
-| `trace`         |              |            |           |         |      X      |
-| `host`          |      X       |            |           |         |             |
+### PLAIN
 
-`SCRAM-*` refers to the SCRAM family of mechanisms: `SCRAM-SHA-1`, `SCRAM-SHA-256`, `SCRAM-SHA-384`, `SCRAM-SHA-512`,
+```php
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\PlainOptions;
+
+$ldap->bindSasl(
+    (new PlainOptions)
+        ->setUsername('user')
+        ->setPassword('12345'),
+    MechanismName::PLAIN,
+);
+```
+
+### CRAM-MD5
+
+```php
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\CramMD5Options;
+
+$ldap->bindSasl(
+    (new CramMD5Options)
+        ->setUsername('user')
+        ->setPassword('12345'),
+    MechanismName::CRAM_MD5,
+);
+```
+
+### DIGEST-MD5
+
+```php
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\DigestMD5Options;
+
+$ldap->bindSasl(
+    (new DigestMD5Options)
+        ->setUsername('user')
+        ->setPassword('12345'),
+    MechanismName::DIGEST_MD5,
+);
+```
+
+Use `setUseIntegrity(true)` to negotiate an integrity security layer, or `setHost()` to override the host in
+the DIGEST-MD5 digest-uri.
+
+### SCRAM
+
+`SCRAM-*` refers to the SCRAM family: `SCRAM-SHA-1`, `SCRAM-SHA-256`, `SCRAM-SHA-384`, `SCRAM-SHA-512`,
 `SCRAM-SHA3-512`, and their channel-binding (`-PLUS`) variants. `SCRAM-SHA-256` is recommended for new deployments.
+
+```php
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\ScramOptions;
+
+$ldap->bindSasl(
+    (new ScramOptions)
+        ->setUsername('user')
+        ->setPassword('12345'),
+    MechanismName::SCRAM_SHA256,
+);
+```
 
 ## Options
 
-* `username`: The user to bind with.
-* `password`: The password for the user during the bind.
-* `use_integrity`: A boolean value for whether or not an integrity security layer should be used via SASL.
-* `trace`: If defined during an anonymous bind, this string will be sent to the server for logging.
-* `host`: If defined, this string value will be used as the host part of the digest-uri in DIGEST-MD5.
+| Class             | Setter               | Mechanisms                  | Description                                            |
+|-------------------|----------------------|-----------------------------|--------------------------------------------------------|
+| `PlainOptions`    | `setUsername()`      | `PLAIN`                     | The authentication identity (username).                |
+| `PlainOptions`    | `setPassword()`      | `PLAIN`                     | The password.                                          |
+| `CramMD5Options`  | `setUsername()`      | `CRAM-MD5`                  | The username.                                          |
+| `CramMD5Options`  | `setPassword()`      | `CRAM-MD5`                  | The password.                                          |
+| `DigestMD5Options`| `setUsername()`      | `DIGEST-MD5`                | The username.                                          |
+| `DigestMD5Options`| `setPassword()`      | `DIGEST-MD5`                | The password.                                          |
+| `DigestMD5Options`| `setUseIntegrity()`  | `DIGEST-MD5`                | Negotiate an integrity security layer (`bool`).        |
+| `DigestMD5Options`| `setHost()`          | `DIGEST-MD5`                | Override the host in the digest-uri.                   |
+| `ScramOptions`    | `setUsername()`      | `SCRAM-*`                   | The username.                                          |
+| `ScramOptions`    | `setPassword()`      | `SCRAM-*`                   | The password.                                          |

--- a/src/FreeDSx/Ldap/LdapClient.php
+++ b/src/FreeDSx/Ldap/LdapClient.php
@@ -39,6 +39,9 @@ use FreeDSx\Ldap\Search\RangeRetrieval;
 use FreeDSx\Ldap\Search\Vlv;
 use FreeDSx\Ldap\Sync\SyncRepl;
 use FreeDSx\Sasl\Exception\SaslException;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\ChallengeOptionsInterface;
+use FreeDSx\Sasl\Options\SelectOptions;
 use SensitiveParameter;
 use Stringable;
 
@@ -88,19 +91,22 @@ class LdapClient
     /**
      * A SASL Bind to LDAP with SASL options and an optional specific mechanism type.
      *
-     * @param array<string, mixed> $options The SASL options (ie. ['username' => '...', 'password' => '...'])
-     * @param string $mechanism A specific mechanism to use. If none is supplied, one will be selected.
      * @throws Exception\BindException
      * @throws OperationException
      * @throws SaslException
      */
     public function bindSasl(
         #[SensitiveParameter]
-        array $options = [],
-        string $mechanism = ''
+        ?ChallengeOptionsInterface $options = null,
+        ?MechanismName $mechanism = null,
+        ?SelectOptions $selectOptions = null,
     ): LdapMessageResponse {
         return $this->sendAndReceive(
-            Operations::bindSasl($options, $mechanism)
+            Operations::bindSasl(
+                $options,
+                $mechanism,
+                selectOptions: $selectOptions,
+            )
                 ->setVersion($this->options->getVersion())
         );
     }

--- a/src/FreeDSx/Ldap/Operation/Request/SaslBindRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/SaslBindRequest.php
@@ -20,6 +20,8 @@ use FreeDSx\Asn1\Type\OctetStringType;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Protocol\LdapEncoder;
+use FreeDSx\Sasl\Options\ChallengeOptionsInterface;
+use FreeDSx\Sasl\Options\SelectOptions;
 
 /**
  * Represents a SASL bind request consisting of a mechanism challenge / response.
@@ -38,13 +40,11 @@ use FreeDSx\Ldap\Protocol\LdapEncoder;
  */
 class SaslBindRequest extends BindRequest
 {
-    /**
-     * @param array<string, mixed> $options
-     */
     public function __construct(
         private string $mechanism,
         private readonly ?string $credentials = null,
-        private readonly array $options = []
+        private readonly ?ChallengeOptionsInterface $options = null,
+        private readonly ?SelectOptions $selectOptions = null,
     ) {
         $this->username = '';
     }
@@ -66,12 +66,14 @@ class SaslBindRequest extends BindRequest
         return $this->credentials;
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function getOptions(): array
+    public function getOptions(): ?ChallengeOptionsInterface
     {
         return $this->options;
+    }
+
+    public function getSelectOptions(): ?SelectOptions
+    {
+        return $this->selectOptions;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Operations.php
+++ b/src/FreeDSx/Ldap/Operations.php
@@ -31,6 +31,9 @@ use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\Request\PasswordModifyRequest;
 use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\ChallengeOptionsInterface;
+use FreeDSx\Sasl\Options\SelectOptions;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
 use FreeDSx\Ldap\Operation\Request\SyncRequest;
@@ -80,18 +83,18 @@ class Operations
 
     /**
      * A SASL bind request with a specific mechanism and their associated options.
-     *
-     * @param array<string, mixed> $options
      */
     public static function bindSasl(
-        array $options = [],
-        string $mechanism = '',
+        ?ChallengeOptionsInterface $options = null,
+        ?MechanismName $mechanism = null,
         ?string $credentials = null,
+        ?SelectOptions $selectOptions = null,
     ): SaslBindRequest {
         return new SaslBindRequest(
-            mechanism: $mechanism,
+            mechanism: $mechanism !== null ? $mechanism->value : '',
             credentials: $credentials,
             options: $options,
+            selectOptions: $selectOptions,
         );
     }
 

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/CramMD5MechanismOptionsBuilder.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/CramMD5MechanismOptionsBuilder.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
 
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
-use FreeDSx\Sasl\Mechanism\CramMD5Mechanism;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\ChallengeOptionsInterface;
+use FreeDSx\Sasl\Options\CramMD5Options;
 
 /**
  * Builds options for the CRAM-MD5 SASL mechanism on the server side.
@@ -34,17 +36,17 @@ class CramMD5MechanismOptionsBuilder implements MechanismOptionsBuilderInterface
      */
     public function buildOptions(
         ?string $received,
-        string $mechanism,
-    ): array {
+        MechanismName $mechanism,
+    ): ?ChallengeOptionsInterface {
         if ($received === null) {
-            return [];
+            return null;
         }
 
-        return [
-            'password' => function (string $username, string $challenge): string {
+        return (new CramMD5Options())->setPasswordCallback(
+            function (string $username, string $challenge): string {
                 $password = $this->requirePassword($this->handler->getPassword(
                     $username,
-                    CramMD5Mechanism::NAME
+                    MechanismName::CRAM_MD5->value,
                 ));
 
                 return hash_hmac(
@@ -53,14 +55,6 @@ class CramMD5MechanismOptionsBuilder implements MechanismOptionsBuilderInterface
                     $password,
                 );
             },
-        ];
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function supports(string $mechanism): bool
-    {
-        return $mechanism === CramMD5Mechanism::NAME;
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/CramMD5MechanismOptionsBuilder.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/CramMD5MechanismOptionsBuilder.php
@@ -46,7 +46,7 @@ class CramMD5MechanismOptionsBuilder implements MechanismOptionsBuilderInterface
             function (string $username, string $challenge): string {
                 $password = $this->requirePassword($this->handler->getPassword(
                     $username,
-                    MechanismName::CRAM_MD5->value,
+                    MechanismName::CRAM_MD5,
                 ));
 
                 return hash_hmac(

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/DigestMD5MechanismOptionsBuilder.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/DigestMD5MechanismOptionsBuilder.php
@@ -16,7 +16,9 @@ namespace FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\SaslUsernameExtractorInterface;
-use FreeDSx\Sasl\Mechanism\DigestMD5Mechanism;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\ChallengeOptionsInterface;
+use FreeDSx\Sasl\Options\DigestMD5Options;
 
 /**
  * Builds options for the DIGEST-MD5 SASL mechanism on the server side.
@@ -40,23 +42,21 @@ class DigestMD5MechanismOptionsBuilder implements MechanismOptionsBuilderInterfa
      */
     public function buildOptions(
         ?string $received,
-        string $mechanism)
-    : array {
+        MechanismName $mechanism,
+    ): ?ChallengeOptionsInterface {
         if ($received === null) {
-            return [];
+            return null;
         }
 
-        $username = $this->usernameExtractor->extractUsername(DigestMD5Mechanism::NAME, $received);
-        $password = $this->requirePassword($this->handler->getPassword($username, DigestMD5Mechanism::NAME));
+        $username = $this->usernameExtractor->extractUsername(
+            MechanismName::DIGEST_MD5,
+            $received,
+        );
+        $password = $this->requirePassword($this->handler->getPassword(
+            $username,
+            MechanismName::DIGEST_MD5->value,
+        ));
 
-        return ['password' => $password];
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function supports(string $mechanism): bool
-    {
-        return $mechanism === DigestMD5Mechanism::NAME;
+        return (new DigestMD5Options())->setPassword($password);
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/DigestMD5MechanismOptionsBuilder.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/DigestMD5MechanismOptionsBuilder.php
@@ -54,7 +54,7 @@ class DigestMD5MechanismOptionsBuilder implements MechanismOptionsBuilderInterfa
         );
         $password = $this->requirePassword($this->handler->getPassword(
             $username,
-            MechanismName::DIGEST_MD5->value,
+            MechanismName::DIGEST_MD5,
         ));
 
         return (new DigestMD5Options())->setPassword($password);

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/MechanismOptionsBuilderFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/MechanismOptionsBuilderFactory.php
@@ -17,10 +17,7 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\UsernameFieldExtractor;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
-use FreeDSx\Sasl\Mechanism\CramMD5Mechanism;
-use FreeDSx\Sasl\Mechanism\DigestMD5Mechanism;
-use FreeDSx\Sasl\Mechanism\PlainMechanism;
-use FreeDSx\Sasl\Mechanism\ScramMechanism;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 
 /**
  * Creates a single MechanismOptionsBuilderInterface instance for the requested SASL mechanism.
@@ -37,19 +34,19 @@ final class MechanismOptionsBuilderFactory
     /**
      * @throws OperationException if the mechanism is unsupported.
      */
-    public function make(string $mechanism): MechanismOptionsBuilderInterface
+    public function make(MechanismName $mechanism): MechanismOptionsBuilderInterface
     {
         return match (true) {
-            $mechanism === PlainMechanism::NAME
+            $mechanism === MechanismName::PLAIN
                 => new PlainMechanismOptionsBuilder($this->authenticator),
-            $mechanism === CramMD5Mechanism::NAME
+            $mechanism === MechanismName::CRAM_MD5
                 => new CramMD5MechanismOptionsBuilder($this->authenticator),
-            $mechanism === DigestMD5Mechanism::NAME
+            $mechanism === MechanismName::DIGEST_MD5
                 => new DigestMD5MechanismOptionsBuilder($this->authenticator, new UsernameFieldExtractor()),
-            in_array($mechanism, ScramMechanism::VARIANTS, true)
+            $mechanism->isScram()
                 => new ScramMechanismOptionsBuilder($this->authenticator),
             default => throw new OperationException(
-                sprintf('The SASL mechanism "%s" is not supported.', $mechanism),
+                sprintf('The SASL mechanism "%s" is not supported.', $mechanism->value),
                 ResultCode::OTHER,
             ),
         };

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/MechanismOptionsBuilderInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/MechanismOptionsBuilderInterface.php
@@ -13,25 +13,22 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
 
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\ChallengeOptionsInterface;
+
 /**
- * Builds the options array passed to a SASL mechanism's challenge() call for a specific mechanism.
+ * Builds the options DTO passed to a SASL mechanism's challenge() call for a specific mechanism.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 interface MechanismOptionsBuilderInterface
 {
     /**
-     * Build the options for the next challenge() call.
-     *
-     * @return array<string, mixed>
+     * Build the options for the next challenge() call, or null when no options are needed.
      */
     public function buildOptions(
         ?string $received,
-        string $mechanism,
-    ): array;
+        MechanismName $mechanism,
+    ): ?ChallengeOptionsInterface;
 
-    /**
-     * Whether this builder handles the given mechanism name.
-     */
-    public function supports(string $mechanism): bool;
 }

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/PlainMechanismOptionsBuilder.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/PlainMechanismOptionsBuilder.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
 
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
-use FreeDSx\Sasl\Mechanism\PlainMechanism;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\ChallengeOptionsInterface;
+use FreeDSx\Sasl\Options\PlainOptions;
 
 /**
  * Builds options for the PLAIN SASL mechanism on the server side.
@@ -32,19 +34,11 @@ class PlainMechanismOptionsBuilder implements MechanismOptionsBuilderInterface
      */
     public function buildOptions(
         ?string $received,
-        string $mechanism,
-    ): array {
-        return [
-            'validate' => fn (?string $authzId, string $authcId, string $password): bool =>
-                $this->authenticator->verifyPassword(
-                    $authcId,
-                    $password
-                ),
-        ];
-    }
-
-    public function supports(string $mechanism): bool
-    {
-        return $mechanism === PlainMechanism::NAME;
+        MechanismName $mechanism,
+    ): ?ChallengeOptionsInterface {
+        return (new PlainOptions())->setValidate(
+            fn (?string $authzId, string $authcId, string $password): bool =>
+                $this->authenticator->verifyPassword($authcId, $password),
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/ScramMechanismOptionsBuilder.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/ScramMechanismOptionsBuilder.php
@@ -60,7 +60,7 @@ class ScramMechanismOptionsBuilder implements MechanismOptionsBuilderInterface
 
             return (new ScramOptions())->setPassword(
                 $this->requirePassword(
-                    $this->handler->getPassword($this->username, $mechanism->value),
+                    $this->handler->getPassword($this->username, $mechanism),
                 ),
             );
         }

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/ScramMechanismOptionsBuilder.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/ScramMechanismOptionsBuilder.php
@@ -16,7 +16,9 @@ namespace FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
-use FreeDSx\Sasl\Mechanism\ScramMechanism;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\ChallengeOptionsInterface;
+use FreeDSx\Sasl\Options\ScramOptions;
 
 /**
  * Builds options for SCRAM SASL mechanisms on the server side.
@@ -40,10 +42,10 @@ class ScramMechanismOptionsBuilder implements MechanismOptionsBuilderInterface
     /**
      * {@inheritDoc}
      */
-    public function buildOptions(?string $received, string $mechanism): array
+    public function buildOptions(?string $received, MechanismName $mechanism): ?ChallengeOptionsInterface
     {
         if ($received === null) {
-            return [];
+            return null;
         }
 
         // Client-final-message contains the proof field 'p='.
@@ -56,25 +58,17 @@ class ScramMechanismOptionsBuilder implements MechanismOptionsBuilderInterface
                 );
             }
 
-            return [
-                'password' => $this->requirePassword(
-                    $this->handler->getPassword($this->username, $mechanism)
+            return (new ScramOptions())->setPassword(
+                $this->requirePassword(
+                    $this->handler->getPassword($this->username, $mechanism->value),
                 ),
-            ];
+            );
         }
 
         // Client-first-message: extract and store the username for the next round.
         $this->username = $this->parseUsername($received);
 
-        return [];
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function supports(string $mechanism): bool
-    {
-        return in_array($mechanism, ScramMechanism::VARIANTS, true);
+        return null;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/SaslExchange.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/SaslExchange.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
 use FreeDSx\Ldap\Operation\Response\BindResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\MechanismOptionsBuilderFactory;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/SaslExchangeInput.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/SaslExchangeInput.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Protocol\Bind\Sasl;
 
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Sasl\Challenge\ChallengeInterface;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 
 /**
  * Bundles the per-invocation parameters for SaslExchange::run().
@@ -25,7 +26,7 @@ final class SaslExchangeInput
 {
     public function __construct(
         private readonly ChallengeInterface $challenge,
-        private readonly string $mechName,
+        private readonly MechanismName $mechName,
         private readonly LdapMessageRequest $initialMessage,
         private readonly ?string $initialCredentials,
     ) {
@@ -36,7 +37,7 @@ final class SaslExchangeInput
         return $this->challenge;
     }
 
-    public function getMechName(): string
+    public function getMechName(): MechanismName
     {
         return $this->mechName;
     }

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/PlainUsernameExtractor.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/PlainUsernameExtractor.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
 
 use FreeDSx\Sasl\Encoder\PlainEncoder;
-use FreeDSx\Sasl\Mechanism\PlainMechanism;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Sasl\SaslContext;
 
 /**
@@ -30,16 +30,11 @@ class PlainUsernameExtractor implements SaslUsernameExtractorInterface
      * {@inheritDoc}
      */
     public function extractUsername(
-        string $mechanism,
-        string $credentials
+        MechanismName $mechanism,
+        string $credentials,
     ): string {
         $message = (new PlainEncoder())->decode($credentials, new SaslContext());
 
-        return $this->requireUsername($message, 'authcid', $mechanism);
-    }
-
-    public function supports(string $mechanism): bool
-    {
-        return $mechanism === PlainMechanism::NAME;
+        return $this->requireUsername($message, 'authcid', $mechanism->value);
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/SaslUsernameExtractorFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/SaslUsernameExtractorFactory.php
@@ -14,10 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
 
 use FreeDSx\Ldap\Exception\RuntimeException;
-use FreeDSx\Sasl\Mechanism\CramMD5Mechanism;
-use FreeDSx\Sasl\Mechanism\DigestMD5Mechanism;
-use FreeDSx\Sasl\Mechanism\PlainMechanism;
-use FreeDSx\Sasl\Mechanism\ScramMechanism;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 
 /**
  * Creates a single SaslUsernameExtractorInterface instance for the requested SASL mechanism.
@@ -29,18 +26,18 @@ final class SaslUsernameExtractorFactory
     /**
      * @throws RuntimeException if no extractor is registered for the given mechanism.
      */
-    public function make(string $mechanism): SaslUsernameExtractorInterface
+    public function make(MechanismName $mechanism): SaslUsernameExtractorInterface
     {
         return match (true) {
-            $mechanism === PlainMechanism::NAME
+            $mechanism === MechanismName::PLAIN
                 => new PlainUsernameExtractor(),
-            in_array($mechanism, ScramMechanism::VARIANTS, true)
+            $mechanism->isScram()
                 => new ScramUsernameExtractor(),
-            $mechanism === CramMD5Mechanism::NAME,
-            $mechanism === DigestMD5Mechanism::NAME
+            $mechanism === MechanismName::CRAM_MD5,
+            $mechanism === MechanismName::DIGEST_MD5
                 => new UsernameFieldExtractor(),
             default => throw new RuntimeException(
-                sprintf('No username extractor is registered for the SASL mechanism "%s".', $mechanism)
+                sprintf('No username extractor is registered for the SASL mechanism "%s".', $mechanism->value)
             ),
         };
     }

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/SaslUsernameExtractorInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/SaslUsernameExtractorInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
 
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 
 /**
  * Extracts a username from raw SASL credential bytes for a specific set of mechanisms.
@@ -27,10 +28,6 @@ interface SaslUsernameExtractorInterface
      *
      * @throws OperationException if the username cannot be extracted from the credentials.
      */
-    public function extractUsername(string $mechanism, string $credentials): string;
+    public function extractUsername(MechanismName $mechanism, string $credentials): string;
 
-    /**
-     * Whether this extractor handles the given mechanism name.
-     */
-    public function supports(string $mechanism): bool;
 }

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/ScramUsernameExtractor.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/ScramUsernameExtractor.php
@@ -15,7 +15,7 @@ namespace FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
 
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
-use FreeDSx\Sasl\Mechanism\ScramMechanism;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 
 /**
  * Extracts the username from a SCRAM client-first-message.
@@ -31,8 +31,10 @@ class ScramUsernameExtractor implements SaslUsernameExtractorInterface
     /**
      * {@inheritDoc}
      */
-    public function extractUsername(string $mechanism, string $credentials): string
-    {
+    public function extractUsername(
+        MechanismName $mechanism,
+        string $credentials,
+    ): string {
         // Strip the GS2 header (everything up to and including ',,').
         $pos = strpos($credentials, ',,');
         $bare = $pos !== false
@@ -50,20 +52,8 @@ class ScramUsernameExtractor implements SaslUsernameExtractorInterface
         }
 
         throw new OperationException(
-            sprintf('The %s credentials did not contain a username.', $mechanism),
+            sprintf('The %s credentials did not contain a username.', $mechanism->value),
             ResultCode::PROTOCOL_ERROR
-        );
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function supports(string $mechanism): bool
-    {
-        return in_array(
-            $mechanism,
-            ScramMechanism::VARIANTS,
-            true,
         );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/UsernameFieldExtractor.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/UsernameExtractor/UsernameFieldExtractor.php
@@ -16,8 +16,7 @@ namespace FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
 use FreeDSx\Sasl\Encoder\CramMD5Encoder;
 use FreeDSx\Sasl\Encoder\DigestMD5Encoder;
 use FreeDSx\Sasl\Encoder\EncoderInterface;
-use FreeDSx\Sasl\Mechanism\CramMD5Mechanism;
-use FreeDSx\Sasl\Mechanism\DigestMD5Mechanism;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Sasl\SaslContext;
 
 /**
@@ -42,8 +41,8 @@ class UsernameFieldExtractor implements SaslUsernameExtractorInterface
     public function __construct(array $encoders = [])
     {
         $this->encoders = $encoders ?: [
-            CramMD5Mechanism::NAME => new CramMD5Encoder(),
-            DigestMD5Mechanism::NAME => new DigestMD5Encoder(),
+            MechanismName::CRAM_MD5->value => new CramMD5Encoder(),
+            MechanismName::DIGEST_MD5->value => new DigestMD5Encoder(),
         ];
     }
 
@@ -51,10 +50,10 @@ class UsernameFieldExtractor implements SaslUsernameExtractorInterface
      * {@inheritDoc}
      */
     public function extractUsername(
-        string $mechanism,
-        string $credentials
+        MechanismName $mechanism,
+        string $credentials,
     ): string {
-        $encoder = $this->encoders[$mechanism];
+        $encoder = $this->encoders[$mechanism->value];
 
         // Always decode as server-side: we are parsing a client response, not a server challenge.
         // For DIGEST-MD5 this is required; for others it is harmless.
@@ -62,14 +61,9 @@ class UsernameFieldExtractor implements SaslUsernameExtractorInterface
         $context->setIsServerMode(true);
         $message = $encoder->decode(
             $credentials,
-            $context
+            $context,
         );
 
-        return $this->requireUsername($message, 'username', $mechanism);
-    }
-
-    public function supports(string $mechanism): bool
-    {
-        return isset($this->encoders[$mechanism]);
+        return $this->requireUsername($message, 'username', $mechanism->value);
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/Bind/SaslBind.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/SaslBind.php
@@ -30,7 +30,9 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
 use FreeDSx\Sasl\Challenge\ChallengeInterface;
 use FreeDSx\Sasl\Exception\SaslException;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Sasl\Sasl;
+use FreeDSx\Sasl\SaslInterface;
 
 /**
  * Handles a SASL bind request on the server side.
@@ -47,7 +49,7 @@ class SaslBind implements BindInterface
     public function __construct(
         private readonly ServerQueue $queue,
         private readonly SaslExchange $exchange,
-        private readonly Sasl $sasl = new Sasl(),
+        private readonly SaslInterface $sasl = new Sasl(),
         private readonly array $mechanisms = [],
         private readonly ResponseFactory $responseFactory = new ResponseFactory(),
         private readonly SaslUsernameExtractorFactory $usernameExtractorFactory = new SaslUsernameExtractorFactory(),
@@ -70,8 +72,10 @@ class SaslBind implements BindInterface
     public function bind(LdapMessageRequest $message): TokenInterface
     {
         $request = $this->validateRequest($message);
-        $mechName = $request->getMechanism();
-        $this->validateMechanism($mechName);
+        $mechNameStr = $request->getMechanism();
+        $this->validateMechanism($mechNameStr);
+
+        $mechName = MechanismName::from($mechNameStr);
 
         $result = $this->exchange->run(new SaslExchangeInput(
             challenge: $this->getServerChallenge($mechName),
@@ -119,7 +123,7 @@ class SaslBind implements BindInterface
         }
     }
 
-    private function getServerChallenge(string $mechName): ChallengeInterface
+    private function getServerChallenge(MechanismName $mechName): ChallengeInterface
     {
         return $this->sasl
             ->get($mechName)
@@ -133,7 +137,7 @@ class SaslBind implements BindInterface
      */
     private function finalize(
         SaslExchangeResult $result,
-        string $mechName,
+        MechanismName $mechName,
     ): TokenInterface {
         $context = $result->getContext();
         $message = $result->getLastMessage();
@@ -162,7 +166,7 @@ class SaslBind implements BindInterface
 
             if ($usernameCredentials === null) {
                 throw new OperationException(
-                    sprintf('Unable to extract username for mechanism "%s": no credentials were received.', $mechName),
+                    sprintf('Unable to extract username for mechanism "%s": no credentials were received.', $mechName->value),
                     ResultCode::PROTOCOL_ERROR
                 );
             }

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSaslBindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSaslBindHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 
 use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\ProtocolException;
@@ -28,8 +29,10 @@ use FreeDSx\Ldap\Protocol\Queue\MessageWrapper\SaslMessageWrapper;
 use FreeDSx\Ldap\Protocol\RootDseLoader;
 use FreeDSx\Sasl\Exception\SaslException;
 use FreeDSx\Sasl\Mechanism\MechanismInterface;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Sasl\Sasl;
 use FreeDSx\Sasl\SaslContext;
+use FreeDSx\Sasl\SaslInterface;
 
 /**
  * Logic for handling a SASL bind.
@@ -48,7 +51,7 @@ class ClientSaslBindHandler implements RequestHandlerInterface
     public function __construct(
         private readonly ClientQueue $queue,
         private readonly RootDseLoader $rootDseLoader,
-        private readonly Sasl $sasl = new Sasl(),
+        private readonly SaslInterface $sasl = new Sasl(),
     ) {
     }
 
@@ -106,16 +109,18 @@ class ClientSaslBindHandler implements RequestHandlerInterface
         SaslBindRequest $request,
     ): MechanismInterface {
         if ($request->getMechanism() !== '') {
-            $mech = $this->sasl->get($request->getMechanism());
-            $request->setMechanism($mech->getName());
+            $mech = $this->sasl->get(MechanismName::from($request->getMechanism()));
+            $request->setMechanism($mech->getName()->value);
 
             return $mech;
         }
         $rootDse = $this->rootDseLoader->load();
-        $availableMechs = $rootDse->get('supportedSaslMechanisms');
-        $availableMechs = $availableMechs === null ? [] : $availableMechs->getValues();
-        $mech = $this->sasl->select($availableMechs, $request->getOptions());
-        $request->setMechanism($mech->getName());
+        $choices = $this->parseKnownMechanisms($rootDse->get('supportedSaslMechanisms'));
+        $mech = $this->sasl->select(
+            $choices,
+            $request->getSelectOptions(),
+        );
+        $request->setMechanism($mech->getName()->value);
 
         return $mech;
     }
@@ -134,7 +139,7 @@ class ClientSaslBindHandler implements RequestHandlerInterface
 
         do {
             $context = $challenge->challenge($saslResponse->getSaslCredentials(), $request->getOptions());
-            $saslBind = Operations::bindSasl($request->getOptions(), $request->getMechanism(), $context->getResponse());
+            $saslBind = Operations::bindSasl($request->getOptions(), MechanismName::from($request->getMechanism()), $context->getResponse());
             $response = $this->sendRequestGetResponse($saslBind, $queue);
             $saslResponse = $response->getResponse();
             if (!$saslResponse instanceof BindResponse) {
@@ -179,6 +184,24 @@ class ClientSaslBindHandler implements RequestHandlerInterface
         }
 
         return $response->getResultCode() !== ResultCode::SASL_BIND_IN_PROGRESS;
+    }
+
+    /**
+     * Converts server-advertised mechanism name strings into known MechanismName values, discarding unrecognised ones.
+     *
+     * @return MechanismName[]
+     */
+    private function parseKnownMechanisms(?Attribute $attribute): array
+    {
+        $known = [];
+        foreach ($attribute?->getValues() ?? [] as $name) {
+            $mech = MechanismName::tryFrom($name);
+            if ($mech !== null) {
+                $known[] = $mech;
+            }
+        }
+
+        return $known;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticatableInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticatableInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Auth;
 
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use SensitiveParameter;
 
 /**
@@ -38,6 +39,6 @@ interface PasswordAuthenticatableInterface
      */
     public function getPassword(
         string $username,
-        string $mechanism,
+        MechanismName $mechanism,
     ): ?string;
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticator.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Server\Backend\Auth;
 
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use SensitiveParameter;
 
 /**
@@ -61,7 +62,7 @@ final class PasswordAuthenticator implements PasswordAuthenticatableInterface
 
     public function getPassword(
         string $username,
-        string $mechanism,
+        MechanismName $mechanism,
     ): ?string {
         $entry = $this->nameResolver->resolve($username, $this->backend);
 

--- a/src/FreeDSx/Ldap/Server/RequestHandler/ProxyBackend.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/ProxyBackend.php
@@ -30,6 +30,7 @@ use FreeDSx\Ldap\Server\Backend\Write\Command\MoveCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Write\WritableBackendTrait;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
@@ -121,8 +122,10 @@ class ProxyBackend implements WritableLdapBackendInterface, PasswordAuthenticata
         }
     }
 
-    public function getPassword(string $username, string $mechanism): ?string
-    {
+    public function getPassword(
+        string $username,
+        MechanismName $mechanism,
+    ): ?string {
         return null;
     }
 

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -20,6 +20,8 @@ use FreeDSx\Ldap\Protocol\Bind\Sasl\SaslExchange;
 use FreeDSx\Ldap\Protocol\Bind\SaslBind;
 use FreeDSx\Ldap\Protocol\Bind\SimpleBind;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\SaslOptions;
 use FreeDSx\Sasl\Sasl;
 use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
@@ -62,7 +64,9 @@ class ServerProtocolFactory
                     $responseFactory,
                     new MechanismOptionsBuilderFactory($passwordAuthenticator),
                 ),
-                sasl: new Sasl(['supported' => $saslMechanisms]),
+                sasl: new Sasl(new SaslOptions(
+                    supported: $this->parseKnownMechanisms($saslMechanisms),
+                )),
                 mechanisms: $saslMechanisms,
                 responseFactory: $responseFactory,
             );
@@ -80,5 +84,24 @@ class ServerProtocolFactory
             authenticator: new Authenticator($authenticators),
             logger: $this->options->getLogger(),
         );
+    }
+
+    /**
+     * Converts mechanism name strings into known MechanismName values, discarding unrecognised ones.
+     *
+     * @param string[] $mechanisms
+     * @return MechanismName[]
+     */
+    private function parseKnownMechanisms(array $mechanisms): array
+    {
+        $known = [];
+        foreach ($mechanisms as $name) {
+            $mech = MechanismName::tryFrom($name);
+            if ($mech !== null) {
+                $known[] = $mech;
+            }
+        }
+
+        return $known;
     }
 }

--- a/tests/bin/ldap-server.php
+++ b/tests/bin/ldap-server.php
@@ -11,6 +11,7 @@ use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
@@ -157,7 +158,7 @@ class LdapServerBackend implements WritableLdapBackendInterface, PasswordAuthent
 
     public function getPassword(
         string $username,
-        string $mechanism,
+        MechanismName $mechanism,
     ): ?string {
         return $this->users[$username] ?? null;
     }

--- a/tests/integration/LdapClientTest.php
+++ b/tests/integration/LdapClientTest.php
@@ -29,6 +29,9 @@ use FreeDSx\Ldap\Operation\Response\SearchResponse;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Search\Result\EntryResult;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\CramMD5Options;
+use FreeDSx\Sasl\Options\DigestMD5Options;
 use Throwable;
 
 class LdapClientTest extends LdapTestCase
@@ -101,8 +104,8 @@ class LdapClientTest extends LdapTestCase
             $this->markTestSkipped('CRAM-MD5 not supported on AD.');
         }
         $response = $this->client->bindSasl(
-            $this->getSaslOptions(),
-            'CRAM-MD5'
+            $this->getCramMD5Options(),
+            MechanismName::CRAM_MD5,
         );
         $response = $response->getResponse();
 
@@ -120,7 +123,7 @@ class LdapClientTest extends LdapTestCase
     {
         $response = $this->client->bindSasl(
             $this->getSaslOptions(),
-            'DIGEST-MD5'
+            MechanismName::DIGEST_MD5,
         );
         $response = $response->getResponse();
 
@@ -137,8 +140,8 @@ class LdapClientTest extends LdapTestCase
     public function testSaslBindWithAnIntegritySecurityLayerIsFunctional(): void
     {
         $this->client->bindSasl(
-            array_merge($this->getSaslOptions(), ['use_integrity' => true]),
-            'DIGEST-MD5'
+            (clone $this->getSaslOptions())->setUseIntegrity(true),
+            MechanismName::DIGEST_MD5,
         );
         $entry = $this->client->read('', ['supportedSaslMechanisms']);
 
@@ -564,22 +567,30 @@ class LdapClientTest extends LdapTestCase
         $this->assertTrue($this->client->isConnected());
     }
 
-    /**
-     * @return array<string, string>
-     */
-    protected function getSaslOptions(): array
+    protected function getSaslOptions(): DigestMD5Options
     {
         if ($this->isActiveDirectory()) {
-            return [
-                'username' => 'admin',
-                'password' => (string) getenv('LDAP_PASSWORD'),
-                'host' => 'ADDC3.example.com'
-            ];
-        } else {
-            return [
-                'username' => 'WillifoA',
-                'password' => 'Password1',
-            ];
+            return (new DigestMD5Options())
+                ->setUsername('admin')
+                ->setPassword((string) getenv('LDAP_PASSWORD'))
+                ->setHost('ADDC3.example.com');
         }
+
+        return (new DigestMD5Options())
+            ->setUsername('WillifoA')
+            ->setPassword('Password1');
+    }
+
+    protected function getCramMD5Options(): CramMD5Options
+    {
+        if ($this->isActiveDirectory()) {
+            return (new CramMD5Options())
+                ->setUsername('admin')
+                ->setPassword((string) getenv('LDAP_PASSWORD'));
+        }
+
+        return (new CramMD5Options())
+            ->setUsername('WillifoA')
+            ->setPassword('Password1');
     }
 }

--- a/tests/integration/LdapSaslServerTest.php
+++ b/tests/integration/LdapSaslServerTest.php
@@ -16,6 +16,10 @@ namespace Tests\Integration\FreeDSx\Ldap;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Operation\Response\BindResponse;
 use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\CramMD5Options;
+use FreeDSx\Sasl\Options\PlainOptions;
+use FreeDSx\Sasl\Options\ScramOptions;
 
 final class LdapSaslServerTest extends ServerTestCase
 {
@@ -34,8 +38,8 @@ final class LdapSaslServerTest extends ServerTestCase
     public function testItCanAuthenticateWithSaslPlain(): void
     {
         $response = $this->ldapClient()->bindSasl(
-            ['username' => 'cn=user,dc=foo,dc=bar', 'password' => '12345'],
-            ServerOptions::SASL_PLAIN,
+            (new PlainOptions())->setUsername('cn=user,dc=foo,dc=bar')->setPassword('12345'),
+            MechanismName::PLAIN,
         )->getResponse();
 
         $this->assertInstanceOf(BindResponse::class, $response);
@@ -47,16 +51,16 @@ final class LdapSaslServerTest extends ServerTestCase
         $this->expectException(BindException::class);
 
         $this->ldapClient()->bindSasl(
-            ['username' => 'cn=user,dc=foo,dc=bar', 'password' => 'wrong'],
-            ServerOptions::SASL_PLAIN,
+            (new PlainOptions())->setUsername('cn=user,dc=foo,dc=bar')->setPassword('wrong'),
+            MechanismName::PLAIN,
         );
     }
 
     public function testItCanAuthenticateWithSaslCramMD5(): void
     {
         $response = $this->ldapClient()->bindSasl(
-            ['username' => 'cn=user,dc=foo,dc=bar', 'password' => '12345'],
-            ServerOptions::SASL_CRAM_MD5,
+            (new CramMD5Options())->setUsername('cn=user,dc=foo,dc=bar')->setPassword('12345'),
+            MechanismName::CRAM_MD5,
         )->getResponse();
 
         $this->assertInstanceOf(BindResponse::class, $response);
@@ -68,16 +72,16 @@ final class LdapSaslServerTest extends ServerTestCase
         $this->expectException(BindException::class);
 
         $this->ldapClient()->bindSasl(
-            ['username' => 'cn=user,dc=foo,dc=bar', 'password' => 'wrong'],
-            ServerOptions::SASL_CRAM_MD5,
+            (new CramMD5Options())->setUsername('cn=user,dc=foo,dc=bar')->setPassword('wrong'),
+            MechanismName::CRAM_MD5,
         );
     }
 
     public function testItCanAuthenticateWithSaslScramSha256(): void
     {
         $response = $this->ldapClient()->bindSasl(
-            ['username' => 'cn=user,dc=foo,dc=bar', 'password' => '12345'],
-            ServerOptions::SASL_SCRAM_SHA_256,
+            (new ScramOptions())->setUsername('cn=user,dc=foo,dc=bar')->setPassword('12345'),
+            MechanismName::SCRAM_SHA256,
         )->getResponse();
 
         $this->assertInstanceOf(
@@ -95,8 +99,8 @@ final class LdapSaslServerTest extends ServerTestCase
         $this->expectException(BindException::class);
 
         $this->ldapClient()->bindSasl(
-            ['username' => 'cn=user,dc=foo,dc=bar', 'password' => 'wrong'],
-            ServerOptions::SASL_SCRAM_SHA_256,
+            (new ScramOptions())->setUsername('cn=user,dc=foo,dc=bar')->setPassword('wrong'),
+            MechanismName::SCRAM_SHA256,
         );
     }
 

--- a/tests/performance/LoadTestCommand.php
+++ b/tests/performance/LoadTestCommand.php
@@ -17,6 +17,7 @@ use InvalidArgumentException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Tests\Performance\FreeDSx\Ldap\Report\Report;
 use Tests\Performance\FreeDSx\Ldap\Threshold\CiThresholds;
@@ -207,11 +208,15 @@ final class LoadTestCommand extends Command
         InputInterface $input,
         OutputInterface $output,
     ): int {
+        $errorOutput = $output instanceof ConsoleOutputInterface
+            ? $output->getErrorOutput()
+            : $output;
+
         try {
             $config = $this->buildConfig($input);
             $thresholds = $this->buildThresholds($input);
         } catch (InvalidArgumentException $e) {
-            $output->writeln('<error>Configuration error: ' . $e->getMessage() . '</error>');
+            $errorOutput->writeln('<error>Configuration error: ' . $e->getMessage() . '</error>');
 
             return Command::INVALID;
         }
@@ -219,7 +224,7 @@ final class LoadTestCommand extends Command
         try {
             $snapshot = (new Driver($config))->run($output);
         } catch (Throwable $e) {
-            $output->writeln('<error>Load test failed: ' . $e->getMessage() . '</error>');
+            $errorOutput->writeln('<error>Load test failed: ' . $e->getMessage() . '</error>');
 
             return Command::FAILURE;
         }
@@ -246,7 +251,7 @@ final class LoadTestCommand extends Command
         }
 
         $this->renderThresholdFailure(
-            $output,
+            $errorOutput,
             $result,
         );
 

--- a/tests/performance/Threshold/CiThresholds.php
+++ b/tests/performance/Threshold/CiThresholds.php
@@ -58,7 +58,7 @@ final class CiThresholds
             ),
             'sqlite:swoole' => new ThresholdSet(
                 maxErrors: 0,
-                minThroughput: 1000.0,
+                minThroughput: 950.0,
                 maxP99Ms: 800.0,
             ),
             'mysql:pcntl' => new ThresholdSet(

--- a/tests/unit/Operation/Request/SaslBindRequestTest.php
+++ b/tests/unit/Operation/Request/SaslBindRequestTest.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Operation\Request\BindRequest;
 use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
+use FreeDSx\Sasl\Options\DigestMD5Options;
 use PHPUnit\Framework\TestCase;
 
 final class SaslBindRequestTest extends TestCase
@@ -88,9 +89,10 @@ final class SaslBindRequestTest extends TestCase
 
     public function test_it_returns_options_set_via_constructor(): void
     {
-        $request = new SaslBindRequest('PLAIN', null, ['foo' => 'bar']);
+        $options = new DigestMD5Options();
+        $request = new SaslBindRequest('PLAIN', null, $options);
 
-        self::assertSame(['foo' => 'bar'], $request->getOptions());
+        self::assertSame($options, $request->getOptions());
     }
 
     public function test_bind_request_throws_for_an_unsupported_authentication_tag(): void

--- a/tests/unit/OperationsTest.php
+++ b/tests/unit/OperationsTest.php
@@ -33,43 +33,24 @@ use FreeDSx\Ldap\Operation\Request\UnbindRequest;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\DigestMD5Options;
 use PHPUnit\Framework\TestCase;
 
 class OperationsTest extends TestCase
 {
     public function test_it_should_create_a_sasl_bind(): void
     {
+        $options = new DigestMD5Options();
+
         self::assertEquals(
-            new SaslBindRequest(
-                '',
-                null,
-                [
-                    'username' => 'foo',
-                    'password' => 'bar'
-                ]
-            ),
-            Operations::bindSasl([
-                'username' => 'foo',
-                'password' => 'bar',
-            ])
+            new SaslBindRequest('', null, $options),
+            Operations::bindSasl($options)
         );
 
         self::assertEquals(
-            new SaslBindRequest(
-                'DIGEST-MD5',
-                null,
-                [
-                    'username' => 'foo',
-                    'password' => 'bar',
-                ]
-            ),
-            Operations::bindSasl(
-                [
-                    'username' => 'foo',
-                    'password' => 'bar',
-                ],
-                'DIGEST-MD5'
-            )
+            new SaslBindRequest('DIGEST-MD5', null, $options),
+            Operations::bindSasl($options, MechanismName::DIGEST_MD5)
         );
     }
 

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/CramMD5MechanismOptionsBuilderTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/CramMD5MechanismOptionsBuilderTest.php
@@ -54,7 +54,7 @@ final class CramMD5MechanismOptionsBuilderTest extends TestCase
     {
         $this->mockHandler
             ->method('getPassword')
-            ->with('cn=user,dc=foo,dc=bar', MechanismName::CRAM_MD5->value)
+            ->with('cn=user,dc=foo,dc=bar', MechanismName::CRAM_MD5)
             ->willReturn('12345');
 
         $options = $this->subject->buildOptions('some-bytes', MechanismName::CRAM_MD5);

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/CramMD5MechanismOptionsBuilderTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/CramMD5MechanismOptionsBuilderTest.php
@@ -17,7 +17,8 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\CramMD5MechanismOptionsBuilder;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
-use FreeDSx\Sasl\Mechanism\CramMD5Mechanism;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\CramMD5Options;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -33,57 +34,41 @@ final class CramMD5MechanismOptionsBuilderTest extends TestCase
         $this->subject = new CramMD5MechanismOptionsBuilder($this->mockHandler);
     }
 
-    public function test_it_supports_the_cram_md5_mechanism(): void
+    public function test_it_returns_null_when_no_bytes_received(): void
     {
-        self::assertTrue($this->subject->supports(CramMD5Mechanism::NAME));
-    }
-
-    public function test_it_does_not_support_other_mechanisms(): void
-    {
-        self::assertFalse($this->subject->supports('PLAIN'));
-        self::assertFalse($this->subject->supports('DIGEST-MD5'));
-    }
-
-    public function test_it_returns_empty_options_when_no_bytes_received(): void
-    {
-        self::assertSame(
-            [],
-            $this->subject->buildOptions(null, CramMD5Mechanism::NAME)
-        );
+        self::assertNull($this->subject->buildOptions(null, MechanismName::CRAM_MD5));
     }
 
     public function test_it_builds_options_with_a_password_callable_when_bytes_are_received(): void
     {
         $options = $this->subject->buildOptions(
             'some-client-response',
-            CramMD5Mechanism::NAME,
+            MechanismName::CRAM_MD5,
         );
 
-        self::assertArrayHasKey(
-            'password',
-            $options
-        );
-        self::assertIsCallable($options['password']);
+        self::assertInstanceOf(CramMD5Options::class, $options);
+        self::assertIsCallable($options->getPasswordCallback());
     }
 
     public function test_the_password_callable_returns_an_hmac_of_the_challenge(): void
     {
         $this->mockHandler
             ->method('getPassword')
-            ->with('cn=user,dc=foo,dc=bar', CramMD5Mechanism::NAME)
+            ->with('cn=user,dc=foo,dc=bar', MechanismName::CRAM_MD5->value)
             ->willReturn('12345');
 
-        $options = $this->subject->buildOptions('some-bytes', CramMD5Mechanism::NAME);
-        $password = $options['password'];
-        assert(is_callable($password));
+        $options = $this->subject->buildOptions('some-bytes', MechanismName::CRAM_MD5);
+        self::assertInstanceOf(CramMD5Options::class, $options);
+        $callback = $options->getPasswordCallback();
+        assert(is_callable($callback));
         // The challenge passed to the callable is the encoded challenge string exactly as the
         // client received it (e.g. "<nonce>"), per RFC 2195.
         $challenge = '<challenge@example.com>';
-        $result = $password('cn=user,dc=foo,dc=bar', $challenge);
+        $result = $callback('cn=user,dc=foo,dc=bar', $challenge);
 
         self::assertSame(
             hash_hmac('md5', '<challenge@example.com>', '12345'),
-            $result
+            $result,
         );
     }
 
@@ -95,14 +80,15 @@ final class CramMD5MechanismOptionsBuilderTest extends TestCase
 
         $options = $this->subject->buildOptions(
             'some-bytes',
-            CramMD5Mechanism::NAME
+            MechanismName::CRAM_MD5,
         );
-        $password = $options['password'];
-        assert(is_callable($password));
+        self::assertInstanceOf(CramMD5Options::class, $options);
+        $callback = $options->getPasswordCallback();
+        assert(is_callable($callback));
 
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
 
-        $password('unknown-user', 'challenge');
+        $callback('unknown-user', 'challenge');
     }
 }

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/DigestMD5MechanismOptionsBuilderTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/DigestMD5MechanismOptionsBuilderTest.php
@@ -56,7 +56,7 @@ final class DigestMD5MechanismOptionsBuilderTest extends TestCase
 
         $this->mockHandler
             ->method('getPassword')
-            ->with('cn=user,dc=foo,dc=bar', MechanismName::DIGEST_MD5->value)
+            ->with('cn=user,dc=foo,dc=bar', MechanismName::DIGEST_MD5)
             ->willReturn('12345');
 
         $options = $this->subject->buildOptions('client-response', MechanismName::DIGEST_MD5);

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/DigestMD5MechanismOptionsBuilderTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/DigestMD5MechanismOptionsBuilderTest.php
@@ -18,7 +18,8 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\DigestMD5MechanismOptionsBuilder;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\SaslUsernameExtractorInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
-use FreeDSx\Sasl\Mechanism\DigestMD5Mechanism;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\DigestMD5Options;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -41,43 +42,27 @@ final class DigestMD5MechanismOptionsBuilderTest extends TestCase
         );
     }
 
-    public function test_it_supports_the_digest_md5_mechanism(): void
+    public function test_it_returns_null_when_no_bytes_received(): void
     {
-        self::assertTrue($this->subject->supports(DigestMD5Mechanism::NAME));
-    }
-
-    public function test_it_does_not_support_other_mechanisms(): void
-    {
-        self::assertFalse($this->subject->supports('PLAIN'));
-        self::assertFalse($this->subject->supports('CRAM-MD5'));
-    }
-
-    public function test_it_returns_empty_options_when_no_bytes_received(): void
-    {
-        self::assertSame(
-            [],
-            $this->subject->buildOptions(null, DigestMD5Mechanism::NAME)
-        );
+        self::assertNull($this->subject->buildOptions(null, MechanismName::DIGEST_MD5));
     }
 
     public function test_it_builds_options_with_the_password_when_bytes_are_received(): void
     {
         $this->mockUsernameExtractor
             ->method('extractUsername')
-            ->with(DigestMD5Mechanism::NAME, 'client-response')
+            ->with(MechanismName::DIGEST_MD5, 'client-response')
             ->willReturn('cn=user,dc=foo,dc=bar');
 
         $this->mockHandler
             ->method('getPassword')
-            ->with('cn=user,dc=foo,dc=bar', DigestMD5Mechanism::NAME)
+            ->with('cn=user,dc=foo,dc=bar', MechanismName::DIGEST_MD5->value)
             ->willReturn('12345');
 
-        $options = $this->subject->buildOptions('client-response', DigestMD5Mechanism::NAME);
+        $options = $this->subject->buildOptions('client-response', MechanismName::DIGEST_MD5);
 
-        self::assertSame(
-            ['password' => '12345'],
-            $options,
-        );
+        self::assertInstanceOf(DigestMD5Options::class, $options);
+        self::assertSame('12345', $options->getPassword());
     }
 
     public function test_it_throws_invalid_credentials_when_password_is_not_found(): void
@@ -93,6 +78,6 @@ final class DigestMD5MechanismOptionsBuilderTest extends TestCase
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
 
-        $this->subject->buildOptions('client-response', DigestMD5Mechanism::NAME);
+        $this->subject->buildOptions('client-response', MechanismName::DIGEST_MD5);
     }
 }

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/MechanismOptionsBuilderFactoryTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/MechanismOptionsBuilderFactoryTest.php
@@ -21,6 +21,7 @@ use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\MechanismOptionsBuilderFactor
 use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\PlainMechanismOptionsBuilder;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\ScramMechanismOptionsBuilder;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -40,7 +41,7 @@ final class MechanismOptionsBuilderFactoryTest extends TestCase
     {
         self::assertInstanceOf(
             PlainMechanismOptionsBuilder::class,
-            $this->subject->make('PLAIN')
+            $this->subject->make(MechanismName::PLAIN),
         );
     }
 
@@ -48,7 +49,7 @@ final class MechanismOptionsBuilderFactoryTest extends TestCase
     {
         self::assertInstanceOf(
             CramMD5MechanismOptionsBuilder::class,
-            $this->subject->make('CRAM-MD5')
+            $this->subject->make(MechanismName::CRAM_MD5),
         );
     }
 
@@ -56,7 +57,7 @@ final class MechanismOptionsBuilderFactoryTest extends TestCase
     {
         self::assertInstanceOf(
             DigestMD5MechanismOptionsBuilder::class,
-            $this->subject->make('DIGEST-MD5')
+            $this->subject->make(MechanismName::DIGEST_MD5),
         );
     }
 
@@ -64,15 +65,15 @@ final class MechanismOptionsBuilderFactoryTest extends TestCase
     {
         self::assertInstanceOf(
             ScramMechanismOptionsBuilder::class,
-            $this->subject->make('SCRAM-SHA-256')
+            $this->subject->make(MechanismName::SCRAM_SHA256),
         );
     }
 
-    public function test_make_unknown_mechanism_throws(): void
+    public function test_make_unsupported_mechanism_throws(): void
     {
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::OTHER);
 
-        $this->subject->make('UNKNOWN');
+        $this->subject->make(MechanismName::ANONYMOUS);
     }
 }

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/PlainMechanismOptionsBuilderTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/PlainMechanismOptionsBuilderTest.php
@@ -15,7 +15,8 @@ namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
 
 use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\PlainMechanismOptionsBuilder;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
-use FreeDSx\Sasl\Mechanism\PlainMechanism;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\PlainOptions;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -31,25 +32,12 @@ final class PlainMechanismOptionsBuilderTest extends TestCase
         $this->subject = new PlainMechanismOptionsBuilder($this->mockAuthenticator);
     }
 
-    public function test_it_supports_the_plain_mechanism(): void
-    {
-        self::assertTrue($this->subject->supports(PlainMechanism::NAME));
-    }
-
-    public function test_it_does_not_support_other_mechanisms(): void
-    {
-        self::assertFalse($this->subject->supports('CRAM-MD5'));
-    }
-
     public function test_it_builds_options_with_a_validate_callable(): void
     {
-        $options = $this->subject->buildOptions(null, PlainMechanism::NAME);
+        $options = $this->subject->buildOptions(null, MechanismName::PLAIN);
 
-        self::assertArrayHasKey(
-            'validate',
-            $options,
-        );
-        self::assertIsCallable($options['validate']);
+        self::assertInstanceOf(PlainOptions::class, $options);
+        self::assertIsCallable($options->getValidate());
     }
 
     public function test_the_validate_callable_delegates_to_backend_verify_password(): void
@@ -60,8 +48,9 @@ final class PlainMechanismOptionsBuilderTest extends TestCase
             ->with('cn=user,dc=foo,dc=bar', '12345')
             ->willReturn(true);
 
-        $options = $this->subject->buildOptions(null, PlainMechanism::NAME);
-        $validate = $options['validate'];
+        $options = $this->subject->buildOptions(null, MechanismName::PLAIN);
+        self::assertInstanceOf(PlainOptions::class, $options);
+        $validate = $options->getValidate();
         assert(is_callable($validate));
         $result = $validate('authzid', 'cn=user,dc=foo,dc=bar', '12345');
 
@@ -74,8 +63,9 @@ final class PlainMechanismOptionsBuilderTest extends TestCase
             ->method('verifyPassword')
             ->willReturn(false);
 
-        $options = $this->subject->buildOptions(null, PlainMechanism::NAME);
-        $validate = $options['validate'];
+        $options = $this->subject->buildOptions(null, MechanismName::PLAIN);
+        self::assertInstanceOf(PlainOptions::class, $options);
+        $validate = $options->getValidate();
         assert(is_callable($validate));
         $result = $validate(null, 'user', 'wrong');
 
@@ -84,10 +74,10 @@ final class PlainMechanismOptionsBuilderTest extends TestCase
 
     public function test_it_builds_the_same_options_regardless_of_received_bytes(): void
     {
-        $optionsWithNull = $this->subject->buildOptions(null, PlainMechanism::NAME);
-        $optionsWithBytes = $this->subject->buildOptions('some-bytes', PlainMechanism::NAME);
+        $optionsWithNull = $this->subject->buildOptions(null, MechanismName::PLAIN);
+        $optionsWithBytes = $this->subject->buildOptions('some-bytes', MechanismName::PLAIN);
 
-        self::assertArrayHasKey('validate', $optionsWithNull);
-        self::assertArrayHasKey('validate', $optionsWithBytes);
+        self::assertInstanceOf(PlainOptions::class, $optionsWithNull);
+        self::assertInstanceOf(PlainOptions::class, $optionsWithBytes);
     }
 }

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/ScramMechanismOptionsBuilderTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/ScramMechanismOptionsBuilderTest.php
@@ -52,7 +52,7 @@ final class ScramMechanismOptionsBuilderTest extends TestCase
         $this->mockHandler
             ->expects(self::once())
             ->method('getPassword')
-            ->with('testuser', MechanismName::SCRAM_SHA256->value)
+            ->with('testuser', MechanismName::SCRAM_SHA256)
             ->willReturn('secret');
 
         $this->subject->buildOptions('n,,n=testuser,r=clientnonce123', MechanismName::SCRAM_SHA256);
@@ -67,7 +67,7 @@ final class ScramMechanismOptionsBuilderTest extends TestCase
         $this->mockHandler
             ->expects(self::once())
             ->method('getPassword')
-            ->with('user', MechanismName::SCRAM_SHA512->value)
+            ->with('user', MechanismName::SCRAM_SHA512)
             ->willReturn('pw');
 
         $this->subject->buildOptions('n,,n=user,r=nonce', MechanismName::SCRAM_SHA512);
@@ -102,7 +102,7 @@ final class ScramMechanismOptionsBuilderTest extends TestCase
         $this->mockHandler
             ->expects(self::once())
             ->method('getPassword')
-            ->with('user,name=test', MechanismName::SCRAM_SHA256->value)
+            ->with('user,name=test', MechanismName::SCRAM_SHA256)
             ->willReturn('pw');
 
         // ',' encoded as '=2C', '=' encoded as '=3D'
@@ -128,7 +128,7 @@ final class ScramMechanismOptionsBuilderTest extends TestCase
         $this->mockHandler
             ->expects(self::once())
             ->method('getPassword')
-            ->with('user', MechanismName::SCRAM_SHA256->value)
+            ->with('user', MechanismName::SCRAM_SHA256)
             ->willReturn('pw');
 
         // No ',,' separator — treat the whole string as the bare client-first-message.

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/ScramMechanismOptionsBuilderTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/ScramMechanismOptionsBuilderTest.php
@@ -17,7 +17,8 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\ScramMechanismOptionsBuilder;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
-use FreeDSx\Sasl\Mechanism\ScramMechanism;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\ScramOptions;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -33,31 +34,17 @@ final class ScramMechanismOptionsBuilderTest extends TestCase
         $this->subject = new ScramMechanismOptionsBuilder($this->mockHandler);
     }
 
-    public function test_it_supports_all_scram_variants(): void
+    public function test_it_returns_null_when_no_bytes_received(): void
     {
-        foreach (ScramMechanism::VARIANTS as $variant) {
-            self::assertTrue($this->subject->supports($variant), "Expected support for $variant");
-        }
+        self::assertNull($this->subject->buildOptions(null, MechanismName::SCRAM_SHA256));
     }
 
-    public function test_it_does_not_support_other_mechanisms(): void
-    {
-        self::assertFalse($this->subject->supports('PLAIN'));
-        self::assertFalse($this->subject->supports('CRAM-MD5'));
-        self::assertFalse($this->subject->supports('DIGEST-MD5'));
-    }
-
-    public function test_it_returns_empty_options_when_no_bytes_received(): void
-    {
-        self::assertSame([], $this->subject->buildOptions(null, ScramMechanism::SHA256));
-    }
-
-    public function test_it_returns_empty_options_for_client_first_message(): void
+    public function test_it_returns_null_for_client_first_message(): void
     {
         // Client-first: GS2 header + username + cnonce, no proof field.
         $clientFirst = 'n,,n=testuser,r=clientnonce123';
 
-        self::assertSame([], $this->subject->buildOptions($clientFirst, ScramMechanism::SHA256));
+        self::assertNull($this->subject->buildOptions($clientFirst, MechanismName::SCRAM_SHA256));
     }
 
     public function test_it_extracts_username_from_client_first_and_provides_password_on_client_final(): void
@@ -65,14 +52,14 @@ final class ScramMechanismOptionsBuilderTest extends TestCase
         $this->mockHandler
             ->expects(self::once())
             ->method('getPassword')
-            ->with('testuser', ScramMechanism::SHA256)
+            ->with('testuser', MechanismName::SCRAM_SHA256->value)
             ->willReturn('secret');
 
-        $this->subject->buildOptions('n,,n=testuser,r=clientnonce123', ScramMechanism::SHA256);
-        $options = $this->subject->buildOptions('c=biws,r=clientnonce123servernonce,p=dGVzdA==', ScramMechanism::SHA256);
+        $this->subject->buildOptions('n,,n=testuser,r=clientnonce123', MechanismName::SCRAM_SHA256);
+        $options = $this->subject->buildOptions('c=biws,r=clientnonce123servernonce,p=dGVzdA==', MechanismName::SCRAM_SHA256);
 
-        self::assertArrayHasKey('password', $options);
-        self::assertSame('secret', $options['password']);
+        self::assertInstanceOf(ScramOptions::class, $options);
+        self::assertSame('secret', $options->getPassword());
     }
 
     public function test_it_passes_the_mechanism_name_to_the_handler(): void
@@ -80,11 +67,11 @@ final class ScramMechanismOptionsBuilderTest extends TestCase
         $this->mockHandler
             ->expects(self::once())
             ->method('getPassword')
-            ->with('user', ScramMechanism::SHA512)
+            ->with('user', MechanismName::SCRAM_SHA512->value)
             ->willReturn('pw');
 
-        $this->subject->buildOptions('n,,n=user,r=nonce', ScramMechanism::SHA512);
-        $this->subject->buildOptions('c=biws,r=fullnonce,p=proof==', ScramMechanism::SHA512);
+        $this->subject->buildOptions('n,,n=user,r=nonce', MechanismName::SCRAM_SHA512);
+        $this->subject->buildOptions('c=biws,r=fullnonce,p=proof==', MechanismName::SCRAM_SHA512);
     }
 
     public function test_it_throws_invalid_credentials_when_user_not_found(): void
@@ -93,12 +80,12 @@ final class ScramMechanismOptionsBuilderTest extends TestCase
             ->method('getPassword')
             ->willReturn(null);
 
-        $this->subject->buildOptions('n,,n=unknown,r=nonce', ScramMechanism::SHA256);
+        $this->subject->buildOptions('n,,n=unknown,r=nonce', MechanismName::SCRAM_SHA256);
 
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
 
-        $this->subject->buildOptions('c=biws,r=fullnonce,p=someproof==', ScramMechanism::SHA256);
+        $this->subject->buildOptions('c=biws,r=fullnonce,p=someproof==', MechanismName::SCRAM_SHA256);
     }
 
     public function test_it_throws_protocol_error_when_client_final_received_before_client_first(): void
@@ -107,7 +94,7 @@ final class ScramMechanismOptionsBuilderTest extends TestCase
         self::expectExceptionCode(ResultCode::PROTOCOL_ERROR);
 
         // Client-final arrives without a prior client-first.
-        $this->subject->buildOptions('c=biws,r=fullnonce,p=proof==', ScramMechanism::SHA256);
+        $this->subject->buildOptions('c=biws,r=fullnonce,p=proof==', MechanismName::SCRAM_SHA256);
     }
 
     public function test_it_decodes_rfc5802_encoded_username(): void
@@ -115,12 +102,12 @@ final class ScramMechanismOptionsBuilderTest extends TestCase
         $this->mockHandler
             ->expects(self::once())
             ->method('getPassword')
-            ->with('user,name=test', ScramMechanism::SHA256)
+            ->with('user,name=test', MechanismName::SCRAM_SHA256->value)
             ->willReturn('pw');
 
         // ',' encoded as '=2C', '=' encoded as '=3D'
-        $this->subject->buildOptions('n,,n=user=2Cname=3Dtest,r=nonce', ScramMechanism::SHA256);
-        $this->subject->buildOptions('c=biws,r=fullnonce,p=proof==', ScramMechanism::SHA256);
+        $this->subject->buildOptions('n,,n=user=2Cname=3Dtest,r=nonce', MechanismName::SCRAM_SHA256);
+        $this->subject->buildOptions('c=biws,r=fullnonce,p=proof==', MechanismName::SCRAM_SHA256);
     }
 
     public function test_it_handles_channel_binding_gs2_header(): void
@@ -130,10 +117,10 @@ final class ScramMechanismOptionsBuilderTest extends TestCase
             ->willReturn('pw');
 
         // 'p=tls-unique,,' GS2 header for channel-binding variants
-        $this->subject->buildOptions('p=tls-unique,,n=user,r=nonce', ScramMechanism::SHA256_PLUS);
-        $options = $this->subject->buildOptions('c=cD10bHMtdW5pcXVlLCwx,r=fullnonce,p=proof==', ScramMechanism::SHA256_PLUS);
+        $this->subject->buildOptions('p=tls-unique,,n=user,r=nonce', MechanismName::SCRAM_SHA256_PLUS);
+        $options = $this->subject->buildOptions('c=cD10bHMtdW5pcXVlLCwx,r=fullnonce,p=proof==', MechanismName::SCRAM_SHA256_PLUS);
 
-        self::assertArrayHasKey('password', $options);
+        self::assertInstanceOf(ScramOptions::class, $options);
     }
 
     public function test_it_parses_username_from_client_first_without_gs2_header(): void
@@ -141,14 +128,14 @@ final class ScramMechanismOptionsBuilderTest extends TestCase
         $this->mockHandler
             ->expects(self::once())
             ->method('getPassword')
-            ->with('user', ScramMechanism::SHA256)
+            ->with('user', MechanismName::SCRAM_SHA256->value)
             ->willReturn('pw');
 
         // No ',,' separator — treat the whole string as the bare client-first-message.
-        $this->subject->buildOptions('n=user,r=nonce', ScramMechanism::SHA256);
-        $options = $this->subject->buildOptions('c=biws,r=fullnonce,p=proof==', ScramMechanism::SHA256);
+        $this->subject->buildOptions('n=user,r=nonce', MechanismName::SCRAM_SHA256);
+        $options = $this->subject->buildOptions('c=biws,r=fullnonce,p=proof==', MechanismName::SCRAM_SHA256);
 
-        self::assertArrayHasKey('password', $options);
+        self::assertInstanceOf(ScramOptions::class, $options);
     }
 
     public function test_it_throws_protocol_error_when_client_first_has_no_username_field(): void
@@ -157,6 +144,6 @@ final class ScramMechanismOptionsBuilderTest extends TestCase
         self::expectExceptionCode(ResultCode::PROTOCOL_ERROR);
 
         // After stripping the GS2 header the bare message contains no 'n=' field.
-        $this->subject->buildOptions('n,,r=nonce-only', ScramMechanism::SHA256);
+        $this->subject->buildOptions('n,,r=nonce-only', MechanismName::SCRAM_SHA256);
     }
 }

--- a/tests/unit/Protocol/Bind/Sasl/SaslExchangeTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/SaslExchangeTest.php
@@ -25,6 +25,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Sasl\Challenge\ChallengeInterface;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Sasl\SaslContext;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -32,9 +33,9 @@ use PHPUnit\Framework\TestCase;
 final class SaslExchangeTest extends TestCase
 {
     /**
-     * Using 'PLAIN' as the mechanism name so that the real MechanismOptionsBuilderFactory
-     * can produce a PlainMechanismOptionsBuilder. The mock challenge ignores the option
-     * array, so the specific mechanism does not affect the exchange-loop behavior under test.
+     * Using PLAIN so that the real MechanismOptionsBuilderFactory can produce a
+     * PlainMechanismOptionsBuilder. The mock challenge ignores the options, so the
+     * specific mechanism does not affect the exchange-loop behavior under test.
      */
     private const MECH = 'PLAIN';
 
@@ -62,7 +63,7 @@ final class SaslExchangeTest extends TestCase
     {
         return new SaslExchangeInput(
             challenge: $this->mockChallenge,
-            mechName: self::MECH,
+            mechName: MechanismName::from(self::MECH),
             initialMessage: new LdapMessageRequest(1, new SaslBindRequest(self::MECH)),
             initialCredentials: $initialCredentials,
         );

--- a/tests/unit/Protocol/Bind/Sasl/UsernameExtractor/PlainUsernameExtractorTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/UsernameExtractor/PlainUsernameExtractorTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
 
 use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\PlainUsernameExtractor;
-use FreeDSx\Sasl\Mechanism\PlainMechanism;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use PHPUnit\Framework\TestCase;
 
 final class PlainUsernameExtractorTest extends TestCase
@@ -26,17 +26,6 @@ final class PlainUsernameExtractorTest extends TestCase
         $this->subject = new PlainUsernameExtractor();
     }
 
-    public function test_it_supports_the_plain_mechanism(): void
-    {
-        self::assertTrue($this->subject->supports(PlainMechanism::NAME));
-    }
-
-    public function test_it_does_not_support_other_mechanisms(): void
-    {
-        self::assertFalse($this->subject->supports('CRAM-MD5'));
-        self::assertFalse($this->subject->supports('DIGEST-MD5'));
-    }
-
     public function test_it_extracts_the_authcid_as_the_username(): void
     {
         // PLAIN format: "authzid\x00authcid\x00passwd"
@@ -44,7 +33,7 @@ final class PlainUsernameExtractorTest extends TestCase
 
         self::assertSame(
             'cn=user,dc=foo,dc=bar',
-            $this->subject->extractUsername(PlainMechanism::NAME, $credentials),
+            $this->subject->extractUsername(MechanismName::PLAIN, $credentials),
         );
     }
 }

--- a/tests/unit/Protocol/Bind/Sasl/UsernameExtractor/SaslUsernameExtractorFactoryTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/UsernameExtractor/SaslUsernameExtractorFactoryTest.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\PlainUsernameExtractor;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\SaslUsernameExtractorFactory;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\ScramUsernameExtractor;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\UsernameFieldExtractor;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use PHPUnit\Framework\TestCase;
 
 final class SaslUsernameExtractorFactoryTest extends TestCase
@@ -33,7 +34,7 @@ final class SaslUsernameExtractorFactoryTest extends TestCase
     {
         self::assertInstanceOf(
             PlainUsernameExtractor::class,
-            $this->subject->make('PLAIN')
+            $this->subject->make(MechanismName::PLAIN),
         );
     }
 
@@ -41,7 +42,7 @@ final class SaslUsernameExtractorFactoryTest extends TestCase
     {
         self::assertInstanceOf(
             ScramUsernameExtractor::class,
-            $this->subject->make('SCRAM-SHA-256')
+            $this->subject->make(MechanismName::SCRAM_SHA256),
         );
     }
 
@@ -49,7 +50,7 @@ final class SaslUsernameExtractorFactoryTest extends TestCase
     {
         self::assertInstanceOf(
             UsernameFieldExtractor::class,
-            $this->subject->make('CRAM-MD5')
+            $this->subject->make(MechanismName::CRAM_MD5),
         );
     }
 
@@ -57,14 +58,14 @@ final class SaslUsernameExtractorFactoryTest extends TestCase
     {
         self::assertInstanceOf(
             UsernameFieldExtractor::class,
-            $this->subject->make('DIGEST-MD5')
+            $this->subject->make(MechanismName::DIGEST_MD5),
         );
     }
 
-    public function test_make_unknown_mechanism_throws(): void
+    public function test_make_unsupported_mechanism_throws(): void
     {
         self::expectException(RuntimeException::class);
 
-        $this->subject->make('UNKNOWN');
+        $this->subject->make(MechanismName::ANONYMOUS);
     }
 }

--- a/tests/unit/Protocol/Bind/Sasl/UsernameExtractor/ScramUsernameExtractorTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/UsernameExtractor/ScramUsernameExtractorTest.php
@@ -16,7 +16,7 @@ namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\ScramUsernameExtractor;
-use FreeDSx\Sasl\Mechanism\ScramMechanism;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use PHPUnit\Framework\TestCase;
 
 final class ScramUsernameExtractorTest extends TestCase
@@ -28,32 +28,15 @@ final class ScramUsernameExtractorTest extends TestCase
         $this->subject = new ScramUsernameExtractor();
     }
 
-    public function test_it_supports_all_scram_variants(): void
-    {
-        foreach (ScramMechanism::VARIANTS as $variant) {
-            self::assertTrue(
-                $this->subject->supports($variant),
-                "Expected support for $variant"
-            );
-        }
-    }
-
-    public function test_it_does_not_support_non_scram_mechanisms(): void
-    {
-        self::assertFalse($this->subject->supports('PLAIN'));
-        self::assertFalse($this->subject->supports('CRAM-MD5'));
-        self::assertFalse($this->subject->supports('DIGEST-MD5'));
-    }
-
     public function test_it_extracts_username_from_standard_client_first(): void
     {
         // n,, GS2 header (no channel binding)
         self::assertSame(
             'testuser',
             $this->subject->extractUsername(
-                ScramMechanism::SHA256,
+                MechanismName::SCRAM_SHA256,
                 'n,,n=testuser,r=clientnonce',
-            )
+            ),
         );
     }
 
@@ -63,8 +46,8 @@ final class ScramUsernameExtractorTest extends TestCase
         self::assertSame(
             'testuser',
             $this->subject->extractUsername(
-                ScramMechanism::SHA256_PLUS,
-                'p=tls-unique,,n=testuser,r=clientnonce'
+                MechanismName::SCRAM_SHA256_PLUS,
+                'p=tls-unique,,n=testuser,r=clientnonce',
             ),
         );
     }
@@ -75,9 +58,9 @@ final class ScramUsernameExtractorTest extends TestCase
         self::assertSame(
             'user,name',
             $this->subject->extractUsername(
-                ScramMechanism::SHA256,
+                MechanismName::SCRAM_SHA256,
                 'n,,n=user=2Cname,r=nonce',
-            )
+            ),
         );
     }
 
@@ -87,9 +70,9 @@ final class ScramUsernameExtractorTest extends TestCase
         self::assertSame(
             'user=name',
             $this->subject->extractUsername(
-                ScramMechanism::SHA256,
-                'n,,n=user=3Dname,r=nonce'
-            )
+                MechanismName::SCRAM_SHA256,
+                'n,,n=user=3Dname,r=nonce',
+            ),
         );
     }
 
@@ -100,8 +83,8 @@ final class ScramUsernameExtractorTest extends TestCase
 
         // Malformed message with no n= field
         $this->subject->extractUsername(
-            ScramMechanism::SHA256,
-            'n,,r=nonce'
+            MechanismName::SCRAM_SHA256,
+            'n,,r=nonce',
         );
     }
 
@@ -111,7 +94,7 @@ final class ScramUsernameExtractorTest extends TestCase
         self::assertSame(
             'testuser',
             $this->subject->extractUsername(
-                ScramMechanism::SHA256,
+                MechanismName::SCRAM_SHA256,
                 'n=testuser,r=nonce',
             ),
         );

--- a/tests/unit/Protocol/Bind/Sasl/UsernameExtractor/UsernameFieldExtractorTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/UsernameExtractor/UsernameFieldExtractorTest.php
@@ -17,8 +17,7 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\UsernameFieldExtractor;
 use FreeDSx\Sasl\Encoder\EncoderInterface;
-use FreeDSx\Sasl\Mechanism\CramMD5Mechanism;
-use FreeDSx\Sasl\Mechanism\DigestMD5Mechanism;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Sasl\Message;
 use FreeDSx\Sasl\SaslContext;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -35,26 +34,8 @@ final class UsernameFieldExtractorTest extends TestCase
         $this->mockEncoder = $this->createMock(EncoderInterface::class);
 
         $this->subject = new UsernameFieldExtractor([
-            CramMD5Mechanism::NAME => $this->mockEncoder,
+            MechanismName::CRAM_MD5->value => $this->mockEncoder,
         ]);
-    }
-
-    public function test_it_supports_mechanisms_that_have_a_registered_encoder(): void
-    {
-        self::assertTrue($this->subject->supports(CramMD5Mechanism::NAME));
-    }
-
-    public function test_it_does_not_support_mechanisms_without_a_registered_encoder(): void
-    {
-        self::assertFalse($this->subject->supports('PLAIN'));
-    }
-
-    public function test_it_defaults_to_supporting_cram_md5_and_digest_md5(): void
-    {
-        $subject = new UsernameFieldExtractor();
-
-        self::assertTrue($subject->supports(CramMD5Mechanism::NAME));
-        self::assertTrue($subject->supports(DigestMD5Mechanism::NAME));
     }
 
     public function test_it_extracts_the_username_field_from_decoded_credentials(): void
@@ -68,7 +49,7 @@ final class UsernameFieldExtractorTest extends TestCase
 
         self::assertSame(
             'cn=user,dc=foo,dc=bar',
-            $this->subject->extractUsername(CramMD5Mechanism::NAME, $credentials),
+            $this->subject->extractUsername(MechanismName::CRAM_MD5, $credentials),
         );
     }
 
@@ -83,7 +64,7 @@ final class UsernameFieldExtractorTest extends TestCase
             )
             ->willReturn(new Message(['username' => 'user']));
 
-        $this->subject->extractUsername(CramMD5Mechanism::NAME, 'bytes');
+        $this->subject->extractUsername(MechanismName::CRAM_MD5, 'bytes');
     }
 
     public function test_it_throws_a_protocol_error_when_the_username_field_is_missing(): void
@@ -96,8 +77,8 @@ final class UsernameFieldExtractorTest extends TestCase
         self::expectExceptionCode(ResultCode::PROTOCOL_ERROR);
 
         $this->subject->extractUsername(
-            CramMD5Mechanism::NAME,
-            'bytes'
+            MechanismName::CRAM_MD5,
+            'bytes',
         );
     }
 }

--- a/tests/unit/Protocol/ClientProtocolHandler/ClientSaslBindHandlerTest.php
+++ b/tests/unit/Protocol/ClientProtocolHandler/ClientSaslBindHandlerTest.php
@@ -26,8 +26,9 @@ use FreeDSx\Ldap\Protocol\Queue\ClientQueue;
 use FreeDSx\Ldap\Protocol\RootDseLoader;
 use FreeDSx\Sasl\Challenge\ChallengeInterface;
 use FreeDSx\Sasl\Mechanism\MechanismInterface;
-use FreeDSx\Sasl\Sasl;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Sasl\SaslContext;
+use FreeDSx\Sasl\SaslInterface;
 use FreeDSx\Sasl\Security\SecurityLayerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -38,7 +39,7 @@ final class ClientSaslBindHandlerTest extends TestCase
 
     private LdapMessageResponse $saslComplete;
 
-    private Sasl&MockObject $mockSasl;
+    private SaslInterface&MockObject $mockSasl;
 
     private ClientQueue&MockObject $mockQueue;
 
@@ -52,7 +53,7 @@ final class ClientSaslBindHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mockSasl = $this->createMock(Sasl::class);
+        $this->mockSasl = $this->createMock(SaslInterface::class);
         $this->mockQueue = $this->createMock(ClientQueue::class);
         $this->mockRootDseLoader = $this->createMock(RootDseLoader::class);
         $this->mockMech = $this->createMock(MechanismInterface::class);
@@ -84,7 +85,7 @@ final class ClientSaslBindHandlerTest extends TestCase
     public function test_it_should_handle_a_sasl_bind_request(): void
     {
         $this->withStandardRootDseResponse();
-        $saslBind = Operations::bindSasl(['username' => 'foo', 'password' => 'bar']);
+        $saslBind = Operations::bindSasl();
         $messageRequest = new LdapMessageRequest(1, $saslBind);
 
         $this->mockQueue
@@ -97,19 +98,21 @@ final class ClientSaslBindHandlerTest extends TestCase
         $this->mockSasl
             ->expects($this->once())
             ->method('select')
-            ->with(['DIGEST-MD5', 'CRAM-MD5'], ['username' => 'foo', 'password' => 'bar'])
+            ->with(
+                [MechanismName::DIGEST_MD5, MechanismName::CRAM_MD5],
+                null,
+            )
             ->willReturn($this->mockMech);
 
         $this->mockMech
             ->method('getName')
-            ->willReturn('DIGEST-MD5');
+            ->willReturn(MechanismName::DIGEST_MD5);
         $this->mockMech
             ->method('challenge')
             ->willReturn($this->mockChallenge);
 
         $this->mockChallenge
             ->method('challenge')
-            ->with(self::anything(), ['username' => 'foo', 'password' => 'bar'])
             ->will($this->onConsecutiveCalls(
                 (new SaslContext())->setResponse('foo'),
                 (new SaslContext())->setResponse('foo')->setIsComplete(true)
@@ -128,8 +131,9 @@ final class ClientSaslBindHandlerTest extends TestCase
         );
     }
 
-    public function test_it_should_detect_a_downgrade_attack(): void {
-        $saslBind = Operations::bindSasl(['username' => 'foo', 'password' => 'bar']);
+    public function test_it_should_detect_a_downgrade_attack(): void
+    {
+        $saslBind = Operations::bindSasl();
         $messageRequest = new LdapMessageRequest(1, $saslBind);
 
         $this->mockQueue
@@ -145,14 +149,13 @@ final class ClientSaslBindHandlerTest extends TestCase
 
         $this->mockMech
             ->method('getName')
-            ->willReturn('PLAIN');
+            ->willReturn(MechanismName::PLAIN);
         $this->mockMech
             ->method('challenge')
             ->willReturn($this->mockChallenge);
 
         $this->mockChallenge
             ->method('challenge')
-            ->with(self::anything(), ['username' => 'foo', 'password' => 'bar'])
             ->will($this->onConsecutiveCalls(
                 (new SaslContext())->setResponse('foo'),
                 (new SaslContext())->setResponse('foo')->setIsComplete(true)
@@ -183,7 +186,7 @@ final class ClientSaslBindHandlerTest extends TestCase
 
     public function test_it_should_not_query_the_rootdse_if_the_mechanism_was_explicitly_specified(): void
     {
-        $saslBind = Operations::bindSasl(['username' => 'foo', 'password' => 'bar'], 'DIGEST-MD5');
+        $saslBind = Operations::bindSasl(null, MechanismName::DIGEST_MD5);
         $messageRequest = new LdapMessageRequest(1, $saslBind);
 
         $this->withStandardRootDseResponse();
@@ -196,12 +199,12 @@ final class ClientSaslBindHandlerTest extends TestCase
 
         $this->mockSasl
             ->method('get')
-            ->with('DIGEST-MD5')
+            ->with(MechanismName::DIGEST_MD5)
             ->willReturn($this->mockMech);
 
         $this->mockMech
             ->method('getName')
-            ->willReturn('DIGEST-MD5');
+            ->willReturn(MechanismName::DIGEST_MD5);
         $this->mockMech
             ->method('challenge')
             ->willReturn($this->mockChallenge);
@@ -225,7 +228,7 @@ final class ClientSaslBindHandlerTest extends TestCase
 
     public function test_it_should_set_the_set_the_security_layer_on_the_queue_if_one_was_negotiated(): void
     {
-        $saslBind = Operations::bindSasl(['username' => 'foo', 'password' => 'bar'], 'DIGEST-MD5');
+        $saslBind = Operations::bindSasl(null, MechanismName::DIGEST_MD5);
         $messageRequest = new LdapMessageRequest(1, $saslBind);
 
         $this->mockQueue
@@ -240,7 +243,7 @@ final class ClientSaslBindHandlerTest extends TestCase
             ->willReturn($this->mockMech);
         $this->mockMech
             ->method('getName')
-            ->willReturn('DIGEST-MD5');
+            ->willReturn(MechanismName::DIGEST_MD5);
         $this->mockMech
             ->method('challenge')
             ->willReturn($this->mockChallenge);
@@ -282,6 +285,5 @@ final class ClientSaslBindHandlerTest extends TestCase
                 '',
                 ['supportedSaslMechanisms' => ['DIGEST-MD5', 'CRAM-MD5']]
             ));
-
     }
 }

--- a/tests/unit/Server/Backend/Auth/NameResolver/PasswordAuthenticatorTest.php
+++ b/tests/unit/Server/Backend/Auth/NameResolver/PasswordAuthenticatorTest.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticator;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Sasl\Mechanism\MechanismName;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -201,7 +202,7 @@ final class PasswordAuthenticatorTest extends TestCase
     public function test_get_password_returns_null_when_entry_not_found(): void
     {
         self::assertNull(
-            $this->subject()->getPassword('unknown', 'SCRAM-SHA-256')
+            $this->subject()->getPassword('unknown', MechanismName::SCRAM_SHA256)
         );
     }
 
@@ -213,7 +214,7 @@ final class PasswordAuthenticatorTest extends TestCase
         );
 
         self::assertNull(
-            $this->subject($entry)->getPassword('cn=Alice,dc=example,dc=com', 'SCRAM-SHA-256')
+            $this->subject($entry)->getPassword('cn=Alice,dc=example,dc=com', MechanismName::SCRAM_SHA256)
         );
     }
 
@@ -226,7 +227,7 @@ final class PasswordAuthenticatorTest extends TestCase
 
         self::assertSame(
             'secret',
-            $this->subject($entry)->getPassword('cn=Alice,dc=example,dc=com', 'SCRAM-SHA-256')
+            $this->subject($entry)->getPassword('cn=Alice,dc=example,dc=com', MechanismName::SCRAM_SHA256)
         );
     }
 
@@ -240,7 +241,7 @@ final class PasswordAuthenticatorTest extends TestCase
 
         self::assertSame(
             $hashed,
-            $this->subject($entry)->getPassword('cn=Alice,dc=example,dc=com', 'SCRAM-SHA-256')
+            $this->subject($entry)->getPassword('cn=Alice,dc=example,dc=com', MechanismName::SCRAM_SHA256)
         );
     }
 }


### PR DESCRIPTION
Upgrading with the changes to SASL. Similar to the socket library, the options were replaced from an array to a DTO. And enums for the mech name. Other small changes.