### PR TITLE
[1.0.0] Add operational attributes to the server.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,12 +59,17 @@
   "scripts": {
     "test-coverage": [
       "@php -d xdebug.mode=coverage vendor/bin/phpunit --testsuite unit --coverage-clover=coverage-unit.xml",
-      "@php -d xdebug.mode=coverage vendor/bin/phpunit --testsuite integration --coverage-clover=coverage-integration.xml"
+      "@php -d xdebug.mode=coverage vendor/bin/phpunit --testsuite integration --coverage-clover=coverage-integration.xml",
+      "@php -d xdebug.mode=coverage vendor/bin/phpunit --testsuite integration-openldap --coverage-clover=coverage-integration-openldap.xml"
     ],
     "test-unit": [
       "@php -d xdebug.mode=off vendor/bin/phpunit --testsuite unit"
     ],
     "test-integration": [
+      "@php -d xdebug.mode=off vendor/bin/phpunit --testsuite integration",
+      "@php -d xdebug.mode=off vendor/bin/phpunit --testsuite integration-openldap"
+    ],
+    "test-integration-server": [
       "@php -d xdebug.mode=off vendor/bin/phpunit --testsuite integration"
     ],
     "test-integration-local": [

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=8.2",
     "freedsx/asn1": "dev-main#46900759ae89b9e709356a86c1d84056c2e7ff67",
-    "freedsx/socket": "dev-main#0e43af8f6af64de9ef3a730d3128e6c12134bc5e",
+    "freedsx/socket": "dev-main#cb6f5b4",
     "freedsx/sasl": "dev-main#85e1ef9",
     "psr/log": "^3"
   },

--- a/docs/Server/General-Usage.md
+++ b/docs/Server/General-Usage.md
@@ -336,6 +336,7 @@ use FreeDSx\Ldap\Server\Backend\Write\Command\MoveCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 use FreeDSx\Ldap\Server\Backend\Write\WritableBackendTrait;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use Generator;
 
 class MyBackend implements WritableLdapBackendInterface
@@ -379,24 +380,33 @@ class MyBackend implements WritableLdapBackendInterface
         return $attribute !== null && $attribute->has($filter->getValue());
     }
 
-    public function add(AddCommand $command): void
-    {
-        // $command->entry — Entry to persist
+    public function add(
+        AddCommand $command,
+        WriteContext $context,
+    ): void {
+        // $command->entry        — Entry to persist
+        // $context->getBoundDn() — ?string: DN of the authenticated user, or null for anonymous
     }
 
-    public function delete(DeleteCommand $command): void
-    {
+    public function delete(
+        DeleteCommand $command,
+        WriteContext $context,
+    ): void {
         // $command->dn — Dn of the entry to remove
     }
 
-    public function update(UpdateCommand $command): void
-    {
+    public function update(
+        UpdateCommand $command,
+        WriteContext $context,
+    ): void {
         // $command->dn      — Dn of the entry to modify
         // $command->changes — Change[] of attribute changes to apply
     }
 
-    public function move(MoveCommand $command): void
-    {
+    public function move(
+        MoveCommand $command,
+        WriteContext $context,
+    ): void {
         // $command->dn           — Dn: current entry DN
         // $command->newRdn       — Rdn: new relative DN
         // $command->deleteOldRdn — bool: whether to remove the old RDN attribute value

--- a/docs/Server/Schema.md
+++ b/docs/Server/Schema.md
@@ -9,6 +9,7 @@ Schema Validation
     * [ServerOptions:setSchemaValidationMode](#setschemavalidationmode)
 * [Custom Schema](#custom-schema)
     * [ServerOptions:setSchema](#setschema)
+* [Operational Attributes](#operational-attributes)
 
 Calling `LdapServer::useStorage()` automatically enables schema validation using the built-in RFC 4519
 schema in `Strict` mode.
@@ -130,4 +131,27 @@ $schema = StandardSchemaProvider::buildCore()->merge(
 );
 
 $options = (new ServerOptions())->setSchema($schema);
+
+## Operational Attributes
+
+`useStorage()` automatically populates and maintains server-managed operational attributes on every write. Clients
+cannot modify these — they are flagged `NO-USER-MODIFICATION` in the schema and client attempts are rejected with
+`constraintViolation`.
+
+**Set on `add`:**
+
+| Attribute | Value |
+|---|---|
+| `createTimestamp` | Current UTC time (`YYYYMMDDHHmmssZ`). |
+| `modifyTimestamp` | Same as `createTimestamp` at add time. |
+| `creatorsName` | DN of the bound user, or an empty string for anonymous. |
+| `modifiersName` | Same as `creatorsName` at add time. |
+| `entryUUID` | Random UUID v4 (RFC 4122). |
+| `structuralObjectClass` | Most-specific structural objectClass. Only set when schema validation is enabled. |
+
+**Updated on `modify` and `move`:** `modifyTimestamp` and `modifiersName` are refreshed. All other operational
+attributes remain unchanged.
+
+**`hasSubordinates` (dynamic):** Never stored. Injected into search results when requested via the `+` shorthand
+or by name. Value is `TRUE` if the entry has at least one direct child, `FALSE` otherwise.
 ```

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,16 @@
   <testsuites>
     <testsuite name="integration">
       <directory>./tests/integration</directory>
+      <exclude>./tests/integration/LdapClientTest.php</exclude>
+      <exclude>./tests/integration/LdapClientReferralTest.php</exclude>
+      <exclude>./tests/integration/Search</exclude>
+      <exclude>./tests/integration/Sync</exclude>
+    </testsuite>
+    <testsuite name="integration-openldap">
+      <file>./tests/integration/LdapClientTest.php</file>
+      <file>./tests/integration/LdapClientReferralTest.php</file>
+      <directory>./tests/integration/Search</directory>
+      <directory>./tests/integration/Sync</directory>
     </testsuite>
     <testsuite name="unit">
       <directory>./tests/unit</directory>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -26,5 +26,6 @@
         <exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/>
         <!-- PER CS 3.0 types_spaces enforces no spaces in union/intersection types; phpcs cannot distinguish type-union | from bitwise | -->
         <exclude name="PSR12.Operators.OperatorSpacing"/>
+        <exclude name="Generic.Files.LineLength"/>
     </rule>
 </ruleset>

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\OperationalAttributeGenerator;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
@@ -77,11 +78,16 @@ class LdapServer
      */
     public function useStorage(EntryStorageInterface $storage): self
     {
+        $schema = $this->options->getSchemaValidationMode() !== SchemaValidationMode::Off
+            ? $this->options->getSchema()
+            : null;
+
         return $this->useBackend(new WritableStorageBackend(
             storage: $storage,
             limits: $this->options->makeSearchLimits(),
             namingContexts: $this->options->getDseNamingContexts(),
             validator: $this->buildSchemaValidator(),
+            operationalAttrs: new OperationalAttributeGenerator($schema),
         ));
     }
 

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -22,6 +22,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteCommandFactory;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
@@ -64,7 +65,13 @@ class ServerDispatchHandler implements ServerProtocolHandlerInterface
                 return;
             }
 
-            $this->writeDispatcher->dispatch($this->commandFactory->fromRequest($request));
+            $this->writeDispatcher->dispatch(
+                $this->commandFactory->fromRequest($request),
+                new WriteContext(
+                    $token,
+                    $message->controls(),
+                ),
+            );
 
             $this->queue->sendMessage($this->responseFactory->getStandardResponse($message));
         } catch (OperationException $e) {

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/OperationalAttributeGenerator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/OperationalAttributeGenerator.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage;
+
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
+use FreeDSx\Ldap\Schema\Definition\ObjectClass;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassType;
+use FreeDSx\Ldap\Schema\Schema;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
+
+/**
+ * Injects server-managed operational attributes into entries on write.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class OperationalAttributeGenerator
+{
+    public function __construct(
+        private readonly ?Schema $schema = null,
+    ) {}
+
+    /**
+     * Sets createTimestamp, modifyTimestamp, creatorsName, modifiersName, entryUUID, and structuralObjectClass.
+     */
+    public function applyForAdd(
+        Entry $entry,
+        WriteContext $context,
+    ): void {
+        $timestamp = $this->generateTimestamp();
+        $boundDn = $context->getBoundDn() ?? '';
+
+        $entry->set(
+            AttributeTypeOid::NAME_CREATE_TIMESTAMP,
+            $timestamp,
+        );
+        $entry->set(
+            AttributeTypeOid::NAME_MODIFY_TIMESTAMP,
+            $timestamp,
+        );
+        $entry->set(
+            AttributeTypeOid::NAME_CREATORS_NAME,
+            $boundDn,
+        );
+        $entry->set(
+            AttributeTypeOid::NAME_MODIFIERS_NAME,
+            $boundDn,
+        );
+        $entry->set(
+            AttributeTypeOid::NAME_ENTRY_UUID,
+            $this->generateUuid(),
+        );
+
+        $structuralOc = $this->resolveStructuralObjectClass($entry);
+
+        if ($structuralOc !== null) {
+            $entry->set(
+                AttributeTypeOid::NAME_STRUCTURAL_OBJECT_CLASS,
+                $structuralOc,
+            );
+        }
+    }
+
+    /**
+     * Updates modifyTimestamp and modifiersName only.
+     */
+    public function applyForModify(
+        Entry $entry,
+        WriteContext $context,
+    ): void {
+        $entry->set(
+            AttributeTypeOid::NAME_MODIFY_TIMESTAMP,
+            $this->generateTimestamp(),
+        );
+        $entry->set(
+            AttributeTypeOid::NAME_MODIFIERS_NAME,
+            $context->getBoundDn() ?? '',
+        );
+    }
+
+    private function generateTimestamp(): string
+    {
+        return gmdate('YmdHis') . 'Z';
+    }
+
+    private function generateUuid(): string
+    {
+        $bytes = random_bytes(16);
+
+        // Set version 4 and RFC 4122 variant bits.
+        $bytes[6] = chr(ord($bytes[6]) & 0x0f | 0x40);
+        $bytes[8] = chr(ord($bytes[8]) & 0x3f | 0x80);
+
+        return vsprintf(
+            '%s%s-%s-%s-%s-%s%s%s',
+            str_split(
+                bin2hex($bytes),
+                4,
+            ),
+        );
+    }
+
+    private function resolveStructuralObjectClass(Entry $entry): ?string
+    {
+        if ($this->schema === null) {
+            return null;
+        }
+
+        $objectClassAttr = $entry->get(
+            'objectClass',
+            true,
+        );
+
+        if ($objectClassAttr === null) {
+            return null;
+        }
+
+        $structural = $this->collectStructuralClasses(
+            $this->schema,
+            $objectClassAttr->getValues(),
+        );
+
+        if ($structural === []) {
+            return null;
+        }
+
+        foreach ($structural as $candidate) {
+            if (!$this->isSuperclassOfAny($candidate, $structural, $this->schema)) {
+                return $candidate->names[0] ?? $candidate->oid;
+            }
+        }
+
+        $first = array_values($structural)[0];
+
+        return $first->names[0] ?? $first->oid;
+    }
+
+    /**
+     * @param string[] $names
+     * @return array<string, ObjectClass>
+     */
+    private function collectStructuralClasses(
+        Schema $schema,
+        array $names,
+    ): array {
+        $structural = [];
+
+        foreach ($names as $name) {
+            $oc = $schema->getObjectClass($name);
+
+            if ($oc === null || $oc->type !== ObjectClassType::StructuralClass) {
+                continue;
+            }
+
+            $structural[$oc->oid] = $oc;
+        }
+
+        return $structural;
+    }
+
+    /**
+     * @param array<string, ObjectClass> $structural
+     */
+    private function isSuperclassOfAny(
+        ObjectClass $candidate,
+        array $structural,
+        Schema $schema,
+    ): bool {
+        foreach ($structural as $other) {
+            if ($other->oid === $candidate->oid) {
+                continue;
+            }
+
+            if ($this->isDirectSuperclassOf($candidate, $other, $schema)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isDirectSuperclassOf(
+        ObjectClass $candidate,
+        ObjectClass $other,
+        Schema $schema,
+    ): bool {
+        foreach ($other->superClassOids as $superOid) {
+            $resolved = $schema->getObjectClass($superOid);
+
+            if ($resolved !== null && $resolved->oid === $candidate->oid) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/SearchStreamBuilder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/SearchStreamBuilder.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage;
+
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
+use FreeDSx\Ldap\Server\SearchLimits;
+use Generator;
+
+/**
+ * Builds EntryStreams for search operations.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class SearchStreamBuilder
+{
+    public function __construct(
+        private EntryStorageInterface $storage,
+        private SearchLimits $limits = new SearchLimits(),
+    ) {}
+
+    public function effectiveTimeLimit(int $requestLimit): int
+    {
+        $serverMax = $this->limits->maxSearchTimeLimit;
+
+        if ($serverMax === 0) {
+            return $requestLimit;
+        }
+
+        if ($requestLimit === 0) {
+            return $serverMax;
+        }
+
+        return min(
+            $requestLimit,
+            $serverMax,
+        );
+    }
+
+    public function buildForBaseObject(
+        Entry $entry,
+        SearchRequest $request,
+    ): EntryStream {
+        $entry = $this->requestsHasSubordinates($request)
+            ? $this->injectHasSubordinates($entry)
+            : $entry;
+
+        return new EntryStream($this->yieldSingle($entry));
+    }
+
+    /**
+     * @throws OperationException
+     */
+    public function buildForList(
+        EntryStream $stream,
+        SearchRequest $request,
+    ): EntryStream {
+        $generator = $this->wrapWithTimeLimitHandling($stream->entries);
+
+        if ($this->requestsHasSubordinates($request)) {
+            $generator = $this->wrapWithHasSubordinates($generator);
+        }
+
+        return new EntryStream(
+            $generator,
+            $stream->isPreFiltered,
+        );
+    }
+
+    private function requestsHasSubordinates(SearchRequest $request): bool
+    {
+        foreach ($request->getAttributes() as $attr) {
+            if ($this->isHasSubordinatesAttribute($attr)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isHasSubordinatesAttribute(Attribute $attr): bool
+    {
+        return strcasecmp($attr->getName(), '+') === 0
+            || strcasecmp($attr->getName(), 'hasSubordinates') === 0;
+    }
+
+    private function injectHasSubordinates(Entry $entry): Entry
+    {
+        $clone = clone $entry;
+        $clone->set(
+            'hasSubordinates',
+            $this->storage->hasChildren($entry->getDn())
+                ? 'TRUE'
+                : 'FALSE',
+        );
+
+        return $clone;
+    }
+
+    /**
+     * @param Generator<Entry> $generator
+     * @return Generator<Entry>
+     */
+    private function wrapWithHasSubordinates(Generator $generator): Generator
+    {
+        foreach ($generator as $entry) {
+            yield $this->injectHasSubordinates($entry);
+        }
+    }
+
+    /**
+     * @param Generator<Entry> $generator
+     * @return Generator<Entry>
+     * @throws OperationException
+     */
+    private function wrapWithTimeLimitHandling(Generator $generator): Generator
+    {
+        try {
+            foreach ($generator as $entry) {
+                yield $entry;
+            }
+        } catch (TimeLimitExceededException) {
+            throw new OperationException(
+                'Time limit exceeded.',
+                ResultCode::TIME_LIMIT_EXCEEDED,
+            );
+        }
+    }
+
+    /**
+     * @return Generator<Entry>
+     */
+    private function yieldSingle(Entry $entry): Generator
+    {
+        yield $entry;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage;
 
 use FreeDSx\Ldap\Control\ControlBag;
-use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -29,14 +28,12 @@ use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\DnTooLongException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\InvalidAttributeException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
-use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
 use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\Backend\Write\WritableBackendTrait;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Backend\ResettableInterface;
 use FreeDSx\Ldap\Server\SearchLimits;
-use Generator;
 
 /**
  * Applies LDAP semantics over a pluggable EntryStorageInterface; writes are routed through EntryStorageInterface::atomic().
@@ -52,22 +49,28 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
      */
     private readonly array $namingContexts;
 
+    private readonly SearchStreamBuilder $searchStream;
+
     /**
      * @param string[] $namingContexts DN strings that may not be deleted.
      */
     public function __construct(
         private readonly EntryStorageInterface $storage,
-        private readonly WriteEntryOperationHandler $entryHandler = new WriteEntryOperationHandler(),
         private readonly SearchLimits $limits = new SearchLimits(),
-        array $namingContexts = [],
         private readonly ?SchemaValidator $validator = null,
+        array $namingContexts = [],
         private readonly OperationalAttributeGenerator $operationalAttrs = new OperationalAttributeGenerator(),
+        private readonly WriteEntryOperationHandler $entryHandler = new WriteEntryOperationHandler(),
     ) {
         $normalised = [];
         foreach ($namingContexts as $namingContext) {
             $normalised[(new Dn($namingContext))->normalize()->toString()] = true;
         }
         $this->namingContexts = $normalised;
+        $this->searchStream = new SearchStreamBuilder(
+            $this->storage,
+            $this->limits,
+        );
     }
 
     public function reset(): void
@@ -120,8 +123,6 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         $baseDn = $request->getBaseDn() ?? new Dn('');
         $normBase = $baseDn->normalize();
 
-        $wantHasSubordinates = $this->requestsHasSubordinates($request);
-
         if ($request->getScope() === SearchRequest::SCOPE_BASE_OBJECT) {
             $entry = $this->storage->find($normBase);
 
@@ -129,9 +130,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
                 $this->throwNoSuchObject($baseDn);
             }
 
-            $entry = $wantHasSubordinates ? $this->injectHasSubordinates($entry) : $entry;
-
-            return new EntryStream($this->yieldSingle($entry));
+            return $this->searchStream->buildForBaseObject(
+                $entry,
+                $request,
+            );
         }
 
         if (!$this->storage->exists($normBase)) {
@@ -143,7 +145,7 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             baseDn: $normBase,
             subtree: $subtree,
             filter: $request->getFilter(),
-            timeLimit: $this->effectiveTimeLimit($request->getTimeLimit()),
+            timeLimit: $this->searchStream->effectiveTimeLimit($request->getTimeLimit()),
             sizeLimit: $request->getSizeLimit(),
         );
 
@@ -157,105 +159,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             );
         }
 
-        $generator = $this->wrapWithTimeLimitHandling($stream->entries);
-
-        if ($wantHasSubordinates) {
-            $generator = $this->wrapWithHasSubordinates($generator);
-        }
-
-        return new EntryStream(
-            $generator,
-            $stream->isPreFiltered,
+        return $this->searchStream->buildForList(
+            $stream,
+            $request,
         );
-    }
-
-    /**
-     * @return Generator<Entry>
-     */
-    private function yieldSingle(Entry $entry): Generator
-    {
-        yield $entry;
-    }
-
-    /**
-     * Clones the entry and injects the hasSubordinates value.
-     */
-    private function injectHasSubordinates(Entry $entry): Entry
-    {
-        $clone = clone $entry;
-        $clone->set(
-            'hasSubordinates',
-            $this->storage->hasChildren($entry->getDn()) ? 'TRUE' : 'FALSE',
-        );
-
-        return $clone;
-    }
-
-    /**
-     * @param Generator<Entry> $generator
-     * @return Generator<Entry>
-     */
-    private function wrapWithHasSubordinates(Generator $generator): Generator
-    {
-        foreach ($generator as $entry) {
-            yield $this->injectHasSubordinates($entry);
-        }
-    }
-
-    private function requestsHasSubordinates(SearchRequest $request): bool
-    {
-        foreach ($request->getAttributes() as $attr) {
-            if ($this->isHasSubordinatesAttribute($attr)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function isHasSubordinatesAttribute(Attribute $attr): bool
-    {
-        return strcasecmp($attr->getName(), '+') === 0
-            || strcasecmp($attr->getName(), 'hasSubordinates') === 0;
-    }
-
-    private function effectiveTimeLimit(int $requestLimit): int
-    {
-        $serverMax = $this->limits->maxSearchTimeLimit;
-
-        if ($serverMax === 0) {
-            return $requestLimit;
-        }
-
-        if ($requestLimit === 0) {
-            return $serverMax;
-        }
-
-        return min(
-            $requestLimit,
-            $serverMax,
-        );
-    }
-
-    /**
-     * Converts TimeLimitExceededException from the storage generator into an LDAP OperationException.
-     *
-     * @param Generator<Entry> $generator
-     * @return Generator<Entry>
-     * @throws OperationException
-     */
-    private function wrapWithTimeLimitHandling(Generator $generator): Generator
-    {
-        try {
-            foreach ($generator as $entry) {
-                yield $entry;
-            }
-        } catch (TimeLimitExceededException) {
-            throw new OperationException(
-                'Time limit exceeded.',
-                ResultCode::TIME_LIMIT_EXCEEDED,
-            );
-        }
     }
 
     /**
@@ -265,8 +172,6 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         AddCommand $command,
         WriteContext $context,
     ): void {
-        $this->validator?->validateAdd($command->entry);
-
         $this->writeAtomic(function (EntryStorageInterface $storage) use ($command, $context): void {
             $dn = $command->entry->getDn()->normalize();
             $this->assertParentExists($storage, $dn);
@@ -275,6 +180,7 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
                 $this->throwEntryAlreadyExists($command->entry->getDn());
             }
 
+            $this->validator?->validateAdd($command->entry);
             $this->operationalAttrs->applyForAdd(
                 $command->entry,
                 $context,

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage;
 
 use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -32,6 +33,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
 use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\Backend\Write\WritableBackendTrait;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Backend\ResettableInterface;
 use FreeDSx\Ldap\Server\SearchLimits;
 use Generator;
@@ -59,6 +61,7 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         private readonly SearchLimits $limits = new SearchLimits(),
         array $namingContexts = [],
         private readonly ?SchemaValidator $validator = null,
+        private readonly OperationalAttributeGenerator $operationalAttrs = new OperationalAttributeGenerator(),
     ) {
         $normalised = [];
         foreach ($namingContexts as $namingContext) {
@@ -117,12 +120,16 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         $baseDn = $request->getBaseDn() ?? new Dn('');
         $normBase = $baseDn->normalize();
 
+        $wantHasSubordinates = $this->requestsHasSubordinates($request);
+
         if ($request->getScope() === SearchRequest::SCOPE_BASE_OBJECT) {
             $entry = $this->storage->find($normBase);
 
             if ($entry === null) {
                 $this->throwNoSuchObject($baseDn);
             }
+
+            $entry = $wantHasSubordinates ? $this->injectHasSubordinates($entry) : $entry;
 
             return new EntryStream($this->yieldSingle($entry));
         }
@@ -150,8 +157,14 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             );
         }
 
+        $generator = $this->wrapWithTimeLimitHandling($stream->entries);
+
+        if ($wantHasSubordinates) {
+            $generator = $this->wrapWithHasSubordinates($generator);
+        }
+
         return new EntryStream(
-            $this->wrapWithTimeLimitHandling($stream->entries),
+            $generator,
             $stream->isPreFiltered,
         );
     }
@@ -162,6 +175,48 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
     private function yieldSingle(Entry $entry): Generator
     {
         yield $entry;
+    }
+
+    /**
+     * Clones the entry and injects the hasSubordinates value.
+     */
+    private function injectHasSubordinates(Entry $entry): Entry
+    {
+        $clone = clone $entry;
+        $clone->set(
+            'hasSubordinates',
+            $this->storage->hasChildren($entry->getDn()) ? 'TRUE' : 'FALSE',
+        );
+
+        return $clone;
+    }
+
+    /**
+     * @param Generator<Entry> $generator
+     * @return Generator<Entry>
+     */
+    private function wrapWithHasSubordinates(Generator $generator): Generator
+    {
+        foreach ($generator as $entry) {
+            yield $this->injectHasSubordinates($entry);
+        }
+    }
+
+    private function requestsHasSubordinates(SearchRequest $request): bool
+    {
+        foreach ($request->getAttributes() as $attr) {
+            if ($this->isHasSubordinatesAttribute($attr)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isHasSubordinatesAttribute(Attribute $attr): bool
+    {
+        return strcasecmp($attr->getName(), '+') === 0
+            || strcasecmp($attr->getName(), 'hasSubordinates') === 0;
     }
 
     private function effectiveTimeLimit(int $requestLimit): int
@@ -206,11 +261,13 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
     /**
      * @throws OperationException
      */
-    public function add(AddCommand $command): void
-    {
+    public function add(
+        AddCommand $command,
+        WriteContext $context,
+    ): void {
         $this->validator?->validateAdd($command->entry);
 
-        $this->writeAtomic(function (EntryStorageInterface $storage) use ($command): void {
+        $this->writeAtomic(function (EntryStorageInterface $storage) use ($command, $context): void {
             $dn = $command->entry->getDn()->normalize();
             $this->assertParentExists($storage, $dn);
 
@@ -218,6 +275,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
                 $this->throwEntryAlreadyExists($command->entry->getDn());
             }
 
+            $this->operationalAttrs->applyForAdd(
+                $command->entry,
+                $context,
+            );
             $storage->store($command->entry);
         });
     }
@@ -225,8 +286,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
     /**
      * @throws OperationException
      */
-    public function delete(DeleteCommand $command): void
-    {
+    public function delete(
+        DeleteCommand $command,
+        WriteContext $context,
+    ): void {
         $this->assertNotNamingContext($command->dn);
 
         $this->writeAtomic(function (EntryStorageInterface $storage) use ($command): void {
@@ -250,13 +313,19 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
     /**
      * @throws OperationException
      */
-    public function update(UpdateCommand $command): void
-    {
-        $this->writeAtomic(function (EntryStorageInterface $storage) use ($command): void {
+    public function update(
+        UpdateCommand $command,
+        WriteContext $context,
+    ): void {
+        $this->writeAtomic(function (EntryStorageInterface $storage) use ($command, $context): void {
             $dn = $command->dn->normalize();
             $entry = $this->findOrFail($storage, $dn);
             $updated = $this->entryHandler->apply($entry, $command);
             $this->validator?->validateModify($command, $updated);
+            $this->operationalAttrs->applyForModify(
+                $updated,
+                $context,
+            );
             $storage->store($updated);
         });
     }
@@ -264,11 +333,13 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
     /**
      * @throws OperationException
      */
-    public function move(MoveCommand $command): void
-    {
+    public function move(
+        MoveCommand $command,
+        WriteContext $context,
+    ): void {
         $this->assertNotNamingContext($command->dn);
 
-        $this->writeAtomic(function (EntryStorageInterface $storage) use ($command): void {
+        $this->writeAtomic(function (EntryStorageInterface $storage) use ($command, $context): void {
             $normOld = $command->dn->normalize();
             $entry = $this->findOrFail($storage, $normOld);
 
@@ -288,6 +359,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
                 $this->throwEntryAlreadyExists($newEntry->getDn());
             }
 
+            $this->operationalAttrs->applyForModify(
+                $newEntry,
+                $context,
+            );
             $storage->remove($normOld);
             $storage->store($newEntry);
         });

--- a/src/FreeDSx/Ldap/Server/Backend/Write/WritableBackendTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/WritableBackendTrait.php
@@ -33,24 +33,50 @@ trait WritableBackendTrait
             || $request instanceof MoveCommand;
     }
 
-    public function handle(WriteRequestInterface $request): void
-    {
+    public function handle(
+        WriteRequestInterface $request,
+        WriteContext $context,
+    ): void {
         if ($request instanceof AddCommand) {
-            $this->add($request);
+            $this->add(
+                $request,
+                $context,
+            );
         } elseif ($request instanceof DeleteCommand) {
-            $this->delete($request);
+            $this->delete(
+                $request,
+                $context,
+            );
         } elseif ($request instanceof UpdateCommand) {
-            $this->update($request);
+            $this->update(
+                $request,
+                $context,
+            );
         } elseif ($request instanceof MoveCommand) {
-            $this->move($request);
+            $this->move(
+                $request,
+                $context,
+            );
         }
     }
 
-    abstract public function add(AddCommand $command): void;
+    abstract public function add(
+        AddCommand $command,
+        WriteContext $context,
+    ): void;
 
-    abstract public function delete(DeleteCommand $command): void;
+    abstract public function delete(
+        DeleteCommand $command,
+        WriteContext $context,
+    ): void;
 
-    abstract public function update(UpdateCommand $command): void;
+    abstract public function update(
+        UpdateCommand $command,
+        WriteContext $context,
+    ): void;
 
-    abstract public function move(MoveCommand $command): void;
+    abstract public function move(
+        MoveCommand $command,
+        WriteContext $context,
+    ): void;
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Write/WriteContext.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/WriteContext.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Write;
+
+use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * Carries request-scoped metadata (identity, controls) for write operations.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class WriteContext
+{
+    public function __construct(
+        private TokenInterface $token,
+        private ControlBag $controls,
+    ) {}
+
+    /**
+     * Bound DN of the authenticated user, or null for anonymous.
+     */
+    public function getBoundDn(): ?string
+    {
+        return $this->token->getUsername();
+    }
+
+    public function isAnonymous(): bool
+    {
+        return $this->token->getUsername() === null;
+    }
+
+    public function getLdapVersion(): int
+    {
+        return $this->token->getVersion();
+    }
+
+    public function getControls(): ControlBag
+    {
+        return $this->controls;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Write/WriteHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/WriteHandlerInterface.php
@@ -22,5 +22,8 @@ interface WriteHandlerInterface
 {
     public function supports(WriteRequestInterface $request): bool;
 
-    public function handle(WriteRequestInterface $request): void;
+    public function handle(
+        WriteRequestInterface $request,
+        WriteContext $context,
+    ): void;
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Write/WriteOperationDispatcher.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/WriteOperationDispatcher.php
@@ -36,11 +36,16 @@ final class WriteOperationDispatcher
     /**
      * @throws OperationException
      */
-    public function dispatch(WriteRequestInterface $request): void
-    {
+    public function dispatch(
+        WriteRequestInterface $request,
+        WriteContext $context,
+    ): void {
         foreach ($this->handlers as $handler) {
             if ($handler->supports($request)) {
-                $handler->handle($request);
+                $handler->handle(
+                    $request,
+                    $context,
+                );
 
                 return;
             }

--- a/src/FreeDSx/Ldap/Server/RequestHandler/ProxyBackend.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/ProxyBackend.php
@@ -34,6 +34,7 @@ use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Write\WritableBackendTrait;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use Generator;
 use SensitiveParameter;
 
@@ -129,26 +130,34 @@ class ProxyBackend implements WritableLdapBackendInterface, PasswordAuthenticata
         return null;
     }
 
-    public function add(AddCommand $command): void
-    {
+    public function add(
+        AddCommand $command,
+        WriteContext $context,
+    ): void {
         $this->ldap()->sendAndReceive(Operations::add($command->entry));
     }
 
-    public function delete(DeleteCommand $command): void
-    {
+    public function delete(
+        DeleteCommand $command,
+        WriteContext $context,
+    ): void {
         $this->ldap()->sendAndReceive(Operations::delete($command->dn->toString()));
     }
 
-    public function update(UpdateCommand $command): void
-    {
+    public function update(
+        UpdateCommand $command,
+        WriteContext $context,
+    ): void {
         $this->ldap()->sendAndReceive(new ModifyRequest(
             $command->dn->toString(),
             ...$command->changes,
         ));
     }
 
-    public function move(MoveCommand $command): void
-    {
+    public function move(
+        MoveCommand $command,
+        WriteContext $context,
+    ): void {
         $this->ldap()->sendAndReceive(new ModifyDnRequest(
             dn: $command->dn->toString(),
             newRdn: $command->newRdn->toString(),

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -345,6 +345,9 @@ class PcntlServerRunner implements ServerRunnerInterface
         Socket $socket,
         int $pid,
     ): never {
+        // Cleanup the child's inherited FD copy without shutting down the parent accept loop.
+        $this->server->close(shutdown: false);
+
         $context = ['pid' => $pid];
         $this->isMainProcess = false;
         $backend = $this->options->getBackend();

--- a/tests/bin/ldap-server.php
+++ b/tests/bin/ldap-server.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Server\Backend\Write\Command\MoveCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 use FreeDSx\Ldap\Server\Backend\Write\WritableBackendTrait;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\ServerOptions;
 
 require __DIR__ . '/../../vendor/autoload.php';
@@ -112,8 +113,10 @@ class LdapServerBackend implements WritableLdapBackendInterface, PasswordAuthent
         return isset($this->users[$name]) && $this->users[$name] === $password;
     }
 
-    public function add(AddCommand $command): void
-    {
+    public function add(
+        AddCommand $command,
+        WriteContext $context,
+    ): void {
         $entry = $command->entry;
         $attrLog = [];
         foreach ($entry->getAttributes() as $attribute) {
@@ -126,13 +129,17 @@ class LdapServerBackend implements WritableLdapBackendInterface, PasswordAuthent
         );
     }
 
-    public function delete(DeleteCommand $command): void
-    {
+    public function delete(
+        DeleteCommand $command,
+        WriteContext $context,
+    ): void {
         $this->logRequest('delete', "dn => {$command->dn->toString()}");
     }
 
-    public function update(UpdateCommand $command): void
-    {
+    public function update(
+        UpdateCommand $command,
+        WriteContext $context,
+    ): void {
         $modLog = [];
         foreach ($command->changes as $change) {
             $attribute = $change->getAttribute();
@@ -148,8 +155,10 @@ class LdapServerBackend implements WritableLdapBackendInterface, PasswordAuthent
         );
     }
 
-    public function move(MoveCommand $command): void
-    {
+    public function move(
+        MoveCommand $command,
+        WriteContext $context,
+    ): void {
         $dnLog = 'ParentDn => ' . $command->newParent?->toString();
         $dnLog .= ', ParentRdn => ' . $command->newRdn->toString();
 

--- a/tests/unit/Server/Backend/Storage/Adapter/JsonFileStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/JsonFileStorageTest.php
@@ -20,8 +20,11 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Search\Filter\PresentFilter;
+use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
+use FreeDSx\Ldap\Server\Token\AnonToken;
 use PHPUnit\Framework\TestCase;
 
 final class JsonFileStorageTest extends TestCase
@@ -45,10 +48,24 @@ final class JsonFileStorageTest extends TestCase
 
         $this->storage = JsonFileStorage::forPcntl($this->tempFile);
         $this->subject = new WritableStorageBackend($this->storage);
-        $this->subject->add(new AddCommand(
-            new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example')),
-        ));
-        $this->subject->add(new AddCommand($this->alice));
+        $this->subject->add(
+            new AddCommand(
+                new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example')),
+            ),
+            $this->context(),
+        );
+        $this->subject->add(
+            new AddCommand($this->alice),
+            $this->context(),
+        );
+    }
+
+    private function context(): WriteContext
+    {
+        return new WriteContext(
+            new AnonToken(),
+            new ControlBag(),
+        );
     }
 
     protected function tearDown(): void
@@ -110,7 +127,10 @@ final class JsonFileStorageTest extends TestCase
     public function test_add_persists_to_file(): void
     {
         $entry = new Entry(new Dn('cn=Persistent,dc=example,dc=com'), new Attribute('cn', 'Persistent'));
-        $this->subject->add(new AddCommand($entry));
+        $this->subject->add(
+            new AddCommand($entry),
+            $this->context(),
+        );
 
         // A second independent backend reading the same file should see the new entry.
         $backend2 = new WritableStorageBackend(JsonFileStorage::forPcntl($this->tempFile));
@@ -120,7 +140,10 @@ final class JsonFileStorageTest extends TestCase
 
     public function test_delete_persists_to_file(): void
     {
-        $this->subject->delete(new DeleteCommand(new Dn('cn=Alice,dc=example,dc=com')));
+        $this->subject->delete(
+            new DeleteCommand(new Dn('cn=Alice,dc=example,dc=com')),
+            $this->context(),
+        );
 
         $backend2 = new WritableStorageBackend(JsonFileStorage::forPcntl($this->tempFile));
 
@@ -154,7 +177,10 @@ final class JsonFileStorageTest extends TestCase
 
         // A write operation changes the file — cache must be cleared.
         $extra = new Entry(new Dn('cn=Extra,dc=example,dc=com'), new Attribute('cn', 'Extra'));
-        $backend->add(new AddCommand($extra));
+        $backend->add(
+            new AddCommand($extra),
+            $this->context(),
+        );
 
         // The backend must re-read the file and see the new entry.
         self::assertNotNull($backend->get(new Dn('cn=Extra,dc=example,dc=com')));
@@ -165,7 +191,10 @@ final class JsonFileStorageTest extends TestCase
         // dc=example,dc=com and Alice are already in storage from setUp.
         // Add a grandchild to verify it is excluded from single-level results.
         $grandchild = new Entry(new Dn('cn=Sub,cn=Alice,dc=example,dc=com'), new Attribute('cn', 'Sub'));
-        $this->subject->add(new AddCommand($grandchild));
+        $this->subject->add(
+            new AddCommand($grandchild),
+            $this->context(),
+        );
 
         $request = (new SearchRequest(new PresentFilter('objectClass')))
             ->base('dc=example,dc=com')
@@ -187,7 +216,10 @@ final class JsonFileStorageTest extends TestCase
         // dc=example,dc=com and Alice are already in storage from setUp.
         // Add a grandchild; the subtree search should return all three entries.
         $grandchild = new Entry(new Dn('cn=Sub,cn=Alice,dc=example,dc=com'), new Attribute('cn', 'Sub'));
-        $this->subject->add(new AddCommand($grandchild));
+        $this->subject->add(
+            new AddCommand($grandchild),
+            $this->context(),
+        );
 
         $request = (new SearchRequest(new PresentFilter('objectClass')))
             ->base('dc=example,dc=com')

--- a/tests/unit/Server/Backend/Storage/Adapter/SqliteStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/SqliteStorageTest.php
@@ -31,8 +31,11 @@ use FreeDSx\Ldap\Server\Backend\Storage\Exception\DnTooLongException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
+use FreeDSx\Ldap\Server\Token\AnonToken;
 use PDO;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -56,10 +59,24 @@ final class SqliteStorageTest extends TestCase
 
         $this->storage = SqliteStorage::forPcntl(':memory:');
         $this->subject = new WritableStorageBackend($this->storage);
-        $this->subject->add(new AddCommand(
-            new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example')),
-        ));
-        $this->subject->add(new AddCommand($this->alice));
+        $this->subject->add(
+            new AddCommand(
+                new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example')),
+            ),
+            $this->context(),
+        );
+        $this->subject->add(
+            new AddCommand($this->alice),
+            $this->context(),
+        );
+    }
+
+    private function context(): WriteContext
+    {
+        return new WriteContext(
+            new AnonToken(),
+            new ControlBag(),
+        );
     }
 
     public function test_get_returns_entry_by_dn(): void
@@ -96,14 +113,20 @@ final class SqliteStorageTest extends TestCase
     public function test_add_persists_entry(): void
     {
         $entry = new Entry(new Dn('cn=Persistent,dc=example,dc=com'), new Attribute('cn', 'Persistent'));
-        $this->subject->add(new AddCommand($entry));
+        $this->subject->add(
+            new AddCommand($entry),
+            $this->context(),
+        );
 
         self::assertNotNull($this->subject->get(new Dn('cn=Persistent,dc=example,dc=com')));
     }
 
     public function test_delete_removes_entry(): void
     {
-        $this->subject->delete(new DeleteCommand(new Dn('cn=Alice,dc=example,dc=com')));
+        $this->subject->delete(
+            new DeleteCommand(new Dn('cn=Alice,dc=example,dc=com')),
+            $this->context(),
+        );
 
         self::assertNull($this->subject->get(new Dn('cn=Alice,dc=example,dc=com')));
     }
@@ -111,7 +134,10 @@ final class SqliteStorageTest extends TestCase
     public function test_list_single_level_returns_direct_children_only(): void
     {
         $grandchild = new Entry(new Dn('cn=Sub,cn=Alice,dc=example,dc=com'), new Attribute('cn', 'Sub'));
-        $this->subject->add(new AddCommand($grandchild));
+        $this->subject->add(
+            new AddCommand($grandchild),
+            $this->context(),
+        );
 
         $request = (new SearchRequest(new AndFilter()))
             ->base('dc=example,dc=com')
@@ -128,7 +154,10 @@ final class SqliteStorageTest extends TestCase
     public function test_list_recursive_includes_base_and_descendants(): void
     {
         $grandchild = new Entry(new Dn('cn=Sub,cn=Alice,dc=example,dc=com'), new Attribute('cn', 'Sub'));
-        $this->subject->add(new AddCommand($grandchild));
+        $this->subject->add(
+            new AddCommand($grandchild),
+            $this->context(),
+        );
 
         $request = (new SearchRequest(new AndFilter()))
             ->base('dc=example,dc=com')
@@ -149,12 +178,18 @@ final class SqliteStorageTest extends TestCase
 
     public function test_interleaved_lists_do_not_share_cursor_state(): void
     {
-        $this->subject->add(new AddCommand(
-            new Entry(new Dn('cn=Bob,dc=example,dc=com'), new Attribute('cn', 'Bob')),
-        ));
-        $this->subject->add(new AddCommand(
-            new Entry(new Dn('cn=Carol,dc=example,dc=com'), new Attribute('cn', 'Carol')),
-        ));
+        $this->subject->add(
+            new AddCommand(
+                new Entry(new Dn('cn=Bob,dc=example,dc=com'), new Attribute('cn', 'Bob')),
+            ),
+            $this->context(),
+        );
+        $this->subject->add(
+            new AddCommand(
+                new Entry(new Dn('cn=Carol,dc=example,dc=com'), new Attribute('cn', 'Carol')),
+            ),
+            $this->context(),
+        );
 
         $outerIterator = $this->storage->list(StorageListOptions::matchAll(
             new Dn('dc=example,dc=com'),
@@ -528,7 +563,10 @@ final class SqliteStorageTest extends TestCase
         );
 
         try {
-            $backend->add(new AddCommand($entry));
+            $backend->add(
+                new AddCommand($entry),
+                $this->context(),
+            );
             self::fail('Expected OperationException was not thrown.');
         } catch (OperationException $e) {
             self::assertSame(
@@ -555,8 +593,14 @@ final class SqliteStorageTest extends TestCase
             new Dn('cn=Doe\,John,dc=example,dc=com'),
             new Attribute('cn', 'Doe,John'),
         );
-        $backend->add(new AddCommand($base));
-        $backend->add(new AddCommand($escaped));
+        $backend->add(
+            new AddCommand($base),
+            $this->context(),
+        );
+        $backend->add(
+            new AddCommand($escaped),
+            $this->context(),
+        );
 
         $request = (new SearchRequest(new AndFilter()))
             ->base('John,dc=example,dc=com')
@@ -581,8 +625,14 @@ final class SqliteStorageTest extends TestCase
             new Dn('cn=Doe\,John,dc=example,dc=com'),
             new Attribute('cn', 'Doe,John'),
         );
-        $backend->add(new AddCommand($base));
-        $backend->add(new AddCommand($escaped));
+        $backend->add(
+            new AddCommand($base),
+            $this->context(),
+        );
+        $backend->add(
+            new AddCommand($escaped),
+            $this->context(),
+        );
 
         $request = (new SearchRequest(new AndFilter()))
             ->base('dc=example,dc=com')

--- a/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
@@ -35,11 +35,14 @@ use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Server\SearchLimits;
 use Generator;
 use PHPUnit\Framework\MockObject\MockObject;
+use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\MoveCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Backend\Write\WriteRequestInterface;
+use FreeDSx\Ldap\Server\Token\AnonToken;
 use PHPUnit\Framework\TestCase;
 
 final class WritableStorageBackendTest extends TestCase
@@ -183,7 +186,10 @@ final class WritableStorageBackendTest extends TestCase
     public function test_add_stores_entry(): void
     {
         $entry = new Entry(new Dn('cn=New,dc=example,dc=com'), new Attribute('cn', 'New'));
-        $this->subject->add(new AddCommand($entry));
+        $this->subject->add(
+            new AddCommand($entry),
+            $this->context(),
+        );
 
         self::assertNotNull($this->subject->get(new Dn('cn=New,dc=example,dc=com')));
     }
@@ -193,7 +199,10 @@ final class WritableStorageBackendTest extends TestCase
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::ENTRY_ALREADY_EXISTS);
 
-        $this->subject->add(new AddCommand($this->alice));
+        $this->subject->add(
+            new AddCommand($this->alice),
+            $this->context(),
+        );
     }
 
     public function test_add_throws_no_such_object_when_parent_does_not_exist(): void
@@ -202,21 +211,30 @@ final class WritableStorageBackendTest extends TestCase
         self::expectExceptionCode(ResultCode::NO_SUCH_OBJECT);
 
         $entry = new Entry(new Dn('cn=New,ou=Missing,dc=example,dc=com'), new Attribute('cn', 'New'));
-        $this->subject->add(new AddCommand($entry));
+        $this->subject->add(
+            new AddCommand($entry),
+            $this->context(),
+        );
     }
 
     public function test_add_allows_root_naming_context_entry(): void
     {
         $backend = new WritableStorageBackend(new InMemoryStorage());
         $root = new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example'));
-        $backend->add(new AddCommand($root));
+        $backend->add(
+            new AddCommand($root),
+            $this->context(),
+        );
 
         self::assertNotNull($backend->get(new Dn('dc=example,dc=com')));
     }
 
     public function test_delete_removes_entry(): void
     {
-        $this->subject->delete(new DeleteCommand(new Dn('cn=Alice,dc=example,dc=com')));
+        $this->subject->delete(
+            new DeleteCommand(new Dn('cn=Alice,dc=example,dc=com')),
+            $this->context(),
+        );
 
         self::assertNull($this->subject->get(new Dn('cn=Alice,dc=example,dc=com')));
     }
@@ -226,7 +244,10 @@ final class WritableStorageBackendTest extends TestCase
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::NO_SUCH_OBJECT);
 
-        $this->subject->delete(new DeleteCommand(new Dn('cn=Nobody,dc=example,dc=com')));
+        $this->subject->delete(
+            new DeleteCommand(new Dn('cn=Nobody,dc=example,dc=com')),
+            $this->context(),
+        );
     }
 
     public function test_delete_throws_not_allowed_on_non_leaf_when_entry_has_subordinates(): void
@@ -235,7 +256,10 @@ final class WritableStorageBackendTest extends TestCase
         self::expectExceptionCode(ResultCode::NOT_ALLOWED_ON_NON_LEAF);
 
         // dc=example,dc=com has cn=Alice as a direct child — cannot be deleted
-        $this->subject->delete(new DeleteCommand(new Dn('dc=example,dc=com')));
+        $this->subject->delete(
+            new DeleteCommand(new Dn('dc=example,dc=com')),
+            $this->context(),
+        );
     }
 
     public function test_delete_throws_unwilling_to_perform_for_configured_naming_context(): void
@@ -252,7 +276,10 @@ final class WritableStorageBackendTest extends TestCase
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
 
-        $backend->delete(new DeleteCommand(new Dn('dc=example,dc=com')));
+        $backend->delete(
+            new DeleteCommand(new Dn('dc=example,dc=com')),
+            $this->context(),
+        );
     }
 
     public function test_delete_naming_context_check_is_case_insensitive(): void
@@ -269,7 +296,10 @@ final class WritableStorageBackendTest extends TestCase
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
 
-        $backend->delete(new DeleteCommand(new Dn('dc=example,dc=com')));
+        $backend->delete(
+            new DeleteCommand(new Dn('dc=example,dc=com')),
+            $this->context(),
+        );
     }
 
     public function test_move_throws_unwilling_to_perform_when_renaming_naming_context(): void
@@ -286,12 +316,15 @@ final class WritableStorageBackendTest extends TestCase
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
 
-        $backend->move(new MoveCommand(
-            new Dn('dc=example,dc=com'),
-            Rdn::create('dc=renamed'),
-            true,
-            null,
-        ));
+        $backend->move(
+            new MoveCommand(
+                new Dn('dc=example,dc=com'),
+                Rdn::create('dc=renamed'),
+                true,
+                null,
+            ),
+            $this->context(),
+        );
     }
 
     public function test_delete_allows_non_naming_context_entries_when_naming_context_configured(): void
@@ -309,17 +342,23 @@ final class WritableStorageBackendTest extends TestCase
             namingContexts: ['dc=example,dc=com'],
         );
 
-        $backend->delete(new DeleteCommand(new Dn('cn=Alice,dc=example,dc=com')));
+        $backend->delete(
+            new DeleteCommand(new Dn('cn=Alice,dc=example,dc=com')),
+            $this->context(),
+        );
 
         self::assertNull($backend->get(new Dn('cn=Alice,dc=example,dc=com')));
     }
 
     public function test_update_add_attribute_value(): void
     {
-        $this->subject->update(new UpdateCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            [new Change(Change::TYPE_ADD, 'mail', 'alice@example.com')],
-        ));
+        $this->subject->update(
+            new UpdateCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                [new Change(Change::TYPE_ADD, 'mail', 'alice@example.com')],
+            ),
+            $this->context(),
+        );
 
         $entry = $this->subject->get(new Dn('cn=Alice,dc=example,dc=com'));
 
@@ -329,10 +368,13 @@ final class WritableStorageBackendTest extends TestCase
 
     public function test_update_add_value_to_existing_attribute(): void
     {
-        $this->subject->update(new UpdateCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            [new Change(Change::TYPE_ADD, 'cn', 'Alicia')],
-        ));
+        $this->subject->update(
+            new UpdateCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                [new Change(Change::TYPE_ADD, 'cn', 'Alicia')],
+            ),
+            $this->context(),
+        );
 
         $entry = $this->subject->get(new Dn('cn=Alice,dc=example,dc=com'));
 
@@ -346,10 +388,13 @@ final class WritableStorageBackendTest extends TestCase
 
     public function test_update_replace_attribute_value(): void
     {
-        $this->subject->update(new UpdateCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            [new Change(Change::TYPE_REPLACE, 'userPassword', 'newpassword')],
-        ));
+        $this->subject->update(
+            new UpdateCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                [new Change(Change::TYPE_REPLACE, 'userPassword', 'newpassword')],
+            ),
+            $this->context(),
+        );
 
         $entry = $this->subject->get(new Dn('cn=Alice,dc=example,dc=com'));
 
@@ -362,10 +407,13 @@ final class WritableStorageBackendTest extends TestCase
 
     public function test_update_delete_attribute(): void
     {
-        $this->subject->update(new UpdateCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            [new Change(Change::TYPE_DELETE, 'userPassword')],
-        ));
+        $this->subject->update(
+            new UpdateCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                [new Change(Change::TYPE_DELETE, 'userPassword')],
+            ),
+            $this->context(),
+        );
 
         $entry = $this->subject->get(new Dn('cn=Alice,dc=example,dc=com'));
 
@@ -374,10 +422,13 @@ final class WritableStorageBackendTest extends TestCase
 
     public function test_update_delete_specific_attribute_value(): void
     {
-        $this->subject->update(new UpdateCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            [new Change(Change::TYPE_DELETE, 'userPassword', 'secret')],
-        ));
+        $this->subject->update(
+            new UpdateCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                [new Change(Change::TYPE_DELETE, 'userPassword', 'secret')],
+            ),
+            $this->context(),
+        );
 
         $entry = $this->subject->get(new Dn('cn=Alice,dc=example,dc=com'));
 
@@ -386,10 +437,13 @@ final class WritableStorageBackendTest extends TestCase
 
     public function test_update_replace_with_no_values_clears_attribute(): void
     {
-        $this->subject->update(new UpdateCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            [new Change(Change::TYPE_REPLACE, 'userPassword')],
-        ));
+        $this->subject->update(
+            new UpdateCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                [new Change(Change::TYPE_REPLACE, 'userPassword')],
+            ),
+            $this->context(),
+        );
 
         self::assertNull(
             $this->subject->get(new Dn('cn=Alice,dc=example,dc=com'))?->get('userPassword'),
@@ -401,20 +455,26 @@ final class WritableStorageBackendTest extends TestCase
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::NO_SUCH_OBJECT);
 
-        $this->subject->update(new UpdateCommand(
-            new Dn('cn=Nobody,dc=example,dc=com'),
-            [new Change(Change::TYPE_REPLACE, 'cn', 'Nobody')],
-        ));
+        $this->subject->update(
+            new UpdateCommand(
+                new Dn('cn=Nobody,dc=example,dc=com'),
+                [new Change(Change::TYPE_REPLACE, 'cn', 'Nobody')],
+            ),
+            $this->context(),
+        );
     }
 
     public function test_move_renames_entry(): void
     {
-        $this->subject->move(new MoveCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            Rdn::create('cn=Alicia'),
-            true,
-            null,
-        ));
+        $this->subject->move(
+            new MoveCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                Rdn::create('cn=Alicia'),
+                true,
+                null,
+            ),
+            $this->context(),
+        );
 
         self::assertNull($this->subject->get(new Dn('cn=Alice,dc=example,dc=com')));
         self::assertNotNull($this->subject->get(new Dn('cn=Alicia,dc=example,dc=com')));
@@ -423,12 +483,15 @@ final class WritableStorageBackendTest extends TestCase
     public function test_move_creates_new_rdn_attribute_when_it_does_not_exist_in_entry(): void
     {
         // Alice has no 'uid' attribute; renaming to uid=alice should create it.
-        $this->subject->move(new MoveCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            Rdn::create('uid=alice'),
-            false,
-            null,
-        ));
+        $this->subject->move(
+            new MoveCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                Rdn::create('uid=alice'),
+                false,
+                null,
+            ),
+            $this->context(),
+        );
 
         $entry = $this->subject->get(new Dn('uid=alice,dc=example,dc=com'));
 
@@ -439,14 +502,20 @@ final class WritableStorageBackendTest extends TestCase
     public function test_move_to_new_parent(): void
     {
         $ou = new Entry(new Dn('ou=People,dc=example,dc=com'), new Attribute('ou', 'People'));
-        $this->subject->add(new AddCommand($ou));
+        $this->subject->add(
+            new AddCommand($ou),
+            $this->context(),
+        );
 
-        $this->subject->move(new MoveCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            Rdn::create('cn=Alice'),
-            false,
-            new Dn('ou=People,dc=example,dc=com'),
-        ));
+        $this->subject->move(
+            new MoveCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                Rdn::create('cn=Alice'),
+                false,
+                new Dn('ou=People,dc=example,dc=com'),
+            ),
+            $this->context(),
+        );
 
         self::assertNull($this->subject->get(new Dn('cn=Alice,dc=example,dc=com')));
         self::assertNotNull($this->subject->get(new Dn('cn=Alice,ou=People,dc=example,dc=com')));
@@ -457,12 +526,15 @@ final class WritableStorageBackendTest extends TestCase
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::NO_SUCH_OBJECT);
 
-        $this->subject->move(new MoveCommand(
-            new Dn('cn=Nobody,dc=example,dc=com'),
-            Rdn::create('cn=Ghost'),
-            true,
-            null,
-        ));
+        $this->subject->move(
+            new MoveCommand(
+                new Dn('cn=Nobody,dc=example,dc=com'),
+                Rdn::create('cn=Ghost'),
+                true,
+                null,
+            ),
+            $this->context(),
+        );
     }
 
     public function test_move_throws_not_allowed_on_non_leaf_when_entry_has_children(): void
@@ -471,12 +543,15 @@ final class WritableStorageBackendTest extends TestCase
         self::expectExceptionCode(ResultCode::NOT_ALLOWED_ON_NON_LEAF);
 
         // dc=example,dc=com has cn=Alice as a direct child — cannot be moved
-        $this->subject->move(new MoveCommand(
-            new Dn('dc=example,dc=com'),
-            Rdn::create('dc=example'),
-            false,
-            null,
-        ));
+        $this->subject->move(
+            new MoveCommand(
+                new Dn('dc=example,dc=com'),
+                Rdn::create('dc=example'),
+                false,
+                null,
+            ),
+            $this->context(),
+        );
     }
 
     public function test_move_throws_no_such_object_when_new_superior_does_not_exist(): void
@@ -484,12 +559,15 @@ final class WritableStorageBackendTest extends TestCase
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::NO_SUCH_OBJECT);
 
-        $this->subject->move(new MoveCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            Rdn::create('cn=Alice'),
-            false,
-            new Dn('ou=Missing,dc=example,dc=com'),
-        ));
+        $this->subject->move(
+            new MoveCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                Rdn::create('cn=Alice'),
+                false,
+                new Dn('ou=Missing,dc=example,dc=com'),
+            ),
+            $this->context(),
+        );
     }
 
     public function test_move_throws_entry_already_exists_when_target_dn_exists(): void
@@ -504,12 +582,15 @@ final class WritableStorageBackendTest extends TestCase
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::ENTRY_ALREADY_EXISTS);
 
-        $backend->move(new MoveCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            Rdn::create('cn=Alicia'),
-            true,
-            null,
-        ));
+        $backend->move(
+            new MoveCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                Rdn::create('cn=Alicia'),
+                true,
+                null,
+            ),
+            $this->context(),
+        );
     }
 
     public function test_supports_returns_true_for_add_command(): void
@@ -562,6 +643,14 @@ final class WritableStorageBackendTest extends TestCase
         iterator_to_array($subject->search($request)->entries);
     }
 
+    private function context(): WriteContext
+    {
+        return new WriteContext(
+            new AnonToken(),
+            new ControlBag(),
+        );
+    }
+
     /**
      * @return Generator<Entry>
      */
@@ -582,10 +671,13 @@ final class WritableStorageBackendTest extends TestCase
         $subject = new WritableStorageBackend($storage);
 
         try {
-            $subject->add(new AddCommand(new Entry(
-                new Dn('cn=New,dc=example,dc=com'),
-                new Attribute('cn', 'New'),
-            )));
+            $subject->add(
+                new AddCommand(new Entry(
+                    new Dn('cn=New,dc=example,dc=com'),
+                    new Attribute('cn', 'New'),
+                )),
+                $this->context(),
+            );
             self::fail('Expected OperationException was not thrown.');
         } catch (OperationException $e) {
             self::assertSame(
@@ -616,7 +708,10 @@ final class WritableStorageBackendTest extends TestCase
         self::expectExceptionCode(ResultCode::UNAVAILABLE);
         self::expectExceptionMessage('The backend storage is currently unavailable.');
 
-        $subject->delete(new DeleteCommand(new Dn('cn=Alice,dc=example,dc=com')));
+        $subject->delete(
+            new DeleteCommand(new Dn('cn=Alice,dc=example,dc=com')),
+            $this->context(),
+        );
     }
 
     public function test_update_converts_storage_io_exception_to_unavailable_operation_exception(): void
@@ -632,10 +727,13 @@ final class WritableStorageBackendTest extends TestCase
         self::expectExceptionCode(ResultCode::UNAVAILABLE);
         self::expectExceptionMessage('The backend storage is currently unavailable.');
 
-        $subject->update(new UpdateCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            [new Change(Change::TYPE_REPLACE, 'cn', 'Alicia')],
-        ));
+        $subject->update(
+            new UpdateCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                [new Change(Change::TYPE_REPLACE, 'cn', 'Alicia')],
+            ),
+            $this->context(),
+        );
     }
 
     public function test_move_converts_storage_io_exception_to_unavailable_operation_exception(): void
@@ -651,12 +749,15 @@ final class WritableStorageBackendTest extends TestCase
         self::expectExceptionCode(ResultCode::UNAVAILABLE);
         self::expectExceptionMessage('The backend storage is currently unavailable.');
 
-        $subject->move(new MoveCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            Rdn::create('cn=Alicia'),
-            true,
-            null,
-        ));
+        $subject->move(
+            new MoveCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                Rdn::create('cn=Alicia'),
+                true,
+                null,
+            ),
+            $this->context(),
+        );
     }
 
     public function test_supports_returns_false_for_unknown_request(): void
@@ -669,24 +770,33 @@ final class WritableStorageBackendTest extends TestCase
     public function test_handle_dispatches_add_command(): void
     {
         $entry = new Entry(new Dn('cn=New,dc=example,dc=com'), new Attribute('cn', 'New'));
-        $this->subject->handle(new AddCommand($entry));
+        $this->subject->handle(
+            new AddCommand($entry),
+            $this->context(),
+        );
 
         self::assertNotNull($this->subject->get(new Dn('cn=New,dc=example,dc=com')));
     }
 
     public function test_handle_dispatches_delete_command(): void
     {
-        $this->subject->handle(new DeleteCommand(new Dn('cn=Alice,dc=example,dc=com')));
+        $this->subject->handle(
+            new DeleteCommand(new Dn('cn=Alice,dc=example,dc=com')),
+            $this->context(),
+        );
 
         self::assertNull($this->subject->get(new Dn('cn=Alice,dc=example,dc=com')));
     }
 
     public function test_handle_dispatches_update_command(): void
     {
-        $this->subject->handle(new UpdateCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            [new Change(Change::TYPE_REPLACE, 'userPassword', 'newpassword')],
-        ));
+        $this->subject->handle(
+            new UpdateCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                [new Change(Change::TYPE_REPLACE, 'userPassword', 'newpassword')],
+            ),
+            $this->context(),
+        );
 
         self::assertSame(
             ['newpassword'],
@@ -696,12 +806,15 @@ final class WritableStorageBackendTest extends TestCase
 
     public function test_handle_dispatches_move_command(): void
     {
-        $this->subject->handle(new MoveCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            Rdn::create('cn=Alicia'),
-            true,
-            null,
-        ));
+        $this->subject->handle(
+            new MoveCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                Rdn::create('cn=Alicia'),
+                true,
+                null,
+            ),
+            $this->context(),
+        );
 
         self::assertNull($this->subject->get(new Dn('cn=Alice,dc=example,dc=com')));
         self::assertNotNull($this->subject->get(new Dn('cn=Alicia,dc=example,dc=com')));
@@ -772,10 +885,13 @@ final class WritableStorageBackendTest extends TestCase
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
 
-        $backend->add(new AddCommand(new Entry(
-            new Dn('cn=Invalid,dc=example,dc=com'),
-            new Attribute('cn', 'Invalid'),
-        )));
+        $backend->add(
+            new AddCommand(new Entry(
+                new Dn('cn=Invalid,dc=example,dc=com'),
+                new Attribute('cn', 'Invalid'),
+            )),
+            $this->context(),
+        );
     }
 
     public function test_add_with_validator_accepts_valid_entry(): void
@@ -788,12 +904,15 @@ final class WritableStorageBackendTest extends TestCase
             ),
         );
 
-        $backend->add(new AddCommand(new Entry(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            new Attribute('objectClass', 'top', 'person'),
-            new Attribute('cn', 'Alice'),
-            new Attribute('sn', 'Smith'),
-        )));
+        $backend->add(
+            new AddCommand(new Entry(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                new Attribute('objectClass', 'top', 'person'),
+                new Attribute('cn', 'Alice'),
+                new Attribute('sn', 'Smith'),
+            )),
+            $this->context(),
+        );
 
         self::assertNotNull($backend->get(new Dn('cn=Alice,dc=example,dc=com')));
     }
@@ -817,10 +936,168 @@ final class WritableStorageBackendTest extends TestCase
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::CONSTRAINT_VIOLATION);
 
-        $backend->update(new UpdateCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            [Change::replace(new Attribute('createTimestamp', '20240101000000Z'))],
-        ));
+        $backend->update(
+            new UpdateCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                [Change::replace(new Attribute('createTimestamp', '20240101000000Z'))],
+            ),
+            $this->context(),
+        );
+    }
+
+    public function test_add_sets_operational_attributes_on_entry(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=New,dc=example,dc=com'),
+            new Attribute('cn', 'New'),
+        );
+
+        $this->subject->add(
+            new AddCommand($entry),
+            $this->context(),
+        );
+
+        $stored = $this->subject->get(new Dn('cn=New,dc=example,dc=com'));
+
+        self::assertNotNull($stored?->get('createTimestamp'));
+        self::assertNotNull($stored->get('modifyTimestamp'));
+        self::assertNotNull($stored->get('creatorsName'));
+        self::assertNotNull($stored->get('modifiersName'));
+        self::assertNotNull($stored->get('entryUUID'));
+    }
+
+    public function test_update_refreshes_modify_operational_attributes(): void
+    {
+        $this->subject->update(
+            new UpdateCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                [Change::replace(new Attribute('userPassword', 'newSecret'))],
+            ),
+            $this->context(),
+        );
+
+        $updated = $this->subject->get(new Dn('cn=Alice,dc=example,dc=com'));
+
+        self::assertNotNull($updated?->get('modifyTimestamp'));
+        self::assertNotNull($updated->get('modifiersName'));
+    }
+
+    public function test_move_refreshes_modify_operational_attributes(): void
+    {
+        $this->subject->move(
+            new MoveCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                Rdn::create('cn=Alicia'),
+                true,
+                null,
+            ),
+            $this->context(),
+        );
+
+        $moved = $this->subject->get(new Dn('cn=Alicia,dc=example,dc=com'));
+
+        self::assertNotNull($moved?->get('modifyTimestamp'));
+        self::assertNotNull($moved->get('modifiersName'));
+    }
+
+    public function test_search_with_plus_includes_has_subordinates(): void
+    {
+        $request = (new SearchRequest(new PresentFilter('objectClass')))
+            ->base('dc=example,dc=com')
+            ->useSubtreeScope()
+            ->select('+');
+
+        $results = iterator_to_array($this->subject->search($request)->entries);
+
+        foreach ($results as $entry) {
+            self::assertNotNull(
+                $entry->get('hasSubordinates'),
+                "Entry {$entry->getDn()->toString()} is missing hasSubordinates.",
+            );
+        }
+    }
+
+    public function test_search_with_has_subordinates_by_name_includes_it(): void
+    {
+        $request = (new SearchRequest(new PresentFilter('objectClass')))
+            ->base('dc=example,dc=com')
+            ->useSubtreeScope()
+            ->select('hasSubordinates');
+
+        $results = iterator_to_array($this->subject->search($request)->entries);
+
+        foreach ($results as $entry) {
+            self::assertNotNull(
+                $entry->get('hasSubordinates'),
+                "Entry {$entry->getDn()->toString()} is missing hasSubordinates.",
+            );
+        }
+    }
+
+    public function test_search_without_plus_does_not_include_has_subordinates(): void
+    {
+        $request = (new SearchRequest(new PresentFilter('objectClass')))
+            ->base('dc=example,dc=com')
+            ->useSubtreeScope()
+            ->select('cn');
+
+        $results = iterator_to_array($this->subject->search($request)->entries);
+
+        foreach ($results as $entry) {
+            self::assertNull(
+                $entry->get('hasSubordinates'),
+                "Entry {$entry->getDn()->toString()} must not have hasSubordinates injected.",
+            );
+        }
+    }
+
+    public function test_search_has_subordinates_is_true_for_parent(): void
+    {
+        // dc=example,dc=com has Alice as a child.
+        $request = (new SearchRequest(new PresentFilter('objectClass')))
+            ->base('dc=example,dc=com')
+            ->useBaseScope()
+            ->select('+');
+
+        $results = iterator_to_array($this->subject->search($request)->entries);
+
+        self::assertCount(1, $results);
+        self::assertSame(
+            'TRUE',
+            $results[0]->get('hasSubordinates')?->getValues()[0],
+        );
+    }
+
+    public function test_search_has_subordinates_is_false_for_leaf(): void
+    {
+        // Alice has no children.
+        $request = (new SearchRequest(new PresentFilter('objectClass')))
+            ->base('cn=Alice,dc=example,dc=com')
+            ->useBaseScope()
+            ->select('+');
+
+        $results = iterator_to_array($this->subject->search($request)->entries);
+
+        self::assertCount(1, $results);
+        self::assertSame(
+            'FALSE',
+            $results[0]->get('hasSubordinates')?->getValues()[0],
+        );
+    }
+
+    public function test_search_has_subordinates_does_not_mutate_stored_entry(): void
+    {
+        $request = (new SearchRequest(new PresentFilter('objectClass')))
+            ->base('dc=example,dc=com')
+            ->useBaseScope()
+            ->select('+');
+
+        iterator_to_array($this->subject->search($request)->entries);
+
+        // Read the stored entry directly — hasSubordinates must not be persisted.
+        $stored = $this->subject->get(new Dn('dc=example,dc=com'));
+
+        self::assertNull($stored?->get('hasSubordinates'));
     }
 
     /**

--- a/tests/unit/Server/Backend/Storage/OperationalAttributeGeneratorTest.php
+++ b/tests/unit/Server/Backend/Storage/OperationalAttributeGeneratorTest.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage;
+
+use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Schema\Definition\ObjectClass;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassType;
+use FreeDSx\Ldap\Schema\Schema;
+use FreeDSx\Ldap\Server\Backend\Storage\OperationalAttributeGenerator;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
+use FreeDSx\Ldap\Server\Token\AnonToken;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use PHPUnit\Framework\TestCase;
+
+final class OperationalAttributeGeneratorTest extends TestCase
+{
+    private OperationalAttributeGenerator $subject;
+
+    private Entry $entry;
+
+    protected function setUp(): void
+    {
+        $this->subject = new OperationalAttributeGenerator();
+        $this->entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('cn', 'Alice'),
+        );
+    }
+
+    private function anonymousContext(): WriteContext
+    {
+        return new WriteContext(
+            new AnonToken(),
+            new ControlBag(),
+        );
+    }
+
+    private function boundContext(string $dn): WriteContext
+    {
+        return new WriteContext(
+            new BindToken($dn, ''),
+            new ControlBag(),
+        );
+    }
+
+    public function test_apply_for_add_sets_create_timestamp(): void
+    {
+        $this->subject->applyForAdd(
+            $this->entry,
+            $this->anonymousContext(),
+        );
+
+        $attr = $this->entry->get('createTimestamp');
+
+        self::assertNotNull($attr);
+        self::assertMatchesRegularExpression(
+            '/^\d{14}Z$/',
+            $attr->getValues()[0] ?? '',
+        );
+    }
+
+    public function test_apply_for_add_sets_modify_timestamp_equal_to_create_timestamp(): void
+    {
+        $this->subject->applyForAdd(
+            $this->entry,
+            $this->anonymousContext(),
+        );
+
+        $create = $this->entry->get('createTimestamp')?->getValues()[0];
+        $modify = $this->entry->get('modifyTimestamp')?->getValues()[0];
+
+        self::assertSame($create, $modify);
+    }
+
+    public function test_apply_for_add_sets_creators_name_to_bound_dn(): void
+    {
+        $this->subject->applyForAdd(
+            $this->entry,
+            $this->boundContext('cn=Admin,dc=example,dc=com'),
+        );
+
+        self::assertSame(
+            'cn=Admin,dc=example,dc=com',
+            $this->entry->get('creatorsName')?->getValues()[0],
+        );
+    }
+
+    public function test_apply_for_add_sets_creators_name_to_empty_string_for_anonymous(): void
+    {
+        $this->subject->applyForAdd(
+            $this->entry,
+            $this->anonymousContext(),
+        );
+
+        self::assertSame(
+            '',
+            $this->entry->get('creatorsName')?->getValues()[0],
+        );
+    }
+
+    public function test_apply_for_add_sets_modifiers_name_to_bound_dn(): void
+    {
+        $this->subject->applyForAdd(
+            $this->entry,
+            $this->boundContext('cn=Admin,dc=example,dc=com'),
+        );
+
+        self::assertSame(
+            'cn=Admin,dc=example,dc=com',
+            $this->entry->get('modifiersName')?->getValues()[0],
+        );
+    }
+
+    public function test_apply_for_add_sets_entry_uuid(): void
+    {
+        $this->subject->applyForAdd(
+            $this->entry,
+            $this->anonymousContext(),
+        );
+
+        $uuid = $this->entry->get('entryUUID')?->getValues()[0] ?? '';
+
+        self::assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+            $uuid,
+        );
+    }
+
+    public function test_apply_for_add_without_schema_does_not_set_structural_object_class(): void
+    {
+        $entryWithOc = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('cn', 'Alice'),
+            new Attribute('objectClass', 'top', 'person'),
+        );
+
+        $this->subject->applyForAdd(
+            $entryWithOc,
+            $this->anonymousContext(),
+        );
+
+        self::assertNull($entryWithOc->get('structuralObjectClass'));
+    }
+
+    public function test_apply_for_add_with_schema_sets_most_specific_structural_object_class(): void
+    {
+        $top = new ObjectClass(
+            oid: '2.5.6.0',
+            names: ['top'],
+            type: ObjectClassType::AbstractClass,
+        );
+        $person = new ObjectClass(
+            oid: '2.5.6.6',
+            names: ['person'],
+            superClassOids: ['2.5.6.0'],
+        );
+        $inetOrgPerson = new ObjectClass(
+            oid: '2.16.840.1.113730.3.2.2',
+            names: ['inetOrgPerson'],
+            superClassOids: ['2.5.6.6'],
+        );
+
+        $schema = (new Schema())
+            ->addObjectClass($top)
+            ->addObjectClass($person)
+            ->addObjectClass($inetOrgPerson);
+
+        $subject = new OperationalAttributeGenerator($schema);
+
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('cn', 'Alice'),
+            new Attribute('objectClass', 'top', 'person', 'inetOrgPerson'),
+        );
+
+        $subject->applyForAdd(
+            $entry,
+            $this->anonymousContext(),
+        );
+
+        self::assertSame(
+            'inetOrgPerson',
+            $entry->get('structuralObjectClass')?->getValues()[0],
+        );
+    }
+
+    public function test_apply_for_add_with_schema_but_no_object_class_skips_structural_object_class(): void
+    {
+        $schema = new Schema();
+        $subject = new OperationalAttributeGenerator($schema);
+
+        $subject->applyForAdd(
+            $this->entry,
+            $this->anonymousContext(),
+        );
+
+        self::assertNull($this->entry->get('structuralObjectClass'));
+    }
+
+    public function test_apply_for_modify_updates_modify_timestamp(): void
+    {
+        $this->subject->applyForAdd(
+            $this->entry,
+            $this->anonymousContext(),
+        );
+        $originalCreate = $this->entry->get('createTimestamp')?->getValues()[0];
+        $originalModify = $this->entry->get('modifyTimestamp')?->getValues()[0];
+
+        $this->subject->applyForModify(
+            $this->entry,
+            $this->anonymousContext(),
+        );
+
+        $updatedModify = $this->entry->get('modifyTimestamp')?->getValues()[0];
+
+        self::assertMatchesRegularExpression(
+            '/^\d{14}Z$/',
+            $updatedModify ?? '',
+        );
+        // createTimestamp must remain unchanged.
+        self::assertSame(
+            $originalCreate,
+            $this->entry->get('createTimestamp')?->getValues()[0],
+        );
+        // modifyTimestamp may equal createTimestamp when called in the same second — just verify it's set.
+        self::assertNotNull($originalModify);
+        self::assertNotNull($updatedModify);
+    }
+
+    public function test_apply_for_modify_updates_modifiers_name(): void
+    {
+        $this->subject->applyForAdd(
+            $this->entry,
+            $this->anonymousContext(),
+        );
+
+        $this->subject->applyForModify(
+            $this->entry,
+            $this->boundContext('cn=Admin,dc=example,dc=com'),
+        );
+
+        self::assertSame(
+            'cn=Admin,dc=example,dc=com',
+            $this->entry->get('modifiersName')?->getValues()[0],
+        );
+    }
+
+    public function test_apply_for_modify_does_not_change_creators_name(): void
+    {
+        $this->subject->applyForAdd(
+            $this->entry,
+            $this->boundContext('cn=Creator,dc=example,dc=com'),
+        );
+
+        $this->subject->applyForModify(
+            $this->entry,
+            $this->boundContext('cn=Modifier,dc=example,dc=com'),
+        );
+
+        self::assertSame(
+            'cn=Creator,dc=example,dc=com',
+            $this->entry->get('creatorsName')?->getValues()[0],
+        );
+    }
+
+    public function test_apply_for_modify_does_not_change_entry_uuid(): void
+    {
+        $this->subject->applyForAdd(
+            $this->entry,
+            $this->anonymousContext(),
+        );
+        $originalUuid = $this->entry->get('entryUUID')?->getValues()[0];
+
+        $this->subject->applyForModify(
+            $this->entry,
+            $this->anonymousContext(),
+        );
+
+        self::assertSame(
+            $originalUuid,
+            $this->entry->get('entryUUID')?->getValues()[0],
+        );
+    }
+
+    public function test_uuid_format_is_valid_rfc4122_v4(): void
+    {
+        $this->subject->applyForAdd(
+            $this->entry,
+            $this->anonymousContext(),
+        );
+
+        $uuid = $this->entry->get('entryUUID')?->getValues()[0] ?? '';
+
+        self::assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+            $uuid,
+            'UUID must match RFC 4122 v4 format with correct version and variant bits.',
+        );
+    }
+
+    public function test_timestamp_matches_generalized_time_format(): void
+    {
+        $this->subject->applyForAdd(
+            $this->entry,
+            $this->anonymousContext(),
+        );
+
+        $ts = $this->entry->get('createTimestamp')?->getValues()[0] ?? '';
+
+        self::assertMatchesRegularExpression(
+            '/^\d{4}\d{2}\d{2}\d{2}\d{2}\d{2}Z$/',
+            $ts,
+            'Timestamp must be in generalized time format YYYYMMDDHHmmssZ.',
+        );
+    }
+}

--- a/tests/unit/Server/Backend/Write/WriteOperationDispatcherTest.php
+++ b/tests/unit/Server/Backend/Write/WriteOperationDispatcherTest.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Write;
 
+use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\Backend\Write\WriteRequestInterface;
+use FreeDSx\Ldap\Server\Token\AnonToken;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -25,9 +28,15 @@ final class WriteOperationDispatcherTest extends TestCase
 {
     private WriteRequestInterface&MockObject $mockRequest;
 
+    private WriteContext $context;
+
     protected function setUp(): void
     {
         $this->mockRequest = $this->createMock(WriteRequestInterface::class);
+        $this->context = new WriteContext(
+            new AnonToken(),
+            new ControlBag(),
+        );
     }
 
     private function handler(bool $supports): WriteHandlerInterface&MockObject
@@ -43,7 +52,10 @@ final class WriteOperationDispatcherTest extends TestCase
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
 
-        (new WriteOperationDispatcher())->dispatch($this->mockRequest);
+        (new WriteOperationDispatcher())->dispatch(
+            $this->mockRequest,
+            $this->context,
+        );
     }
 
     public function test_throws_unwilling_to_perform_when_no_handler_supports_request(): void
@@ -54,15 +66,24 @@ final class WriteOperationDispatcherTest extends TestCase
         (new WriteOperationDispatcher(
             $this->handler(false),
             $this->handler(false),
-        ))->dispatch($this->mockRequest);
+        ))->dispatch(
+            $this->mockRequest,
+            $this->context,
+        );
     }
 
     public function test_dispatches_to_first_supporting_handler(): void
     {
         $handler = $this->handler(true);
-        $handler->expects(self::once())->method('handle')->with($this->mockRequest);
+        $handler->expects(self::once())->method('handle')->with(
+            $this->mockRequest,
+            $this->context,
+        );
 
-        (new WriteOperationDispatcher($handler))->dispatch($this->mockRequest);
+        (new WriteOperationDispatcher($handler))->dispatch(
+            $this->mockRequest,
+            $this->context,
+        );
     }
 
     public function test_stops_after_first_matching_handler(): void
@@ -73,7 +94,10 @@ final class WriteOperationDispatcherTest extends TestCase
         $second = $this->handler(true);
         $second->expects(self::never())->method('handle');
 
-        (new WriteOperationDispatcher($first, $second))->dispatch($this->mockRequest);
+        (new WriteOperationDispatcher($first, $second))->dispatch(
+            $this->mockRequest,
+            $this->context,
+        );
     }
 
     public function test_skips_non_supporting_handlers_before_matching(): void
@@ -82,8 +106,14 @@ final class WriteOperationDispatcherTest extends TestCase
         $skip->expects(self::never())->method('handle');
 
         $match = $this->handler(true);
-        $match->expects(self::once())->method('handle')->with($this->mockRequest);
+        $match->expects(self::once())->method('handle')->with(
+            $this->mockRequest,
+            $this->context,
+        );
 
-        (new WriteOperationDispatcher($skip, $match))->dispatch($this->mockRequest);
+        (new WriteOperationDispatcher($skip, $match))->dispatch(
+            $this->mockRequest,
+            $this->context,
+        );
     }
 }

--- a/tests/unit/Server/RequestHandler/ProxyBackendTest.php
+++ b/tests/unit/Server/RequestHandler/ProxyBackendTest.php
@@ -33,9 +33,11 @@ use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\MoveCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Rdn;
 use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Server\Token\AnonToken;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use FreeDSx\Ldap\Server\RequestHandler\ProxyBackend;
@@ -51,6 +53,14 @@ final class ProxyBackendTest extends TestCase
         $this->mockLdap = $this->createMock(LdapClient::class);
         $this->subject = new ProxyBackend();
         $this->subject->setLdapClient($this->mockLdap);
+    }
+
+    private function context(): WriteContext
+    {
+        return new WriteContext(
+            new AnonToken(),
+            new ControlBag(),
+        );
     }
 
     private function makeRequest(
@@ -208,7 +218,10 @@ final class ProxyBackendTest extends TestCase
             ->method('sendAndReceive')
             ->with(self::isInstanceOf(AddRequest::class));
 
-        $this->subject->add(new AddCommand($entry));
+        $this->subject->add(
+            new AddCommand($entry),
+            $this->context(),
+        );
     }
 
     public function test_delete_sends_delete_request_to_upstream(): void
@@ -218,7 +231,10 @@ final class ProxyBackendTest extends TestCase
             ->method('sendAndReceive')
             ->with(self::isInstanceOf(DeleteRequest::class));
 
-        $this->subject->delete(new DeleteCommand(new Dn('cn=Alice,dc=example,dc=com')));
+        $this->subject->delete(
+            new DeleteCommand(new Dn('cn=Alice,dc=example,dc=com')),
+            $this->context(),
+        );
     }
 
     public function test_update_sends_modify_request_to_upstream(): void
@@ -228,10 +244,13 @@ final class ProxyBackendTest extends TestCase
             ->method('sendAndReceive')
             ->with(self::isInstanceOf(ModifyRequest::class));
 
-        $this->subject->update(new UpdateCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            [Change::replace('cn', 'Alicia')],
-        ));
+        $this->subject->update(
+            new UpdateCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                [Change::replace('cn', 'Alicia')],
+            ),
+            $this->context(),
+        );
     }
 
     public function test_move_sends_modify_dn_request_to_upstream(): void
@@ -241,11 +260,14 @@ final class ProxyBackendTest extends TestCase
             ->method('sendAndReceive')
             ->with(self::isInstanceOf(ModifyDnRequest::class));
 
-        $this->subject->move(new MoveCommand(
-            new Dn('cn=Alice,dc=example,dc=com'),
-            Rdn::create('cn=Alicia'),
-            true,
-            null,
-        ));
+        $this->subject->move(
+            new MoveCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                Rdn::create('cn=Alicia'),
+                true,
+                null,
+            ),
+            $this->context(),
+        );
     }
 }


### PR DESCRIPTION
Now that the server handles writes to various storage adapters (and handles the schema and all the LDAP specific write logic), we should also handle operational attributes defined in RFC-4512. This makes sure they are persisted on entry creation / modification. Small blurb in the server schema docs added.

Also discovered a race condition due to forked PCNTL processes in the server shutdown loop. Applied a fixed in the socket library and made an update for it here.