### PR TITLE
[1.0.0] Upgrade PHPUnit to the latest version allowed for this version of PHP.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psr/log": "^3"
   },
   "require-dev": {
-    "phpunit/phpunit": "^10.5",
+    "phpunit/phpunit": "^11",
     "symplify/easy-coding-standard": "^13.1",
     "phpstan/phpstan": "^2.1",
     "symfony/process": "^5.4",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,9 +10,9 @@
          processIsolation="false"
          stopOnFailure="false"
          bootstrap="vendor/autoload.php"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
 >
-    <source restrictDeprecations="true">
+    <source ignoreIndirectDeprecations="true">
         <include>
             <directory suffix=".php">./src</directory>
         </include>

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -27,6 +27,7 @@ use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
 use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\SocketPool;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ContainerTest extends TestCase
@@ -68,9 +69,8 @@ class ContainerTest extends TestCase
 
     /**
      * @param class-string $class
-     *
-     * @dataProvider buildableDependenciesDataProvider
      */
+    #[DataProvider('buildableDependenciesDataProvider')]
     public function test_it_builds_the_dependencies(
         string $class,
     ): void {

--- a/tests/unit/Operation/Request/AddRequestTest.php
+++ b/tests/unit/Operation/Request/AddRequestTest.php
@@ -18,6 +18,7 @@ use FreeDSx\Asn1\Type\AbstractType;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class AddRequestTest extends TestCase
@@ -90,10 +91,9 @@ final class AddRequestTest extends TestCase
     }
 
     /**
-     * @dataProvider malformedAsn1DataProvider
-     *
      * @param AbstractType<mixed> $type
      */
+    #[DataProvider('malformedAsn1DataProvider')]
     public function test_it_should_detect_a_malformed_asn1_request(AbstractType $type): void
     {
         $this->expectException(ProtocolException::class);

--- a/tests/unit/Operation/Request/AnonBindRequestTest.php
+++ b/tests/unit/Operation/Request/AnonBindRequestTest.php
@@ -18,6 +18,7 @@ use FreeDSx\Asn1\Type\AbstractType;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Operation\Request\AnonBindRequest;
 use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class AnonBindRequestTest extends TestCase
@@ -88,10 +89,9 @@ final class AnonBindRequestTest extends TestCase
     }
 
     /**
-     * @dataProvider malformedAsn1DataProvider
-     *
      * @param AbstractType<mixed> $type
      */
+    #[DataProvider('malformedAsn1DataProvider')]
     public function test_it_should_detect_invalid_asn1(AbstractType $type): void
     {
         $this->expectException(ProtocolException::class);

--- a/tests/unit/Operation/Request/CancelRequestTest.php
+++ b/tests/unit/Operation/Request/CancelRequestTest.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Operation\Request\CancelRequest;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Protocol\LdapEncoder;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class CancelRequestTest extends TestCase
@@ -69,10 +70,9 @@ final class CancelRequestTest extends TestCase
     }
 
     /**
-     * @dataProvider malformedAsn1DataProvider
-     *
      * @param AbstractType<mixed> $type
      */
+    #[DataProvider('malformedAsn1DataProvider')]
     public function test_it_should_detect_invalid_asn1_from_asn1(AbstractType $type): void
     {
         $this->expectException(ProtocolException::class);

--- a/tests/unit/Operation/Request/CompareRequestTest.php
+++ b/tests/unit/Operation/Request/CompareRequestTest.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Operation\Request\CompareRequest;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class CompareRequestTest extends TestCase
@@ -85,10 +86,9 @@ final class CompareRequestTest extends TestCase
     }
 
     /**
-     * @dataProvider malformedAsn1DataProvider
-     *
      * @param AbstractType<mixed> $type
      */
+    #[DataProvider('malformedAsn1DataProvider')]
     public function test_it_should_detect_invalid_asn1_from_asn1(AbstractType $type): void
     {
         $this->expectException(ProtocolException::class);

--- a/tests/unit/Operation/Request/DeleteRequestTest.php
+++ b/tests/unit/Operation/Request/DeleteRequestTest.php
@@ -18,6 +18,7 @@ use FreeDSx\Asn1\Type\AbstractType;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class DeleteRequestTest extends TestCase
@@ -65,10 +66,9 @@ final class DeleteRequestTest extends TestCase
     }
 
     /**
-     * @dataProvider malformedAsn1DataProvider
-     *
      * @param AbstractType<mixed> $type
      */
+    #[DataProvider('malformedAsn1DataProvider')]
     public function test_it_should_not_be_constructed_from_invalid_asn1(AbstractType $type): void
     {
         $this->expectException(ProtocolException::class);

--- a/tests/unit/Operation/Request/ExtendedRequestTest.php
+++ b/tests/unit/Operation/Request/ExtendedRequestTest.php
@@ -17,6 +17,7 @@ use FreeDSx\Asn1\Asn1;
 use FreeDSx\Asn1\Type\AbstractType;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class ExtendedRequestTest extends TestCase
@@ -95,10 +96,9 @@ final class ExtendedRequestTest extends TestCase
     }
 
     /**
-     * @dataProvider malformedAsn1DataProvider
-     *
      * @param AbstractType<mixed> $type
      */
+    #[DataProvider('malformedAsn1DataProvider')]
     public function test_it_should_detect_invalid_asn1(AbstractType $type): void
     {
         $this->expectException(ProtocolException::class);

--- a/tests/unit/Operation/Request/ModifyDnRequestTest.php
+++ b/tests/unit/Operation/Request/ModifyDnRequestTest.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Rdn;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class ModifyDnRequestTest extends TestCase
@@ -137,10 +138,9 @@ final class ModifyDnRequestTest extends TestCase
     }
 
     /**
-     * @dataProvider malformedAsn1DataProvider
-     *
      * @param AbstractType<mixed> $type
      */
+    #[DataProvider('malformedAsn1DataProvider')]
     public function test_it_should_not_be_constructed_from_invalid_asn1(AbstractType $type): void
     {
         $this->expectException(ProtocolException::class);

--- a/tests/unit/Operation/Request/SearchRequestTest.php
+++ b/tests/unit/Operation/Request/SearchRequestTest.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Search\Result\EntryResult;
 use FreeDSx\Ldap\Search\Result\ReferralResult;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class SearchRequestTest extends TestCase
@@ -273,10 +274,9 @@ final class SearchRequestTest extends TestCase
     }
 
     /**
-     * @dataProvider malformedAsn1DataProvider
-     *
      * @param AbstractType<mixed> $type
      */
+    #[DataProvider('malformedAsn1DataProvider')]
     public function test_it_should_not_be_constructed_from_invalid_asn1(AbstractType $type): void
     {
         $this->expectException(ProtocolException::class);

--- a/tests/unit/Operation/Request/SimpleBindRequestTest.php
+++ b/tests/unit/Operation/Request/SimpleBindRequestTest.php
@@ -18,6 +18,7 @@ use FreeDSx\Asn1\Type\AbstractType;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class SimpleBindRequestTest extends TestCase
@@ -72,9 +73,7 @@ final class SimpleBindRequestTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider unallowedUsernamePasswordProvider
-     */
+    #[DataProvider('unallowedUsernamePasswordProvider')]
     public function test_it_should_not_allow_empty_username_and_password_combos(
         string $username,
         string $password,
@@ -126,10 +125,9 @@ final class SimpleBindRequestTest extends TestCase
     }
 
     /**
-     * @dataProvider malformedAsn1DataProvider
-     *
      * @param AbstractType<mixed> $type
      */
+    #[DataProvider('malformedAsn1DataProvider')]
     public function test_it_should_detect_invalid_asn1_from_asn1(AbstractType $type): void
     {
         $this->expectException(ProtocolException::class);

--- a/tests/unit/Protocol/ClientProtocolHandler/ClientReferralHandlerTest.php
+++ b/tests/unit/Protocol/ClientProtocolHandler/ClientReferralHandlerTest.php
@@ -93,10 +93,10 @@ class ClientReferralHandlerTest extends TestCase
 
         $this->mockLdapClient
             ->method('send')
-            ->will(self::onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 null,
                 $message,
-            ));
+            );
 
         self::assertEquals(
             $message,
@@ -183,13 +183,17 @@ class ClientReferralHandlerTest extends TestCase
 
         $message = new LdapMessageResponse(2, new DeleteResponse(0));
 
+        $callCount = 0;
         $this->mockLdapClient
             ->method('send')
-            ->will(self::onConsecutiveCalls(
-                self::throwException(new ConnectionException()),
-                $message,
-                $message,
-            ));
+            ->willReturnCallback(static function () use (&$callCount, $message): mixed {
+                $callCount++;
+                if ($callCount === 1) {
+                    throw new ConnectionException();
+                }
+
+                return $message;
+            });
 
         self::assertEquals(
             $message,
@@ -227,13 +231,17 @@ class ClientReferralHandlerTest extends TestCase
 
         $message = new LdapMessageResponse(2, new DeleteResponse(0));
 
+        $callCount = 0;
         $this->mockLdapClient
             ->method('send')
-            ->will(self::onConsecutiveCalls(
-                self::throwException(new OperationException('fail', ResultCode::REFERRAL)),
-                $message,
-                $message,
-            ));
+            ->willReturnCallback(static function () use (&$callCount, $message): mixed {
+                $callCount++;
+                if ($callCount === 1) {
+                    throw new OperationException('fail', ResultCode::REFERRAL);
+                }
+
+                return $message;
+            });
 
         self::assertEquals(
             $message,

--- a/tests/unit/Protocol/ClientProtocolHandler/ClientSaslBindHandlerTest.php
+++ b/tests/unit/Protocol/ClientProtocolHandler/ClientSaslBindHandlerTest.php
@@ -64,7 +64,7 @@ final class ClientSaslBindHandlerTest extends TestCase
             ->willReturnSelf();
         $this->mockQueue
             ->method('generateId')
-            ->will($this->onConsecutiveCalls(2, 3, 4, 5, 6));
+            ->willReturnOnConsecutiveCalls(2, 3, 4, 5, 6);
 
         $this->saslChallenge = new LdapMessageResponse(
             1,
@@ -90,10 +90,10 @@ final class ClientSaslBindHandlerTest extends TestCase
 
         $this->mockQueue
             ->method('getMessage')
-            ->will(self::onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 $this->saslChallenge,
                 $this->saslComplete,
-            ));
+            );
 
         $this->mockSasl
             ->expects($this->once())
@@ -113,10 +113,10 @@ final class ClientSaslBindHandlerTest extends TestCase
 
         $this->mockChallenge
             ->method('challenge')
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 (new SaslContext())->setResponse('foo'),
                 (new SaslContext())->setResponse('foo')->setIsComplete(true),
-            ));
+            );
 
         $this->mockRootDseLoader
             ->method('load')
@@ -138,10 +138,10 @@ final class ClientSaslBindHandlerTest extends TestCase
 
         $this->mockQueue
             ->method('getMessage')
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 $this->saslChallenge,
                 $this->saslComplete,
-            ));
+            );
 
         $this->mockSasl
             ->method('select')
@@ -156,15 +156,15 @@ final class ClientSaslBindHandlerTest extends TestCase
 
         $this->mockChallenge
             ->method('challenge')
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 (new SaslContext())->setResponse('foo'),
                 (new SaslContext())->setResponse('foo')->setIsComplete(true),
-            ));
+            );
 
         $this->mockRootDseLoader
             ->method('load')
             ->with($this->anything())
-            ->will(self::onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 Entry::fromArray('', [
                     'supportedSaslMechanisms' => ['DIGEST-MD5', 'CRAM-MD5'],
                 ]),
@@ -174,7 +174,7 @@ final class ClientSaslBindHandlerTest extends TestCase
                 Entry::fromArray('', [
                     'supportedSaslMechanisms' => ['DIGEST-MD5', 'CRAM-MD5'],
                 ]),
-            ));
+            );
 
         self::expectException(BindException::class);
         self::expectExceptionMessageMatches(
@@ -192,10 +192,10 @@ final class ClientSaslBindHandlerTest extends TestCase
         $this->withStandardRootDseResponse();
         $this->mockQueue
             ->method('getMessage')
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 $this->saslChallenge,
                 $this->saslComplete,
-            ));
+            );
 
         $this->mockSasl
             ->method('get')
@@ -211,10 +211,10 @@ final class ClientSaslBindHandlerTest extends TestCase
 
         $this->mockChallenge
             ->method('challenge')
-            ->will(self::onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 (new SaslContext())->setResponse('foo'),
                 (new SaslContext())->setResponse('foo')->setIsComplete(true),
-            ));
+            );
 
         $this->mockRootDseLoader
             ->expects(self::never())
@@ -233,10 +233,10 @@ final class ClientSaslBindHandlerTest extends TestCase
 
         $this->mockQueue
             ->method('getMessage')
-            ->will(self::onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 $this->saslChallenge,
                 $this->saslComplete,
-            ));
+            );
 
         $this->mockSasl
             ->method('get')
@@ -256,10 +256,10 @@ final class ClientSaslBindHandlerTest extends TestCase
 
         $this->mockChallenge
             ->method('challenge')
-            ->will(self::onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 (new SaslContext())->setResponse('foo'),
                 $completedContext,
-            ));
+            );
 
         $mockSecurityLayer = $this->createMock(SecurityLayerInterface::class);
         $this->mockMech

--- a/tests/unit/Protocol/ClientProtocolHandler/ClientSearchHandlerTest.php
+++ b/tests/unit/Protocol/ClientProtocolHandler/ClientSearchHandlerTest.php
@@ -149,7 +149,7 @@ final class ClientSearchHandlerTest extends TestCase
 
         $this->mockQueue
             ->method('getMessage')
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 new LdapMessageResponse(1, $entries[0]),
                 new LdapMessageResponse(1, $entries[1]),
                 new LdapMessageResponse(1, $referrals[0]),
@@ -159,7 +159,7 @@ final class ClientSearchHandlerTest extends TestCase
                     'cn=foo',
                     'bar',
                 )),
-            ));
+            );
 
         $this->mockQueue
             ->expects($this->exactly(5))

--- a/tests/unit/Protocol/ClientProtocolHandler/ClientSyncHandlerTest.php
+++ b/tests/unit/Protocol/ClientProtocolHandler/ClientSyncHandlerTest.php
@@ -123,7 +123,7 @@ final class ClientSyncHandlerTest extends TestCase
             ->expects($this->exactly(5))
             ->method('getMessage')
             ->with(1)
-            ->will(self::onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 new LdapMessageResponse(1, $entries[0]),
                 new LdapMessageResponse(1, $entries[1]),
                 new LdapMessageResponse(1, $referrals[0]),
@@ -137,7 +137,7 @@ final class ClientSyncHandlerTest extends TestCase
                     ),
                     new SyncDoneControl('foo'),
                 ),
-            ));
+            );
 
         self::assertEquals(
             self::makeSearchResponseFromEntries(

--- a/tests/unit/Protocol/ClientProtocolHandler/RequestCancelerTest.php
+++ b/tests/unit/Protocol/ClientProtocolHandler/RequestCancelerTest.php
@@ -55,11 +55,11 @@ final class RequestCancelerTest extends TestCase
         $cancelResponse = new ExtendedResponse(new LdapResult(ResultCode::CANCELED));
         $this->mockQueue
             ->method('getMessage')
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 new LdapMessageResponse(1, new SearchResultEntry(Entry::create(''))),
                 new LdapMessageResponse(1, new SearchResultReference()),
                 new LdapMessageResponse(2, $cancelResponse),
-            ));
+            );
 
         $this->mockQueue
             ->method('generateId')
@@ -92,11 +92,11 @@ final class RequestCancelerTest extends TestCase
 
         $this->mockQueue
             ->method('getMessage')
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 new LdapMessageResponse(1, new SearchResultEntry(Entry::create(''))),
                 new LdapMessageResponse(1, new SearchResultReference()),
                 new LdapMessageResponse(2, new ExtendedResponse(new LdapResult(ResultCode::CANCELED))),
-            ));
+            );
 
         $this->mockQueue
             ->method('generateId')

--- a/tests/unit/Protocol/LdapQueueTest.php
+++ b/tests/unit/Protocol/LdapQueueTest.php
@@ -40,10 +40,10 @@ final class LdapQueueTest extends TestCase
         $this->mockSocket
             ->expects($this->any())
             ->method('read')
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 'foo',
                 false,
-            ));
+            );
 
         $this->subject = new LdapQueue(
             $this->mockSocket,

--- a/tests/unit/Protocol/Queue/ClientQueueTest.php
+++ b/tests/unit/Protocol/Queue/ClientQueueTest.php
@@ -57,10 +57,10 @@ final class ClientQueueTest extends TestCase
 
         $this->mockSocket
             ->method('read')
-            ->will(self::onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 'foo',
                 false,
-            ));
+            );
 
         $this->subject = new ClientQueue(
             $this->mockPool,

--- a/tests/unit/Protocol/Queue/ServerQueueTest.php
+++ b/tests/unit/Protocol/Queue/ServerQueueTest.php
@@ -42,10 +42,10 @@ final class ServerQueueTest extends TestCase
 
         $this->mockSocket
             ->method('read')
-            ->will(self::onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 'foo',
                 false,
-            ));
+            );
 
         $this->mockEncoder
             ->method('getLastPosition')

--- a/tests/unit/Protocol/ServerAuthorizationTest.php
+++ b/tests/unit/Protocol/ServerAuthorizationTest.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class ServerAuthorizationTest extends TestCase
@@ -89,17 +90,13 @@ final class ServerAuthorizationTest extends TestCase
         ));
     }
 
-    /**
-     * @dataProvider authExpectedRequestsDataProvider
-     */
+    #[DataProvider('authExpectedRequestsDataProvider')]
     public function test_it_should_require_authentication_for_all_other_operations(RequestInterface $request): void
     {
         self::assertTrue($this->subject->isAuthenticationRequired($request));
     }
 
-    /**
-     * @dataProvider authExpectedRequestsDataProvider
-     */
+    #[DataProvider('authExpectedRequestsDataProvider')]
     public function test_it_should_not_require_authentication_if_it_has_been_explicitly_disabled(RequestInterface $request): void
     {
         $this->subject = new ServerAuthorization(
@@ -172,9 +169,7 @@ final class ServerAuthorizationTest extends TestCase
         self::assertTrue($this->subject->isAuthenticationRequest(Operations::bind('foo', 'bar')));
     }
 
-    /**
-     * @dataProvider authExpectedRequestsDataProvider
-     */
+    #[DataProvider('authExpectedRequestsDataProvider')]
     public function test_it_should_tell_if_a_request_is_not_an_authentication_type(RequestInterface $request): void
     {
         self::assertFalse($this->subject->isAuthenticationRequest($request));

--- a/tests/unit/Protocol/ServerProtocolHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandlerTest.php
@@ -90,12 +90,16 @@ final class ServerProtocolHandlerTest extends TestCase
 
     public function test_it_should_enforce_anonymous_bind_requirements(): void
     {
+        $messages = [new LdapMessageRequest(1, new AnonBindRequest('foo'))];
         $this->mockQueue
             ->method('getMessage')
-            ->will($this->onConsecutiveCalls(
-                new LdapMessageRequest(1, new AnonBindRequest('foo')),
-                $this->throwException(new ConnectionException()),
-            ));
+            ->willReturnCallback(static function () use (&$messages): LdapMessageRequest {
+                if ($messages === []) {
+                    throw new ConnectionException();
+                }
+
+                return array_shift($messages);
+            });
 
         $this->mockQueue
             ->expects(self::once())
@@ -120,13 +124,19 @@ final class ServerProtocolHandlerTest extends TestCase
 
     public function test_it_should_not_allow_a_previous_message_ID_from_a_new_request(): void
     {
+        $messages = [
+            new LdapMessageRequest(1, new SimpleBindRequest('foo', 'bar')),
+            new LdapMessageRequest(1, new ExtendedRequest(ExtendedRequest::OID_WHOAMI)),
+        ];
         $this->mockQueue
             ->method('getMessage')
-            ->will($this->onConsecutiveCalls(
-                new LdapMessageRequest(1, new SimpleBindRequest('foo', 'bar')),
-                new LdapMessageRequest(1, new ExtendedRequest(ExtendedRequest::OID_WHOAMI)),
-                $this->throwException(new ConnectionException()),
-            ));
+            ->willReturnCallback(static function () use (&$messages): LdapMessageRequest {
+                if ($messages === []) {
+                    throw new ConnectionException();
+                }
+
+                return array_shift($messages);
+            });
 
         $this->mockAuthenticator
             ->method('bind')
@@ -156,17 +166,18 @@ final class ServerProtocolHandlerTest extends TestCase
         $this->mockQueue
             ->method('isConnected')
             ->willReturn(true);
+        $messages = [
+            new LdapMessageRequest(1, new ModifyDnRequest('cn=foo,dc=bar', 'cn=bar', true)),
+        ];
         $this->mockQueue
             ->method('getMessage')
-            ->will(
-                $this->onConsecutiveCalls(
-                    new LdapMessageRequest(
-                        1,
-                        new ModifyDnRequest('cn=foo,dc=bar', 'cn=bar', true),
-                    ),
-                    $this->throwException(new ConnectionException()),
-                ),
-            );
+            ->willReturnCallback(static function () use (&$messages): LdapMessageRequest {
+                if ($messages === []) {
+                    throw new ConnectionException();
+                }
+
+                return array_shift($messages);
+            });
 
         $this->mockQueue
             ->expects($this->atLeast(1))
@@ -246,15 +257,18 @@ final class ServerProtocolHandlerTest extends TestCase
 
     public function test_it_should_not_allow_a_message_with_an_ID_of_zero(): void
     {
+        $messages = [
+            new LdapMessageRequest(0, new ExtendedRequest(ExtendedRequest::OID_START_TLS)),
+        ];
         $this->mockQueue
             ->method('getMessage')
-            ->will($this->onConsecutiveCalls(
-                new LdapMessageRequest(
-                    0,
-                    new ExtendedRequest(ExtendedRequest::OID_START_TLS),
-                ),
-                $this->throwException(new ConnectionException()),
-            ));
+            ->willReturnCallback(static function () use (&$messages): LdapMessageRequest {
+                if ($messages === []) {
+                    throw new ConnectionException();
+                }
+
+                return array_shift($messages);
+            });
 
         $this->mockQueue
             ->expects($this->atLeast(1))
@@ -272,15 +286,18 @@ final class ServerProtocolHandlerTest extends TestCase
 
     public function test_it_should_send_a_bind_request_to_the_bind_request_handler(): void
     {
+        $messages = [
+            new LdapMessageRequest(1, new SimpleBindRequest('foo@bar', 'bar')),
+        ];
         $this->mockQueue
             ->method('getMessage')
-            ->will($this->onConsecutiveCalls(
-                new LdapMessageRequest(
-                    1,
-                    new SimpleBindRequest('foo@bar', 'bar'),
-                ),
-                $this->throwException(new ConnectionException()),
-            ));
+            ->willReturnCallback(static function () use (&$messages): LdapMessageRequest {
+                if ($messages === []) {
+                    throw new ConnectionException();
+                }
+
+                return array_shift($messages);
+            });
 
         $this->mockAuthenticator
             ->expects($this->once())
@@ -298,15 +315,21 @@ final class ServerProtocolHandlerTest extends TestCase
     {
         $this->mockQueue
             ->method('isConnected')
-            ->will($this->onConsecutiveCalls(true, false));
+            ->willReturnOnConsecutiveCalls(true, false);
 
+        $messages = [
+            new LdapMessageRequest(1, new SimpleBindRequest('foo@bar', 'bar')),
+            new LdapMessageRequest(2, new ModifyRequest('cn=foo,dc=bar')),
+        ];
         $this->mockQueue
             ->method('getMessage')
-            ->will($this->onConsecutiveCalls(
-                new LdapMessageRequest(1, new SimpleBindRequest('foo@bar', 'bar')),
-                new LdapMessageRequest(2, new ModifyRequest('cn=foo,dc=bar')),
-                $this->throwException(new ConnectionException()),
-            ));
+            ->willReturnCallback(static function () use (&$messages): LdapMessageRequest {
+                if ($messages === []) {
+                    throw new ConnectionException();
+                }
+
+                return array_shift($messages);
+            });
 
         $this->mockAuthenticator
             ->expects($this->once())

--- a/tests/unit/Search/DirSyncTest.php
+++ b/tests/unit/Search/DirSyncTest.php
@@ -191,10 +191,10 @@ final class DirSyncTest extends TestCase
         $this->client
             ->expects($this->any())
             ->method('send')
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 $this->initialResponse,
                 $this->secondResponse,
-            ));
+            );
 
         $this->subject->getChanges();
         self::assertSame(
@@ -258,10 +258,10 @@ final class DirSyncTest extends TestCase
         $this->client
             ->expects($this->any())
             ->method('send')
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 $this->initialResponse,
                 $this->secondResponse,
-            ));
+            );
 
         $this->subject->getChanges();
         $this->subject->getChanges();

--- a/tests/unit/Search/Filter/AndFilterTest.php
+++ b/tests/unit/Search/Filter/AndFilterTest.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Search\Filter\AndFilter;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Search\Filter\SubstringFilter;
 use FreeDSx\Ldap\Search\Filters;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class AndFilterTest extends TestCase
@@ -119,10 +120,9 @@ final class AndFilterTest extends TestCase
     }
 
     /**
-     * @dataProvider malformedAsn1DataProvider
-     *
      * @param AbstractType<mixed> $type
      */
+    #[DataProvider('malformedAsn1DataProvider')]
     public function test_it_should_not_be_constructed_from_invalid_asn1(AbstractType $type): void
     {
         self::expectException(ProtocolException::class);

--- a/tests/unit/Search/Filter/OrFilterTest.php
+++ b/tests/unit/Search/Filter/OrFilterTest.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Search\Filter\OrFilter;
 use FreeDSx\Ldap\Search\Filter\SubstringFilter;
 use FreeDSx\Ldap\Search\Filters;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class OrFilterTest extends TestCase
@@ -123,10 +124,9 @@ final class OrFilterTest extends TestCase
     }
 
     /**
-     * @dataProvider malformedAsn1DataProvider
-     *
      * @param AbstractType<mixed> $type
      */
+    #[DataProvider('malformedAsn1DataProvider')]
     public function test_it_should_not_be_constructed_from_invalid_asn1(AbstractType $type): void
     {
         $this->expectException(ProtocolException::class);

--- a/tests/unit/Search/FilterParserTest.php
+++ b/tests/unit/Search/FilterParserTest.php
@@ -16,6 +16,7 @@ namespace Tests\Unit\FreeDSx\Ldap\Search;
 use FreeDSx\Ldap\Exception\FilterParseException;
 use FreeDSx\Ldap\Search\FilterParser;
 use FreeDSx\Ldap\Search\Filters;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class FilterParserTest extends TestCase
@@ -118,9 +119,7 @@ final class FilterParserTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider invalidMatchingRuleDataProvider
-     */
+    #[DataProvider('invalidMatchingRuleDataProvider')]
     public function test_it_should_error_on_invalid_matching_rule_syntax(string $filter): void
     {
         self::expectException(FilterParseException::class);
@@ -249,9 +248,7 @@ final class FilterParserTest extends TestCase
         FilterParser::parse('foo=bar)');
     }
 
-    /**
-     * @dataProvider malformedFilterDataProvider
-     */
+    #[DataProvider('malformedFilterDataProvider')]
     public function test_it_should_error_on_unrecognized_values_at_the_end_of_the_filter(string $filter): void
     {
         self::expectException(FilterParseException::class);

--- a/tests/unit/Search/PagingTest.php
+++ b/tests/unit/Search/PagingTest.php
@@ -89,12 +89,12 @@ final class PagingTest extends TestCase
             ->expects($this->atMost(2))
             ->method('sendAndReceive')
             ->with($this->search, $this->anything())
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 self::makeSearchResponseFromEntries(
                     controls: [new PagingControl(100, 'foo')],
                 ),
                 self::makeSearchResponseFromEntries(),
-            ));
+            );
 
         $this->subject->getEntries();
         $this->subject->end();

--- a/tests/unit/Search/RangeRetrievalTest.php
+++ b/tests/unit/Search/RangeRetrievalTest.php
@@ -169,10 +169,10 @@ final class RangeRetrievalTest extends TestCase
         $this->mockClient
             ->expects($this->exactly(2))
             ->method('readOrFail')
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 $entry1,
                 $entry2,
-            ));
+            );
 
         self::assertEquals(
             ['foo', 'bar'],

--- a/tests/unit/Search/VlvTest.php
+++ b/tests/unit/Search/VlvTest.php
@@ -313,14 +313,14 @@ final class VlvTest extends TestCase
         $this->mockClient
             ->expects($this->atMost(2))
             ->method('sendAndReceive')
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 $this::makeSearchResponseFromEntries(
                     controls: [new VlvResponseControl(1, 200, 0, 'foo')],
                 ),
                 $this::makeSearchResponseFromEntries(
                     controls: [new VlvResponseControl(20, 200, 0, 'foo')],
                 ),
-            ));
+            );
 
         $this->subject->asPercentage();
         $this->subject->getEntries();
@@ -343,14 +343,14 @@ final class VlvTest extends TestCase
         $this->mockClient
             ->expects($this->atMost(2))
             ->method('sendAndReceive')
-            ->will($this->onConsecutiveCalls(
+            ->willReturnOnConsecutiveCalls(
                 $this::makeSearchResponseFromEntries(
                     controls: [new VlvResponseControl(100, 200, 0, 'foo')],
                 ),
                 $this::makeSearchResponseFromEntries(
                     controls: [new VlvResponseControl(80, 200, 0, 'foo')],
                 ),
-            ));
+            );
 
         $this->subject->asPercentage(true);
         $this->subject->startAt(50);

--- a/tests/unit/Server/Backend/Storage/Adapter/MysqlFilterTranslatorTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/MysqlFilterTranslatorTest.php
@@ -25,6 +25,7 @@ use FreeDSx\Ldap\Search\Filter\PresentFilter;
 use FreeDSx\Ldap\Search\Filter\SubstringFilter;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\MysqlFilterTranslator;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\InvalidAttributeException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class MysqlFilterTranslatorTest extends TestCase
@@ -331,9 +332,7 @@ final class MysqlFilterTranslatorTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider provideInvalidAttributeDescriptions
-     */
+    #[DataProvider('provideInvalidAttributeDescriptions')]
     public function test_invalid_attribute_description_throws(string $attribute): void
     {
         $this->expectException(InvalidAttributeException::class);

--- a/tests/unit/Server/Backend/Storage/Adapter/SqliteFilterTranslatorTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/SqliteFilterTranslatorTest.php
@@ -25,6 +25,7 @@ use FreeDSx\Ldap\Search\Filter\PresentFilter;
 use FreeDSx\Ldap\Search\Filter\SubstringFilter;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqliteFilterTranslator;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\InvalidAttributeException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class SqliteFilterTranslatorTest extends TestCase
@@ -315,9 +316,7 @@ final class SqliteFilterTranslatorTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider provideInvalidAttributeDescriptions
-     */
+    #[DataProvider('provideInvalidAttributeDescriptions')]
     public function test_invalid_attribute_description_throws(string $attribute): void
     {
         $this->expectException(InvalidAttributeException::class);

--- a/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
@@ -34,6 +34,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Server\SearchLimits;
 use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
@@ -820,9 +821,7 @@ final class WritableStorageBackendTest extends TestCase
         self::assertNotNull($this->subject->get(new Dn('cn=Alicia,dc=example,dc=com')));
     }
 
-    /**
-     * @dataProvider provideMaxSearchTimeLimitCases
-     */
+    #[DataProvider('provideMaxSearchTimeLimitCases')]
     public function test_max_search_time_limit_computes_effective_time_limit(
         int $serverMax,
         int $requestLimit,


### PR DESCRIPTION
Updating PHPUnit to as high as it can go for PHP 8.2. I forgot about this after I bumped the PHP version from 8.1 to 8.2.