### PR TITLE
[1.0.0] Add a schema to the backend.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",
-    "symplify/easy-coding-standard": "^9.4",
+    "symplify/easy-coding-standard": "^13.1",
     "phpstan/phpstan": "^2.1",
     "symfony/process": "^5.4",
     "symfony/console": "^6.4",

--- a/docs/Server/Schema.md
+++ b/docs/Server/Schema.md
@@ -1,0 +1,133 @@
+Schema Validation
+=================
+
+* [Default Behavior](#default-behavior)
+* [What Gets Validated](#what-gets-validated)
+* [Entry Requirements](#entry-requirements)
+    * [extensibleObject](#extensibleobject)
+* [Validation Mode](#validation-mode)
+    * [ServerOptions:setSchemaValidationMode](#setschemavalidationmode)
+* [Custom Schema](#custom-schema)
+    * [ServerOptions:setSchema](#setschema)
+
+Calling `LdapServer::useStorage()` automatically enables schema validation using the built-in RFC 4519
+schema in `Strict` mode.
+
+## Default Behavior
+
+```php
+use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+
+$server = new LdapServer();
+$server->useStorage(new InMemoryStorage());
+```
+
+## What Gets Validated
+
+Every `add` and `modify` is checked before reaching storage:
+
+- At least one structural `objectClass` known to the schema is present.
+- All `MUST` attributes for the object class chain are present.
+- No attributes outside the `MUST` + `MAY` set appear (unless `extensibleObject` is included).
+- Single-valued attributes carry at most one value.
+- Attributes marked `NO-USER-MODIFICATION` are not writable by clients.
+
+Failures return `objectClassViolation` (65), `undefinedAttributeType` (17), or `constraintViolation` (19)
+with a diagnostic message naming the offending attribute or class.
+
+## Entry Requirements
+
+An entry needs a structural `objectClass` the schema recognises and every `MUST` attribute it requires.
+
+```php
+use FreeDSx\Ldap\Entry\Entry;
+
+$entry = Entry::fromArray(
+    'cn=alice,ou=people,dc=example,dc=com',
+    [
+        'objectClass' => 'inetOrgPerson',
+        'cn'          => 'alice',
+        'sn'          => 'Smith',   // MUST for inetOrgPerson
+    ],
+);
+```
+
+### extensibleObject
+
+Adding `extensibleObject` as an auxiliary class bypasses the attribute-set checks.
+
+```php
+$entry = Entry::fromArray(
+    'cn=alice,ou=people,dc=example,dc=com',
+    [
+        'objectClass' => ['inetOrgPerson', 'extensibleObject'],
+        'cn'          => 'alice',
+        'sn'          => 'Smith',
+        'uidNumber'   => '1001',   // not in inetOrgPerson MAY; allowed via extensibleObject
+    ],
+);
+```
+
+## Validation Mode
+
+------------------
+#### setSchemaValidationMode
+
+**Default**: `SchemaValidationMode::Strict`
+
+| Mode | Behaviour |
+|------|-----------|
+| `Strict` | Violations are rejected with an LDAP error. |
+| `Off` | All writes pass through without checks. |
+
+```php
+use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\Schema\SchemaValidationMode;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\ServerOptions;
+
+$server = new LdapServer(
+    (new ServerOptions())->setSchemaValidationMode(SchemaValidationMode::Off)
+);
+$server->useStorage(new InMemoryStorage());
+```
+
+## Custom Schema
+
+------------------
+#### setSchema
+
+Replaces the active schema. Use `StandardSchemaProvider::buildCore()->merge(...)` to extend the
+standard definitions rather than replace them.
+
+**Default**: `StandardSchemaProvider::buildCore()`
+
+```php
+use FreeDSx\Ldap\Schema\Definition\AttributeType;
+use FreeDSx\Ldap\Schema\Definition\AttributeUsage;
+use FreeDSx\Ldap\Schema\Definition\ObjectClass;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassType;
+use FreeDSx\Ldap\Schema\Schema;
+use FreeDSx\Ldap\Schema\StandardSchemaProvider;
+use FreeDSx\Ldap\ServerOptions;
+
+$schema = StandardSchemaProvider::buildCore()->merge(
+    (new Schema())
+        ->addAttributeType(new AttributeType(
+            oid: '1.3.6.1.4.1.99999.1',
+            names: ['myCustomAttr'],
+            equalityOid: '2.5.13.2',
+            usage: AttributeUsage::UserApplications,
+        ))
+        ->addObjectClass(new ObjectClass(
+            oid: '1.3.6.1.4.1.99999.2',
+            names: ['myCustomClass'],
+            type: ObjectClassType::StructuralClass,
+            superClassOids: ['2.5.6.6'],
+            must: ['myCustomAttr'],
+        ))
+);
+
+$options = (new ServerOptions())->setSchema($schema);
+```

--- a/ecs.php
+++ b/ecs.php
@@ -5,26 +5,18 @@ declare(strict_types=1);
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
 use PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\CodingStandard\Fixer\Strict\BlankLineAfterStrictTypesFixer;
-use Symplify\EasyCodingStandard\ValueObject\Option;
-use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
+use Symplify\EasyCodingStandard\Config\ECSConfig;
 
-return static function (ContainerConfigurator $containerConfigurator): void {
-    $parameters = $containerConfigurator->parameters();
-    $parameters->set(Option::PATHS, [
+return ECSConfig::configure()
+    ->withPaths([
         __DIR__ . '/src',
         __DIR__ . '/tests',
+    ])
+    ->withPhpCsFixerSets(psr12: true)
+    ->withConfiguredRule(ArraySyntaxFixer::class, ['syntax' => 'short'])
+    ->withRules([
+        BlankLineAfterStrictTypesFixer::class,
+        BlankLineAfterOpeningTagFixer::class,
+        NoUnusedImportsFixer::class,
     ]);
-
-    $services = $containerConfigurator->services();
-    $services->set(ArraySyntaxFixer::class)
-        ->call('configure', [[
-            'syntax' => 'short',
-        ]]);
-    $services->set(BlankLineAfterStrictTypesFixer::class);
-    $services->set(BlankLineAfterOpeningTagFixer::class);
-    $services->set(NoUnusedImportsFixer::class);
-
-    $containerConfigurator->import(SetList::PSR_12);
-};

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap;
 
+use FreeDSx\Ldap\Schema\SchemaValidationMode;
+use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
@@ -67,8 +69,11 @@ class LdapServer
     /**
      * Specify an entry storage implementation to back the LDAP server.
      *
-     * Use useBackend() instead when implementing a fully custom backend (e.g.
-     * a proxy) that handles LDAP semantics itself.
+     * Schema validation is applied automatically. If you don't want it, set {@see SchemaValidationMode::Off} in your
+     * server options.
+     *
+     * Use {@see useBackend()} instead when implementing a fully custom backend (e.g. a proxy) that handles LDAP
+     * semantics itself.
      */
     public function useStorage(EntryStorageInterface $storage): self
     {
@@ -76,7 +81,22 @@ class LdapServer
             storage: $storage,
             limits: $this->options->makeSearchLimits(),
             namingContexts: $this->options->getDseNamingContexts(),
+            validator: $this->buildSchemaValidator(),
         ));
+    }
+
+    private function buildSchemaValidator(): ?SchemaValidator
+    {
+        $mode = $this->options->getSchemaValidationMode();
+
+        if ($mode === SchemaValidationMode::Off) {
+            return null;
+        }
+
+        return new SchemaValidator(
+            $this->options->getSchema(),
+            $mode,
+        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSubschemaHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSubschemaHandler.php
@@ -20,11 +20,14 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassOid;
+use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\ServerOptions;
 
 /**
- * Returns a minimal stub subschema entry, satisfying clients that follow up on the subschemaSubentry DN advertised in the RootDSE.
+ * Returns the full RFC 4512 subschema entry from the active schema registry.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -42,11 +45,35 @@ class ServerSubschemaHandler implements ServerProtocolHandlerInterface
     ): void {
         $schemaDn = $this->options->getSubschemaEntry();
         $rdn = $schemaDn->getRdn();
+        $schema = $this->options->getSchema();
 
-        $entry = Entry::fromArray($schemaDn->toString(), [
-            'objectClass'    => ['top', 'subschema'],
-            $rdn->getName()  => [$rdn->getValue()],
-        ]);
+        $entry = Entry::fromArray(
+            $schemaDn->toString(),
+            array_filter([
+                AttributeTypeOid::NAME_OBJECT_CLASS => [
+                    ObjectClassOid::NAME_TOP,
+                    ObjectClassOid::NAME_SUBSCHEMA,
+                ],
+                $rdn->getName() => [$rdn->getValue()],
+                AttributeTypeOid::NAME_ATTRIBUTE_TYPES => array_map(
+                    fn ($at) => $at->toDescriptionString(),
+                    $schema->getAttributeTypes(),
+                ),
+                AttributeTypeOid::NAME_OBJECT_CLASSES => array_map(
+                    fn ($oc) => $oc->toDescriptionString(),
+                    $schema->getObjectClasses(),
+                ),
+                AttributeTypeOid::NAME_MATCHING_RULES => array_map(
+                    fn ($mr) => $mr->toDescriptionString(),
+                    $schema->getMatchingRules(),
+                ),
+                AttributeTypeOid::NAME_LDAP_SYNTAXES => array_map(
+                    fn ($ls) => $ls->toDescriptionString(),
+                    $schema->getLdapSyntaxes(),
+                ),
+                AttributeTypeOid::NAME_MATCHING_RULE_USE => $this->buildMatchingRuleUse($schema),
+            ]),
+        );
 
         $this->queue->sendMessage(
             new LdapMessageResponse(
@@ -58,5 +85,40 @@ class ServerSubschemaHandler implements ServerProtocolHandlerInterface
                 new SearchResultDone(ResultCode::SUCCESS),
             ),
         );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildMatchingRuleUse(Schema $schema): array
+    {
+        $ruleToAttrs = [];
+        foreach ($schema->getAttributeTypes() as $attrType) {
+            $name = $attrType->names[0] ?? $attrType->oid;
+
+            if ($attrType->equalityOid !== null) {
+                $ruleToAttrs[$attrType->equalityOid][] = $name;
+            }
+
+            if ($attrType->orderingOid !== null) {
+                $ruleToAttrs[$attrType->orderingOid][] = $name;
+            }
+
+            if ($attrType->substringOid !== null) {
+                $ruleToAttrs[$attrType->substringOid][] = $name;
+            }
+        }
+
+        $use = [];
+        foreach ($ruleToAttrs as $ruleOid => $attrNames) {
+            $rule = $schema->getMatchingRule($ruleOid);
+            if ($rule === null) {
+                continue;
+            }
+
+            $use[] = $rule->toMatchingRuleUseString($attrNames);
+        }
+
+        return $use;
     }
 }

--- a/src/FreeDSx/Ldap/Schema/Definition/AttributeType.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/AttributeType.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Definition;
+
+/**
+ * An attribute type definition per RFC 4512 §4.1.2.
+ */
+final readonly class AttributeType
+{
+    use DefinitionStringTrait;
+
+    /**
+     * @param list<string> $names
+     * @param array<string, list<string>> $extensions
+     */
+    public function __construct(
+        public string $oid,
+        public array $names,
+        public ?string $equalityOid = null,
+        public ?string $orderingOid = null,
+        public ?string $substringOid = null,
+        public ?string $syntaxOid = null,
+        public bool $singleValue = false,
+        public bool $collective = false,
+        public bool $noUserModification = false,
+        public AttributeUsage $usage = AttributeUsage::UserApplications,
+        public ?string $superTypeOid = null,
+        public ?string $desc = null,
+        public bool $obsolete = false,
+        public array $extensions = [],
+    ) {
+    }
+
+    /**
+     * Produces the description string used in the subschema attributeTypes attribute.
+     */
+    public function toDescriptionString(): string
+    {
+        $parts = array_filter([
+            '( ' . $this->oid,
+            $this->token(
+                DefinitionKeyword::NAME,
+                $this->names !== []
+                    ? $this->formatDescriptors($this->names)
+                    : null,
+            ),
+            $this->token(
+                DefinitionKeyword::DESC,
+                $this->desc !== null
+                    ? $this->quoteString($this->desc)
+                    : null,
+            ),
+            $this->flag(
+                DefinitionKeyword::OBSOLETE,
+                $this->obsolete,
+            ),
+            $this->token(
+                DefinitionKeyword::SUP,
+                $this->superTypeOid,
+            ),
+            $this->token(
+                DefinitionKeyword::EQUALITY,
+                $this->equalityOid,
+            ),
+            $this->token(
+                DefinitionKeyword::ORDERING,
+                $this->orderingOid,
+            ),
+            $this->token(
+                DefinitionKeyword::SUBSTR,
+                $this->substringOid,
+            ),
+            $this->token(
+                DefinitionKeyword::SYNTAX,
+                $this->syntaxOid,
+            ),
+            $this->flag(
+                DefinitionKeyword::SINGLE_VALUE,
+                $this->singleValue,
+            ),
+            $this->flag(
+                DefinitionKeyword::COLLECTIVE,
+                $this->collective,
+            ),
+            $this->flag(
+                DefinitionKeyword::NO_USER_MODIFICATION,
+                $this->noUserModification,
+            ),
+            $this->token(
+                DefinitionKeyword::USAGE,
+                $this->usage !== AttributeUsage::UserApplications
+                    ? $this->usage->value
+                    : null,
+            ),
+        ]);
+
+        foreach ($this->extensions as $name => $values) {
+            $parts[] = $name . ' ' . $this->formatDescriptors($values);
+        }
+
+        return implode(' ', $parts) . ' )';
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Definition/AttributeTypeOid.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/AttributeTypeOid.php
@@ -200,6 +200,10 @@ final class AttributeTypeOid
     public const NAME_MATCHING_RULE_USE = 'matchingRuleUse';
     public const DESC_MATCHING_RULE_USE = 'matching rule use descriptions';
 
+    public const OID_LDAP_SYNTAXES = '1.3.6.1.4.1.1466.101.120.16';
+    public const NAME_LDAP_SYNTAXES = 'ldapSyntaxes';
+    public const DESC_LDAP_SYNTAXES = 'LDAP syntax descriptions';
+
     public const OID_DIT_STRUCTURE_RULES = '2.5.21.1';
     public const NAME_DIT_STRUCTURE_RULES = 'dITStructureRules';
     public const DESC_DIT_STRUCTURE_RULES = 'DIT structure rules';
@@ -212,5 +216,7 @@ final class AttributeTypeOid
     public const NAME_NAME_FORMS = 'nameForms';
     public const DESC_NAME_FORMS = 'name forms';
 
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 }

--- a/src/FreeDSx/Ldap/Schema/Definition/AttributeTypeOid.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/AttributeTypeOid.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Definition;
+
+/**
+ * OIDs, names, aliases, and descriptions for standard LDAP attribute types (RFC 4519 + RFC 4512 operational).
+ */
+final class AttributeTypeOid
+{
+    public const OID_OBJECT_CLASS = '2.5.4.0';
+    public const NAME_OBJECT_CLASS = 'objectClass';
+    public const DESC_OBJECT_CLASS = 'object classes of the entity';
+
+    public const OID_ALIASED_OBJECT_NAME = '2.5.4.1';
+    public const NAME_ALIASED_OBJECT_NAME = 'aliasedObjectName';
+    public const ALIAS_ALIASED_OBJECT_NAME = 'aliasedEntryName';
+    public const DESC_ALIASED_OBJECT_NAME = 'name of aliased object';
+
+    public const OID_NAME = '2.5.4.41';
+    public const NAME_NAME = 'name';
+    public const DESC_NAME = 'common supertype of name attributes';
+
+    public const OID_CN = '2.5.4.3';
+    public const NAME_CN = 'cn';
+    public const ALIAS_CN = 'commonName';
+    public const DESC_CN = 'common name(s) of the object';
+
+    public const OID_SN = '2.5.4.4';
+    public const NAME_SN = 'sn';
+    public const ALIAS_SN = 'surname';
+    public const DESC_SN = 'last (family) name(s) for which the entity is known';
+
+    public const OID_GIVEN_NAME = '2.5.4.42';
+    public const NAME_GIVEN_NAME = 'givenName';
+    public const DESC_GIVEN_NAME = 'first name(s) for which the entity is known';
+
+    public const OID_INITIALS = '2.5.4.43';
+    public const NAME_INITIALS = 'initials';
+    public const DESC_INITIALS = 'initials of some or all of the names';
+
+    public const OID_C = '2.5.4.6';
+    public const NAME_C = 'c';
+    public const ALIAS_C = 'countryName';
+    public const DESC_C = 'two-letter ISO 3166 country code';
+
+    public const OID_L = '2.5.4.7';
+    public const NAME_L = 'l';
+    public const ALIAS_L = 'localityName';
+    public const DESC_L = 'locality in which the entity resides';
+
+    public const OID_ST = '2.5.4.8';
+    public const NAME_ST = 'st';
+    public const ALIAS_ST = 'stateOrProvinceName';
+    public const DESC_ST = 'state or province in which the entity resides';
+
+    public const OID_STREET = '2.5.4.9';
+    public const NAME_STREET = 'street';
+    public const ALIAS_STREET = 'streetAddress';
+    public const DESC_STREET = 'site for the local distribution of postal addresses';
+
+    public const OID_O = '2.5.4.10';
+    public const NAME_O = 'o';
+    public const ALIAS_O = 'organizationName';
+    public const DESC_O = 'organization(s) to which the entity belongs';
+
+    public const OID_OU = '2.5.4.11';
+    public const NAME_OU = 'ou';
+    public const ALIAS_OU = 'organizationalUnitName';
+    public const DESC_OU = 'organizational units of which the entity is a member';
+
+    public const OID_TITLE = '2.5.4.12';
+    public const NAME_TITLE = 'title';
+    public const DESC_TITLE = 'title(s) held by the entity';
+
+    public const OID_DESCRIPTION = '2.5.4.13';
+    public const NAME_DESCRIPTION = 'description';
+    public const DESC_DESCRIPTION = 'descriptive information';
+
+    public const OID_POSTAL_CODE = '2.5.4.17';
+    public const NAME_POSTAL_CODE = 'postalCode';
+    public const DESC_POSTAL_CODE = 'codes used by a postal service';
+
+    public const OID_TELEPHONE_NUMBER = '2.5.4.20';
+    public const NAME_TELEPHONE_NUMBER = 'telephoneNumber';
+    public const DESC_TELEPHONE_NUMBER = 'telephone numbers';
+
+    public const OID_MEMBER = '2.5.4.31';
+    public const NAME_MEMBER = 'member';
+    public const DESC_MEMBER = 'distinguished names of objects on a list or in a group';
+
+    public const OID_SEE_ALSO = '2.5.4.34';
+    public const NAME_SEE_ALSO = 'seeAlso';
+    public const DESC_SEE_ALSO = 'distinguished name(s) of objects related to the entity';
+
+    public const OID_USER_PASSWORD = '2.5.4.35';
+    public const NAME_USER_PASSWORD = 'userPassword';
+    public const DESC_USER_PASSWORD = 'passwords used to authenticate the entity';
+
+    public const OID_UNIQUE_MEMBER = '2.5.4.50';
+    public const NAME_UNIQUE_MEMBER = 'uniqueMember';
+    public const DESC_UNIQUE_MEMBER = 'distinguished names with optional unique identifiers';
+
+    public const OID_UID = '0.9.2342.19200300.100.1.1';
+    public const NAME_UID = 'uid';
+    public const ALIAS_UID = 'userid';
+    public const DESC_UID = 'user identifiers';
+
+    public const OID_MAIL = '0.9.2342.19200300.100.1.3';
+    public const NAME_MAIL = 'mail';
+    public const ALIAS_MAIL = 'rfc822Mailbox';
+    public const DESC_MAIL = 'electronic mail addresses';
+
+    public const OID_DC = '0.9.2342.19200300.100.1.25';
+    public const NAME_DC = 'dc';
+    public const ALIAS_DC = 'domainComponent';
+    public const DESC_DC = 'DNS label of the domain component';
+
+    public const OID_JPEG_PHOTO = '0.9.2342.19200300.100.1.60';
+    public const NAME_JPEG_PHOTO = 'jpegPhoto';
+    public const DESC_JPEG_PHOTO = 'JPEG images';
+
+    public const OID_DISPLAY_NAME = '2.16.840.1.113730.3.1.241';
+    public const NAME_DISPLAY_NAME = 'displayName';
+    public const DESC_DISPLAY_NAME = 'preferred name for display';
+
+    public const OID_EMPLOYEE_NUMBER = '2.16.840.1.113730.3.1.3';
+    public const NAME_EMPLOYEE_NUMBER = 'employeeNumber';
+    public const DESC_EMPLOYEE_NUMBER = 'numerically identifies an employee within an organization';
+
+    public const OID_MEMBER_OF = '1.2.840.113556.1.2.102';
+    public const NAME_MEMBER_OF = 'memberOf';
+    public const DESC_MEMBER_OF = 'distinguished names of groups the entity is a member of';
+
+    public const OID_LABELED_URI = '1.3.6.1.4.1.250.1.57';
+    public const NAME_LABELED_URI = 'labeledURI';
+    public const DESC_LABELED_URI = 'URIs with optional labels';
+
+    public const OID_CREATE_TIMESTAMP = '2.5.18.1';
+    public const NAME_CREATE_TIMESTAMP = 'createTimestamp';
+    public const DESC_CREATE_TIMESTAMP = 'time at which the object was created';
+
+    public const OID_MODIFY_TIMESTAMP = '2.5.18.2';
+    public const NAME_MODIFY_TIMESTAMP = 'modifyTimestamp';
+    public const DESC_MODIFY_TIMESTAMP = 'time at which the object was last modified';
+
+    public const OID_CREATORS_NAME = '2.5.18.3';
+    public const NAME_CREATORS_NAME = 'creatorsName';
+    public const DESC_CREATORS_NAME = 'name of the creator of the object';
+
+    public const OID_MODIFIERS_NAME = '2.5.18.4';
+    public const NAME_MODIFIERS_NAME = 'modifiersName';
+    public const DESC_MODIFIERS_NAME = 'name of the last modifier of the object';
+
+    public const OID_SUBSCHEMA_SUBENTRY = '2.5.18.10';
+    public const NAME_SUBSCHEMA_SUBENTRY = 'subschemaSubentry';
+    public const DESC_SUBSCHEMA_SUBENTRY = 'DN of the subschema entry governing the entity';
+
+    public const OID_HAS_SUBORDINATES = '2.5.18.9';
+    public const NAME_HAS_SUBORDINATES = 'hasSubordinates';
+    public const DESC_HAS_SUBORDINATES = 'whether the entry has any subordinate entries';
+
+    public const OID_STRUCTURAL_OBJECT_CLASS = '2.5.21.9';
+    public const NAME_STRUCTURAL_OBJECT_CLASS = 'structuralObjectClass';
+    public const DESC_STRUCTURAL_OBJECT_CLASS = 'structural object class of the entry';
+
+    public const OID_ENTRY_UUID = '1.3.6.1.1.16.4';
+    public const NAME_ENTRY_UUID = 'entryUUID';
+    public const DESC_ENTRY_UUID = 'universally unique identifier for the entry';
+
+    public const OID_ENTRY_DN = '1.3.6.1.1.20';
+    public const NAME_ENTRY_DN = 'entryDN';
+    public const DESC_ENTRY_DN = 'DN of the entry';
+
+    // RFC 4512 subschema attributes
+
+    public const OID_ATTRIBUTE_TYPES = '2.5.21.5';
+    public const NAME_ATTRIBUTE_TYPES = 'attributeTypes';
+    public const DESC_ATTRIBUTE_TYPES = 'attribute type descriptions';
+
+    public const OID_OBJECT_CLASSES = '2.5.21.6';
+    public const NAME_OBJECT_CLASSES = 'objectClasses';
+    public const DESC_OBJECT_CLASSES = 'object class descriptions';
+
+    public const OID_MATCHING_RULES = '2.5.21.4';
+    public const NAME_MATCHING_RULES = 'matchingRules';
+    public const DESC_MATCHING_RULES = 'matching rule descriptions';
+
+    public const OID_MATCHING_RULE_USE = '2.5.21.8';
+    public const NAME_MATCHING_RULE_USE = 'matchingRuleUse';
+    public const DESC_MATCHING_RULE_USE = 'matching rule use descriptions';
+
+    public const OID_DIT_STRUCTURE_RULES = '2.5.21.1';
+    public const NAME_DIT_STRUCTURE_RULES = 'dITStructureRules';
+    public const DESC_DIT_STRUCTURE_RULES = 'DIT structure rules';
+
+    public const OID_DIT_CONTENT_RULES = '2.5.21.2';
+    public const NAME_DIT_CONTENT_RULES = 'dITContentRules';
+    public const DESC_DIT_CONTENT_RULES = 'DIT content rules';
+
+    public const OID_NAME_FORMS = '2.5.21.7';
+    public const NAME_NAME_FORMS = 'nameForms';
+    public const DESC_NAME_FORMS = 'name forms';
+
+    private function __construct() {}
+}

--- a/src/FreeDSx/Ldap/Schema/Definition/AttributeUsage.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/AttributeUsage.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Definition;
+
+enum AttributeUsage: string
+{
+    case UserApplications = 'userApplications';
+    case DirectoryOperation = 'directoryOperation';
+    case DistributedOperation = 'distributedOperation';
+    case DsaOperation = 'dSAOperation';
+}

--- a/src/FreeDSx/Ldap/Schema/Definition/DefinitionKeyword.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/DefinitionKeyword.php
@@ -46,5 +46,9 @@ final class DefinitionKeyword
 
     public const MAY = 'MAY';
 
-    private function __construct() {}
+    public const APPLIES = 'APPLIES';
+
+    private function __construct()
+    {
+    }
 }

--- a/src/FreeDSx/Ldap/Schema/Definition/DefinitionKeyword.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/DefinitionKeyword.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Definition;
+
+/**
+ * RFC 4512 schema description-string keywords used by definition value objects.
+ */
+final class DefinitionKeyword
+{
+    public const NAME = 'NAME';
+
+    public const DESC = 'DESC';
+
+    public const OBSOLETE = 'OBSOLETE';
+
+    public const SYNTAX = 'SYNTAX';
+
+    public const SUP = 'SUP';
+
+    public const EQUALITY = 'EQUALITY';
+
+    public const ORDERING = 'ORDERING';
+
+    public const SUBSTR = 'SUBSTR';
+
+    public const SINGLE_VALUE = 'SINGLE-VALUE';
+
+    public const COLLECTIVE = 'COLLECTIVE';
+
+    public const NO_USER_MODIFICATION = 'NO-USER-MODIFICATION';
+
+    public const USAGE = 'USAGE';
+
+    public const MUST = 'MUST';
+
+    public const MAY = 'MAY';
+
+    private function __construct() {}
+}

--- a/src/FreeDSx/Ldap/Schema/Definition/DefinitionStringTrait.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/DefinitionStringTrait.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Definition;
+
+/**
+ * Shared string-formatting helpers for schema definition value objects that produce RFC 4512 description strings.
+ */
+trait DefinitionStringTrait
+{
+    /**
+     * Returns "KEYWORD value" when value is non-null, otherwise null (for use with array_filter).
+     */
+    private function token(
+        string $keyword,
+        ?string $value,
+    ): ?string {
+        return $value !== null
+            ? $keyword . ' ' . $value
+            : null;
+    }
+
+    /**
+     * Returns the keyword string when $include is true, otherwise null (for use with array_filter).
+     */
+    private function flag(
+        string $keyword,
+        bool $include,
+    ): ?string {
+        return $include
+            ? $keyword
+            : null;
+    }
+
+    /**
+     * Returns a single-quoted, backslash-escaped value suitable for DESC fields.
+     */
+    private function quoteString(string $value): string
+    {
+        return "'" . addcslashes($value, "'\\") . "'";
+    }
+
+    /**
+     * Formats one or more quoted descriptor strings per RFC 4512 §1.4.
+     *
+     * @param list<string> $values
+     */
+    private function formatDescriptors(array $values): string
+    {
+        if (count($values) === 1) {
+            return "'" . addcslashes($values[0], "'\\") . "'";
+        }
+
+        $quoted = array_map(
+            fn (string $v) => "'" . addcslashes($v, "'\\") . "'",
+            $values,
+        );
+
+        return '( ' . implode(' $ ', $quoted) . ' )';
+    }
+
+    /**
+     * Formats one or more OIDs per RFC 4512 §1.4.
+     *
+     * @param list<string> $oids
+     */
+    private function formatOids(array $oids): string
+    {
+        if (count($oids) === 1) {
+            return $oids[0];
+        }
+
+        return '( ' . implode(' $ ', $oids) . ' )';
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Definition/LdapSyntax.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/LdapSyntax.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Definition;
+
+/**
+ * An LDAP syntax definition per RFC 4512 §4.1.5.
+ */
+final readonly class LdapSyntax
+{
+    use DefinitionStringTrait;
+
+    /**
+     * @param array<string, list<string>> $extensions
+     */
+    public function __construct(
+        public string $oid,
+        public ?string $desc = null,
+        public array $extensions = [],
+    ) {
+    }
+
+    /**
+     * Produces the description string used in the subschema ldapSyntaxes attribute.
+     */
+    public function toDescriptionString(): string
+    {
+        $parts = array_filter([
+            '( ' . $this->oid,
+            $this->token(
+                DefinitionKeyword::DESC,
+                $this->desc !== null
+                    ? $this->quoteString($this->desc)
+                    : null,
+            ),
+        ]);
+
+        foreach ($this->extensions as $name => $values) {
+            $parts[] = $name . ' ' . $this->formatDescriptors($values);
+        }
+
+        return implode(' ', $parts) . ' )';
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Definition/MatchingRule.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/MatchingRule.php
@@ -38,6 +38,33 @@ final readonly class MatchingRule
     }
 
     /**
+     * Produces the matchingRuleUse description string for this rule and the attribute types that reference it.
+     *
+     * @param list<string> $appliesTo attribute type OIDs or names
+     */
+    public function toMatchingRuleUseString(array $appliesTo): string
+    {
+        $parts = array_filter([
+            '( ' . $this->oid,
+            $this->names !== []
+                ? DefinitionKeyword::NAME . ' ' . $this->formatDescriptors($this->names)
+                : null,
+            $this->token(
+                DefinitionKeyword::DESC,
+                $this->desc !== null
+                    ? $this->quoteString($this->desc)
+                    : null
+            ),
+            $this->obsolete
+                ? DefinitionKeyword::OBSOLETE
+                : null,
+            DefinitionKeyword::APPLIES . ' ' . $this->formatOids($appliesTo),
+        ]);
+
+        return implode(' ', $parts) . ' )';
+    }
+
+    /**
      * Produces the description string used in the subschema matchingRules attribute.
      */
     public function toDescriptionString(): string

--- a/src/FreeDSx/Ldap/Schema/Definition/MatchingRule.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/MatchingRule.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Definition;
+
+use FreeDSx\Ldap\Schema\Matching\MatchingRuleComparatorInterface;
+
+/**
+ * A matching rule definition per RFC 4512 §4.1.3; carries its comparator strategy.
+ */
+final readonly class MatchingRule
+{
+    use DefinitionStringTrait;
+
+    /**
+     * @param list<string> $names
+     * @param array<string, list<string>> $extensions
+     */
+    public function __construct(
+        public string $oid,
+        public array $names,
+        public string $syntaxOid,
+        public MatchingRuleComparatorInterface $comparator,
+        public ?string $desc = null,
+        public bool $obsolete = false,
+        public array $extensions = [],
+    ) {
+    }
+
+    /**
+     * Produces the description string used in the subschema matchingRules attribute.
+     */
+    public function toDescriptionString(): string
+    {
+        $parts = array_filter([
+            '( ' . $this->oid,
+            $this->names !== [] ? DefinitionKeyword::NAME . ' ' . $this->formatDescriptors($this->names) : null,
+            $this->token(DefinitionKeyword::DESC, $this->desc !== null ? $this->quoteString($this->desc) : null),
+            $this->obsolete ? DefinitionKeyword::OBSOLETE : null,
+            DefinitionKeyword::SYNTAX . ' ' . $this->syntaxOid,
+        ]);
+
+        foreach ($this->extensions as $name => $values) {
+            $parts[] = $name . ' ' . $this->formatDescriptors($values);
+        }
+
+        return implode(' ', $parts) . ' )';
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Definition/MatchingRuleOid.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/MatchingRuleOid.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Definition;
+
+/**
+ * OIDs and names for standard LDAP matching rules (RFC 4517 + AD extensions).
+ */
+final class MatchingRuleOid
+{
+    public const OID_OBJECT_IDENTIFIER_MATCH = '2.5.13.0';
+    public const NAME_OBJECT_IDENTIFIER_MATCH = 'objectIdentifierMatch';
+
+    public const OID_DISTINGUISHED_NAME_MATCH = '2.5.13.1';
+    public const NAME_DISTINGUISHED_NAME_MATCH = 'distinguishedNameMatch';
+
+    public const OID_CASE_IGNORE_MATCH = '2.5.13.2';
+    public const NAME_CASE_IGNORE_MATCH = 'caseIgnoreMatch';
+
+    public const OID_CASE_IGNORE_ORDERING_MATCH = '2.5.13.3';
+    public const NAME_CASE_IGNORE_ORDERING_MATCH = 'caseIgnoreOrderingMatch';
+
+    public const OID_CASE_IGNORE_SUBSTRINGS_MATCH = '2.5.13.4';
+    public const NAME_CASE_IGNORE_SUBSTRINGS_MATCH = 'caseIgnoreSubstringsMatch';
+
+    public const OID_CASE_EXACT_MATCH = '2.5.13.5';
+    public const NAME_CASE_EXACT_MATCH = 'caseExactMatch';
+
+    public const OID_CASE_EXACT_ORDERING_MATCH = '2.5.13.6';
+    public const NAME_CASE_EXACT_ORDERING_MATCH = 'caseExactOrderingMatch';
+
+    public const OID_CASE_EXACT_SUBSTRINGS_MATCH = '2.5.13.7';
+    public const NAME_CASE_EXACT_SUBSTRINGS_MATCH = 'caseExactSubstringsMatch';
+
+    public const OID_BOOLEAN_MATCH = '2.5.13.13';
+    public const NAME_BOOLEAN_MATCH = 'booleanMatch';
+
+    public const OID_INTEGER_MATCH = '2.5.13.14';
+    public const NAME_INTEGER_MATCH = 'integerMatch';
+
+    public const OID_INTEGER_ORDERING_MATCH = '2.5.13.15';
+    public const NAME_INTEGER_ORDERING_MATCH = 'integerOrderingMatch';
+
+    public const OID_OCTET_STRING_MATCH = '2.5.13.17';
+    public const NAME_OCTET_STRING_MATCH = 'octetStringMatch';
+
+    public const OID_GENERALIZED_TIME_MATCH = '2.5.13.18';
+    public const NAME_GENERALIZED_TIME_MATCH = 'generalizedTimeMatch';
+
+    public const OID_GENERALIZED_TIME_ORDERING_MATCH = '2.5.13.19';
+    public const NAME_GENERALIZED_TIME_ORDERING_MATCH = 'generalizedTimeOrderingMatch';
+
+    public const OID_TELEPHONE_NUMBER_MATCH = '2.5.13.20';
+    public const NAME_TELEPHONE_NUMBER_MATCH = 'telephoneNumberMatch';
+
+    public const OID_UNIQUE_MEMBER_MATCH = '2.5.13.23';
+    public const NAME_UNIQUE_MEMBER_MATCH = 'uniqueMemberMatch';
+
+    public const OID_CASE_EXACT_IA5_MATCH = '1.3.6.1.4.1.1466.109.114.1';
+    public const NAME_CASE_EXACT_IA5_MATCH = 'caseExactIA5Match';
+
+    public const OID_CASE_IGNORE_IA5_MATCH = '1.3.6.1.4.1.1466.109.114.2';
+    public const NAME_CASE_IGNORE_IA5_MATCH = 'caseIgnoreIA5Match';
+
+    public const OID_BIT_AND_MATCH = '1.2.840.113556.1.4.803';
+    public const NAME_BIT_AND_MATCH = 'bitAndMatch';
+
+    public const OID_BIT_OR_MATCH = '1.2.840.113556.1.4.804';
+    public const NAME_BIT_OR_MATCH = 'bitOrMatch';
+
+    private function __construct() {}
+}

--- a/src/FreeDSx/Ldap/Schema/Definition/MatchingRuleOid.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/MatchingRuleOid.php
@@ -78,5 +78,7 @@ final class MatchingRuleOid
     public const OID_BIT_OR_MATCH = '1.2.840.113556.1.4.804';
     public const NAME_BIT_OR_MATCH = 'bitOrMatch';
 
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 }

--- a/src/FreeDSx/Ldap/Schema/Definition/ObjectClass.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/ObjectClass.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Definition;
+
+/**
+ * An object class definition per RFC 4512 §4.1.1.
+ */
+final readonly class ObjectClass
+{
+    use DefinitionStringTrait;
+
+    /**
+     * @param list<string> $names
+     * @param list<string> $superClassOids
+     * @param list<string> $must attribute type OIDs or names required by this class
+     * @param list<string> $may attribute type OIDs or names permitted by this class
+     * @param array<string, list<string>> $extensions
+     */
+    public function __construct(
+        public string $oid,
+        public array $names,
+        public ObjectClassType $type = ObjectClassType::StructuralClass,
+        public array $superClassOids = [],
+        public array $must = [],
+        public array $may = [],
+        public ?string $desc = null,
+        public bool $obsolete = false,
+        public array $extensions = [],
+    ) {
+    }
+
+    /**
+     * Produces the description string used in the subschema objectClasses attribute.
+     */
+    public function toDescriptionString(): string
+    {
+        $parts = array_filter([
+            '( ' . $this->oid,
+            $this->token(
+                DefinitionKeyword::NAME,
+                $this->names !== []
+                    ? $this->formatDescriptors($this->names)
+                    : null
+            ),
+            $this->token(
+                DefinitionKeyword::DESC,
+                $this->desc !== null
+                    ? $this->quoteString($this->desc)
+                    : null
+            ),
+            $this->flag(
+                DefinitionKeyword::OBSOLETE,
+                $this->obsolete
+            ),
+            $this->token(
+                DefinitionKeyword::SUP,
+                $this->superClassOids !== []
+                    ? $this->formatOids($this->superClassOids)
+                    : null
+            ),
+            $this->type->value,
+            $this->token(
+                DefinitionKeyword::MUST,
+                $this->must !== []
+                    ? $this->formatOids($this->must)
+                    : null
+            ),
+            $this->token(
+                DefinitionKeyword::MAY,
+                $this->may !== []
+                    ? $this->formatOids($this->may)
+                    : null
+            ),
+        ]);
+
+        foreach ($this->extensions as $name => $values) {
+            $parts[] = $name . ' ' . $this->formatDescriptors($values);
+        }
+
+        return implode(' ', $parts) . ' )';
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Definition/ObjectClassOid.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/ObjectClassOid.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Definition;
+
+/**
+ * OIDs, names, and descriptions for standard LDAP object classes (RFC 4519 + RFC 4512).
+ */
+final class ObjectClassOid
+{
+    public const OID_TOP = '2.5.6.0';
+    public const NAME_TOP = 'top';
+    public const DESC_TOP = 'top of the class hierarchy';
+
+    public const OID_PERSON = '2.5.6.6';
+    public const NAME_PERSON = 'person';
+    public const DESC_PERSON = 'natural persons';
+
+    public const OID_ORGANIZATIONAL_PERSON = '2.5.6.7';
+    public const NAME_ORGANIZATIONAL_PERSON = 'organizationalPerson';
+    public const DESC_ORGANIZATIONAL_PERSON = 'people associated with an organization';
+
+    public const OID_ORGANIZATIONAL_UNIT = '2.5.6.5';
+    public const NAME_ORGANIZATIONAL_UNIT = 'organizationalUnit';
+    public const DESC_ORGANIZATIONAL_UNIT = 'organizational units';
+
+    public const OID_ORGANIZATION = '2.5.6.4';
+    public const NAME_ORGANIZATION = 'organization';
+    public const DESC_ORGANIZATION = 'organizations';
+
+    public const OID_GROUP_OF_NAMES = '2.5.6.9';
+    public const NAME_GROUP_OF_NAMES = 'groupOfNames';
+    public const DESC_GROUP_OF_NAMES = 'group whose members are distinguished names';
+
+    public const OID_GROUP_OF_UNIQUE_NAMES = '2.5.6.17';
+    public const NAME_GROUP_OF_UNIQUE_NAMES = 'groupOfUniqueNames';
+    public const DESC_GROUP_OF_UNIQUE_NAMES = 'group whose members are unique distinguished names';
+
+    public const OID_INET_ORG_PERSON = '2.16.840.1.113730.3.2.2';
+    public const NAME_INET_ORG_PERSON = 'inetOrgPerson';
+    public const DESC_INET_ORG_PERSON = 'internet-enabled person (RFC 2798)';
+
+    public const OID_DOMAIN = '0.9.2342.19200300.100.4.13';
+    public const NAME_DOMAIN = 'domain';
+    public const DESC_DOMAIN = 'DNS domains';
+
+    public const OID_DC_OBJECT = '1.3.6.1.4.1.1466.344';
+    public const NAME_DC_OBJECT = 'dcObject';
+    public const DESC_DC_OBJECT = 'auxiliary class for domain component';
+
+    public const OID_SUBSCHEMA = '2.5.20.1';
+    public const NAME_SUBSCHEMA = 'subschema';
+    public const DESC_SUBSCHEMA = 'server subschema entry';
+
+    public const OID_EXTENSIBLE_OBJECT = '1.3.6.1.4.1.1466.101.120.111';
+    public const NAME_EXTENSIBLE_OBJECT = 'extensibleObject';
+    public const DESC_EXTENSIBLE_OBJECT = 'any attribute type allowed';
+
+    private function __construct() {}
+}

--- a/src/FreeDSx/Ldap/Schema/Definition/ObjectClassOid.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/ObjectClassOid.php
@@ -66,5 +66,7 @@ final class ObjectClassOid
     public const NAME_EXTENSIBLE_OBJECT = 'extensibleObject';
     public const DESC_EXTENSIBLE_OBJECT = 'any attribute type allowed';
 
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 }

--- a/src/FreeDSx/Ldap/Schema/Definition/ObjectClassType.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/ObjectClassType.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Definition;
+
+enum ObjectClassType: string
+{
+    case StructuralClass = 'STRUCTURAL';
+    case AuxiliaryClass = 'AUXILIARY';
+    case AbstractClass = 'ABSTRACT';
+}

--- a/src/FreeDSx/Ldap/Schema/Definition/SyntaxOid.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/SyntaxOid.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Definition;
+
+/**
+ * OIDs and descriptions for standard LDAP syntaxes (RFC 4517).
+ */
+final class SyntaxOid
+{
+    public const OID_DIRECTORY_STRING = '1.3.6.1.4.1.1466.115.121.1.15';
+    public const DESC_DIRECTORY_STRING = 'Directory String';
+
+    public const OID_DISTINGUISHED_NAME = '1.3.6.1.4.1.1466.115.121.1.12';
+    public const DESC_DISTINGUISHED_NAME = 'DN';
+
+    public const OID_INTEGER = '1.3.6.1.4.1.1466.115.121.1.27';
+    public const DESC_INTEGER = 'INTEGER';
+
+    public const OID_BOOLEAN = '1.3.6.1.4.1.1466.115.121.1.7';
+    public const DESC_BOOLEAN = 'Boolean';
+
+    public const OID_GENERALIZED_TIME = '1.3.6.1.4.1.1466.115.121.1.24';
+    public const DESC_GENERALIZED_TIME = 'Generalized Time';
+
+    public const OID_OCTET_STRING = '1.3.6.1.4.1.1466.115.121.1.40';
+    public const DESC_OCTET_STRING = 'Octet String';
+
+    public const OID_TELEPHONE_NUMBER = '1.3.6.1.4.1.1466.115.121.1.50';
+    public const DESC_TELEPHONE_NUMBER = 'Telephone Number';
+
+    public const OID_IA5_STRING = '1.3.6.1.4.1.1466.115.121.1.26';
+    public const DESC_IA5_STRING = 'IA5 String';
+
+    public const OID_BIT_STRING = '1.3.6.1.4.1.1466.115.121.1.6';
+    public const DESC_BIT_STRING = 'Bit String';
+
+    public const OID_NUMERIC_STRING = '1.3.6.1.4.1.1466.115.121.1.36';
+    public const DESC_NUMERIC_STRING = 'Numeric String';
+
+    public const OID_OID = '1.3.6.1.4.1.1466.115.121.1.38';
+    public const DESC_OID = 'OID';
+
+    public const OID_PRINTABLE_STRING = '1.3.6.1.4.1.1466.115.121.1.44';
+    public const DESC_PRINTABLE_STRING = 'Printable String';
+
+    public const OID_POSTAL_ADDRESS = '1.3.6.1.4.1.1466.115.121.1.41';
+    public const DESC_POSTAL_ADDRESS = 'Postal Address';
+
+    public const OID_JPEG = '1.3.6.1.4.1.1466.115.121.1.28';
+    public const DESC_JPEG = 'JPEG';
+
+    private function __construct() {}
+}

--- a/src/FreeDSx/Ldap/Schema/Definition/SyntaxOid.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/SyntaxOid.php
@@ -60,5 +60,7 @@ final class SyntaxOid
     public const OID_JPEG = '1.3.6.1.4.1.1466.115.121.1.28';
     public const DESC_JPEG = 'JPEG';
 
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 }

--- a/src/FreeDSx/Ldap/Schema/Matching/BitMaskComparator.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/BitMaskComparator.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Matching;
+
+/**
+ * Bit-mask comparator for bitwise AND (bitAndMatch) and OR (bitOrMatch) matching rules.
+ */
+final readonly class BitMaskComparator implements MatchingRuleComparatorInterface
+{
+    public function __construct(private bool $requireAllBits)
+    {
+    }
+
+    public function equals(
+        string $a,
+        string $b,
+    ): bool {
+        $mask = (int) $b;
+
+        return $this->requireAllBits
+            ? ((int) $a & $mask) === $mask
+            : ((int) $a & $mask) !== 0;
+    }
+
+    public function compare(
+        string $a,
+        string $b,
+    ): int {
+        return (int) $a <=> (int) $b;
+    }
+
+    public function substringMatches(
+        string $value,
+        SubstringAssertion $assertion,
+    ): bool {
+        return false;
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Matching/BooleanComparator.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/BooleanComparator.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Matching;
+
+/**
+ * Boolean comparator (booleanMatch): compares RFC 4517 boolean literals TRUE/FALSE case-insensitively.
+ */
+final class BooleanComparator implements MatchingRuleComparatorInterface
+{
+    public function equals(
+        string $a,
+        string $b,
+    ): bool {
+        return strtoupper($a) === strtoupper($b);
+    }
+
+    public function compare(
+        string $a,
+        string $b,
+    ): int {
+        return strcmp(strtoupper($a), strtoupper($b));
+    }
+
+    public function substringMatches(
+        string $value,
+        SubstringAssertion $assertion,
+    ): bool {
+        return false;
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Matching/CaseExactComparator.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/CaseExactComparator.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Matching;
+
+/**
+ * Case-sensitive string comparator (caseExactMatch / caseExactSubstringsMatch / caseExactOrderingMatch).
+ * Delegates to OctetStringComparator since both perform byte-exact comparison.
+ */
+final readonly class CaseExactComparator implements MatchingRuleComparatorInterface
+{
+    private OctetStringComparator $inner;
+
+    public function __construct()
+    {
+        $this->inner = new OctetStringComparator();
+    }
+
+    public function equals(
+        string $a,
+        string $b,
+    ): bool {
+        return $this->inner->equals($a, $b);
+    }
+
+    public function compare(
+        string $a,
+        string $b,
+    ): int {
+        return $this->inner->compare($a, $b);
+    }
+
+    public function substringMatches(
+        string $value,
+        SubstringAssertion $assertion,
+    ): bool {
+        return $this->inner->substringMatches(
+            $value,
+            $assertion,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Matching/CaseIgnoreComparator.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/CaseIgnoreComparator.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Matching;
+
+/**
+ * Case-insensitive string comparator (caseIgnoreMatch / caseIgnoreSubstringsMatch / caseIgnoreOrderingMatch).
+ */
+final class CaseIgnoreComparator implements MatchingRuleComparatorInterface
+{
+    public function equals(
+        string $a,
+        string $b,
+    ): bool {
+        return strtolower($a) === strtolower($b);
+    }
+
+    public function compare(
+        string $a,
+        string $b,
+    ): int {
+        return strcasecmp(
+            $a,
+            $b,
+        );
+    }
+
+    public function substringMatches(
+        string $value,
+        SubstringAssertion $assertion,
+    ): bool {
+        $lower = strtolower($value);
+
+        if ($assertion->initial !== null && !str_starts_with($lower, strtolower($assertion->initial))) {
+            return false;
+        }
+
+        $pos = $assertion->initial !== null ? strlen($assertion->initial) : 0;
+
+        foreach ($assertion->any as $substr) {
+            $found = stripos($lower, strtolower($substr), $pos);
+            if ($found === false) {
+                return false;
+            }
+            $pos = $found + strlen($substr);
+        }
+
+        return $assertion->final === null
+            || str_ends_with($lower, strtolower($assertion->final));
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Matching/CaseIgnoreComparator.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/CaseIgnoreComparator.php
@@ -55,7 +55,13 @@ final class CaseIgnoreComparator implements MatchingRuleComparatorInterface
             $pos = $found + strlen($substr);
         }
 
-        return $assertion->final === null
-            || str_ends_with($lower, strtolower($assertion->final));
+        if ($assertion->final === null) {
+            return true;
+        }
+
+        $finalLower = strtolower($assertion->final);
+        $finalStart = strlen($lower) - strlen($finalLower);
+
+        return $finalStart >= $pos && str_ends_with($lower, $finalLower);
     }
 }

--- a/src/FreeDSx/Ldap/Schema/Matching/CaseIgnoreIa5Comparator.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/CaseIgnoreIa5Comparator.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Matching;
+
+/**
+ * Case-insensitive IA5 (ASCII) string comparator (caseIgnoreIA5Match / caseIgnoreIA5SubstringsMatch).
+ * Behaviorally identical to CaseIgnoreComparator since IA5 is a subset of ASCII.
+ */
+final readonly class CaseIgnoreIa5Comparator implements MatchingRuleComparatorInterface
+{
+    private CaseIgnoreComparator $inner;
+
+    public function __construct()
+    {
+        $this->inner = new CaseIgnoreComparator();
+    }
+
+    public function equals(
+        string $a,
+        string $b,
+    ): bool {
+        return $this->inner->equals($a, $b);
+    }
+
+    public function compare(
+        string $a,
+        string $b,
+    ): int {
+        return $this->inner->compare($a, $b);
+    }
+
+    public function substringMatches(
+        string $value,
+        SubstringAssertion $assertion,
+    ): bool {
+        return $this->inner->substringMatches(
+            $value,
+            $assertion,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Matching/DistinguishedNameComparator.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/DistinguishedNameComparator.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Matching;
+
+use FreeDSx\Ldap\Entry\Dn;
+
+/**
+ * DN equality comparator (distinguishedNameMatch): normalizes both sides before comparing.
+ */
+final class DistinguishedNameComparator implements MatchingRuleComparatorInterface
+{
+    public function equals(
+        string $a,
+        string $b,
+    ): bool {
+        return $this->normalize($a) === $this->normalize($b);
+    }
+
+    public function compare(
+        string $a,
+        string $b,
+    ): int {
+        return strcmp(
+            $this->normalize($a),
+            $this->normalize($b),
+        );
+    }
+
+    public function substringMatches(
+        string $value,
+        SubstringAssertion $assertion,
+    ): bool {
+        return false;
+    }
+
+    private function normalize(string $dn): string
+    {
+        return strtolower(
+            (new Dn($dn))->normalize()->toString()
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Matching/GeneralizedTimeComparator.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/GeneralizedTimeComparator.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Matching;
+
+use DateTimeImmutable;
+use DateTimeZone;
+
+/**
+ * Generalized time comparator (generalizedTimeMatch / generalizedTimeOrderingMatch).
+ * Timestamps are parsed and compared as UTC Unix timestamps.
+ */
+final class GeneralizedTimeComparator implements MatchingRuleComparatorInterface
+{
+    /**
+     * RFC 4517 §3.3.13 allows three forms:
+     * - Z suffix (UTC): 20060102150405Z
+     * - Numeric offset: 20060102150405+0500
+     * - No suffix (treated as UTC per LDAP convention): 20060102150405
+     */
+    private const FORMATS = [
+        'YmdHis\Z',
+        'YmdHisO',
+        'YmdHis',
+    ];
+
+    private static DateTimeZone $utc;
+
+    public function equals(
+        string $a,
+        string $b
+    ): bool {
+        $tsA = $this->toTimestamp($a);
+        $tsB = $this->toTimestamp($b);
+
+        if ($tsA === null || $tsB === null) {
+            return false;
+        }
+
+        return $tsA === $tsB;
+    }
+
+    public function compare(
+        string $a,
+        string $b
+    ): int {
+        return ($this->toTimestamp($a) ?? 0) <=> ($this->toTimestamp($b) ?? 0);
+    }
+
+    public function substringMatches(
+        string $value,
+        SubstringAssertion $assertion,
+    ): bool {
+        return false;
+    }
+
+    private function toTimestamp(string $value): ?int
+    {
+        self::$utc ??= new DateTimeZone('UTC');
+
+        foreach (self::FORMATS as $format) {
+            $dt = DateTimeImmutable::createFromFormat($format, $value, self::$utc);
+            if ($dt !== false) {
+                return $dt->getTimestamp();
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Matching/IntegerComparator.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/IntegerComparator.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Matching;
+
+/**
+ * Integer comparator (integerMatch / integerOrderingMatch): compares string representations as integers.
+ */
+final class IntegerComparator implements MatchingRuleComparatorInterface
+{
+    public function equals(
+        string $a,
+        string $b,
+    ): bool {
+        return (int) $a === (int) $b;
+    }
+
+    public function compare(
+        string $a,
+        string $b,
+    ): int {
+        return (int) $a <=> (int) $b;
+    }
+
+    public function substringMatches(
+        string $value,
+        SubstringAssertion $assertion,
+    ): bool {
+        return false;
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Matching/MatchingRuleComparatorInterface.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/MatchingRuleComparatorInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Matching;
+
+interface MatchingRuleComparatorInterface
+{
+    /**
+     * Whether two attribute values are considered equal under this matching rule.
+     */
+    public function equals(
+        string $a,
+        string $b,
+    ): bool;
+
+    /**
+     * Ordering comparison: negative if $a < $b, zero if equal, positive if $a > $b.
+     */
+    public function compare(
+        string $a,
+        string $b,
+    ): int;
+
+    /**
+     * Whether $value satisfies the given substring assertion.
+     */
+    public function substringMatches(
+        string $value,
+        SubstringAssertion $assertion,
+    ): bool;
+}

--- a/src/FreeDSx/Ldap/Schema/Matching/OctetStringComparator.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/OctetStringComparator.php
@@ -50,7 +50,13 @@ final class OctetStringComparator implements MatchingRuleComparatorInterface
             $pos = $found + strlen($substr);
         }
 
-        return $assertion->final === null
-            || str_ends_with($value, $assertion->final);
+        if ($assertion->final === null) {
+            return true;
+        }
+
+        $finalStart = strlen($value) - strlen($assertion->final);
+
+        return $finalStart >= $pos
+            && str_ends_with($value, $assertion->final);
     }
 }

--- a/src/FreeDSx/Ldap/Schema/Matching/OctetStringComparator.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/OctetStringComparator.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Matching;
+
+/**
+ * Exact byte-for-byte comparator (octetStringMatch): no case folding or normalization.
+ */
+final class OctetStringComparator implements MatchingRuleComparatorInterface
+{
+    public function equals(
+        string $a,
+        string $b,
+    ): bool {
+        return $a === $b;
+    }
+
+    public function compare(
+        string $a,
+        string $b,
+    ): int {
+        return strcmp($a, $b);
+    }
+
+    public function substringMatches(
+        string $value,
+        SubstringAssertion $assertion,
+    ): bool {
+        if ($assertion->initial !== null && !str_starts_with($value, $assertion->initial)) {
+            return false;
+        }
+
+        $pos = $assertion->initial !== null ? strlen($assertion->initial) : 0;
+
+        foreach ($assertion->any as $substr) {
+            $found = strpos($value, $substr, $pos);
+            if ($found === false) {
+                return false;
+            }
+            $pos = $found + strlen($substr);
+        }
+
+        return $assertion->final === null
+            || str_ends_with($value, $assertion->final);
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Matching/SubstringAssertion.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/SubstringAssertion.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Matching;
+
+/**
+ * The three components of an LDAP substring filter assertion.
+ */
+final readonly class SubstringAssertion
+{
+    /**
+     * @param list<string> $any
+     */
+    public function __construct(
+        public ?string $initial = null,
+        public array $any = [],
+        public ?string $final = null,
+    ) {
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Matching/TelephoneNumberComparator.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/TelephoneNumberComparator.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Matching;
+
+/**
+ * Telephone number comparator (telephoneNumberMatch): strips spaces and hyphens before comparing case-insensitively.
+ */
+final class TelephoneNumberComparator implements MatchingRuleComparatorInterface
+{
+    public function equals(
+        string $a,
+        string $b,
+    ): bool {
+        return $this->normalize($a) === $this->normalize($b);
+    }
+
+    public function compare(
+        string $a,
+        string $b,
+    ): int {
+        return strcmp(
+            $this->normalize($a),
+            $this->normalize($b),
+        );
+    }
+
+    public function substringMatches(
+        string $value,
+        SubstringAssertion $assertion,
+    ): bool {
+        $normalized = $this->normalize($value);
+        $normalizedAssertion = new SubstringAssertion(
+            initial: $assertion->initial !== null ? $this->normalize($assertion->initial) : null,
+            any: array_map($this->normalize(...), $assertion->any),
+            final: $assertion->final !== null ? $this->normalize($assertion->final) : null,
+        );
+
+        return (new CaseIgnoreComparator())->substringMatches(
+            $normalized,
+            $normalizedAssertion,
+        );
+    }
+
+    private function normalize(string $value): string
+    {
+        return strtolower(str_replace(
+            [' ', '-'],
+            '',
+            $value,
+        ));
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Schema.php
+++ b/src/FreeDSx/Ldap/Schema/Schema.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema;
+
+use FreeDSx\Ldap\Schema\Definition\AttributeType;
+use FreeDSx\Ldap\Schema\Definition\LdapSyntax;
+use FreeDSx\Ldap\Schema\Definition\MatchingRule;
+use FreeDSx\Ldap\Schema\Definition\ObjectClass;
+use FreeDSx\Ldap\Schema\Matching\MatchingRuleComparatorInterface;
+
+/**
+ * Registry of schema definitions; built incrementally via add*() methods.
+ */
+final class Schema
+{
+    /**
+     * @var array<string, AttributeType>
+     */
+    private array $attributeTypes = [];
+
+    /**
+     * @var array<string, ObjectClass>
+     */
+    private array $objectClasses = [];
+
+    /**
+     * @var array<string, MatchingRule>
+     */
+    private array $matchingRules = [];
+
+    /**
+     * @var array<string, LdapSyntax>
+     */
+    private array $ldapSyntaxes = [];
+
+    public function addAttributeType(AttributeType $type): static
+    {
+        $this->attributeTypes[$type->oid] = $type;
+        foreach ($type->names as $name) {
+            $this->attributeTypes[strtolower($name)] = $type;
+        }
+
+        return $this;
+    }
+
+    public function addObjectClass(ObjectClass $class): static
+    {
+        $this->objectClasses[$class->oid] = $class;
+        foreach ($class->names as $name) {
+            $this->objectClasses[strtolower($name)] = $class;
+        }
+
+        return $this;
+    }
+
+    public function addMatchingRule(MatchingRule $rule): static
+    {
+        $this->matchingRules[$rule->oid] = $rule;
+        foreach ($rule->names as $name) {
+            $this->matchingRules[strtolower($name)] = $rule;
+        }
+
+        return $this;
+    }
+
+    public function addSyntax(LdapSyntax $syntax): static
+    {
+        $this->ldapSyntaxes[$syntax->oid] = $syntax;
+
+        return $this;
+    }
+
+    public function getAttributeType(string $nameOrOid): ?AttributeType
+    {
+        return $this->attributeTypes[$nameOrOid]
+            ?? $this->attributeTypes[strtolower($nameOrOid)]
+            ?? null;
+    }
+
+    public function getObjectClass(string $nameOrOid): ?ObjectClass
+    {
+        return $this->objectClasses[$nameOrOid]
+            ?? $this->objectClasses[strtolower($nameOrOid)]
+            ?? null;
+    }
+
+    public function getMatchingRule(string $nameOrOid): ?MatchingRule
+    {
+        return $this->matchingRules[$nameOrOid]
+            ?? $this->matchingRules[strtolower($nameOrOid)]
+            ?? null;
+    }
+
+    public function getSyntax(string $oid): ?LdapSyntax
+    {
+        return $this->ldapSyntaxes[$oid] ?? null;
+    }
+
+    public function getComparator(string $ruleNameOrOid): ?MatchingRuleComparatorInterface
+    {
+        return $this->getMatchingRule($ruleNameOrOid)?->comparator;
+    }
+
+    /**
+     * @return list<AttributeType>
+     */
+    public function getAttributeTypes(): array
+    {
+        return $this->uniqueObjects($this->attributeTypes);
+    }
+
+    /**
+     * @return list<ObjectClass>
+     */
+    public function getObjectClasses(): array
+    {
+        return $this->uniqueObjects($this->objectClasses);
+    }
+
+    /**
+     * @return list<MatchingRule>
+     */
+    public function getMatchingRules(): array
+    {
+        return $this->uniqueObjects($this->matchingRules);
+    }
+
+    /**
+     * @return list<LdapSyntax>
+     */
+    public function getLdapSyntaxes(): array
+    {
+        return array_values($this->ldapSyntaxes);
+    }
+
+    /**
+     * Merges another schema into a new instance; definitions from $other override on OID/name collision.
+     */
+    public function merge(Schema $other): static
+    {
+        $merged = clone $this;
+        foreach ($other->getAttributeTypes() as $type) {
+            $merged->addAttributeType($type);
+        }
+        foreach ($other->getObjectClasses() as $class) {
+            $merged->addObjectClass($class);
+        }
+        foreach ($other->getMatchingRules() as $rule) {
+            $merged->addMatchingRule($rule);
+        }
+        foreach ($other->getLdapSyntaxes() as $syntax) {
+            $merged->addSyntax($syntax);
+        }
+
+        return $merged;
+    }
+
+    /**
+     * Deduplicates an array of objects by identity, preserving insertion order.
+     *
+     * @template T of object
+     * @param array<string, T> $map
+     * @return list<T>
+     */
+    private function uniqueObjects(array $map): array
+    {
+        $seen = [];
+        $result = [];
+        foreach ($map as $object) {
+            $id = spl_object_id($object);
+            if (isset($seen[$id])) {
+                continue;
+            }
+            $seen[$id] = true;
+            $result[] = $object;
+        }
+
+        return $result;
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/SchemaValidationMode.php
+++ b/src/FreeDSx/Ldap/Schema/SchemaValidationMode.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema;
+
+enum SchemaValidationMode
+{
+    case Strict;
+    case Off;
+}

--- a/src/FreeDSx/Ldap/Schema/StandardSchemaProvider.php
+++ b/src/FreeDSx/Ldap/Schema/StandardSchemaProvider.php
@@ -737,5 +737,7 @@ final class StandardSchemaProvider
         ];
     }
 
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 }

--- a/src/FreeDSx/Ldap/Schema/StandardSchemaProvider.php
+++ b/src/FreeDSx/Ldap/Schema/StandardSchemaProvider.php
@@ -1,0 +1,741 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema;
+
+use FreeDSx\Ldap\Schema\Definition\AttributeType;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
+use FreeDSx\Ldap\Schema\Definition\AttributeUsage;
+use FreeDSx\Ldap\Schema\Definition\LdapSyntax;
+use FreeDSx\Ldap\Schema\Definition\MatchingRule;
+use FreeDSx\Ldap\Schema\Definition\MatchingRuleOid;
+use FreeDSx\Ldap\Schema\Definition\ObjectClass;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassOid;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassType;
+use FreeDSx\Ldap\Schema\Definition\SyntaxOid;
+use FreeDSx\Ldap\Schema\Matching\BitMaskComparator;
+use FreeDSx\Ldap\Schema\Matching\BooleanComparator;
+use FreeDSx\Ldap\Schema\Matching\CaseExactComparator;
+use FreeDSx\Ldap\Schema\Matching\CaseIgnoreComparator;
+use FreeDSx\Ldap\Schema\Matching\CaseIgnoreIa5Comparator;
+use FreeDSx\Ldap\Schema\Matching\DistinguishedNameComparator;
+use FreeDSx\Ldap\Schema\Matching\GeneralizedTimeComparator;
+use FreeDSx\Ldap\Schema\Matching\IntegerComparator;
+use FreeDSx\Ldap\Schema\Matching\OctetStringComparator;
+use FreeDSx\Ldap\Schema\Matching\TelephoneNumberComparator;
+
+/**
+ * Builds the core Schema with RFC 4517/4519/4512 standard definitions.
+ */
+final class StandardSchemaProvider
+{
+    public static function buildCore(): Schema
+    {
+        $schema = new Schema();
+
+        foreach (self::syntaxes() as $syntax) {
+            $schema->addSyntax($syntax);
+        }
+        foreach (self::matchingRules() as $rule) {
+            $schema->addMatchingRule($rule);
+        }
+        foreach (self::attributeTypes() as $type) {
+            $schema->addAttributeType($type);
+        }
+        foreach (self::objectClasses() as $class) {
+            $schema->addObjectClass($class);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * @return list<LdapSyntax>
+     */
+    private static function syntaxes(): array
+    {
+        return [
+            new LdapSyntax(SyntaxOid::OID_DIRECTORY_STRING, SyntaxOid::DESC_DIRECTORY_STRING),
+            new LdapSyntax(SyntaxOid::OID_DISTINGUISHED_NAME, SyntaxOid::DESC_DISTINGUISHED_NAME),
+            new LdapSyntax(SyntaxOid::OID_INTEGER, SyntaxOid::DESC_INTEGER),
+            new LdapSyntax(SyntaxOid::OID_BOOLEAN, SyntaxOid::DESC_BOOLEAN),
+            new LdapSyntax(SyntaxOid::OID_GENERALIZED_TIME, SyntaxOid::DESC_GENERALIZED_TIME),
+            new LdapSyntax(SyntaxOid::OID_OCTET_STRING, SyntaxOid::DESC_OCTET_STRING),
+            new LdapSyntax(SyntaxOid::OID_TELEPHONE_NUMBER, SyntaxOid::DESC_TELEPHONE_NUMBER),
+            new LdapSyntax(SyntaxOid::OID_IA5_STRING, SyntaxOid::DESC_IA5_STRING),
+            new LdapSyntax(SyntaxOid::OID_BIT_STRING, SyntaxOid::DESC_BIT_STRING),
+            new LdapSyntax(SyntaxOid::OID_NUMERIC_STRING, SyntaxOid::DESC_NUMERIC_STRING),
+            new LdapSyntax(SyntaxOid::OID_OID, SyntaxOid::DESC_OID),
+            new LdapSyntax(SyntaxOid::OID_PRINTABLE_STRING, SyntaxOid::DESC_PRINTABLE_STRING),
+            new LdapSyntax(SyntaxOid::OID_POSTAL_ADDRESS, SyntaxOid::DESC_POSTAL_ADDRESS),
+            new LdapSyntax(SyntaxOid::OID_JPEG, SyntaxOid::DESC_JPEG),
+        ];
+    }
+
+    /**
+     * @return list<MatchingRule>
+     */
+    private static function matchingRules(): array
+    {
+        $caseIgnore = new CaseIgnoreComparator();
+        $caseExact = new CaseExactComparator();
+        $integer = new IntegerComparator();
+        $generalizedTime = new GeneralizedTimeComparator();
+
+        return [
+            new MatchingRule(
+                MatchingRuleOid::OID_DISTINGUISHED_NAME_MATCH,
+                [MatchingRuleOid::NAME_DISTINGUISHED_NAME_MATCH],
+                SyntaxOid::OID_DISTINGUISHED_NAME,
+                new DistinguishedNameComparator(),
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                [MatchingRuleOid::NAME_CASE_IGNORE_MATCH],
+                SyntaxOid::OID_DIRECTORY_STRING,
+                $caseIgnore,
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_CASE_IGNORE_ORDERING_MATCH,
+                [MatchingRuleOid::NAME_CASE_IGNORE_ORDERING_MATCH],
+                SyntaxOid::OID_DIRECTORY_STRING,
+                $caseIgnore,
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                [MatchingRuleOid::NAME_CASE_IGNORE_SUBSTRINGS_MATCH],
+                SyntaxOid::OID_DIRECTORY_STRING,
+                $caseIgnore,
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_CASE_EXACT_MATCH,
+                [MatchingRuleOid::NAME_CASE_EXACT_MATCH],
+                SyntaxOid::OID_DIRECTORY_STRING,
+                $caseExact,
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_CASE_EXACT_ORDERING_MATCH,
+                [MatchingRuleOid::NAME_CASE_EXACT_ORDERING_MATCH],
+                SyntaxOid::OID_DIRECTORY_STRING,
+                $caseExact,
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_CASE_EXACT_SUBSTRINGS_MATCH,
+                [MatchingRuleOid::NAME_CASE_EXACT_SUBSTRINGS_MATCH],
+                SyntaxOid::OID_DIRECTORY_STRING,
+                $caseExact,
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_BOOLEAN_MATCH,
+                [MatchingRuleOid::NAME_BOOLEAN_MATCH],
+                SyntaxOid::OID_BOOLEAN,
+                new BooleanComparator(),
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_INTEGER_MATCH,
+                [MatchingRuleOid::NAME_INTEGER_MATCH],
+                SyntaxOid::OID_INTEGER,
+                $integer,
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_INTEGER_ORDERING_MATCH,
+                [MatchingRuleOid::NAME_INTEGER_ORDERING_MATCH],
+                SyntaxOid::OID_INTEGER,
+                $integer,
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_OCTET_STRING_MATCH,
+                [MatchingRuleOid::NAME_OCTET_STRING_MATCH],
+                SyntaxOid::OID_OCTET_STRING,
+                new OctetStringComparator(),
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_GENERALIZED_TIME_MATCH,
+                [MatchingRuleOid::NAME_GENERALIZED_TIME_MATCH],
+                SyntaxOid::OID_GENERALIZED_TIME,
+                $generalizedTime,
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_GENERALIZED_TIME_ORDERING_MATCH,
+                [MatchingRuleOid::NAME_GENERALIZED_TIME_ORDERING_MATCH],
+                SyntaxOid::OID_GENERALIZED_TIME,
+                $generalizedTime,
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_TELEPHONE_NUMBER_MATCH,
+                [MatchingRuleOid::NAME_TELEPHONE_NUMBER_MATCH],
+                SyntaxOid::OID_TELEPHONE_NUMBER,
+                new TelephoneNumberComparator(),
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_CASE_EXACT_IA5_MATCH,
+                [MatchingRuleOid::NAME_CASE_EXACT_IA5_MATCH],
+                SyntaxOid::OID_IA5_STRING,
+                $caseExact,
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_CASE_IGNORE_IA5_MATCH,
+                [MatchingRuleOid::NAME_CASE_IGNORE_IA5_MATCH],
+                SyntaxOid::OID_IA5_STRING,
+                new CaseIgnoreIa5Comparator(),
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_BIT_AND_MATCH,
+                [MatchingRuleOid::NAME_BIT_AND_MATCH],
+                SyntaxOid::OID_INTEGER,
+                new BitMaskComparator(requireAllBits: true),
+            ),
+            new MatchingRule(
+                MatchingRuleOid::OID_BIT_OR_MATCH,
+                [MatchingRuleOid::NAME_BIT_OR_MATCH],
+                SyntaxOid::OID_INTEGER,
+                new BitMaskComparator(requireAllBits: false),
+            ),
+        ];
+    }
+
+    /**
+     * @return list<AttributeType>
+     */
+    private static function attributeTypes(): array
+    {
+        return [
+            ...self::userAttributeTypes(),
+            ...self::operationalAttributeTypes(),
+        ];
+    }
+
+    /**
+     * @return list<AttributeType>
+     */
+    private static function userAttributeTypes(): array
+    {
+        return [
+            new AttributeType(
+                AttributeTypeOid::OID_OBJECT_CLASS,
+                [AttributeTypeOid::NAME_OBJECT_CLASS],
+                equalityOid: MatchingRuleOid::OID_OBJECT_IDENTIFIER_MATCH,
+                syntaxOid: SyntaxOid::OID_OID,
+                desc: AttributeTypeOid::DESC_OBJECT_CLASS,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_ALIASED_OBJECT_NAME,
+                [AttributeTypeOid::NAME_ALIASED_OBJECT_NAME, AttributeTypeOid::ALIAS_ALIASED_OBJECT_NAME],
+                equalityOid: MatchingRuleOid::OID_DISTINGUISHED_NAME_MATCH,
+                syntaxOid: SyntaxOid::OID_DISTINGUISHED_NAME,
+                singleValue: true,
+                desc: AttributeTypeOid::DESC_ALIASED_OBJECT_NAME,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_NAME,
+                [AttributeTypeOid::NAME_NAME],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                orderingOid: MatchingRuleOid::OID_CASE_IGNORE_ORDERING_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                desc: AttributeTypeOid::DESC_NAME,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_CN,
+                [AttributeTypeOid::NAME_CN, AttributeTypeOid::ALIAS_CN],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                orderingOid: MatchingRuleOid::OID_CASE_IGNORE_ORDERING_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                superTypeOid: AttributeTypeOid::OID_NAME,
+                desc: AttributeTypeOid::DESC_CN,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_SN,
+                [AttributeTypeOid::NAME_SN, AttributeTypeOid::ALIAS_SN],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                orderingOid: MatchingRuleOid::OID_CASE_IGNORE_ORDERING_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                superTypeOid: AttributeTypeOid::OID_NAME,
+                desc: AttributeTypeOid::DESC_SN,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_GIVEN_NAME,
+                [AttributeTypeOid::NAME_GIVEN_NAME],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                orderingOid: MatchingRuleOid::OID_CASE_IGNORE_ORDERING_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                superTypeOid: AttributeTypeOid::OID_NAME,
+                desc: AttributeTypeOid::DESC_GIVEN_NAME,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_INITIALS,
+                [AttributeTypeOid::NAME_INITIALS],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                superTypeOid: AttributeTypeOid::OID_NAME,
+                desc: AttributeTypeOid::DESC_INITIALS,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_UID,
+                [AttributeTypeOid::NAME_UID, AttributeTypeOid::ALIAS_UID],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                desc: AttributeTypeOid::DESC_UID,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_MAIL,
+                [AttributeTypeOid::NAME_MAIL, AttributeTypeOid::ALIAS_MAIL],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_IA5_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_IA5_STRING,
+                desc: AttributeTypeOid::DESC_MAIL,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_USER_PASSWORD,
+                [AttributeTypeOid::NAME_USER_PASSWORD],
+                equalityOid: MatchingRuleOid::OID_OCTET_STRING_MATCH,
+                syntaxOid: SyntaxOid::OID_OCTET_STRING,
+                desc: AttributeTypeOid::DESC_USER_PASSWORD,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_MEMBER,
+                [AttributeTypeOid::NAME_MEMBER],
+                equalityOid: MatchingRuleOid::OID_DISTINGUISHED_NAME_MATCH,
+                syntaxOid: SyntaxOid::OID_DISTINGUISHED_NAME,
+                desc: AttributeTypeOid::DESC_MEMBER,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_UNIQUE_MEMBER,
+                [AttributeTypeOid::NAME_UNIQUE_MEMBER],
+                equalityOid: MatchingRuleOid::OID_UNIQUE_MEMBER_MATCH,
+                syntaxOid: SyntaxOid::OID_DISTINGUISHED_NAME,
+                desc: AttributeTypeOid::DESC_UNIQUE_MEMBER,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_O,
+                [AttributeTypeOid::NAME_O, AttributeTypeOid::ALIAS_O],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                orderingOid: MatchingRuleOid::OID_CASE_IGNORE_ORDERING_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                desc: AttributeTypeOid::DESC_O,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_OU,
+                [AttributeTypeOid::NAME_OU, AttributeTypeOid::ALIAS_OU],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                orderingOid: MatchingRuleOid::OID_CASE_IGNORE_ORDERING_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                desc: AttributeTypeOid::DESC_OU,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_TITLE,
+                [AttributeTypeOid::NAME_TITLE],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                orderingOid: MatchingRuleOid::OID_CASE_IGNORE_ORDERING_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                desc: AttributeTypeOid::DESC_TITLE,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_DESCRIPTION,
+                [AttributeTypeOid::NAME_DESCRIPTION],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                desc: AttributeTypeOid::DESC_DESCRIPTION,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_SEE_ALSO,
+                [AttributeTypeOid::NAME_SEE_ALSO],
+                equalityOid: MatchingRuleOid::OID_DISTINGUISHED_NAME_MATCH,
+                syntaxOid: SyntaxOid::OID_DISTINGUISHED_NAME,
+                desc: AttributeTypeOid::DESC_SEE_ALSO,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_TELEPHONE_NUMBER,
+                [AttributeTypeOid::NAME_TELEPHONE_NUMBER],
+                equalityOid: MatchingRuleOid::OID_TELEPHONE_NUMBER_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_TELEPHONE_NUMBER,
+                desc: AttributeTypeOid::DESC_TELEPHONE_NUMBER,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_C,
+                [AttributeTypeOid::NAME_C, AttributeTypeOid::ALIAS_C],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_PRINTABLE_STRING,
+                singleValue: true,
+                desc: AttributeTypeOid::DESC_C,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_L,
+                [AttributeTypeOid::NAME_L, AttributeTypeOid::ALIAS_L],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                orderingOid: MatchingRuleOid::OID_CASE_IGNORE_ORDERING_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                desc: AttributeTypeOid::DESC_L,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_ST,
+                [AttributeTypeOid::NAME_ST, AttributeTypeOid::ALIAS_ST],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                orderingOid: MatchingRuleOid::OID_CASE_IGNORE_ORDERING_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                desc: AttributeTypeOid::DESC_ST,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_STREET,
+                [AttributeTypeOid::NAME_STREET, AttributeTypeOid::ALIAS_STREET],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                desc: AttributeTypeOid::DESC_STREET,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_POSTAL_CODE,
+                [AttributeTypeOid::NAME_POSTAL_CODE],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                desc: AttributeTypeOid::DESC_POSTAL_CODE,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_DC,
+                [AttributeTypeOid::NAME_DC, AttributeTypeOid::ALIAS_DC],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_IA5_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_IA5_STRING,
+                singleValue: true,
+                desc: AttributeTypeOid::DESC_DC,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_DISPLAY_NAME,
+                [AttributeTypeOid::NAME_DISPLAY_NAME],
+                equalityOid: MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+                substringOid: MatchingRuleOid::OID_CASE_IGNORE_SUBSTRINGS_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                singleValue: true,
+                desc: AttributeTypeOid::DESC_DISPLAY_NAME,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_EMPLOYEE_NUMBER,
+                [AttributeTypeOid::NAME_EMPLOYEE_NUMBER],
+                equalityOid: MatchingRuleOid::OID_CASE_EXACT_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                singleValue: true,
+                desc: AttributeTypeOid::DESC_EMPLOYEE_NUMBER,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_MEMBER_OF,
+                [AttributeTypeOid::NAME_MEMBER_OF],
+                equalityOid: MatchingRuleOid::OID_DISTINGUISHED_NAME_MATCH,
+                syntaxOid: SyntaxOid::OID_DISTINGUISHED_NAME,
+                desc: AttributeTypeOid::DESC_MEMBER_OF,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_LABELED_URI,
+                [AttributeTypeOid::NAME_LABELED_URI],
+                equalityOid: MatchingRuleOid::OID_CASE_EXACT_MATCH,
+                syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+                desc: AttributeTypeOid::DESC_LABELED_URI,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_JPEG_PHOTO,
+                [AttributeTypeOid::NAME_JPEG_PHOTO],
+                syntaxOid: SyntaxOid::OID_JPEG,
+                desc: AttributeTypeOid::DESC_JPEG_PHOTO,
+            ),
+        ];
+    }
+
+    /**
+     * @return list<AttributeType>
+     */
+    private static function operationalAttributeTypes(): array
+    {
+        return [
+            new AttributeType(
+                AttributeTypeOid::OID_CREATE_TIMESTAMP,
+                [AttributeTypeOid::NAME_CREATE_TIMESTAMP],
+                equalityOid: MatchingRuleOid::OID_GENERALIZED_TIME_MATCH,
+                orderingOid: MatchingRuleOid::OID_GENERALIZED_TIME_ORDERING_MATCH,
+                syntaxOid: SyntaxOid::OID_GENERALIZED_TIME,
+                singleValue: true,
+                noUserModification: true,
+                usage: AttributeUsage::DirectoryOperation,
+                desc: AttributeTypeOid::DESC_CREATE_TIMESTAMP,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_MODIFY_TIMESTAMP,
+                [AttributeTypeOid::NAME_MODIFY_TIMESTAMP],
+                equalityOid: MatchingRuleOid::OID_GENERALIZED_TIME_MATCH,
+                orderingOid: MatchingRuleOid::OID_GENERALIZED_TIME_ORDERING_MATCH,
+                syntaxOid: SyntaxOid::OID_GENERALIZED_TIME,
+                singleValue: true,
+                noUserModification: true,
+                usage: AttributeUsage::DirectoryOperation,
+                desc: AttributeTypeOid::DESC_MODIFY_TIMESTAMP,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_CREATORS_NAME,
+                [AttributeTypeOid::NAME_CREATORS_NAME],
+                equalityOid: MatchingRuleOid::OID_DISTINGUISHED_NAME_MATCH,
+                syntaxOid: SyntaxOid::OID_DISTINGUISHED_NAME,
+                singleValue: true,
+                noUserModification: true,
+                usage: AttributeUsage::DirectoryOperation,
+                desc: AttributeTypeOid::DESC_CREATORS_NAME,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_MODIFIERS_NAME,
+                [AttributeTypeOid::NAME_MODIFIERS_NAME],
+                equalityOid: MatchingRuleOid::OID_DISTINGUISHED_NAME_MATCH,
+                syntaxOid: SyntaxOid::OID_DISTINGUISHED_NAME,
+                singleValue: true,
+                noUserModification: true,
+                usage: AttributeUsage::DirectoryOperation,
+                desc: AttributeTypeOid::DESC_MODIFIERS_NAME,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_SUBSCHEMA_SUBENTRY,
+                [AttributeTypeOid::NAME_SUBSCHEMA_SUBENTRY],
+                equalityOid: MatchingRuleOid::OID_DISTINGUISHED_NAME_MATCH,
+                syntaxOid: SyntaxOid::OID_DISTINGUISHED_NAME,
+                singleValue: true,
+                noUserModification: true,
+                usage: AttributeUsage::DirectoryOperation,
+                desc: AttributeTypeOid::DESC_SUBSCHEMA_SUBENTRY,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_HAS_SUBORDINATES,
+                [AttributeTypeOid::NAME_HAS_SUBORDINATES],
+                equalityOid: MatchingRuleOid::OID_BOOLEAN_MATCH,
+                syntaxOid: SyntaxOid::OID_BOOLEAN,
+                singleValue: true,
+                noUserModification: true,
+                usage: AttributeUsage::DirectoryOperation,
+                desc: AttributeTypeOid::DESC_HAS_SUBORDINATES,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_STRUCTURAL_OBJECT_CLASS,
+                [AttributeTypeOid::NAME_STRUCTURAL_OBJECT_CLASS],
+                equalityOid: MatchingRuleOid::OID_OBJECT_IDENTIFIER_MATCH,
+                syntaxOid: SyntaxOid::OID_OID,
+                singleValue: true,
+                noUserModification: true,
+                usage: AttributeUsage::DirectoryOperation,
+                desc: AttributeTypeOid::DESC_STRUCTURAL_OBJECT_CLASS,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_ENTRY_UUID,
+                [AttributeTypeOid::NAME_ENTRY_UUID],
+                equalityOid: MatchingRuleOid::OID_OCTET_STRING_MATCH,
+                syntaxOid: SyntaxOid::OID_OCTET_STRING,
+                singleValue: true,
+                noUserModification: true,
+                usage: AttributeUsage::DirectoryOperation,
+                desc: AttributeTypeOid::DESC_ENTRY_UUID,
+            ),
+            new AttributeType(
+                AttributeTypeOid::OID_ENTRY_DN,
+                [AttributeTypeOid::NAME_ENTRY_DN],
+                equalityOid: MatchingRuleOid::OID_DISTINGUISHED_NAME_MATCH,
+                syntaxOid: SyntaxOid::OID_DISTINGUISHED_NAME,
+                singleValue: true,
+                noUserModification: true,
+                usage: AttributeUsage::DirectoryOperation,
+                desc: AttributeTypeOid::DESC_ENTRY_DN,
+            ),
+        ];
+    }
+
+    /**
+     * @return list<ObjectClass>
+     */
+    private static function objectClasses(): array
+    {
+        return [
+            new ObjectClass(
+                ObjectClassOid::OID_TOP,
+                [ObjectClassOid::NAME_TOP],
+                type: ObjectClassType::AbstractClass,
+                must: [AttributeTypeOid::NAME_OBJECT_CLASS],
+                desc: ObjectClassOid::DESC_TOP,
+            ),
+            new ObjectClass(
+                ObjectClassOid::OID_PERSON,
+                [ObjectClassOid::NAME_PERSON],
+                type: ObjectClassType::StructuralClass,
+                superClassOids: [ObjectClassOid::OID_TOP],
+                must: [AttributeTypeOid::NAME_SN, AttributeTypeOid::NAME_CN],
+                may: [
+                    AttributeTypeOid::NAME_USER_PASSWORD,
+                    AttributeTypeOid::NAME_TELEPHONE_NUMBER,
+                    AttributeTypeOid::NAME_SEE_ALSO,
+                    AttributeTypeOid::NAME_DESCRIPTION,
+                ],
+                desc: ObjectClassOid::DESC_PERSON,
+            ),
+            new ObjectClass(
+                ObjectClassOid::OID_ORGANIZATIONAL_PERSON,
+                [ObjectClassOid::NAME_ORGANIZATIONAL_PERSON],
+                type: ObjectClassType::StructuralClass,
+                superClassOids: [ObjectClassOid::OID_PERSON],
+                may: [
+                    AttributeTypeOid::NAME_TITLE,
+                    AttributeTypeOid::NAME_ST,
+                    AttributeTypeOid::NAME_L,
+                    AttributeTypeOid::NAME_C,
+                    AttributeTypeOid::NAME_STREET,
+                    AttributeTypeOid::NAME_POSTAL_CODE,
+                    AttributeTypeOid::NAME_OU,
+                    AttributeTypeOid::NAME_TELEPHONE_NUMBER,
+                ],
+                desc: ObjectClassOid::DESC_ORGANIZATIONAL_PERSON,
+            ),
+            new ObjectClass(
+                ObjectClassOid::OID_INET_ORG_PERSON,
+                [ObjectClassOid::NAME_INET_ORG_PERSON],
+                type: ObjectClassType::StructuralClass,
+                superClassOids: [ObjectClassOid::OID_ORGANIZATIONAL_PERSON],
+                may: [
+                    AttributeTypeOid::NAME_UID,
+                    AttributeTypeOid::NAME_MAIL,
+                    AttributeTypeOid::NAME_GIVEN_NAME,
+                    AttributeTypeOid::NAME_INITIALS,
+                    AttributeTypeOid::NAME_DISPLAY_NAME,
+                    AttributeTypeOid::NAME_EMPLOYEE_NUMBER,
+                    AttributeTypeOid::NAME_MEMBER_OF,
+                    AttributeTypeOid::NAME_LABELED_URI,
+                    AttributeTypeOid::NAME_JPEG_PHOTO,
+                    AttributeTypeOid::NAME_DESCRIPTION,
+                ],
+                desc: ObjectClassOid::DESC_INET_ORG_PERSON,
+            ),
+            new ObjectClass(
+                ObjectClassOid::OID_GROUP_OF_NAMES,
+                [ObjectClassOid::NAME_GROUP_OF_NAMES],
+                type: ObjectClassType::StructuralClass,
+                superClassOids: [ObjectClassOid::OID_TOP],
+                must: [AttributeTypeOid::NAME_MEMBER, AttributeTypeOid::NAME_CN],
+                may: [
+                    AttributeTypeOid::NAME_DESCRIPTION,
+                    AttributeTypeOid::NAME_O,
+                    AttributeTypeOid::NAME_OU,
+                    AttributeTypeOid::NAME_SEE_ALSO,
+                ],
+                desc: ObjectClassOid::DESC_GROUP_OF_NAMES,
+            ),
+            new ObjectClass(
+                ObjectClassOid::OID_GROUP_OF_UNIQUE_NAMES,
+                [ObjectClassOid::NAME_GROUP_OF_UNIQUE_NAMES],
+                type: ObjectClassType::StructuralClass,
+                superClassOids: [ObjectClassOid::OID_TOP],
+                must: [AttributeTypeOid::NAME_UNIQUE_MEMBER, AttributeTypeOid::NAME_CN],
+                may: [
+                    AttributeTypeOid::NAME_DESCRIPTION,
+                    AttributeTypeOid::NAME_O,
+                    AttributeTypeOid::NAME_OU,
+                    AttributeTypeOid::NAME_SEE_ALSO,
+                ],
+                desc: ObjectClassOid::DESC_GROUP_OF_UNIQUE_NAMES,
+            ),
+            new ObjectClass(
+                ObjectClassOid::OID_ORGANIZATIONAL_UNIT,
+                [ObjectClassOid::NAME_ORGANIZATIONAL_UNIT],
+                type: ObjectClassType::StructuralClass,
+                superClassOids: [ObjectClassOid::OID_TOP],
+                must: [AttributeTypeOid::NAME_OU],
+                may: [
+                    AttributeTypeOid::NAME_DESCRIPTION,
+                    AttributeTypeOid::NAME_L,
+                    AttributeTypeOid::NAME_ST,
+                    AttributeTypeOid::NAME_TELEPHONE_NUMBER,
+                    AttributeTypeOid::NAME_POSTAL_CODE,
+                    AttributeTypeOid::NAME_SEE_ALSO,
+                ],
+                desc: ObjectClassOid::DESC_ORGANIZATIONAL_UNIT,
+            ),
+            new ObjectClass(
+                ObjectClassOid::OID_ORGANIZATION,
+                [ObjectClassOid::NAME_ORGANIZATION],
+                type: ObjectClassType::StructuralClass,
+                superClassOids: [ObjectClassOid::OID_TOP],
+                must: [AttributeTypeOid::NAME_O],
+                may: [
+                    AttributeTypeOid::NAME_DESCRIPTION,
+                    AttributeTypeOid::NAME_L,
+                    AttributeTypeOid::NAME_ST,
+                    AttributeTypeOid::NAME_C,
+                    AttributeTypeOid::NAME_TELEPHONE_NUMBER,
+                    AttributeTypeOid::NAME_POSTAL_CODE,
+                    AttributeTypeOid::NAME_SEE_ALSO,
+                ],
+                desc: ObjectClassOid::DESC_ORGANIZATION,
+            ),
+            new ObjectClass(
+                ObjectClassOid::OID_DOMAIN,
+                [ObjectClassOid::NAME_DOMAIN],
+                type: ObjectClassType::StructuralClass,
+                superClassOids: [ObjectClassOid::OID_TOP],
+                must: [AttributeTypeOid::NAME_DC],
+                may: [
+                    AttributeTypeOid::NAME_O,
+                    AttributeTypeOid::NAME_DESCRIPTION,
+                    AttributeTypeOid::NAME_L,
+                    AttributeTypeOid::NAME_ST,
+                    AttributeTypeOid::NAME_C,
+                ],
+                desc: ObjectClassOid::DESC_DOMAIN,
+            ),
+            new ObjectClass(
+                ObjectClassOid::OID_DC_OBJECT,
+                [ObjectClassOid::NAME_DC_OBJECT],
+                type: ObjectClassType::AuxiliaryClass,
+                superClassOids: [ObjectClassOid::OID_TOP],
+                must: [AttributeTypeOid::NAME_DC],
+                desc: ObjectClassOid::DESC_DC_OBJECT,
+            ),
+            new ObjectClass(
+                ObjectClassOid::OID_SUBSCHEMA,
+                [ObjectClassOid::NAME_SUBSCHEMA],
+                type: ObjectClassType::AuxiliaryClass,
+                superClassOids: [ObjectClassOid::OID_TOP],
+                may: [
+                    AttributeTypeOid::NAME_DIT_STRUCTURE_RULES,
+                    AttributeTypeOid::NAME_NAME_FORMS,
+                    AttributeTypeOid::NAME_DIT_CONTENT_RULES,
+                    AttributeTypeOid::NAME_OBJECT_CLASSES,
+                    AttributeTypeOid::NAME_ATTRIBUTE_TYPES,
+                    AttributeTypeOid::NAME_MATCHING_RULES,
+                    AttributeTypeOid::NAME_MATCHING_RULE_USE,
+                ],
+                desc: ObjectClassOid::DESC_SUBSCHEMA,
+            ),
+            new ObjectClass(
+                ObjectClassOid::OID_EXTENSIBLE_OBJECT,
+                [ObjectClassOid::NAME_EXTENSIBLE_OBJECT],
+                type: ObjectClassType::AuxiliaryClass,
+                superClassOids: [ObjectClassOid::OID_TOP],
+                desc: ObjectClassOid::DESC_EXTENSIBLE_OBJECT,
+            ),
+        ];
+    }
+
+    private function __construct() {}
+}

--- a/src/FreeDSx/Ldap/Schema/Validation/ObjectClassChain.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/ObjectClassChain.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Validation;
+
+use FreeDSx\Ldap\Schema\Definition\ObjectClass;
+use FreeDSx\Ldap\Schema\Schema;
+
+/**
+ * Resolves the full MUST and MAY attribute sets by walking the object class inheritance chain.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ObjectClassChain
+{
+    /**
+     * Lowercased canonical attribute names that are required.
+     *
+     * @var list<string>
+     */
+    public array $must;
+
+    /**
+     * Lowercased canonical attribute names that are permitted.
+     *
+     * @var list<string>
+     */
+    public array $may;
+
+    /**
+     * @param list<ObjectClass> $objectClasses
+     */
+    public function __construct(
+        Schema $schema,
+        array $objectClasses,
+    ) {
+        $must = [];
+        $may = [];
+        $visited = [];
+        $queue = $objectClasses;
+
+        while ($queue !== []) {
+            $oc = array_shift($queue);
+
+            if (isset($visited[$oc->oid])) {
+                continue;
+            }
+
+            $visited[$oc->oid] = true;
+
+            foreach ($oc->must as $name) {
+                $must[] = strtolower($schema->getAttributeType($name)?->names[0] ?? $name);
+            }
+
+            foreach ($oc->may as $name) {
+                $may[] = strtolower($schema->getAttributeType($name)?->names[0] ?? $name);
+            }
+
+            foreach ($oc->superClassOids as $superOid) {
+                $super = $schema->getObjectClass($superOid);
+                if ($super !== null) {
+                    $queue[] = $super;
+                }
+            }
+        }
+
+        $this->must = array_values(array_unique($must));
+        $this->may = array_values(array_unique($may));
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Validation;
+
+use FreeDSx\Ldap\Entry\Change;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Definition\AttributeUsage;
+use FreeDSx\Ldap\Schema\Definition\ObjectClass;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassType;
+use FreeDSx\Ldap\Schema\Schema;
+use FreeDSx\Ldap\Schema\SchemaValidationMode;
+use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
+
+/**
+ * Validates entries against the schema for add and modify operations.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class SchemaValidator
+{
+    private const EXTENSIBLE_OBJECT = 'extensibleObject';
+
+    public function __construct(
+        private readonly Schema $schema,
+        private readonly SchemaValidationMode $mode,
+    ) {
+    }
+
+    /**
+     * Validates an entry before it is added to storage.
+     *
+     * @throws OperationException
+     */
+    public function validateAdd(Entry $entry): void
+    {
+        if ($this->mode === SchemaValidationMode::Off) {
+            return;
+        }
+
+        $this->checkNoUserModificationInEntry($entry);
+        $this->validateStructure($entry);
+    }
+
+    /**
+     * Validates the changes and resulting entry from an update operation.
+     *
+     * @throws OperationException
+     */
+    public function validateModify(
+        UpdateCommand $command,
+        Entry $result,
+    ): void {
+        if ($this->mode === SchemaValidationMode::Off) {
+            return;
+        }
+
+        $this->checkNoUserModificationInChanges($command->changes);
+        $this->validateStructure($result);
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function validateStructure(Entry $entry): void
+    {
+        if ($this->hasExtensibleObject($entry)) {
+            $this->checkSingleValuedAttributes($entry);
+
+            return;
+        }
+
+        $objectClasses = $this->collectObjectClasses($entry);
+
+        $this->checkStructuralClass($entry, $objectClasses);
+        $chain = new ObjectClassChain($this->schema, $objectClasses);
+        $this->checkRequiredAttributes($entry, $chain->must);
+        $this->checkAllowedAttributes($entry, $chain->must, $chain->may);
+        $this->checkSingleValuedAttributes($entry);
+    }
+
+    private function hasExtensibleObject(Entry $entry): bool
+    {
+        foreach ($entry->get('objectClass')?->getValues() ?? [] as $oc) {
+            if (strcasecmp($oc, self::EXTENSIBLE_OBJECT) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<ObjectClass>
+     */
+    private function collectObjectClasses(Entry $entry): array
+    {
+        return array_values(array_filter(
+            array_map(
+                fn (string $name) => $this->schema->getObjectClass($name),
+                $entry->get('objectClass')?->getValues() ?? [],
+            ),
+        ));
+    }
+
+    /**
+     * @param list<ObjectClass> $objectClasses
+     * @throws OperationException
+     */
+    private function checkStructuralClass(
+        Entry $entry,
+        array $objectClasses,
+    ): void {
+        foreach ($objectClasses as $oc) {
+            if ($oc->type === ObjectClassType::StructuralClass) {
+                return;
+            }
+        }
+
+        $this->fail(
+            sprintf(
+                'Entry "%s" must have at least one structural object class.',
+                $entry->getDn()->toString(),
+            ),
+            ResultCode::OBJECT_CLASS_VIOLATION,
+        );
+    }
+
+    /**
+     * @param list<string> $must
+     * @throws OperationException
+     */
+    private function checkRequiredAttributes(
+        Entry $entry,
+        array $must,
+    ): void {
+        $entryNames = $this->buildEntryAttrSet($entry);
+
+        foreach ($must as $required) {
+            if (isset($entryNames[$required])) {
+                continue;
+            }
+
+            $this->fail(
+                sprintf('Required attribute "%s" is missing.', $required),
+                ResultCode::OBJECT_CLASS_VIOLATION,
+            );
+        }
+    }
+
+    /**
+     * @param list<string> $must
+     * @param list<string> $may
+     * @throws OperationException
+     */
+    private function checkAllowedAttributes(
+        Entry $entry,
+        array $must,
+        array $may,
+    ): void {
+        $allowed = array_flip(array_merge($must, $may));
+
+        foreach ($entry->getAttributes() as $attr) {
+            $attrType = $this->schema->getAttributeType($attr->getName());
+
+            if ($attrType === null) {
+                $this->fail(
+                    sprintf('Undefined attribute type: "%s".', $attr->getName()),
+                    ResultCode::UNDEFINED_ATTRIBUTE_TYPE,
+                );
+
+                continue;
+            }
+
+            if ($attrType->usage !== AttributeUsage::UserApplications) {
+                continue;
+            }
+
+            if (isset($allowed[strtolower($attrType->names[0] ?? $attr->getName())])) {
+                continue;
+            }
+
+            $this->fail(
+                sprintf('Attribute "%s" is not permitted by any object class.', $attr->getName()),
+                ResultCode::OBJECT_CLASS_VIOLATION,
+            );
+        }
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function checkSingleValuedAttributes(Entry $entry): void
+    {
+        foreach ($entry->getAttributes() as $attr) {
+            $attrType = $this->schema->getAttributeType($attr->getName());
+            if ($attrType === null || !$attrType->singleValue) {
+                continue;
+            }
+
+            if (count($attr->getValues()) <= 1) {
+                continue;
+            }
+
+            $this->fail(
+                sprintf(
+                    'Attribute "%s" is single-valued but has %d values.',
+                    $attr->getName(),
+                    count($attr->getValues()),
+                ),
+                ResultCode::CONSTRAINT_VIOLATION,
+            );
+        }
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function checkNoUserModificationInEntry(Entry $entry): void
+    {
+        foreach ($entry->getAttributes() as $attr) {
+            $attrType = $this->schema->getAttributeType($attr->getName());
+            if ($attrType === null || !$attrType->noUserModification) {
+                continue;
+            }
+
+            $this->fail(
+                sprintf('Attribute "%s" cannot be set by users.', $attr->getName()),
+                ResultCode::CONSTRAINT_VIOLATION,
+            );
+        }
+    }
+
+    /**
+     * @param Change[] $changes
+     * @throws OperationException
+     */
+    private function checkNoUserModificationInChanges(array $changes): void
+    {
+        foreach ($changes as $change) {
+            $attrType = $this->schema->getAttributeType($change->getAttribute()->getName());
+            if ($attrType === null || !$attrType->noUserModification) {
+                continue;
+            }
+
+            $this->fail(
+                sprintf('Attribute "%s" cannot be modified by users.', $change->getAttribute()->getName()),
+                ResultCode::CONSTRAINT_VIOLATION,
+            );
+        }
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function buildEntryAttrSet(Entry $entry): array
+    {
+        $result = [];
+
+        foreach ($entry->getAttributes() as $attr) {
+            $attrType = $this->schema->getAttributeType($attr->getName());
+            $result[strtolower($attrType?->names[0] ?? $attr->getName())] = true;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function fail(
+        string $message,
+        int $code,
+    ): void {
+        throw new OperationException(
+            $message,
+            $code,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/SwooleWriterQueue.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/SwooleWriterQueue.php
@@ -64,6 +64,11 @@ final class SwooleWriterQueue implements WriterQueueInterface
         }
     }
 
+    public function __destruct()
+    {
+        $this->jobs?->close();
+    }
+
     private function ensureStarted(): void
     {
         if ($this->started) {

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/FilterEvaluator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/FilterEvaluator.php
@@ -17,6 +17,10 @@ use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Matching\CaseIgnoreComparator;
+use FreeDSx\Ldap\Schema\Matching\MatchingRuleComparatorInterface;
+use FreeDSx\Ldap\Schema\Matching\SubstringAssertion;
+use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Search\Filter\AndFilter;
 use FreeDSx\Ldap\Search\Filter\ApproximateFilter;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
@@ -31,7 +35,9 @@ use FreeDSx\Ldap\Search\Filter\SubstringFilter;
 use WeakMap;
 
 /**
- * Pure-PHP FilterEvaluatorInterface using RFC 4511 §4.5.1 three-valued logic; names/values compare case-insensitively.
+ * Pure-PHP FilterEvaluatorInterface using RFC 4511 §4.5.1 three-valued logic.
+ *
+ * Uses schema-driven comparators with CaseIgnoreComparator as the default fallback per RFC 4511 §4.5.1.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -60,12 +66,7 @@ final class FilterEvaluator implements FilterEvaluatorInterface
     private ?array $attributeIndex = null;
 
     /**
-     * @var WeakMap<object, string>
-     */
-    private WeakMap $loweredSingleValueCache;
-
-    /**
-     * @var WeakMap<object, array{startsWith: ?string, endsWith: ?string, contains: list<string>}>
+     * @var WeakMap<object, SubstringAssertion>
      */
     private WeakMap $substringCache;
 
@@ -74,9 +75,11 @@ final class FilterEvaluator implements FilterEvaluatorInterface
      */
     private WeakMap $orderedDigitCache;
 
-    public function __construct()
+    private readonly CaseIgnoreComparator $defaultComparator;
+
+    public function __construct(private readonly ?Schema $schema = null)
     {
-        $this->loweredSingleValueCache = new WeakMap();
+        $this->defaultComparator = new CaseIgnoreComparator();
         $this->substringCache = new WeakMap();
         $this->orderedDigitCache = new WeakMap();
     }
@@ -191,10 +194,11 @@ final class FilterEvaluator implements FilterEvaluatorInterface
             return FilterResult::Undefined;
         }
 
-        $filterValue = $this->lowerSingleValue($filter);
+        $comparator = $this->resolveEqualityComparator($filter->getAttribute());
+        $filterValue = $filter->getValue();
 
         foreach ($attribute->getValues() as $value) {
-            if (strtolower($value) === $filterValue) {
+            if ($comparator->equals($value, $filterValue)) {
                 return FilterResult::True;
             }
         }
@@ -212,52 +216,16 @@ final class FilterEvaluator implements FilterEvaluatorInterface
             return FilterResult::Undefined;
         }
 
-        $compiled = $this->substringLowered($filter);
+        $comparator = $this->resolveSubstringComparator($filter->getAttribute());
+        $assertion = $this->buildSubstringAssertion($filter);
 
         foreach ($attribute->getValues() as $value) {
-            if ($this->substringMatches(
-                strtolower($value),
-                $compiled['startsWith'],
-                $compiled['endsWith'],
-                $compiled['contains'],
-            )) {
+            if ($comparator->substringMatches($value, $assertion)) {
                 return FilterResult::True;
             }
         }
 
         return FilterResult::False;
-    }
-
-    /**
-     * @param string[] $contains
-     */
-    private function substringMatches(
-        string $value,
-        ?string $startsWith,
-        ?string $endsWith,
-        array $contains,
-    ): bool {
-        if ($startsWith !== null && !str_starts_with($value, $startsWith)) {
-            return false;
-        }
-
-        $pos = $startsWith !== null ? strlen($startsWith) : 0;
-
-        foreach ($contains as $substr) {
-            $found = strpos($value, $substr, $pos);
-            if ($found === false) {
-                return false;
-            }
-            $pos = $found + strlen($substr);
-        }
-
-        if ($endsWith === null) {
-            return true;
-        }
-
-        $endsWithStart = strlen($value) - strlen($endsWith);
-
-        return $endsWithStart >= $pos && str_ends_with($value, $endsWith);
     }
 
     private function evaluateGreaterOrEqual(
@@ -271,10 +239,14 @@ final class FilterEvaluator implements FilterEvaluatorInterface
         }
 
         $filterValue = $filter->getValue();
-        $filterIsDigit = $this->orderedFilterValueIsDigit($filter);
+        $comparator = $this->resolveOrderingComparator($filter->getAttribute());
+        $filterIsDigit = $comparator === null && $this->orderedFilterValueIsDigit($filter);
 
         foreach ($attribute->getValues() as $value) {
-            if ($this->compareOrdered($value, $filterValue, $filterIsDigit) >= 0) {
+            $cmp = $comparator?->compare($value, $filterValue)
+                ?? $this->compareOrdered($value, $filterValue, $filterIsDigit);
+
+            if ($cmp >= 0) {
                 return FilterResult::True;
             }
         }
@@ -293,10 +265,14 @@ final class FilterEvaluator implements FilterEvaluatorInterface
         }
 
         $filterValue = $filter->getValue();
-        $filterIsDigit = $this->orderedFilterValueIsDigit($filter);
+        $comparator = $this->resolveOrderingComparator($filter->getAttribute());
+        $filterIsDigit = $comparator === null && $this->orderedFilterValueIsDigit($filter);
 
         foreach ($attribute->getValues() as $value) {
-            if ($this->compareOrdered($value, $filterValue, $filterIsDigit) <= 0) {
+            $cmp = $comparator?->compare($value, $filterValue)
+                ?? $this->compareOrdered($value, $filterValue, $filterIsDigit);
+
+            if ($cmp <= 0) {
                 return FilterResult::True;
             }
         }
@@ -326,10 +302,10 @@ final class FilterEvaluator implements FilterEvaluatorInterface
             return FilterResult::Undefined;
         }
 
-        $filterValue = $this->lowerSingleValue($filter);
+        $filterValue = $filter->getValue();
 
         foreach ($attribute->getValues() as $value) {
-            if (strtolower($value) === $filterValue) {
+            if ($this->defaultComparator->equals($value, $filterValue)) {
                 return FilterResult::True;
             }
         }
@@ -368,10 +344,7 @@ final class FilterEvaluator implements FilterEvaluatorInterface
         $values = [];
 
         if ($filterAttributeName !== null) {
-            $attribute = $this->lookupAttribute($entry, $filterAttributeName);
-            if ($attribute !== null) {
-                $values = $attribute->getValues();
-            }
+            $values = $this->lookupAttribute($entry, $filterAttributeName)?->getValues() ?? [];
         } else {
             foreach ($entry->getAttributes() as $attribute) {
                 array_push(
@@ -429,8 +402,23 @@ final class FilterEvaluator implements FilterEvaluatorInterface
         string $value,
         string $filterValue,
     ): bool {
+        if ($rule === null) {
+            return $this->defaultComparator->equals(
+                $value,
+                $filterValue,
+            );
+        }
+
+        $schemaComparator = $this->schema?->getComparator($rule);
+        if ($schemaComparator !== null) {
+            return $schemaComparator->equals(
+                $value,
+                $filterValue,
+            );
+        }
+
         return match ($rule) {
-            null, self::MATCHING_RULE_CASE_IGNORE => strtolower($value) === strtolower($filterValue),
+            self::MATCHING_RULE_CASE_IGNORE => strtolower($value) === strtolower($filterValue),
             self::MATCHING_RULE_CASE_EXACT => $value === $filterValue,
             self::MATCHING_RULE_BIT_AND => ((int) $value & (int) $filterValue) === (int) $filterValue,
             self::MATCHING_RULE_BIT_OR => ((int) $value & (int) $filterValue) !== 0,
@@ -439,6 +427,65 @@ final class FilterEvaluator implements FilterEvaluatorInterface
                 ResultCode::INAPPROPRIATE_MATCHING,
             ),
         };
+    }
+
+    private function resolveEqualityComparator(string $attrName): MatchingRuleComparatorInterface
+    {
+        if ($this->schema === null) {
+            return $this->defaultComparator;
+        }
+
+        $attrType = $this->schema->getAttributeType($attrName);
+        $comparator = $attrType?->equalityOid !== null
+            ? $this->schema->getComparator($attrType->equalityOid)
+            : null;
+
+        return $comparator ?? $this->defaultComparator;
+    }
+
+    private function resolveSubstringComparator(string $attrName): MatchingRuleComparatorInterface
+    {
+        if ($this->schema === null) {
+            return $this->defaultComparator;
+        }
+
+        $attrType = $this->schema->getAttributeType($attrName);
+        $comparator = $attrType?->substringOid !== null
+            ? $this->schema->getComparator($attrType->substringOid)
+            : null;
+
+        return $comparator ?? $this->defaultComparator;
+    }
+
+    /**
+     * Returns null when schema is unavailable or the attribute is unknown — caller falls back to the digit heuristic.
+     */
+    private function resolveOrderingComparator(string $attrName): ?MatchingRuleComparatorInterface
+    {
+        if ($this->schema === null) {
+            return null;
+        }
+
+        $attrType = $this->schema->getAttributeType($attrName);
+
+        if ($attrType === null) {
+            return null;
+        }
+
+        if ($attrType->orderingOid !== null) {
+            return $this->schema->getComparator($attrType->orderingOid) ?? $this->defaultComparator;
+        }
+
+        return $this->defaultComparator;
+    }
+
+    private function buildSubstringAssertion(SubstringFilter $filter): SubstringAssertion
+    {
+        return $this->substringCache[$filter] ??= new SubstringAssertion(
+            initial: $filter->getStartsWith(),
+            any: array_values($filter->getContains()),
+            final: $filter->getEndsWith(),
+        );
     }
 
     /**
@@ -462,27 +509,6 @@ final class FilterEvaluator implements FilterEvaluatorInterface
         }
 
         return $this->attributeIndex[strtolower($filterAttributeName)] ?? null;
-    }
-
-    private function lowerSingleValue(EqualityFilter|ApproximateFilter $filter): string
-    {
-        return $this->loweredSingleValueCache[$filter] ??= strtolower($filter->getValue());
-    }
-
-    /**
-     * @return array{startsWith: ?string, endsWith: ?string, contains: list<string>}
-     */
-    private function substringLowered(SubstringFilter $filter): array
-    {
-        return $this->substringCache[$filter] ??= [
-            'startsWith' => $filter->getStartsWith() !== null
-                ? strtolower($filter->getStartsWith())
-                : null,
-            'endsWith' => $filter->getEndsWith() !== null
-                ? strtolower($filter->getEndsWith())
-                : null,
-            'contains' => array_values(array_map('strtolower', $filter->getContains())),
-        ];
     }
 
     private function orderedFilterValueIsDigit(

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -29,6 +29,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Exception\DnTooLongException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\InvalidAttributeException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
+use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\Backend\Write\WritableBackendTrait;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\ResettableInterface;
@@ -57,6 +58,7 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         private readonly WriteEntryOperationHandler $entryHandler = new WriteEntryOperationHandler(),
         private readonly SearchLimits $limits = new SearchLimits(),
         array $namingContexts = [],
+        private readonly ?SchemaValidator $validator = null,
     ) {
         $normalised = [];
         foreach ($namingContexts as $namingContext) {
@@ -206,6 +208,8 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
      */
     public function add(AddCommand $command): void
     {
+        $this->validator?->validateAdd($command->entry);
+
         $this->writeAtomic(function (EntryStorageInterface $storage) use ($command): void {
             $dn = $command->entry->getDn()->normalize();
             $this->assertParentExists($storage, $dn);
@@ -251,10 +255,9 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         $this->writeAtomic(function (EntryStorageInterface $storage) use ($command): void {
             $dn = $command->dn->normalize();
             $entry = $this->findOrFail($storage, $dn);
-            $storage->store($this->entryHandler->apply(
-                $entry,
-                $command,
-            ));
+            $updated = $this->entryHandler->apply($entry, $command);
+            $this->validator?->validateModify($command, $updated);
+            $storage->store($updated);
         });
     }
 

--- a/src/FreeDSx/Ldap/Server/RequestHandler/HandlerFactory.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/HandlerFactory.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\RequestHandler;
 
-use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
-use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\DnBindNameResolver;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticator;
@@ -95,20 +93,6 @@ class HandlerFactory implements HandlerFactoryInterface
         return new PasswordAuthenticator(
             $nameResolver,
             $backend
-        );
-    }
-
-    public function makeSchemaValidator(): ?SchemaValidator
-    {
-        $mode = $this->options->getSchemaValidationMode();
-
-        if ($mode === SchemaValidationMode::Off) {
-            return null;
-        }
-
-        return new SchemaValidator(
-            $this->options->getSchema(),
-            $mode,
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/RequestHandler/HandlerFactory.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/HandlerFactory.php
@@ -18,11 +18,11 @@ use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticator;
 use FreeDSx\Ldap\Server\Backend\GenericBackend;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluator;
+use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluator;
-use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
 use FreeDSx\Ldap\ServerOptions;
 
 /**
@@ -50,7 +50,7 @@ class HandlerFactory implements HandlerFactoryInterface
      */
     public function makeFilterEvaluator(): FilterEvaluatorInterface
     {
-        return $this->options->getFilterEvaluator() ?? new FilterEvaluator();
+        return $this->options->getFilterEvaluator() ?? new FilterEvaluator($this->options->getSchema());
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/RequestHandler/HandlerFactory.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/HandlerFactory.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\RequestHandler;
 
+use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
+use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\DnBindNameResolver;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticator;
@@ -93,6 +95,20 @@ class HandlerFactory implements HandlerFactoryInterface
         return new PasswordAuthenticator(
             $nameResolver,
             $backend
+        );
+    }
+
+    public function makeSchemaValidator(): ?SchemaValidator
+    {
+        $mode = $this->options->getSchemaValidationMode();
+
+        if ($mode === SchemaValidationMode::Off) {
+            return null;
+        }
+
+        return new SchemaValidator(
+            $this->options->getSchema(),
+            $mode,
         );
     }
 

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -15,14 +15,17 @@ namespace FreeDSx\Ldap;
 
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Schema\Schema;
+use FreeDSx\Ldap\Schema\SchemaValidationMode;
+use FreeDSx\Ldap\Schema\StandardSchemaProvider;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
 use Psr\Log\LoggerInterface;
 
 final class ServerOptions
@@ -124,6 +127,10 @@ final class ServerOptions
     private array $writeHandlers = [];
 
     private ?FilterEvaluatorInterface $filterEvaluator = null;
+
+    private ?Schema $schema = null;
+
+    private SchemaValidationMode $schemaValidationMode = SchemaValidationMode::Strict;
 
     private ?LoggerInterface $logger = null;
 
@@ -416,6 +423,30 @@ final class ServerOptions
     public function setFilterEvaluator(?FilterEvaluatorInterface $filterEvaluator): self
     {
         $this->filterEvaluator = $filterEvaluator;
+
+        return $this;
+    }
+
+    public function getSchema(): Schema
+    {
+        return $this->schema ??= StandardSchemaProvider::buildCore();
+    }
+
+    public function setSchema(Schema $schema): self
+    {
+        $this->schema = $schema;
+
+        return $this;
+    }
+
+    public function getSchemaValidationMode(): SchemaValidationMode
+    {
+        return $this->schemaValidationMode;
+    }
+
+    public function setSchemaValidationMode(SchemaValidationMode $mode): self
+    {
+        $this->schemaValidationMode = $mode;
 
         return $this;
     }

--- a/tests/bin/ldap-backend-storage.php
+++ b/tests/bin/ldap-backend-storage.php
@@ -92,6 +92,7 @@ $entries = [
     new Entry(
         new Dn('cn=user,dc=foo,dc=bar'),
         new Attribute('cn', 'user'),
+        new Attribute('sn', 'Admin'),
         new Attribute('objectClass', 'inetOrgPerson'),
         new Attribute('userPassword', $passwordHash),
     ),
@@ -103,7 +104,7 @@ $entries = [
     new Entry(
         new Dn('cn=alice,ou=people,dc=foo,dc=bar'),
         new Attribute('cn', 'alice'),
-        new Attribute('objectClass', 'inetOrgPerson'),
+        new Attribute('objectClass', 'inetOrgPerson', 'extensibleObject'),
         new Attribute('sn', 'Smith'),
         new Attribute('mail', 'alice@foo.bar'),
         new Attribute('uidNumber', '99'),
@@ -114,7 +115,7 @@ for ($i = 1; $i <= $seedEntriesOpt; $i++) {
     $entries[] = new Entry(
         new Dn("cn=seed-{$i},ou=people,dc=foo,dc=bar"),
         new Attribute('cn', "seed-{$i}"),
-        new Attribute('objectClass', 'inetOrgPerson'),
+        new Attribute('objectClass', 'inetOrgPerson', 'extensibleObject'),
         new Attribute('sn', 'Seeded'),
         new Attribute('mail', "seed-{$i}@foo.bar"),
         new Attribute('uidNumber', (string) (1000 + $i)),

--- a/tests/integration/Storage/LdapBackendFileStorageTest.php
+++ b/tests/integration/Storage/LdapBackendFileStorageTest.php
@@ -76,7 +76,7 @@ final class LdapBackendFileStorageTest extends LdapBackendStorageTest
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=persistent,dc=foo,dc=bar',
-            ['cn' => 'persistent', 'objectClass' => 'inetOrgPerson']
+            ['cn' => 'persistent', 'sn' => 'Persistent', 'objectClass' => 'inetOrgPerson']
         ));
 
         // Close the first connection so the PCNTL child exits and flushes.

--- a/tests/integration/Storage/LdapBackendSqliteStorageTest.php
+++ b/tests/integration/Storage/LdapBackendSqliteStorageTest.php
@@ -83,7 +83,7 @@ final class LdapBackendSqliteStorageTest extends LdapBackendStorageTest
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=persistent,dc=foo,dc=bar',
-            ['cn' => 'persistent', 'objectClass' => 'inetOrgPerson']
+            ['cn' => 'persistent', 'sn' => 'Persistent', 'objectClass' => 'inetOrgPerson']
         ));
 
         $this->ldapClient()->unbind();

--- a/tests/integration/Storage/LdapBackendStorageTest.php
+++ b/tests/integration/Storage/LdapBackendStorageTest.php
@@ -186,7 +186,7 @@ class LdapBackendStorageTest extends ServerTestCase
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=charlie,dc=foo,dc=bar',
-            ['cn' => 'charlie', 'objectClass' => 'inetOrgPerson']
+            ['cn' => 'charlie', 'sn' => 'Charlie', 'objectClass' => 'inetOrgPerson']
         ));
 
         $entries = $this->ldapClient()->search(
@@ -206,7 +206,7 @@ class LdapBackendStorageTest extends ServerTestCase
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=user,dc=foo,dc=bar',
-            ['cn' => 'user']
+            ['cn' => 'user', 'sn' => 'User', 'objectClass' => 'inetOrgPerson']
         ));
     }
 

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSubschemaHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSubschemaHandlerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\ResultCode;
@@ -99,5 +100,79 @@ final class ServerSubschemaHandlerTest extends TestCase
             );
 
         $this->subject->handleRequest($this->makeMessage(), $this->mockToken);
+    }
+
+    public function test_it_returns_non_empty_attribute_types_in_rfc4512_format(): void
+    {
+        $entry = $this->handleAndCaptureEntry();
+        $values = $entry->get('attributeTypes')?->getValues() ?? [];
+
+        self::assertGreaterThan(0, count($values));
+        self::assertStringStartsWith('( ', $values[0]);
+    }
+
+    public function test_it_returns_non_empty_object_classes(): void
+    {
+        $entry = $this->handleAndCaptureEntry();
+
+        self::assertGreaterThan(
+            0,
+            count($entry->get('objectClasses')?->getValues() ?? []),
+        );
+    }
+
+    public function test_it_returns_non_empty_matching_rules(): void
+    {
+        $entry = $this->handleAndCaptureEntry();
+
+        self::assertGreaterThan(
+            0,
+            count($entry->get('matchingRules')?->getValues() ?? []),
+        );
+    }
+
+    public function test_it_returns_non_empty_ldap_syntaxes(): void
+    {
+        $entry = $this->handleAndCaptureEntry();
+
+        self::assertGreaterThan(
+            0,
+            count($entry->get('ldapSyntaxes')?->getValues() ?? []),
+        );
+    }
+
+    public function test_it_returns_non_empty_matching_rule_use(): void
+    {
+        $entry = $this->handleAndCaptureEntry();
+
+        self::assertGreaterThan(
+            0,
+            count($entry->get('matchingRuleUse')?->getValues() ?? []),
+        );
+    }
+
+    private function handleAndCaptureEntry(): Entry
+    {
+        $captured = null;
+
+        $this->mockQueue
+            ->expects($this->once())
+            ->method('sendMessage')
+            ->with(
+                self::callback(static function (LdapMessageResponse $response) use (&$captured): bool {
+                    /** @var SearchResultEntry $result */
+                    $result = $response->getResponse();
+                    $captured = $result->getEntry();
+
+                    return true;
+                }),
+                self::anything(),
+            );
+
+        $this->subject->handleRequest($this->makeMessage(), $this->mockToken);
+
+        assert($captured instanceof Entry);
+
+        return $captured;
     }
 }

--- a/tests/unit/Schema/Definition/AttributeTypeTest.php
+++ b/tests/unit/Schema/Definition/AttributeTypeTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Definition;
+
+use FreeDSx\Ldap\Schema\Definition\AttributeType;
+use FreeDSx\Ldap\Schema\Definition\AttributeUsage;
+use PHPUnit\Framework\TestCase;
+
+final class AttributeTypeTest extends TestCase
+{
+    public function test_description_string_minimal(): void
+    {
+        $attr = new AttributeType(
+            oid: '2.5.4.3',
+            names: ['cn'],
+        );
+
+        self::assertSame(
+            "( 2.5.4.3 NAME 'cn' )",
+            $attr->toDescriptionString(),
+        );
+    }
+
+    public function test_description_string_with_alias(): void
+    {
+        $attr = new AttributeType(
+            oid: '2.5.4.3',
+            names: ['cn', 'commonName'],
+        );
+
+        self::assertSame(
+            "( 2.5.4.3 NAME ( 'cn' \$ 'commonName' ) )",
+            $attr->toDescriptionString(),
+        );
+    }
+
+    public function test_description_string_with_all_string_fields(): void
+    {
+        $attr = new AttributeType(
+            oid: '2.5.4.3',
+            names: ['cn'],
+            equalityOid: '2.5.13.2',
+            orderingOid: '2.5.13.3',
+            substringOid: '2.5.13.4',
+            syntaxOid: '1.3.6.1.4.1.1466.115.121.1.15',
+            superTypeOid: '2.5.4.41',
+            desc: 'common name',
+        );
+
+        self::assertSame(
+            "( 2.5.4.3 NAME 'cn' DESC 'common name' SUP 2.5.4.41 EQUALITY 2.5.13.2 ORDERING 2.5.13.3 SUBSTR 2.5.13.4 SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )",
+            $attr->toDescriptionString(),
+        );
+    }
+
+    public function test_description_string_with_boolean_flags(): void
+    {
+        $attr = new AttributeType(
+            oid: '2.5.4.3',
+            names: ['cn'],
+            singleValue: true,
+            collective: true,
+        );
+
+        self::assertSame(
+            "( 2.5.4.3 NAME 'cn' SINGLE-VALUE COLLECTIVE )",
+            $attr->toDescriptionString(),
+        );
+    }
+
+    public function test_description_string_no_user_modification(): void
+    {
+        $attr = new AttributeType(
+            oid: '2.5.18.1',
+            names: ['createTimestamp'],
+            noUserModification: true,
+            usage: AttributeUsage::DirectoryOperation,
+        );
+
+        self::assertSame(
+            "( 2.5.18.1 NAME 'createTimestamp' NO-USER-MODIFICATION USAGE directoryOperation )",
+            $attr->toDescriptionString(),
+        );
+    }
+
+    public function test_description_string_usage_user_applications_is_omitted(): void
+    {
+        $attr = new AttributeType(
+            oid: '2.5.4.3',
+            names: ['cn'],
+            usage: AttributeUsage::UserApplications,
+        );
+
+        self::assertStringNotContainsString(
+            'USAGE',
+            $attr->toDescriptionString(),
+        );
+    }
+
+    public function test_description_string_with_obsolete(): void
+    {
+        $attr = new AttributeType(
+            oid: '2.5.4.3',
+            names: ['cn'],
+            obsolete: true,
+        );
+
+        self::assertSame(
+            "( 2.5.4.3 NAME 'cn' OBSOLETE )",
+            $attr->toDescriptionString(),
+        );
+    }
+}

--- a/tests/unit/Schema/Definition/LdapSyntaxTest.php
+++ b/tests/unit/Schema/Definition/LdapSyntaxTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Definition;
+
+use FreeDSx\Ldap\Schema\Definition\LdapSyntax;
+use PHPUnit\Framework\TestCase;
+
+final class LdapSyntaxTest extends TestCase
+{
+    public function test_description_string_with_desc(): void
+    {
+        $syntax = new LdapSyntax(
+            oid: '1.3.6.1.4.1.1466.115.121.1.15',
+            desc: 'Directory String',
+        );
+
+        self::assertSame(
+            "( 1.3.6.1.4.1.1466.115.121.1.15 DESC 'Directory String' )",
+            $syntax->toDescriptionString(),
+        );
+    }
+
+    public function test_description_string_without_desc(): void
+    {
+        $syntax = new LdapSyntax(oid: '1.3.6.1.4.1.1466.115.121.1.40');
+
+        self::assertSame(
+            '( 1.3.6.1.4.1.1466.115.121.1.40 )',
+            $syntax->toDescriptionString(),
+        );
+    }
+
+    public function test_description_string_with_extensions(): void
+    {
+        $syntax = new LdapSyntax(
+            oid: '1.3.6.1.4.1.1466.115.121.1.15',
+            desc: 'Directory String',
+            extensions: ['X-ORIGIN' => ['RFC 4517']],
+        );
+
+        self::assertSame(
+            "( 1.3.6.1.4.1.1466.115.121.1.15 DESC 'Directory String' X-ORIGIN 'RFC 4517' )",
+            $syntax->toDescriptionString(),
+        );
+    }
+}

--- a/tests/unit/Schema/Definition/MatchingRuleTest.php
+++ b/tests/unit/Schema/Definition/MatchingRuleTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Definition;
+
+use FreeDSx\Ldap\Schema\Definition\MatchingRule;
+use FreeDSx\Ldap\Schema\Matching\CaseIgnoreComparator;
+use PHPUnit\Framework\TestCase;
+
+final class MatchingRuleTest extends TestCase
+{
+    private CaseIgnoreComparator $comparator;
+
+    protected function setUp(): void
+    {
+        $this->comparator = new CaseIgnoreComparator();
+    }
+
+    public function test_description_string_single_name(): void
+    {
+        $rule = new MatchingRule(
+            oid: '2.5.13.2',
+            names: ['caseIgnoreMatch'],
+            syntaxOid: '1.3.6.1.4.1.1466.115.121.1.15',
+            comparator: $this->comparator,
+        );
+
+        self::assertSame(
+            "( 2.5.13.2 NAME 'caseIgnoreMatch' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )",
+            $rule->toDescriptionString(),
+        );
+    }
+
+    public function test_description_string_multiple_names(): void
+    {
+        $rule = new MatchingRule(
+            oid: '2.5.13.2',
+            names: ['caseIgnoreMatch', 'caseIgnore'],
+            syntaxOid: '1.3.6.1.4.1.1466.115.121.1.15',
+            comparator: $this->comparator,
+        );
+
+        self::assertSame(
+            "( 2.5.13.2 NAME ( 'caseIgnoreMatch' \$ 'caseIgnore' ) SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )",
+            $rule->toDescriptionString(),
+        );
+    }
+
+    public function test_description_string_with_desc(): void
+    {
+        $rule = new MatchingRule(
+            oid: '2.5.13.2',
+            names: ['caseIgnoreMatch'],
+            syntaxOid: '1.3.6.1.4.1.1466.115.121.1.15',
+            comparator: $this->comparator,
+            desc: 'case insensitive match',
+        );
+
+        self::assertSame(
+            "( 2.5.13.2 NAME 'caseIgnoreMatch' DESC 'case insensitive match' SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )",
+            $rule->toDescriptionString(),
+        );
+    }
+
+    public function test_description_string_with_obsolete(): void
+    {
+        $rule = new MatchingRule(
+            oid: '2.5.13.2',
+            names: ['caseIgnoreMatch'],
+            syntaxOid: '1.3.6.1.4.1.1466.115.121.1.15',
+            comparator: $this->comparator,
+            obsolete: true,
+        );
+
+        self::assertSame(
+            "( 2.5.13.2 NAME 'caseIgnoreMatch' OBSOLETE SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )",
+            $rule->toDescriptionString(),
+        );
+    }
+}

--- a/tests/unit/Schema/Definition/ObjectClassTest.php
+++ b/tests/unit/Schema/Definition/ObjectClassTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Definition;
+
+use FreeDSx\Ldap\Schema\Definition\ObjectClass;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassType;
+use PHPUnit\Framework\TestCase;
+
+final class ObjectClassTest extends TestCase
+{
+    public function test_description_string_structural_minimal(): void
+    {
+        $oc = new ObjectClass(
+            oid: '2.5.6.6',
+            names: ['person'],
+            type: ObjectClassType::StructuralClass,
+        );
+
+        self::assertSame(
+            "( 2.5.6.6 NAME 'person' STRUCTURAL )",
+            $oc->toDescriptionString(),
+        );
+    }
+
+    public function test_description_string_abstract(): void
+    {
+        $oc = new ObjectClass(
+            oid: '2.5.6.0',
+            names: ['top'],
+            type: ObjectClassType::AbstractClass,
+        );
+
+        self::assertSame(
+            "( 2.5.6.0 NAME 'top' ABSTRACT )",
+            $oc->toDescriptionString(),
+        );
+    }
+
+    public function test_description_string_auxiliary(): void
+    {
+        $oc = new ObjectClass(
+            oid: '1.3.6.1.4.1.1466.344',
+            names: ['dcObject'],
+            type: ObjectClassType::AuxiliaryClass,
+        );
+
+        self::assertSame(
+            "( 1.3.6.1.4.1.1466.344 NAME 'dcObject' AUXILIARY )",
+            $oc->toDescriptionString(),
+        );
+    }
+
+    public function test_description_string_with_sup_must_may(): void
+    {
+        $oc = new ObjectClass(
+            oid: '2.5.6.6',
+            names: ['person'],
+            type: ObjectClassType::StructuralClass,
+            superClassOids: ['top'],
+            must: ['sn', 'cn'],
+            may: ['description'],
+            desc: 'natural persons',
+        );
+
+        self::assertSame(
+            "( 2.5.6.6 NAME 'person' DESC 'natural persons' SUP top STRUCTURAL MUST ( sn \$ cn ) MAY description )",
+            $oc->toDescriptionString(),
+        );
+    }
+
+    public function test_description_string_with_single_sup(): void
+    {
+        $oc = new ObjectClass(
+            oid: '2.5.6.7',
+            names: ['organizationalPerson'],
+            type: ObjectClassType::StructuralClass,
+            superClassOids: ['person'],
+        );
+
+        self::assertSame(
+            "( 2.5.6.7 NAME 'organizationalPerson' SUP person STRUCTURAL )",
+            $oc->toDescriptionString(),
+        );
+    }
+
+    public function test_description_string_with_obsolete(): void
+    {
+        $oc = new ObjectClass(
+            oid: '2.5.6.6',
+            names: ['person'],
+            obsolete: true,
+        );
+
+        self::assertSame(
+            "( 2.5.6.6 NAME 'person' OBSOLETE STRUCTURAL )",
+            $oc->toDescriptionString(),
+        );
+    }
+}

--- a/tests/unit/Schema/Matching/BitMaskComparatorTest.php
+++ b/tests/unit/Schema/Matching/BitMaskComparatorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Matching;
+
+use FreeDSx\Ldap\Schema\Matching\BitMaskComparator;
+use FreeDSx\Ldap\Schema\Matching\SubstringAssertion;
+use PHPUnit\Framework\TestCase;
+
+final class BitMaskComparatorTest extends TestCase
+{
+    public function test_bit_and_all_bits_set(): void
+    {
+        $subject = new BitMaskComparator(requireAllBits: true);
+        $result = $subject->equals('7', '3'); // 0b111 & 0b011 === 0b011
+
+        self::assertTrue($result);
+    }
+
+    public function test_bit_and_not_all_bits_set(): void
+    {
+        $subject = new BitMaskComparator(requireAllBits: true);
+        $result = $subject->equals('4', '3'); // 0b100 & 0b011 === 0
+
+        self::assertFalse($result);
+    }
+
+    public function test_bit_or_any_bit_set(): void
+    {
+        $subject = new BitMaskComparator(requireAllBits: false);
+        $result = $subject->equals('4', '6'); // 0b100 & 0b110 !== 0
+
+        self::assertTrue($result);
+    }
+
+    public function test_bit_or_no_bits_set(): void
+    {
+        $subject = new BitMaskComparator(requireAllBits: false);
+        $result = $subject->equals('8', '7'); // 0b1000 & 0b0111 === 0
+
+        self::assertFalse($result);
+    }
+
+    public function test_compare_equal(): void
+    {
+        $subject = new BitMaskComparator(requireAllBits: true);
+        $result = $subject->compare('5', '5');
+
+        self::assertSame(0, $result);
+    }
+
+    public function test_compare_less_than(): void
+    {
+        $subject = new BitMaskComparator(requireAllBits: true);
+        $result = $subject->compare('3', '10');
+
+        self::assertLessThan(0, $result);
+    }
+
+    public function test_substring_always_returns_false(): void
+    {
+        $subject = new BitMaskComparator(requireAllBits: true);
+        $result = $subject->substringMatches(
+            '7',
+            new SubstringAssertion(initial: '7'),
+        );
+
+        self::assertFalse($result);
+    }
+}

--- a/tests/unit/Schema/Matching/BooleanComparatorTest.php
+++ b/tests/unit/Schema/Matching/BooleanComparatorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Matching;
+
+use FreeDSx\Ldap\Schema\Matching\BooleanComparator;
+use FreeDSx\Ldap\Schema\Matching\SubstringAssertion;
+use PHPUnit\Framework\TestCase;
+
+final class BooleanComparatorTest extends TestCase
+{
+    private BooleanComparator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new BooleanComparator();
+    }
+
+    public function test_equals_true_literal(): void
+    {
+        $result = $this->subject->equals('TRUE', 'TRUE');
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_case_insensitive(): void
+    {
+        $result = $this->subject->equals('true', 'TRUE');
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_false_literal(): void
+    {
+        $result = $this->subject->equals('FALSE', 'FALSE');
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_true_vs_false(): void
+    {
+        $result = $this->subject->equals('TRUE', 'FALSE');
+
+        self::assertFalse($result);
+    }
+
+    public function test_compare_equal(): void
+    {
+        $result = $this->subject->compare('TRUE', 'TRUE');
+
+        self::assertSame(0, $result);
+    }
+
+    public function test_substring_always_returns_false(): void
+    {
+        $result = $this->subject->substringMatches(
+            'TRUE',
+            new SubstringAssertion(initial: 'T'),
+        );
+
+        self::assertFalse($result);
+    }
+}

--- a/tests/unit/Schema/Matching/CaseExactComparatorTest.php
+++ b/tests/unit/Schema/Matching/CaseExactComparatorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Matching;
+
+use FreeDSx\Ldap\Schema\Matching\CaseExactComparator;
+use FreeDSx\Ldap\Schema\Matching\SubstringAssertion;
+use PHPUnit\Framework\TestCase;
+
+final class CaseExactComparatorTest extends TestCase
+{
+    private CaseExactComparator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new CaseExactComparator();
+    }
+
+    public function test_equals_same_case(): void
+    {
+        $result = $this->subject->equals('foo', 'foo');
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_different_case_returns_false(): void
+    {
+        $result = $this->subject->equals('Foo', 'foo');
+
+        self::assertFalse($result);
+    }
+
+    public function test_equals_mismatch(): void
+    {
+        $result = $this->subject->equals('foo', 'bar');
+
+        self::assertFalse($result);
+    }
+
+    public function test_compare_equal(): void
+    {
+        $result = $this->subject->compare('foo', 'foo');
+
+        self::assertSame(0, $result);
+    }
+
+    public function test_compare_case_sensitive(): void
+    {
+        $result = $this->subject->compare('foo', 'FOO');
+
+        self::assertNotSame(0, $result);
+    }
+
+    public function test_substring_case_sensitive_match(): void
+    {
+        $result = $this->subject->substringMatches(
+            'FooBar',
+            new SubstringAssertion(initial: 'Foo'),
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_substring_case_sensitive_no_match(): void
+    {
+        $result = $this->subject->substringMatches(
+            'FooBar',
+            new SubstringAssertion(initial: 'foo'),
+        );
+
+        self::assertFalse($result);
+    }
+}

--- a/tests/unit/Schema/Matching/CaseIgnoreComparatorTest.php
+++ b/tests/unit/Schema/Matching/CaseIgnoreComparatorTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Matching;
+
+use FreeDSx\Ldap\Schema\Matching\CaseIgnoreComparator;
+use FreeDSx\Ldap\Schema\Matching\SubstringAssertion;
+use PHPUnit\Framework\TestCase;
+
+final class CaseIgnoreComparatorTest extends TestCase
+{
+    private CaseIgnoreComparator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new CaseIgnoreComparator();
+    }
+
+    public function test_equals_same_case(): void
+    {
+        $result = $this->subject->equals('foo', 'foo');
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_different_case(): void
+    {
+        self::assertTrue($this->subject->equals('Foo', 'foo'));
+        self::assertTrue($this->subject->equals('FOO', 'foo'));
+    }
+
+    public function test_equals_returns_false_on_mismatch(): void
+    {
+        $result = $this->subject->equals('foo', 'bar');
+
+        self::assertFalse($result);
+    }
+
+    public function test_compare_equal_strings(): void
+    {
+        $result = $this->subject->compare('foo', 'FOO');
+
+        self::assertSame(0, $result);
+    }
+
+    public function test_compare_less_than(): void
+    {
+        $result = $this->subject->compare('a', 'B');
+
+        self::assertLessThan(0, $result);
+    }
+
+    public function test_compare_greater_than(): void
+    {
+        $result = $this->subject->compare('b', 'A');
+
+        self::assertGreaterThan(0, $result);
+    }
+
+    public function test_substring_initial_match(): void
+    {
+        $result = $this->subject->substringMatches(
+            'FooBar',
+            new SubstringAssertion(initial: 'foo'),
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_substring_initial_no_match(): void
+    {
+        $result = $this->subject->substringMatches(
+            'FooBar',
+            new SubstringAssertion(initial: 'bar'),
+        );
+
+        self::assertFalse($result);
+    }
+
+    public function test_substring_any_match(): void
+    {
+        $result = $this->subject->substringMatches(
+            'FooBarBaz',
+            new SubstringAssertion(any: ['BAR']),
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_substring_final_match(): void
+    {
+        $result = $this->subject->substringMatches(
+            'FooBar',
+            new SubstringAssertion(final: 'BAR'),
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_substring_final_no_match(): void
+    {
+        $result = $this->subject->substringMatches(
+            'FooBar',
+            new SubstringAssertion(final: 'Foo'),
+        );
+
+        self::assertFalse($result);
+    }
+
+    public function test_substring_combined(): void
+    {
+        $result = $this->subject->substringMatches(
+            'FooBarBaz',
+            new SubstringAssertion(
+                initial: 'foo',
+                any: ['bar'],
+                final: 'baz',
+            ),
+        );
+
+        self::assertTrue($result);
+    }
+}

--- a/tests/unit/Schema/Matching/CaseIgnoreIa5ComparatorTest.php
+++ b/tests/unit/Schema/Matching/CaseIgnoreIa5ComparatorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Matching;
+
+use FreeDSx\Ldap\Schema\Matching\CaseIgnoreIa5Comparator;
+use FreeDSx\Ldap\Schema\Matching\SubstringAssertion;
+use PHPUnit\Framework\TestCase;
+
+final class CaseIgnoreIa5ComparatorTest extends TestCase
+{
+    private CaseIgnoreIa5Comparator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new CaseIgnoreIa5Comparator();
+    }
+
+    public function test_equals_case_insensitive(): void
+    {
+        $result = $this->subject->equals('user@example.com', 'USER@EXAMPLE.COM');
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_different_values(): void
+    {
+        $result = $this->subject->equals('foo@example.com', 'bar@example.com');
+
+        self::assertFalse($result);
+    }
+
+    public function test_compare_equal(): void
+    {
+        $result = $this->subject->compare('foo', 'FOO');
+
+        self::assertSame(0, $result);
+    }
+
+    public function test_compare_less_than(): void
+    {
+        $result = $this->subject->compare('a', 'B');
+
+        self::assertLessThan(0, $result);
+    }
+
+    public function test_substring_case_insensitive_match(): void
+    {
+        $result = $this->subject->substringMatches(
+            'user@example.com',
+            new SubstringAssertion(initial: 'USER'),
+        );
+
+        self::assertTrue($result);
+    }
+}

--- a/tests/unit/Schema/Matching/DistinguishedNameComparatorTest.php
+++ b/tests/unit/Schema/Matching/DistinguishedNameComparatorTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Matching;
+
+use FreeDSx\Ldap\Schema\Matching\DistinguishedNameComparator;
+use FreeDSx\Ldap\Schema\Matching\SubstringAssertion;
+use PHPUnit\Framework\TestCase;
+
+final class DistinguishedNameComparatorTest extends TestCase
+{
+    private DistinguishedNameComparator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new DistinguishedNameComparator();
+    }
+
+    public function test_equals_same_dn(): void
+    {
+        $result = $this->subject->equals(
+            'cn=foo,dc=example,dc=com',
+            'cn=foo,dc=example,dc=com',
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_case_insensitive(): void
+    {
+        $result = $this->subject->equals(
+            'CN=Foo,DC=Example,DC=Com',
+            'cn=foo,dc=example,dc=com',
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_different_dn(): void
+    {
+        $result = $this->subject->equals(
+            'cn=foo,dc=example,dc=com',
+            'cn=bar,dc=example,dc=com',
+        );
+
+        self::assertFalse($result);
+    }
+
+    public function test_compare_equal(): void
+    {
+        $result = $this->subject->compare(
+            'cn=foo,dc=example,dc=com',
+            'CN=foo,DC=example,DC=com',
+        );
+
+        self::assertSame(0, $result);
+    }
+
+    public function test_substring_always_returns_false(): void
+    {
+        $result = $this->subject->substringMatches(
+            'cn=foo,dc=example,dc=com',
+            new SubstringAssertion(initial: 'cn=foo'),
+        );
+
+        self::assertFalse($result);
+    }
+}

--- a/tests/unit/Schema/Matching/GeneralizedTimeComparatorTest.php
+++ b/tests/unit/Schema/Matching/GeneralizedTimeComparatorTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Matching;
+
+use FreeDSx\Ldap\Schema\Matching\GeneralizedTimeComparator;
+use FreeDSx\Ldap\Schema\Matching\SubstringAssertion;
+use PHPUnit\Framework\TestCase;
+
+final class GeneralizedTimeComparatorTest extends TestCase
+{
+    private GeneralizedTimeComparator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new GeneralizedTimeComparator();
+    }
+
+    public function test_equals_same_utc_timestamp(): void
+    {
+        $result = $this->subject->equals(
+            '20060102150405Z',
+            '20060102150405Z',
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_utc_z_and_offset_zero(): void
+    {
+        $result = $this->subject->equals(
+            '20060102150405Z',
+            '20060102150405+0000',
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_different_times(): void
+    {
+        $result = $this->subject->equals(
+            '20060102150405Z',
+            '20060102160405Z',
+        );
+
+        self::assertFalse($result);
+    }
+
+    public function test_equals_invalid_value_returns_false(): void
+    {
+        $result = $this->subject->equals(
+            'not-a-time',
+            '20060102150405Z',
+        );
+
+        self::assertFalse($result);
+    }
+
+    public function test_compare_earlier_time_is_less(): void
+    {
+        $result = $this->subject->compare(
+            '20060102140405Z',
+            '20060102150405Z',
+        );
+
+        self::assertLessThan(0, $result);
+    }
+
+    public function test_compare_later_time_is_greater(): void
+    {
+        $result = $this->subject->compare(
+            '20060102160405Z',
+            '20060102150405Z',
+        );
+
+        self::assertGreaterThan(0, $result);
+    }
+
+    public function test_compare_equal(): void
+    {
+        $result = $this->subject->compare(
+            '20060102150405Z',
+            '20060102150405Z',
+        );
+
+        self::assertSame(0, $result);
+    }
+
+    public function test_substring_always_returns_false(): void
+    {
+        $result = $this->subject->substringMatches(
+            '20060102150405Z',
+            new SubstringAssertion(initial: '2006'),
+        );
+
+        self::assertFalse($result);
+    }
+}

--- a/tests/unit/Schema/Matching/IntegerComparatorTest.php
+++ b/tests/unit/Schema/Matching/IntegerComparatorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Matching;
+
+use FreeDSx\Ldap\Schema\Matching\IntegerComparator;
+use FreeDSx\Ldap\Schema\Matching\SubstringAssertion;
+use PHPUnit\Framework\TestCase;
+
+final class IntegerComparatorTest extends TestCase
+{
+    private IntegerComparator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new IntegerComparator();
+    }
+
+    public function test_equals_same_value(): void
+    {
+        $result = $this->subject->equals('42', '42');
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_equivalent_integer_representations(): void
+    {
+        $result = $this->subject->equals('042', '42');
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_different_values(): void
+    {
+        $result = $this->subject->equals('1', '2');
+
+        self::assertFalse($result);
+    }
+
+    public function test_compare_equal(): void
+    {
+        $result = $this->subject->compare('5', '5');
+
+        self::assertSame(0, $result);
+    }
+
+    public function test_compare_less_than(): void
+    {
+        $result = $this->subject->compare('3', '10');
+
+        self::assertLessThan(0, $result);
+    }
+
+    public function test_compare_greater_than(): void
+    {
+        $result = $this->subject->compare('10', '3');
+
+        self::assertGreaterThan(0, $result);
+    }
+
+    public function test_substring_always_returns_false(): void
+    {
+        $result = $this->subject->substringMatches(
+            '42',
+            new SubstringAssertion(initial: '4'),
+        );
+
+        self::assertFalse($result);
+    }
+}

--- a/tests/unit/Schema/Matching/OctetStringComparatorTest.php
+++ b/tests/unit/Schema/Matching/OctetStringComparatorTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Matching;
+
+use FreeDSx\Ldap\Schema\Matching\OctetStringComparator;
+use FreeDSx\Ldap\Schema\Matching\SubstringAssertion;
+use PHPUnit\Framework\TestCase;
+
+final class OctetStringComparatorTest extends TestCase
+{
+    private OctetStringComparator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new OctetStringComparator();
+    }
+
+    public function test_equals_identical_bytes(): void
+    {
+        $result = $this->subject->equals('foo', 'foo');
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_case_sensitive(): void
+    {
+        $result = $this->subject->equals('Foo', 'foo');
+
+        self::assertFalse($result);
+    }
+
+    public function test_compare_equal(): void
+    {
+        $result = $this->subject->compare('abc', 'abc');
+
+        self::assertSame(0, $result);
+    }
+
+    public function test_compare_less_than(): void
+    {
+        $result = $this->subject->compare('abc', 'abd');
+
+        self::assertLessThan(0, $result);
+    }
+
+    public function test_substring_case_sensitive_initial(): void
+    {
+        $result = $this->subject->substringMatches(
+            'FooBar',
+            new SubstringAssertion(initial: 'Foo'),
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_substring_case_sensitive_no_match(): void
+    {
+        $result = $this->subject->substringMatches(
+            'FooBar',
+            new SubstringAssertion(initial: 'foo'),
+        );
+
+        self::assertFalse($result);
+    }
+
+    public function test_substring_any_and_final(): void
+    {
+        $result = $this->subject->substringMatches(
+            'FooBarBaz',
+            new SubstringAssertion(
+                any: ['Bar'],
+                final: 'Baz',
+            ),
+        );
+
+        self::assertTrue($result);
+    }
+}

--- a/tests/unit/Schema/Matching/TelephoneNumberComparatorTest.php
+++ b/tests/unit/Schema/Matching/TelephoneNumberComparatorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Matching;
+
+use FreeDSx\Ldap\Schema\Matching\SubstringAssertion;
+use FreeDSx\Ldap\Schema\Matching\TelephoneNumberComparator;
+use PHPUnit\Framework\TestCase;
+
+final class TelephoneNumberComparatorTest extends TestCase
+{
+    private TelephoneNumberComparator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new TelephoneNumberComparator();
+    }
+
+    public function test_equals_strips_spaces_and_hyphens(): void
+    {
+        $result = $this->subject->equals(
+            '+1 800 555-1234',
+            '+18005551234',
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_case_insensitive(): void
+    {
+        $result = $this->subject->equals('1-800-FOO', '1800foo');
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_different_numbers(): void
+    {
+        $result = $this->subject->equals(
+            '+1 800 555-1234',
+            '+1 800 555-9999',
+        );
+
+        self::assertFalse($result);
+    }
+
+    public function test_compare_equal_after_normalization(): void
+    {
+        $result = $this->subject->compare(
+            '+1 800 555-1234',
+            '+18005551234',
+        );
+
+        self::assertSame(0, $result);
+    }
+
+    public function test_substring_strips_formatting_before_matching(): void
+    {
+        $result = $this->subject->substringMatches(
+            '1 800 555-1234',
+            new SubstringAssertion(initial: '1800'),
+        );
+
+        self::assertTrue($result);
+    }
+}

--- a/tests/unit/Schema/SchemaTest.php
+++ b/tests/unit/Schema/SchemaTest.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema;
+
+use FreeDSx\Ldap\Schema\Definition\AttributeType;
+use FreeDSx\Ldap\Schema\Definition\LdapSyntax;
+use FreeDSx\Ldap\Schema\Definition\MatchingRule;
+use FreeDSx\Ldap\Schema\Definition\ObjectClass;
+use FreeDSx\Ldap\Schema\Matching\CaseIgnoreComparator;
+use FreeDSx\Ldap\Schema\Schema;
+use PHPUnit\Framework\TestCase;
+
+final class SchemaTest extends TestCase
+{
+    private Schema $subject;
+
+    private AttributeType $cn;
+
+    private ObjectClass $person;
+
+    private MatchingRule $caseIgnore;
+
+    private LdapSyntax $dirString;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Schema();
+
+        $this->cn = new AttributeType(
+            oid: '2.5.4.3',
+            names: ['cn', 'commonName'],
+        );
+        $this->person = new ObjectClass(
+            oid: '2.5.6.6',
+            names: ['person'],
+        );
+        $this->caseIgnore = new MatchingRule(
+            oid: '2.5.13.2',
+            names: ['caseIgnoreMatch'],
+            syntaxOid: '1.3.6.1.4.1.1466.115.121.1.15',
+            comparator: new CaseIgnoreComparator(),
+        );
+        $this->dirString = new LdapSyntax(
+            oid: '1.3.6.1.4.1.1466.115.121.1.15',
+            desc: 'Directory String',
+        );
+    }
+
+    public function test_add_and_get_attribute_type_by_oid(): void
+    {
+        $this->subject->addAttributeType($this->cn);
+
+        self::assertSame(
+            $this->cn,
+            $this->subject->getAttributeType('2.5.4.3'),
+        );
+    }
+
+    public function test_add_and_get_attribute_type_by_primary_name(): void
+    {
+        $this->subject->addAttributeType($this->cn);
+
+        self::assertSame(
+            $this->cn,
+            $this->subject->getAttributeType('cn'),
+        );
+    }
+
+    public function test_add_and_get_attribute_type_by_alias(): void
+    {
+        $this->subject->addAttributeType($this->cn);
+
+        self::assertSame(
+            $this->cn,
+            $this->subject->getAttributeType('commonName'),
+        );
+    }
+
+    public function test_get_attribute_type_case_insensitive(): void
+    {
+        $this->subject->addAttributeType($this->cn);
+
+        self::assertSame(
+            $this->cn,
+            $this->subject->getAttributeType('CN'),
+        );
+        self::assertSame(
+            $this->cn,
+            $this->subject->getAttributeType('CommonName'),
+        );
+    }
+
+    public function test_get_attribute_type_returns_null_when_not_found(): void
+    {
+        self::assertNull($this->subject->getAttributeType('sn'));
+    }
+
+    public function test_add_and_get_object_class_by_oid(): void
+    {
+        $this->subject->addObjectClass($this->person);
+
+        self::assertSame(
+            $this->person,
+            $this->subject->getObjectClass('2.5.6.6'),
+        );
+    }
+
+    public function test_add_and_get_object_class_by_name(): void
+    {
+        $this->subject->addObjectClass($this->person);
+
+        self::assertSame(
+            $this->person,
+            $this->subject->getObjectClass('person'),
+        );
+    }
+
+    public function test_get_object_class_case_insensitive(): void
+    {
+        $this->subject->addObjectClass($this->person);
+
+        self::assertSame(
+            $this->person,
+            $this->subject->getObjectClass('Person'),
+        );
+    }
+
+    public function test_get_object_class_returns_null_when_not_found(): void
+    {
+        self::assertNull($this->subject->getObjectClass('inetOrgPerson'));
+    }
+
+    public function test_add_and_get_matching_rule_by_oid(): void
+    {
+        $this->subject->addMatchingRule($this->caseIgnore);
+
+        self::assertSame(
+            $this->caseIgnore,
+            $this->subject->getMatchingRule('2.5.13.2'),
+        );
+    }
+
+    public function test_add_and_get_matching_rule_by_name(): void
+    {
+        $this->subject->addMatchingRule($this->caseIgnore);
+
+        self::assertSame(
+            $this->caseIgnore,
+            $this->subject->getMatchingRule('caseIgnoreMatch'),
+        );
+    }
+
+    public function test_get_matching_rule_returns_null_when_not_found(): void
+    {
+        self::assertNull($this->subject->getMatchingRule('caseExactMatch'));
+    }
+
+    public function test_add_and_get_syntax_by_oid(): void
+    {
+        $this->subject->addSyntax($this->dirString);
+
+        self::assertSame(
+            $this->dirString,
+            $this->subject->getSyntax('1.3.6.1.4.1.1466.115.121.1.15'),
+        );
+    }
+
+    public function test_get_syntax_returns_null_when_not_found(): void
+    {
+        self::assertNull($this->subject->getSyntax('1.3.6.1.4.1.1466.115.121.1.27'));
+    }
+
+    public function test_get_comparator_returns_comparator_for_registered_rule(): void
+    {
+        $this->subject->addMatchingRule($this->caseIgnore);
+
+        self::assertInstanceOf(
+            CaseIgnoreComparator::class,
+            $this->subject->getComparator('2.5.13.2'),
+        );
+    }
+
+    public function test_get_comparator_returns_null_for_unknown_rule(): void
+    {
+        self::assertNull($this->subject->getComparator('2.5.13.99'));
+    }
+
+    public function test_get_attribute_types_returns_unique_list(): void
+    {
+        $this->subject->addAttributeType($this->cn);
+
+        $types = $this->subject->getAttributeTypes();
+
+        self::assertCount(1, $types);
+        self::assertSame(
+            $this->cn,
+            $types[0],
+        );
+    }
+
+    public function test_get_object_classes_returns_unique_list(): void
+    {
+        $this->subject->addObjectClass($this->person);
+
+        $classes = $this->subject->getObjectClasses();
+
+        self::assertCount(1, $classes);
+        self::assertSame(
+            $this->person,
+            $classes[0],
+        );
+    }
+
+    public function test_get_matching_rules_returns_unique_list(): void
+    {
+        $this->subject->addMatchingRule($this->caseIgnore);
+
+        $rules = $this->subject->getMatchingRules();
+
+        self::assertCount(1, $rules);
+        self::assertSame(
+            $this->caseIgnore,
+            $rules[0],
+        );
+    }
+
+    public function test_merge_combines_definitions(): void
+    {
+        $this->subject->addAttributeType($this->cn);
+
+        $other = (new Schema())->addObjectClass($this->person);
+        $merged = $this->subject->merge($other);
+
+        self::assertSame(
+            $this->cn,
+            $merged->getAttributeType('cn'),
+        );
+        self::assertSame(
+            $this->person,
+            $merged->getObjectClass('person'),
+        );
+    }
+
+    public function test_merge_does_not_mutate_original(): void
+    {
+        $this->subject->addAttributeType($this->cn);
+
+        $other = (new Schema())->addObjectClass($this->person);
+        $this->subject->merge($other);
+
+        self::assertNull($this->subject->getObjectClass('person'));
+    }
+
+    public function test_merge_other_overrides_on_collision(): void
+    {
+        $original = new AttributeType(
+            oid: '2.5.4.3',
+            names: ['cn'],
+            desc: 'original',
+        );
+        $override = new AttributeType(
+            oid: '2.5.4.3',
+            names: ['cn'],
+            desc: 'override',
+        );
+        $this->subject->addAttributeType($original);
+
+        $other = (new Schema())->addAttributeType($override);
+        $merged = $this->subject->merge($other);
+
+        self::assertSame(
+            'override',
+            $merged->getAttributeType('cn')?->desc,
+        );
+    }
+
+    public function test_fluent_add_methods_return_same_instance(): void
+    {
+        $schema = new Schema();
+
+        self::assertSame(
+            $schema,
+            $schema->addAttributeType($this->cn),
+        );
+        self::assertSame(
+            $schema,
+            $schema->addObjectClass($this->person),
+        );
+        self::assertSame(
+            $schema,
+            $schema->addMatchingRule($this->caseIgnore),
+        );
+        self::assertSame(
+            $schema,
+            $schema->addSyntax($this->dirString),
+        );
+    }
+}

--- a/tests/unit/Schema/StandardSchemaProviderTest.php
+++ b/tests/unit/Schema/StandardSchemaProviderTest.php
@@ -30,12 +30,10 @@ final class StandardSchemaProviderTest extends TestCase
         $this->schema = StandardSchemaProvider::buildCore();
     }
 
-    public function test_build_core_returns_schema_instance(): void
+    public function test_build_core_returns_non_empty_schema(): void
     {
-        self::assertInstanceOf(
-            Schema::class,
-            $this->schema,
-        );
+        self::assertNotEmpty($this->schema->getAttributeTypes());
+        self::assertNotEmpty($this->schema->getObjectClasses());
     }
 
     public function test_has_expected_syntax_count(): void

--- a/tests/unit/Schema/StandardSchemaProviderTest.php
+++ b/tests/unit/Schema/StandardSchemaProviderTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema;
+
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
+use FreeDSx\Ldap\Schema\Definition\MatchingRuleOid;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassOid;
+use FreeDSx\Ldap\Schema\Definition\SyntaxOid;
+use FreeDSx\Ldap\Schema\Schema;
+use FreeDSx\Ldap\Schema\StandardSchemaProvider;
+use PHPUnit\Framework\TestCase;
+
+final class StandardSchemaProviderTest extends TestCase
+{
+    private Schema $schema;
+
+    protected function setUp(): void
+    {
+        $this->schema = StandardSchemaProvider::buildCore();
+    }
+
+    public function test_build_core_returns_schema_instance(): void
+    {
+        self::assertInstanceOf(
+            Schema::class,
+            $this->schema,
+        );
+    }
+
+    public function test_has_expected_syntax_count(): void
+    {
+        self::assertCount(
+            14,
+            $this->schema->getLdapSyntaxes(),
+        );
+    }
+
+    public function test_has_expected_matching_rule_count(): void
+    {
+        self::assertCount(
+            18,
+            $this->schema->getMatchingRules(),
+        );
+    }
+
+    public function test_has_expected_attribute_type_count(): void
+    {
+        self::assertCount(
+            38,
+            $this->schema->getAttributeTypes(),
+        );
+    }
+
+    public function test_has_expected_object_class_count(): void
+    {
+        self::assertCount(
+            12,
+            $this->schema->getObjectClasses(),
+        );
+    }
+
+    // --- syntaxes ---
+
+    public function test_directory_string_syntax_registered(): void
+    {
+        $syntax = $this->schema->getSyntax(SyntaxOid::OID_DIRECTORY_STRING);
+
+        self::assertNotNull($syntax);
+        self::assertSame(
+            SyntaxOid::DESC_DIRECTORY_STRING,
+            $syntax->desc,
+        );
+    }
+
+    public function test_integer_syntax_registered(): void
+    {
+        self::assertNotNull($this->schema->getSyntax(SyntaxOid::OID_INTEGER));
+    }
+
+    // --- matching rules ---
+
+    public function test_case_ignore_match_registered_by_oid(): void
+    {
+        self::assertNotNull(
+            $this->schema->getMatchingRule(MatchingRuleOid::OID_CASE_IGNORE_MATCH),
+        );
+    }
+
+    public function test_case_ignore_match_registered_by_name(): void
+    {
+        self::assertNotNull(
+            $this->schema->getMatchingRule(MatchingRuleOid::NAME_CASE_IGNORE_MATCH),
+        );
+    }
+
+    public function test_case_exact_match_registered(): void
+    {
+        self::assertNotNull(
+            $this->schema->getMatchingRule(MatchingRuleOid::OID_CASE_EXACT_MATCH),
+        );
+    }
+
+    public function test_distinguished_name_match_registered(): void
+    {
+        self::assertNotNull(
+            $this->schema->getMatchingRule(MatchingRuleOid::OID_DISTINGUISHED_NAME_MATCH),
+        );
+    }
+
+    public function test_integer_match_registered(): void
+    {
+        self::assertNotNull(
+            $this->schema->getMatchingRule(MatchingRuleOid::OID_INTEGER_MATCH),
+        );
+    }
+
+    public function test_boolean_match_registered(): void
+    {
+        self::assertNotNull(
+            $this->schema->getMatchingRule(MatchingRuleOid::OID_BOOLEAN_MATCH),
+        );
+    }
+
+    public function test_bit_and_match_registered(): void
+    {
+        self::assertNotNull(
+            $this->schema->getMatchingRule(MatchingRuleOid::OID_BIT_AND_MATCH),
+        );
+    }
+
+    public function test_bit_or_match_registered(): void
+    {
+        self::assertNotNull(
+            $this->schema->getMatchingRule(MatchingRuleOid::OID_BIT_OR_MATCH),
+        );
+    }
+
+    // --- attribute types ---
+
+    public function test_cn_registered_by_oid(): void
+    {
+        self::assertNotNull(
+            $this->schema->getAttributeType(AttributeTypeOid::OID_CN),
+        );
+    }
+
+    public function test_cn_registered_by_name(): void
+    {
+        self::assertNotNull(
+            $this->schema->getAttributeType(AttributeTypeOid::NAME_CN),
+        );
+    }
+
+    public function test_cn_registered_by_alias(): void
+    {
+        self::assertNotNull(
+            $this->schema->getAttributeType(AttributeTypeOid::ALIAS_CN),
+        );
+    }
+
+    public function test_uid_registered(): void
+    {
+        self::assertNotNull(
+            $this->schema->getAttributeType(AttributeTypeOid::OID_UID),
+        );
+    }
+
+    public function test_create_timestamp_is_no_user_modification(): void
+    {
+        $attr = $this->schema->getAttributeType(AttributeTypeOid::NAME_CREATE_TIMESTAMP);
+
+        self::assertNotNull($attr);
+        self::assertTrue($attr->noUserModification);
+    }
+
+    public function test_object_class_attribute_registered(): void
+    {
+        self::assertNotNull(
+            $this->schema->getAttributeType(AttributeTypeOid::NAME_OBJECT_CLASS),
+        );
+    }
+
+    // --- object classes ---
+
+    public function test_top_registered(): void
+    {
+        self::assertNotNull(
+            $this->schema->getObjectClass(ObjectClassOid::NAME_TOP),
+        );
+    }
+
+    public function test_person_registered_by_oid(): void
+    {
+        self::assertNotNull(
+            $this->schema->getObjectClass(ObjectClassOid::OID_PERSON),
+        );
+    }
+
+    public function test_person_registered_by_name(): void
+    {
+        self::assertNotNull(
+            $this->schema->getObjectClass(ObjectClassOid::NAME_PERSON),
+        );
+    }
+
+    public function test_inet_org_person_registered(): void
+    {
+        self::assertNotNull(
+            $this->schema->getObjectClass(ObjectClassOid::NAME_INET_ORG_PERSON),
+        );
+    }
+
+    public function test_extensible_object_registered(): void
+    {
+        self::assertNotNull(
+            $this->schema->getObjectClass(ObjectClassOid::NAME_EXTENSIBLE_OBJECT),
+        );
+    }
+
+    public function test_subschema_registered(): void
+    {
+        self::assertNotNull(
+            $this->schema->getObjectClass(ObjectClassOid::NAME_SUBSCHEMA),
+        );
+    }
+}

--- a/tests/unit/Schema/Validation/ObjectClassChainTest.php
+++ b/tests/unit/Schema/Validation/ObjectClassChainTest.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Validation;
+
+use FreeDSx\Ldap\Schema\Definition\AttributeType;
+use FreeDSx\Ldap\Schema\Definition\ObjectClass;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassType;
+use FreeDSx\Ldap\Schema\Schema;
+use FreeDSx\Ldap\Schema\Validation\ObjectClassChain;
+use PHPUnit\Framework\TestCase;
+
+final class ObjectClassChainTest extends TestCase
+{
+    private Schema $schema;
+
+    protected function setUp(): void
+    {
+        $this->schema = (new Schema())
+            ->addAttributeType(new AttributeType('1.1', ['cn']))
+            ->addAttributeType(new AttributeType('1.2', ['sn']))
+            ->addAttributeType(new AttributeType('1.3', ['description']))
+            ->addAttributeType(new AttributeType('1.4', ['ou']))
+            ->addAttributeType(new AttributeType('1.5', ['objectClass']));
+    }
+
+    public function test_empty_input_yields_empty_must_and_may(): void
+    {
+        $chain = new ObjectClassChain(
+            $this->schema,
+            [],
+        );
+
+        self::assertSame(
+            [],
+            $chain->must,
+        );
+        self::assertSame(
+            [],
+            $chain->may,
+        );
+    }
+
+    public function test_single_class_must_and_may_are_collected(): void
+    {
+        $oc = new ObjectClass(
+            '2.1',
+            ['person'],
+            must: ['cn'],
+            may: ['description'],
+        );
+        $chain = new ObjectClassChain(
+            $this->schema,
+            [$oc],
+        );
+
+        self::assertSame(
+            ['cn'],
+            $chain->must,
+        );
+        self::assertSame(
+            ['description'],
+            $chain->may,
+        );
+    }
+
+    public function test_attributes_are_lowercased(): void
+    {
+        $oc = new ObjectClass(
+            '2.1',
+            ['Person'],
+            must: ['CN'],
+            may: ['Description'],
+        );
+        $chain = new ObjectClassChain(
+            $this->schema,
+            [$oc],
+        );
+
+        self::assertSame(
+            ['cn'],
+            $chain->must,
+        );
+        self::assertSame(
+            ['description'],
+            $chain->may,
+        );
+    }
+
+    public function test_canonical_name_is_used_when_attribute_is_known(): void
+    {
+        $schema = (new Schema())
+            ->addAttributeType(new AttributeType('1.1', ['commonName', 'cn']));
+
+        $oc = new ObjectClass(
+            '2.1',
+            ['person'],
+            must: ['cn'],
+        );
+        $chain = new ObjectClassChain(
+            $schema,
+            [$oc],
+        );
+
+        self::assertSame(
+            ['commonname'],
+            $chain->must,
+        );
+    }
+
+    public function test_superclass_must_and_may_are_inherited(): void
+    {
+        $parent = new ObjectClass(
+            '2.0',
+            ['top'],
+            must: ['objectClass'],
+        );
+        $child = new ObjectClass(
+            '2.1',
+            ['person'],
+            superClassOids: ['2.0'],
+            must: ['cn'],
+            may: ['description'],
+        );
+
+        $schema = (new Schema())
+            ->addObjectClass($parent)
+            ->addAttributeType(new AttributeType('1.1', ['cn']))
+            ->addAttributeType(new AttributeType('1.5', ['objectClass']))
+            ->addAttributeType(new AttributeType('1.3', ['description']));
+
+        $chain = new ObjectClassChain(
+            $schema,
+            [$child],
+        );
+
+        self::assertContains(
+            'cn',
+            $chain->must,
+        );
+        self::assertContains(
+            'objectclass',
+            $chain->must,
+        );
+        self::assertContains(
+            'description',
+            $chain->may,
+        );
+    }
+
+    public function test_duplicate_attributes_across_classes_are_deduplicated(): void
+    {
+        $oc1 = new ObjectClass(
+            '2.1',
+            ['person'],
+            must: ['cn', 'sn'],
+        );
+        $oc2 = new ObjectClass(
+            '2.2',
+            ['orgPerson'],
+            must: ['cn', 'ou'],
+        );
+
+        $chain = new ObjectClassChain(
+            $this->schema,
+            [$oc1, $oc2],
+        );
+
+        self::assertSame(
+            ['cn', 'sn', 'ou'],
+            $chain->must,
+        );
+    }
+
+    public function test_diamond_inheritance_visits_each_class_once(): void
+    {
+        $root = new ObjectClass(
+            '2.0',
+            ['top'],
+            must: ['objectClass'],
+        );
+        $left = new ObjectClass(
+            '2.1',
+            ['left'],
+            superClassOids: ['2.0'],
+            must: ['cn'],
+        );
+        $right = new ObjectClass(
+            '2.2',
+            ['right'],
+            superClassOids: ['2.0'],
+            must: ['sn'],
+        );
+        $child = new ObjectClass(
+            '2.3',
+            ['child'],
+            superClassOids: ['2.1', '2.2'],
+            must: ['ou'],
+        );
+
+        $schema = (new Schema())
+            ->addObjectClass($root)
+            ->addObjectClass($left)
+            ->addObjectClass($right)
+            ->addAttributeType(new AttributeType('1.1', ['cn']))
+            ->addAttributeType(new AttributeType('1.2', ['sn']))
+            ->addAttributeType(new AttributeType('1.4', ['ou']))
+            ->addAttributeType(new AttributeType('1.5', ['objectClass']));
+
+        $chain = new ObjectClassChain(
+            $schema,
+            [$child],
+        );
+
+        self::assertCount(
+            1,
+            array_filter($chain->must, fn (string $a) => $a === 'objectclass'),
+        );
+    }
+
+    public function test_unknown_superclass_oid_is_skipped_gracefully(): void
+    {
+        $oc = new ObjectClass(
+            '2.1',
+            ['person'],
+            superClassOids: ['99.99.99'],
+            must: ['cn'],
+        );
+        $chain = new ObjectClassChain(
+            $this->schema,
+            [$oc],
+        );
+
+        self::assertSame(
+            ['cn'],
+            $chain->must,
+        );
+    }
+
+    public function test_unknown_attribute_name_falls_back_to_original_lowercased(): void
+    {
+        $oc = new ObjectClass(
+            '2.1',
+            ['custom'],
+            must: ['unknownAttr'],
+        );
+        $chain = new ObjectClassChain(
+            $this->schema,
+            [$oc],
+        );
+
+        self::assertSame(
+            ['unknownattr'],
+            $chain->must,
+        );
+    }
+
+    public function test_auxiliary_class_attributes_are_included(): void
+    {
+        $aux = new ObjectClass(
+            '2.5',
+            ['posixAccount'],
+            ObjectClassType::AuxiliaryClass,
+            must: ['ou'],
+        );
+        $structural = new ObjectClass(
+            '2.1',
+            ['person'],
+            must: ['cn', 'sn'],
+        );
+
+        $chain = new ObjectClassChain(
+            $this->schema,
+            [$structural, $aux],
+        );
+
+        self::assertContains(
+            'cn',
+            $chain->must,
+        );
+        self::assertContains(
+            'ou',
+            $chain->must,
+        );
+    }
+}

--- a/tests/unit/Schema/Validation/SchemaValidatorTest.php
+++ b/tests/unit/Schema/Validation/SchemaValidatorTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Validation;
+
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Change;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\SchemaValidationMode;
+use FreeDSx\Ldap\Schema\StandardSchemaProvider;
+use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
+use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
+use PHPUnit\Framework\TestCase;
+
+final class SchemaValidatorTest extends TestCase
+{
+    private SchemaValidator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new SchemaValidator(
+            StandardSchemaProvider::buildCore(),
+            SchemaValidationMode::Strict,
+        );
+    }
+
+    private function personEntry(string $dn = 'cn=Alice,dc=example,dc=com'): Entry
+    {
+        return new Entry(
+            new Dn($dn),
+            new Attribute('objectClass', 'top', 'person'),
+            new Attribute('cn', 'Alice'),
+            new Attribute('sn', 'Smith'),
+        );
+    }
+
+    public function test_valid_add_passes(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $this->subject->validateAdd($this->personEntry());
+    }
+
+    public function test_add_missing_structural_class_throws_object_class_violation(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'top'),
+            new Attribute('cn', 'Alice'),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
+
+        $this->subject->validateAdd($entry);
+    }
+
+    public function test_add_missing_must_attribute_throws_object_class_violation(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'top', 'person'),
+            new Attribute('cn', 'Alice'),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
+
+        $this->subject->validateAdd($entry);
+    }
+
+    public function test_add_disallowed_attribute_throws_object_class_violation(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'top', 'person'),
+            new Attribute('cn', 'Alice'),
+            new Attribute('sn', 'Smith'),
+            new Attribute('employeeNumber', '42'),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
+
+        $this->subject->validateAdd($entry);
+    }
+
+    public function test_add_undefined_attribute_type_throws(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'top', 'person'),
+            new Attribute('cn', 'Alice'),
+            new Attribute('sn', 'Smith'),
+            new Attribute('unknownAttr99', 'value'),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::UNDEFINED_ATTRIBUTE_TYPE);
+
+        $this->subject->validateAdd($entry);
+    }
+
+    public function test_add_single_valued_violation_throws_constraint_violation(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'top', 'person', 'organizationalPerson', 'inetOrgPerson'),
+            new Attribute('cn', 'Alice'),
+            new Attribute('sn', 'Smith'),
+            new Attribute('employeeNumber', '001', '002'),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::CONSTRAINT_VIOLATION);
+
+        $this->subject->validateAdd($entry);
+    }
+
+    public function test_add_no_user_modification_attribute_throws_constraint_violation(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'top', 'person'),
+            new Attribute('cn', 'Alice'),
+            new Attribute('sn', 'Smith'),
+            new Attribute('createTimestamp', '20240101000000Z'),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::CONSTRAINT_VIOLATION);
+
+        $this->subject->validateAdd($entry);
+    }
+
+    public function test_add_extensible_object_bypasses_attribute_checks(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'extensibleObject'),
+            new Attribute('anyAttr', 'value'),
+        );
+
+        $this->expectNotToPerformAssertions();
+        $this->subject->validateAdd($entry);
+    }
+
+    public function test_valid_modify_passes(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $command = new UpdateCommand(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            [Change::replace(new Attribute('sn', 'Jones'))],
+        );
+        $result = $this->personEntry();
+
+        $this->subject->validateModify($command, $result);
+    }
+
+    public function test_modify_no_user_modification_attribute_throws_constraint_violation(): void
+    {
+        $command = new UpdateCommand(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            [Change::replace(new Attribute('createTimestamp', '20240101000000Z'))],
+        );
+        $result = $this->personEntry();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::CONSTRAINT_VIOLATION);
+
+        $this->subject->validateModify($command, $result);
+    }
+
+    public function test_off_mode_does_not_throw_on_violations(): void
+    {
+        $subject = new SchemaValidator(
+            StandardSchemaProvider::buildCore(),
+            SchemaValidationMode::Off,
+        );
+
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'top'),
+        );
+
+        $this->expectNotToPerformAssertions();
+        $subject->validateAdd($entry);
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
@@ -22,6 +22,9 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Search\Filter\PresentFilter;
+use FreeDSx\Ldap\Schema\SchemaValidationMode;
+use FreeDSx\Ldap\Schema\StandardSchemaProvider;
+use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
@@ -754,6 +757,70 @@ final class WritableStorageBackendTest extends TestCase
             'client limit used when below server max'          => [5, 3, 3],
             'no server cap preserves client limit'             => [0, 10, 10],
         ];
+    }
+
+    public function test_add_with_validator_rejects_invalid_entry(): void
+    {
+        $backend = new WritableStorageBackend(
+            storage: new InMemoryStorage([$this->base]),
+            validator: new SchemaValidator(
+                StandardSchemaProvider::buildCore(),
+                SchemaValidationMode::Strict,
+            ),
+        );
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
+
+        $backend->add(new AddCommand(new Entry(
+            new Dn('cn=Invalid,dc=example,dc=com'),
+            new Attribute('cn', 'Invalid'),
+        )));
+    }
+
+    public function test_add_with_validator_accepts_valid_entry(): void
+    {
+        $backend = new WritableStorageBackend(
+            storage: new InMemoryStorage([$this->base]),
+            validator: new SchemaValidator(
+                StandardSchemaProvider::buildCore(),
+                SchemaValidationMode::Strict,
+            ),
+        );
+
+        $backend->add(new AddCommand(new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'top', 'person'),
+            new Attribute('cn', 'Alice'),
+            new Attribute('sn', 'Smith'),
+        )));
+
+        self::assertNotNull($backend->get(new Dn('cn=Alice,dc=example,dc=com')));
+    }
+
+    public function test_update_with_validator_rejects_invalid_modification(): void
+    {
+        $valid = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'top', 'person'),
+            new Attribute('cn', 'Alice'),
+            new Attribute('sn', 'Smith'),
+        );
+        $backend = new WritableStorageBackend(
+            storage: new InMemoryStorage([$this->base, $valid]),
+            validator: new SchemaValidator(
+                StandardSchemaProvider::buildCore(),
+                SchemaValidationMode::Strict,
+            ),
+        );
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::CONSTRAINT_VIOLATION);
+
+        $backend->update(new UpdateCommand(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            [Change::replace(new Attribute('createTimestamp', '20240101000000Z'))],
+        ));
     }
 
     /**

--- a/tests/unit/Server/Backend/Storage/FilterEvaluatorTest.php
+++ b/tests/unit/Server/Backend/Storage/FilterEvaluatorTest.php
@@ -24,6 +24,7 @@ use FreeDSx\Ldap\Search\Filter\MatchingRuleFilter;
 use FreeDSx\Ldap\Search\Filter\PresentFilter;
 use FreeDSx\Ldap\Search\Filter\SubstringFilter;
 use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Schema\StandardSchemaProvider;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluator;
 use PHPUnit\Framework\TestCase;
 
@@ -858,5 +859,76 @@ final class FilterEvaluatorTest extends TestCase
             $snapshot,
             serialize($filter),
         );
+    }
+
+    public function test_schema_equality_uses_octet_string_match_for_userpassword(): void
+    {
+        $subject = new FilterEvaluator(StandardSchemaProvider::buildCore());
+        $entry = new Entry(
+            new Dn('cn=Test,dc=example,dc=com'),
+            new Attribute('userPassword', 'Secret'),
+        );
+
+        self::assertTrue(
+            $subject->evaluate($entry, Filters::equal('userPassword', 'Secret'))
+        );
+        self::assertFalse(
+            $subject->evaluate($entry, Filters::equal('userPassword', 'secret'))
+        );
+    }
+
+    public function test_equality_without_schema_falls_back_to_case_ignore_for_userpassword(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Test,dc=example,dc=com'),
+            new Attribute('userPassword', 'Secret'),
+        );
+
+        self::assertTrue(
+            $this->subject->evaluate($entry, Filters::equal('userPassword', 'secret'))
+        );
+    }
+
+    public function test_schema_matching_rule_filter_resolves_non_hardcoded_oid(): void
+    {
+        $subject = new FilterEvaluator(StandardSchemaProvider::buildCore());
+        $entry = new Entry(
+            new Dn('cn=Test,dc=example,dc=com'),
+            new Attribute('uidNumber', '1001'),
+        );
+
+        self::assertTrue($subject->evaluate(
+            $entry,
+            new MatchingRuleFilter('2.5.13.14', 'uidNumber', '1001'),
+        ));
+        self::assertFalse($subject->evaluate(
+            $entry,
+            new MatchingRuleFilter('2.5.13.14', 'uidNumber', '1002'),
+        ));
+    }
+
+    public function test_without_schema_non_hardcoded_matching_rule_throws_inappropriate_matching(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INAPPROPRIATE_MATCHING);
+
+        $this->subject->evaluate(
+            $this->entry,
+            new MatchingRuleFilter('2.5.13.14', 'cn', 'Alice'),
+        );
+    }
+
+    public function test_schema_gte_uses_digit_heuristic_for_attribute_unknown_to_schema(): void
+    {
+        $subject = new FilterEvaluator(StandardSchemaProvider::buildCore());
+        $entry = new Entry(
+            new Dn('cn=Test,dc=example,dc=com'),
+            new Attribute('uidNumber', '99'),
+        );
+
+        self::assertFalse($subject->evaluate(
+            $entry,
+            Filters::greaterThanOrEqual('uidNumber', '100')
+        ));
     }
 }


### PR DESCRIPTION
Now that the backend actually has persistence built-in, and we are already handling that logic, it makes sense to integrate a schema per RFC 4512. This way library users can define an explicit schema that clients must adhere to. Otherwise currently there's nothing preventing any client to write anything they want to any entry.

This also helps lay the foundation for put in some kind of ACL, or at least a decision hook, for restricting entry modifications / access based on the authenticated client.

So this does the following:
* Adds the base schema models / DTOs.
* Adds a way to set them in the server options.
* Exposes it in the sub-schema entry so it's discoverable by clients.
* Enforces schema validation on filter evaluation and writes.

Explicitly ignoring LDIF for now. I can always add it later. This was already a lot of files to properly support this.