### PR TITLE
[1.0.0] Batch the writes in swoole to fix contention under concurrent load.

### DIFF
--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqliteStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqliteStorage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter;
 
+use Closure;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SqliteDialect;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactoryInterface;
@@ -55,11 +56,14 @@ final class SqliteStorage implements PdoStorageFactoryInterface
     public static function forSwoole(string $dbPath): EntryStorageInterface
     {
         $factory = new self($dbPath);
+        $writesStorage = $factory->createShared();
 
         return new WriteSerializingStorage(
             reads: $factory->createPerCoroutine(),
-            writes: $factory->createShared(),
-            queue: new SwooleWriterQueue(),
+            writes: $writesStorage,
+            queue: new SwooleWriterQueue(
+                batchWrapper: static fn(Closure $cb) => $writesStorage->atomic(static fn() => $cb()),
+            ),
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/SwooleWriterQueue.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/SwooleWriterQueue.php
@@ -33,8 +33,13 @@ final class SwooleWriterQueue implements WriterQueueInterface
 
     private bool $started = false;
 
-    public function __construct(private readonly int $capacity = 1024)
-    {
+    /**
+     * @param Closure(Closure(): void): void|null $batchWrapper Wraps a batch of jobs in an outer transaction.
+     */
+    public function __construct(
+        private readonly int $capacity = 1024,
+        private readonly ?Closure $batchWrapper = null,
+    ) {
     }
 
     /**
@@ -81,22 +86,82 @@ final class SwooleWriterQueue implements WriterQueueInterface
      */
     private function spawnWriter(Channel $jobs): void
     {
-        Coroutine::create(static function () use ($jobs): void {
+        $batchWrapper = $this->batchWrapper;
+        $executeBatch = self::executeBatch(...);
+
+        Coroutine::create(static function () use ($jobs, $batchWrapper, $executeBatch): void {
             while (true) {
-                $job = $jobs->pop();
-                if ($job === false) {
+                $first = $jobs->pop();
+                if ($first === false) {
                     return;
                 }
 
-                [$closure, $reply] = $job;
+                $batch = [$first];
+                while (!$jobs->isEmpty()) {
+                    $next = $jobs->pop();
+                    if ($next === false) {
+                        break;
+                    }
+                    $batch[] = $next;
+                }
 
-                try {
-                    $closure();
-                    $reply->push(true);
-                } catch (Throwable $e) {
-                    $reply->push($e);
+                if (count($batch) === 1 || $batchWrapper === null) {
+                    foreach ($batch as [$closure, $reply]) {
+                        try {
+                            $closure();
+                            $reply->push(true);
+                        } catch (Throwable $e) {
+                            $reply->push($e);
+                        }
+                    }
+                } else {
+                    $executeBatch(
+                        $batch,
+                        $batchWrapper,
+                    );
                 }
             }
         });
+    }
+
+    /**
+     * Executes a batch under a single outer transaction, isolating per-job failures via savepoints.
+     *
+     * @internal
+     *
+     * @param list<array{Closure, Channel<mixed>}> $batch
+     * @param Closure(Closure(): void): void $batchWrapper
+     */
+    public static function executeBatch(
+        array $batch,
+        Closure $batchWrapper,
+    ): void {
+        $results = array_fill(
+            0,
+            count($batch),
+            true,
+        );
+
+        try {
+            $batchWrapper(static function () use ($batch, &$results): void {
+                foreach ($batch as $i => [$closure]) {
+                    try {
+                        $closure();
+                    } catch (Throwable $e) {
+                        $results[$i] = $e;
+                    }
+                }
+            });
+        } catch (Throwable $e) {
+            foreach ($batch as [, $reply]) {
+                $reply->push($e);
+            }
+
+            return;
+        }
+
+        foreach ($batch as $i => [, $reply]) {
+            $reply->push($results[$i]);
+        }
     }
 }

--- a/tests/performance/Threshold/CiThresholds.php
+++ b/tests/performance/Threshold/CiThresholds.php
@@ -59,7 +59,7 @@ final class CiThresholds
             'sqlite:swoole' => new ThresholdSet(
                 maxErrors: 0,
                 minThroughput: 950.0,
-                maxP99Ms: 800.0,
+                maxP99Ms: 500.0,
             ),
             'mysql:pcntl' => new ThresholdSet(
                 maxErrors: 0,

--- a/tests/unit/Server/Backend/Storage/Adapter/Writer/SwooleWriterQueueTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Writer/SwooleWriterQueueTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Adapter\Writer;
+
+use Closure;
+use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Writer\SwooleWriterQueue;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use Swoole\Coroutine;
+use Swoole\Coroutine\Channel;
+use Throwable;
+
+final class SwooleWriterQueueTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!extension_loaded('swoole')) {
+            $this->markTestSkipped('The swoole extension is required for this test.');
+        }
+    }
+
+    public function test_throws_when_called_outside_a_coroutine(): void
+    {
+        $queue = new SwooleWriterQueue();
+
+        $this->expectException(RuntimeException::class);
+        $queue->run(static fn() => null);
+    }
+
+    public function test_single_job_executes_successfully(): void
+    {
+        $executed = false;
+
+        Coroutine\run(function () use (&$executed): void {
+            $queue = new SwooleWriterQueue();
+            $queue->run(static function () use (&$executed): void {
+                $executed = true;
+            });
+        });
+
+        self::assertTrue($executed);
+    }
+
+    public function test_run_rethrows_job_exception_to_caller(): void
+    {
+        $thrown = null;
+
+        Coroutine\run(function () use (&$thrown): void {
+            $queue = new SwooleWriterQueue();
+
+            try {
+                $queue->run(static function (): void {
+                    throw new LogicException('job failed');
+                });
+            } catch (LogicException $e) {
+                $thrown = $e;
+            }
+        });
+
+        self::assertNotNull($thrown);
+        self::assertSame(
+            'job failed',
+            $thrown->getMessage()
+        );
+    }
+
+    public function test_single_job_does_not_invoke_batch_wrapper(): void
+    {
+        $wrapperCalls = 0;
+        $batchWrapper = static function (Closure $cb) use (&$wrapperCalls): void {
+            $wrapperCalls++;
+            $cb();
+        };
+
+        Coroutine\run(function () use ($batchWrapper): void {
+            $queue = new SwooleWriterQueue(batchWrapper: $batchWrapper);
+            $queue->run(static fn() => null);
+        });
+
+        self::assertSame(
+            0,
+            $wrapperCalls,
+        );
+    }
+
+    public function test_executeBatch_calls_wrapper_once_and_runs_all_closures(): void
+    {
+        $wrapperCalls = 0;
+        $executed = [];
+        $batchWrapper = static function (Closure $cb) use (&$wrapperCalls): void {
+            $wrapperCalls++;
+            $cb();
+        };
+
+        Coroutine\run(function () use ($batchWrapper, &$executed): void {
+            $replies = [new Channel(1), new Channel(1), new Channel(1)];
+            $batch = [
+                [static function () use (&$executed): void { $executed[] = 'a'; }, $replies[0]],
+                [static function () use (&$executed): void { $executed[] = 'b'; }, $replies[1]],
+                [static function () use (&$executed): void { $executed[] = 'c'; }, $replies[2]],
+            ];
+
+            SwooleWriterQueue::executeBatch($batch, $batchWrapper);
+
+            foreach ($replies as $reply) {
+                $reply->pop();
+            }
+        });
+
+        self::assertSame(
+            1,
+            $wrapperCalls,
+        );
+        self::assertSame(
+            ['a', 'b', 'c'],
+            $executed,
+        );
+    }
+
+    public function test_executeBatch_isolates_per_job_failure(): void
+    {
+        $batchWrapper = static function (Closure $cb): void {
+            $cb();
+        };
+        $results = [];
+
+        Coroutine\run(function () use ($batchWrapper, &$results): void {
+            $replies = [new Channel(1), new Channel(1), new Channel(1)];
+            $batch = [
+                [static fn() => null, $replies[0]],
+                [static function (): void { throw new LogicException('b failed'); }, $replies[1]],
+                [static fn() => null, $replies[2]],
+            ];
+
+            SwooleWriterQueue::executeBatch($batch, $batchWrapper);
+
+            $results[0] = $replies[0]->pop();
+            $results[1] = $replies[1]->pop();
+            $results[2] = $replies[2]->pop();
+        });
+
+        self::assertTrue($results[0]);
+        self::assertInstanceOf(LogicException::class, $results[1]);
+        self::assertSame('b failed', $results[1]->getMessage());
+        self::assertTrue($results[2]);
+    }
+
+    public function test_executeBatch_broadcasts_wrapper_failure_to_all_callers(): void
+    {
+        $batchWrapper = static function (Closure $cb): void {
+            throw new LogicException('transaction failed');
+        };
+        $results = [];
+
+        Coroutine\run(function () use ($batchWrapper, &$results): void {
+            $replies = [new Channel(1), new Channel(1), new Channel(1)];
+            $batch = [
+                [static fn() => null, $replies[0]],
+                [static fn() => null, $replies[1]],
+                [static fn() => null, $replies[2]],
+            ];
+
+            SwooleWriterQueue::executeBatch($batch, $batchWrapper);
+
+            $results[0] = $replies[0]->pop();
+            $results[1] = $replies[1]->pop();
+            $results[2] = $replies[2]->pop();
+        });
+
+        foreach ($results as $result) {
+            self::assertInstanceOf(LogicException::class, $result);
+            self::assertSame('transaction failed', $result->getMessage());
+        }
+    }
+
+    public function test_concurrent_job_failure_isolates_to_failing_caller(): void
+    {
+        $batchWrapper = static function (Closure $cb): void {
+            $cb();
+        };
+        $results = [];
+
+        Coroutine\run(function () use ($batchWrapper, &$results): void {
+            $queue = new SwooleWriterQueue(batchWrapper: $batchWrapper);
+            $done = new Channel(3);
+
+            Coroutine::create(function () use ($queue, $done, &$results): void {
+                try {
+                    $queue->run(static fn() => null);
+                    $results['a'] = true;
+                } catch (Throwable $e) {
+                    $results['a'] = $e;
+                }
+                $done->push('a');
+            });
+            Coroutine::create(function () use ($queue, $done, &$results): void {
+                try {
+                    $queue->run(static function (): void {
+                        throw new LogicException('job b failed');
+                    });
+                    $results['b'] = true;
+                } catch (Throwable $e) {
+                    $results['b'] = $e;
+                }
+                $done->push('b');
+            });
+            Coroutine::create(function () use ($queue, $done, &$results): void {
+                try {
+                    $queue->run(static fn() => null);
+                    $results['c'] = true;
+                } catch (Throwable $e) {
+                    $results['c'] = $e;
+                }
+                $done->push('c');
+            });
+
+            for ($i = 0; $i < 3; $i++) {
+                $done->pop();
+            }
+        });
+
+        self::assertTrue($results['a']);
+        self::assertInstanceOf(LogicException::class, $results['b']);
+        self::assertSame(
+            'job b failed',
+            $results['b']->getMessage()
+        );
+        self::assertTrue($results['c']);
+    }
+}


### PR DESCRIPTION
Optimizing the current write strategy under swoole. With everything currently funneled under a single coroutine writer, we need to batch the writes to be performant. Otherwise under any heavy concurrent load containing writes things start to back up.