### PR TITLE
[1.0.0] Add a configurable ACL system to the server.

### DIFF
--- a/docs/Server/Access-Control.md
+++ b/docs/Server/Access-Control.md
@@ -1,0 +1,238 @@
+Access Control
+================
+
+* [Overview](#overview)
+* [Default Behaviour: SimpleAccessControl](#default-behaviour-simpleaccesscontrol)
+* [Rule-Based Access Control](#rule-based-access-control)
+    * [Rule Evaluation Order](#rule-evaluation-order)
+    * [Default Effect](#default-effect)
+* [Subject Reference](#subject-reference)
+* [Target Reference](#target-reference)
+* [Attribute Rules](#attribute-rules)
+* [Custom Access Control](#custom-access-control)
+
+## Overview
+
+Access control operates at two levels:
+
+- **Operation level**: Checked before each operation executes. Denial sends `INSUFFICIENT_ACCESS_RIGHTS` to the
+  client. Covers the following operations: Search, Add, Modify, Delete, ModifyDn, and Compare.
+- **Attribute level**: Checked for each attribute involved in Compare, Add, and Modify operations. Also applied to
+  each Search result entry: disallowed attributes are stripped before the entry is sent; if the entry itself is
+  denied at operation level, it is suppressed entirely from results (not sent to the client).
+
+Configure via `ServerOptions::setOperationRules()` / `ServerOptions::setAttributeRules()`. See [Configuration](Configuration.md).
+
+Bind, WhoAmI, and StartTLS are handled before access control and are always permitted.
+
+## Default Behaviour: SimpleAccessControl
+
+When no rules are configured, the server uses `SimpleAccessControl`: all operations are denied for anonymous clients
+and allowed for authenticated clients. No attribute filtering is applied.
+
+## Rule-Based Access Control
+
+Configure operation and attribute rules on `ServerOptions`. Rules are evaluated in definition order (first match wins).
+If no rule matches, a configurable default effect applies (deny by default).
+
+```php
+use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
+use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
+use FreeDSx\Ldap\Server\AccessControl\Target\Target;
+
+$server = new LdapServer(
+    (new ServerOptions())
+        ->setOperationRules([
+            // Admin group can do anything.
+            OperationRule::allow(
+                Subject::group('cn=admins,dc=example,dc=com'),
+            ),
+            // Authenticated users can search and compare.
+            OperationRule::allow(
+                Subject::authenticated(),
+                Target::any(),
+                OperationType::Search,
+                OperationType::Compare,
+            ),
+            // Users can modify their own entry.
+            OperationRule::allow(
+                Subject::self(),
+                Target::any(),
+                OperationType::Modify,
+            ),
+            // Deny everything else.
+            OperationRule::deny(Subject::anyone()),
+        ])
+        ->setAttributeRules([
+            // Users can see their own userPassword.
+            AttributeRule::allow(
+                Subject::self(),
+                Target::any(),
+                'userPassword',
+            ),
+            // Hide userPassword from everyone else.
+            AttributeRule::deny(
+                Subject::anyone(),
+                Target::any(),
+                'userPassword',
+            ),
+        ])
+);
+
+$server->useBackend(new MyDirectoryBackend());
+```
+
+### Rule Evaluation Order
+
+Rules are evaluated in definition order. For each rule:
+
+| Check          | Passes when…                                                           | On fail                                                             |
+|----------------|------------------------------------------------------------------------|---------------------------------------------------------------------|
+| Operation type | Rule has no operations listed, **or** current operation is in the list | Skip to next rule                                                   |
+| Target DN      | Target matcher returns true for the entry DN                           | Skip to next rule                                                   |
+| Subject        | Subject matcher returns true for the bound user                        | Skip to next rule                                                   |
+| Effect         | —                                                                      | `Allow` → permit; `Deny` → reject with `INSUFFICIENT_ACCESS_RIGHTS` |
+
+If no rule matches, the [default effect](#default-effect) is applied.
+
+For attribute rules the same logic applies per attribute. Any attribute that matches no rule is kept (default allow).
+
+### Default Effect
+
+When no operation rule matches, `setDefaultAccessRule()` determines the outcome (default: `Effect::Deny`).
+
+```php
+use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;
+
+// Allow everything not explicitly matched (open policy).
+(new ServerOptions())->setDefaultAccessRule(Effect::Allow);
+```
+
+## Subject Reference
+
+Use the `Subject` factory to build subject matchers.
+
+| Factory method                                                                                       | Matches                                                               |
+|------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
+| `Subject::anyone()`                                                                                  | Every client (including anonymous)                                    |
+| `Subject::anonymous()`                                                                               | Anonymous (unbound) clients only                                      |
+| `Subject::authenticated()`                                                                           | Any successfully bound client                                         |
+| `Subject::self()`                                                                                    | A client whose bound DN equals the target entry DN (case-insensitive) |
+| `Subject::dn(string $dn)`                                                                            | A client bound as the specific DN (case-insensitive)                  |
+| `Subject::dnSubtree(string $dn)`                                                                     | A client whose bound DN is within the given subtree                   |
+| `Subject::group(string $groupDn, string $memberAttribute = 'member', int $maxCacheSize = 200)` | A client whose bound DN appears in the group entry's member attribute |
+| `Subject::callback(Closure $fn)`                                                                     | Delegates to `fn(TokenInterface $token, Dn $targetDn): bool`          |
+
+**Group membership caching**: `Subject::group()` fetches the group entry once per connection. The cache size is
+controlled by `$maxCacheSize` (default: 200, FIFO; 0 to disable cache). Membership changes made after the first evaluation for a
+given connection are not visible until the client reconnects.
+
+**Group rename**: If a referenced group entry is renamed or deleted, the rule fails closed (access denied). Protect
+ACL group entries with their own rules to prevent unauthorized `ModifyDn` on them:
+
+```php
+// Prevent non-admins from renaming entries under ou=groups.
+OperationRule::deny(
+    Subject::authenticated(),
+    Target::subtree('ou=groups,dc=example,dc=com'),
+    OperationType::ModifyDn,
+),
+```
+
+## Target Reference
+
+Use the `Target` factory to build target matchers.
+
+| Factory method                | Matches                                 |
+|-------------------------------|-----------------------------------------|
+| `Target::any()`               | Every entry DN                          |
+| `Target::dn(string $dn)`      | The specific DN only (case-insensitive) |
+| `Target::subtree(string $dn)` | The given DN and all entries beneath it |
+
+## Attribute Rules
+
+`AttributeRule` follows the same subject/target/first-match-wins structure as operation rules. An empty attribute list
+matches all attributes.
+
+Attribute rules are enforced in three places:
+
+- **Search**: denied attributes are stripped from each result entry before it is sent. If the bound user is denied
+  the Search operation on an entry's DN, the entry is suppressed entirely (not sent at all).
+- **Compare**: a Compare request is rejected if the bound user is denied access to the compared attribute.
+- **Add / Modify**: the request is rejected if the bound user is denied access to any attribute being written.
+
+```php
+->setAttributeRules([
+    // Only admins can see or write userPassword.
+    AttributeRule::allow(
+        Subject::group('cn=admins,dc=example,dc=com'),
+        Target::any(),
+        'userPassword',
+    ),
+    AttributeRule::deny(
+        Subject::anyone(),
+        Target::any(),
+        'userPassword',
+    ),
+    // Strip all attributes from ou=internal entries for non-admins (only DN returned).
+    AttributeRule::deny(
+        Subject::authenticated(),
+        Target::subtree('ou=internal,dc=example,dc=com'),
+    ),
+])
+```
+
+## Custom Access Control
+
+For cases where the built-in rule system is insufficient, implement `AccessControlInterface` and pass it via
+`LdapServer::useAccessControl()`:
+
+```php
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+class MyAccessControl implements AccessControlInterface
+{
+    public function authorizeOperation(
+        OperationType $operation,
+        TokenInterface $token,
+        Dn $dn,
+    ): void {
+        if (!$this->isAllowed($operation, $token, $dn)) {
+            throw new OperationException(
+                'Access denied.',
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+            );
+        }
+    }
+
+    public function authorizeAttribute(
+        TokenInterface $token,
+        Dn $dn,
+        string $attribute,
+    ): void {
+        // Throw OperationException to deny access to the attribute.
+    }
+
+    /**
+     * Return null to suppress the entry from search results entirely.
+     */
+    public function filterEntry(
+        TokenInterface $token,
+        Entry $entry,
+    ): ?Entry {
+        return $entry;
+    }
+}
+
+$server->useAccessControl(new MyAccessControl());
+```

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -11,6 +11,8 @@ LDAP Server Configuration
     * [ServerOptions:setRequireAuthentication](#setrequireauthentication)
     * [ServerOptions:setAllowAnonymous](#setallowanonymous)
     * [ServerOptions:setSocketAcceptTimeout](#setsocketaccepttimeout)
+* [Access Control](#access-control)
+    * [ServerOptions:setAccessControl](#setaccesscontrol)
 * [Backend](#backend)
     * [ServerOptions:setBackend](#setbackend)
     * [ServerOptions:setFilterEvaluator](#setfilterevaluator)
@@ -139,6 +141,41 @@ in the accept loop.
 
 **Default**: `0.5`
 
+
+## Access Control
+
+------------------
+#### setAccessControl
+
+This should be an object instance that implements `FreeDSx\Ldap\Server\AccessControl\AccessControlInterface`. It
+controls which operations clients are permitted to perform and which attributes are accessible in searches,
+compares, and write operations.
+
+```php
+use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
+use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
+use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
+
+$server = new LdapServer(
+    (new ServerOptions())
+        ->setAccessControl(new RuleBasedAccessControl(
+            operationRules: [
+                OperationRule::allow(Subject::authenticated()),
+                OperationRule::deny(Subject::anyone()),
+            ],
+        ))
+);
+```
+
+See [Access Control](Access-Control.md) for more information, including:
+
+* Rule-based access control
+* Subject and target matchers
+* Attribute filtering
+
+**Default**: `SimpleAccessControl` Denies all operations for anonymous clients, allows all for authenticated clients.
 
 ## Backend
 

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -15,6 +15,11 @@ namespace FreeDSx\Ldap;
 
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\AccessControl\BackendAwareInterface;
+use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
+use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\OperationalAttributeGenerator;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
@@ -38,6 +43,8 @@ class LdapServer
 {
     private Container $container;
 
+    private ?AccessControlInterface $accessControl = null;
+
     public function __construct(
         private readonly ServerOptions $options = new ServerOptions(),
         ?Container $container = null,
@@ -54,9 +61,88 @@ class LdapServer
      */
     public function run(): void
     {
+        $this->init();
+
         $runner = $this->options->getServerRunner() ?? $this->container->get(ServerRunnerInterface::class);
 
         $runner->run();
+    }
+
+    /**
+     * Specify a fully custom access control implementation; rare — prefer ServerOptions rules instead.
+     */
+    public function useAccessControl(AccessControlInterface $acl): self
+    {
+        $this->accessControl = $acl;
+
+        return $this;
+    }
+
+    private function init(): void
+    {
+        $this->options->setAccessControl($this->resolveAccessControl());
+    }
+
+    private function resolveAccessControl(): AccessControlInterface
+    {
+        if ($this->accessControl !== null) {
+            return $this->injectBackendIfNeeded($this->accessControl);
+        }
+
+        $operationRules = $this->options->getOperationRules();
+        $attributeRules = $this->options->getAttributeRules();
+
+        if ($operationRules === [] && $attributeRules === []) {
+            return $this->options->getAccessControl();
+        }
+
+        $backend = $this->options->getBackend();
+        if ($backend !== null) {
+            $this->propagateBackend(
+                $backend,
+                $operationRules,
+                $attributeRules,
+            );
+        }
+
+        return new RuleBasedAccessControl(
+            $operationRules,
+            $attributeRules,
+            $this->options->getDefaultAccessRule(),
+        );
+    }
+
+    private function injectBackendIfNeeded(AccessControlInterface $acl): AccessControlInterface
+    {
+        $backend = $this->options->getBackend();
+
+        if ($backend !== null && $acl instanceof BackendAwareInterface) {
+            $acl->setBackend($backend);
+        }
+
+        return $acl;
+    }
+
+    /**
+     * @param OperationRule[] $operationRules
+     * @param AttributeRule[] $attributeRules
+     */
+    private function propagateBackend(
+        LdapBackendInterface $backend,
+        array $operationRules,
+        array $attributeRules,
+    ): void {
+        foreach ($operationRules as $rule) {
+            if ($rule->subject instanceof BackendAwareInterface) {
+                $rule->subject->setBackend($backend);
+            }
+        }
+
+        foreach ($attributeRules as $rule) {
+            if ($rule->subject instanceof BackendAwareInterface) {
+                $rule->subject->setBackend($backend);
+            }
+        }
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/PlainMechanismOptionsBuilder.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/PlainMechanismOptionsBuilder.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
 
+use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Sasl\Options\ChallengeOptionsInterface;
@@ -35,8 +36,15 @@ class PlainMechanismOptionsBuilder implements MechanismOptionsBuilderInterface
         MechanismName $mechanism,
     ): ?ChallengeOptionsInterface {
         return (new PlainOptions())->setValidate(
-            fn(?string $authzId, string $authcId, string $password): bool
-                => $this->authenticator->verifyPassword($authcId, $password),
+            function (?string $authzId, string $authcId, string $password): bool {
+                try {
+                    $this->authenticator->authenticate($authcId, $password);
+
+                    return true;
+                } catch (OperationException) {
+                    return false;
+                }
+            },
         );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/Bind/SaslBind.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/SaslBind.php
@@ -194,7 +194,7 @@ class SaslBind implements BindInterface
             $this->queue->setMessageWrapper(new SaslMessageWrapper($mech->securityLayer(), $context));
         }
 
-        return new BindToken(
+        return BindToken::fromDn(
             $username,
             '',
         );

--- a/src/FreeDSx/Ldap/Protocol/Bind/SimpleBind.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/SimpleBind.php
@@ -13,16 +13,13 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\Bind;
 
-use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Operation\Request\BindRequest;
 use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
-use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
-use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -61,19 +58,9 @@ class SimpleBind implements BindInterface
         return $token;
     }
 
-    /**
-     * @throws OperationException
-     */
     private function simpleBind(SimpleBindRequest $request): TokenInterface
     {
-        if (!$this->authenticator->verifyPassword($request->getUsername(), $request->getPassword())) {
-            throw new OperationException(
-                'Invalid credentials.',
-                ResultCode::INVALID_CREDENTIALS,
-            );
-        }
-
-        return new BindToken(
+        return $this->authenticator->authenticate(
             $request->getUsername(),
             $request->getPassword(),
         );

--- a/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
@@ -65,6 +65,7 @@ class ServerProtocolHandlerFactory
                 queue: $this->queue,
                 backend: $this->handlerFactory->makeBackend(),
                 filterEvaluator: $this->handlerFactory->makeFilterEvaluator(),
+                accessControl: $this->options->getAccessControl(),
                 limits: $this->options->makeSearchLimits(),
             );
         } elseif ($request instanceof UnbindRequest) {
@@ -74,6 +75,7 @@ class ServerProtocolHandlerFactory
                 queue: $this->queue,
                 backend: $this->handlerFactory->makeBackend(),
                 writeDispatcher: $this->handlerFactory->makeWriteDispatcher(),
+                accessControl: $this->options->getAccessControl(),
             );
         }
     }
@@ -124,6 +126,7 @@ class ServerProtocolHandlerFactory
             queue: $this->queue,
             backend: $this->handlerFactory->makeBackend(),
             filterEvaluator: $this->handlerFactory->makeFilterEvaluator(),
+            accessControl: $this->options->getAccessControl(),
             requestHistory: $this->requestHistory,
             limits: $this->options->makeSearchLimits(),
         );

--- a/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
@@ -22,7 +22,7 @@ use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
 use FreeDSx\Ldap\Operation\Request\UnbindRequest;
 use FreeDSx\Ldap\Server\Token\AnonToken;
-use FreeDSx\Ldap\Server\Token\BindToken;
+use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\ServerOptions;
 
@@ -97,7 +97,7 @@ class ServerAuthorization
             return true;
         }
 
-        return $this->token instanceof BindToken;
+        return $this->token instanceof AuthenticatedTokenInterface;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -16,10 +16,13 @@ namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\AccessControl\OperationType;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteCommandFactory;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
@@ -31,14 +34,15 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class ServerDispatchHandler implements ServerProtocolHandlerInterface
+readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
 {
     public function __construct(
-        private readonly ServerQueue $queue,
-        private readonly LdapBackendInterface $backend,
-        private readonly WriteOperationDispatcher $writeDispatcher,
-        private readonly WriteCommandFactory $commandFactory = new WriteCommandFactory(),
-        private readonly ResponseFactory $responseFactory = new ResponseFactory(),
+        private ServerQueue $queue,
+        private LdapBackendInterface $backend,
+        private WriteOperationDispatcher $writeDispatcher,
+        private AccessControlInterface $accessControl,
+        private WriteCommandFactory $commandFactory = new WriteCommandFactory(),
+        private ResponseFactory $responseFactory = new ResponseFactory(),
     ) {}
 
     /**
@@ -52,8 +56,21 @@ class ServerDispatchHandler implements ServerProtocolHandlerInterface
     ): void {
         try {
             $request = $message->getRequest();
+            $this->authorizeRequest(
+                $request,
+                $token,
+            );
+            $this->authorizeWriteAttributes(
+                $request,
+                $token,
+            );
 
             if ($request instanceof Request\CompareRequest) {
+                $this->accessControl->authorizeAttribute(
+                    $token,
+                    $request->getDn(),
+                    $request->getFilter()->getAttribute(),
+                );
                 $match = $this->backend->compare($request->getDn(), $request->getFilter());
                 $this->queue->sendMessage($this->responseFactory->getStandardResponse(
                     $message,
@@ -81,5 +98,100 @@ class ServerDispatchHandler implements ServerProtocolHandlerInterface
                 $e->getMessage(),
             ));
         }
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function authorizeWriteAttributes(
+        RequestInterface $request,
+        TokenInterface $token,
+    ): void {
+        if ($request instanceof Request\AddRequest) {
+            $dn = $request->getEntry()->getDn();
+            foreach ($request->getEntry()->getAttributes() as $attribute) {
+                $this->accessControl->authorizeAttribute(
+                    $token,
+                    $dn,
+                    $attribute->getName(),
+                );
+            }
+
+            return;
+        }
+
+        if ($request instanceof Request\ModifyRequest) {
+            $dn = $request->getDn();
+            foreach ($request->getChanges() as $change) {
+                $this->accessControl->authorizeAttribute(
+                    $token,
+                    $dn,
+                    $change->getAttribute()->getName(),
+                );
+            }
+        }
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function authorizeRequest(
+        RequestInterface $request,
+        TokenInterface $token,
+    ): void {
+        if ($request instanceof Request\ModifyDnRequest) {
+            $this->authorizeModifyDn(
+                $request,
+                $token,
+            );
+
+            return;
+        }
+
+        $result = match (true) {
+            $request instanceof Request\CompareRequest => [OperationType::Compare, $request->getDn()],
+            $request instanceof Request\AddRequest => [OperationType::Add, $request->getEntry()->getDn()],
+            $request instanceof Request\DeleteRequest => [OperationType::Delete, $request->getDn()],
+            $request instanceof Request\ModifyRequest => [OperationType::Modify, $request->getDn()],
+            default => null,
+        };
+
+        if ($result === null) {
+            return;
+        }
+
+        [$operationType, $dn] = $result;
+
+        $this->accessControl->authorizeOperation(
+            $operationType,
+            $token,
+            $dn,
+        );
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function authorizeModifyDn(
+        Request\ModifyDnRequest $request,
+        TokenInterface $token,
+    ): void {
+        $this->accessControl->authorizeOperation(
+            OperationType::ModifyDn,
+            $token,
+            $request->getDn(),
+        );
+
+        $newParentDn = $request->getNewParentDn();
+
+        if ($newParentDn === null) {
+            return;
+        }
+
+        $this->accessControl->authorizeOperation(
+            OperationType::ModifyDn,
+            $token,
+            $newParentDn,
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -22,6 +22,8 @@ use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\AccessControl\OperationType;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Paging\PagingRequest;
 use FreeDSx\Ldap\Server\Paging\PagingRequestComparator;
@@ -46,6 +48,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         private readonly ServerQueue $queue,
         private readonly LdapBackendInterface $backend,
         private readonly FilterEvaluatorInterface $filterEvaluator,
+        private readonly AccessControlInterface $accessControl,
         private readonly RequestHistory $requestHistory,
         private readonly PagingRequestComparator $requestComparator = new PagingRequestComparator(),
         private readonly SearchLimits $limits = new SearchLimits(),
@@ -65,7 +68,17 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         $response = null;
         $controls = [];
         try {
-            $response = $this->handlePaging($pagingRequest, $message);
+            $baseDn = $this->assertBaseDnProvided($searchRequest);
+            $this->accessControl->authorizeOperation(
+                OperationType::Search,
+                $token,
+                $baseDn,
+            );
+            $response = $this->handlePaging(
+                $pagingRequest,
+                $message,
+                $token,
+            );
             if ($response->isSizeLimitExceeded()) {
                 $searchResult = SearchResult::makeSizeLimitResult(
                     $response->getEntries(),
@@ -125,21 +138,30 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
     private function handlePaging(
         PagingRequest $pagingRequest,
         LdapMessageRequest $message,
+        TokenInterface $token,
     ): PagingResponse {
         if (!$pagingRequest->isPagingStart()) {
-            return $this->handleExistingCookie($pagingRequest, $message);
+            return $this->handleExistingCookie(
+                $pagingRequest,
+                $message,
+                $token,
+            );
         }
 
-        return $this->handlePagingStart($pagingRequest);
+        return $this->handlePagingStart(
+            $pagingRequest,
+            $token,
+        );
     }
 
     /**
      * @throws OperationException
      */
-    private function handlePagingStart(PagingRequest $pagingRequest): PagingResponse
-    {
+    private function handlePagingStart(
+        PagingRequest $pagingRequest,
+        TokenInterface $token,
+    ): PagingResponse {
         $searchRequest = $pagingRequest->getSearchRequest();
-        $this->assertBaseDnProvided($searchRequest);
 
         $result = $this->backend->search(
             $searchRequest,
@@ -153,6 +175,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
             $pagingRequest->getSize(),
             $searchRequest,
             0,
+            $token,
             $isPreFiltered,
         );
 
@@ -170,6 +193,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
     private function handleExistingCookie(
         PagingRequest $pagingRequest,
         LdapMessageRequest $message,
+        TokenInterface $token,
     ): PagingResponse {
         $newPagingRequest = $this->makePagingRequest($message);
 
@@ -204,6 +228,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
             $pagingRequest->getSize(),
             $pagingRequest->getSearchRequest(),
             $pagingRequest->getTotalSent(),
+            $token,
             $isPreFiltered,
         );
 
@@ -258,6 +283,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         int $pageSize,
         SearchRequest $request,
         int $totalAlreadySent,
+        TokenInterface $token,
         bool $isPreFiltered = false,
     ): CollectedPage {
         $page = [];
@@ -278,8 +304,23 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
             $entry = $generator->current();
 
             if ($entry instanceof Entry && ($isPreFiltered || $this->filterEvaluator->evaluate($entry, $filter))) {
-                $page[] = $this->applyAttributeFilter(
+                $filtered = $this->accessControl->filterEntry(
+                    $token,
                     $entry,
+                );
+
+                if ($filtered === null) {
+                    $generator->next();
+                    continue;
+                }
+
+                if ($filtered !== $entry && !$this->filterEvaluator->evaluate($filtered, $filter)) {
+                    $generator->next();
+                    continue;
+                }
+
+                $page[] = $this->applyAttributeFilter(
+                    $filtered,
                     $request->getAttributes(),
                     $request->getAttributesOnly(),
                 );

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -19,6 +19,8 @@ use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\AccessControl\OperationType;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
@@ -39,6 +41,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         private readonly ServerQueue $queue,
         private readonly LdapBackendInterface $backend,
         private readonly FilterEvaluatorInterface $filterEvaluator,
+        private readonly AccessControlInterface $accessControl,
         private readonly SearchLimits $limits = new SearchLimits(),
     ) {}
 
@@ -52,7 +55,12 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         $request = $this->getSearchRequestFromMessage($message);
 
         try {
-            $this->assertBaseDnProvided($request);
+            $baseDn = $this->assertBaseDnProvided($request);
+            $this->accessControl->authorizeOperation(
+                OperationType::Search,
+                $token,
+                $baseDn,
+            );
 
             $backendResult = $this->backend->search(
                 $request,
@@ -65,6 +73,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
                     $backendResult,
                     $request,
                     $state,
+                    $token,
                 ),
                 (string) $request->getBaseDn(),
                 $state,
@@ -93,6 +102,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         EntryStream $backend,
         SearchRequest $request,
         SearchResultState $state,
+        TokenInterface $token,
     ): Generator {
         $sizeLimit = $this->effectiveSizeLimit(
             $request->getSizeLimit(),
@@ -107,8 +117,21 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
                 continue;
             }
 
-            yield $this->applyAttributeFilter(
+            $filtered = $this->accessControl->filterEntry(
+                $token,
                 $entry,
+            );
+
+            if ($filtered === null) {
+                continue;
+            }
+
+            if ($filtered !== $entry && !$this->filterEvaluator->evaluate($filtered, $filter)) {
+                continue;
+            }
+
+            yield $this->applyAttributeFilter(
+                $filtered,
                 $request->getAttributes(),
                 $request->getAttributesOnly(),
             );

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Control\PagingControl;
 use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\RuntimeException;
@@ -107,14 +108,18 @@ trait ServerSearchTrait
     /**
      * @throws OperationException
      */
-    private function assertBaseDnProvided(SearchRequest $request): void
+    private function assertBaseDnProvided(SearchRequest $request): Dn
     {
-        if ($request->getBaseDn() === null) {
+        $baseDn = $request->getBaseDn();
+
+        if ($baseDn === null) {
             throw new OperationException(
                 'No base DN provided.',
                 ResultCode::PROTOCOL_ERROR,
             );
         }
+
+        return $baseDn;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
@@ -15,13 +15,13 @@ namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use Exception;
 use FreeDSx\Asn1\Exception\EncoderException;
-use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -41,14 +41,16 @@ class ServerWhoAmIHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
     ): void {
-        $userId = $token->getUsername();
+        $userId = null;
 
-        if ($userId !== null) {
+        if ($token instanceof AuthenticatedTokenInterface) {
+            $resolvedDn = $token->getResolvedDn();
+
             try {
-                (new Dn($userId))->toArray();
-                $userId = 'dn:' . $userId;
+                $resolvedDn->toArray();
+                $userId = 'dn:' . $resolvedDn->toString();
             } catch (Exception) {
-                $userId = 'u:' . $userId;
+                $userId = 'u:' . $token->getUsername();
             }
         }
 

--- a/src/FreeDSx/Ldap/Server/AccessControl/AccessControlInterface.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/AccessControlInterface.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * Guards LDAP operations and read-side attribute visibility.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface AccessControlInterface
+{
+    /**
+     * Assert that $token may perform $operation on $dn.
+     *
+     * @throws OperationException with ResultCode::INSUFFICIENT_ACCESS_RIGHTS on denial
+     */
+    public function authorizeOperation(
+        OperationType $operation,
+        TokenInterface $token,
+        Dn $dn,
+    ): void;
+
+    /**
+     * Assert that $token may access $attribute on $dn (gates Compare, Add, and Modify operations).
+     *
+     * @throws OperationException with ResultCode::INSUFFICIENT_ACCESS_RIGHTS on denial
+     */
+    public function authorizeAttribute(
+        TokenInterface $token,
+        Dn $dn,
+        string $attribute,
+    ): void;
+
+    /**
+     * Return $entry with unreadable attributes removed, or null to suppress the entry entirely.
+     */
+    public function filterEntry(
+        TokenInterface $token,
+        Entry $entry,
+    ): ?Entry;
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/BackendAwareInterface.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/BackendAwareInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl;
+
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+
+/**
+ * Implemented by access control classes or matchers that need a backend injected at startup.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface BackendAwareInterface
+{
+    public function setBackend(LdapBackendInterface $backend): void;
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/OperationType.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/OperationType.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl;
+
+enum OperationType
+{
+    case Search;
+    case Add;
+    case Modify;
+    case Delete;
+    case ModifyDn;
+    case Compare;
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Rule/AttributeRule.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Rule/AttributeRule.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Rule;
+
+use FreeDSx\Ldap\Server\AccessControl\Subject\SubjectMatcherInterface;
+use FreeDSx\Ldap\Server\AccessControl\Target\AnyTargetMatcher;
+use FreeDSx\Ldap\Server\AccessControl\Target\TargetMatcherInterface;
+
+/**
+ * An ordered access control rule evaluated by filterEntry() per attribute.
+ *
+ * An empty $attributes list matches all attributes. Attribute names are stored lowercase.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class AttributeRule
+{
+    /**
+     * @param string[] $attributes Lowercase attribute names. Empty matches all attributes.
+     */
+    public function __construct(
+        public Effect $effect,
+        public SubjectMatcherInterface $subject,
+        public TargetMatcherInterface $target,
+        public array $attributes,
+    ) {}
+
+    public static function allow(
+        SubjectMatcherInterface $subject,
+        TargetMatcherInterface $target = new AnyTargetMatcher(),
+        string ...$attributes,
+    ): self {
+        return new self(
+            Effect::Allow,
+            $subject,
+            $target,
+            array_map('strtolower', $attributes),
+        );
+    }
+
+    public static function deny(
+        SubjectMatcherInterface $subject,
+        TargetMatcherInterface $target = new AnyTargetMatcher(),
+        string ...$attributes,
+    ): self {
+        return new self(
+            Effect::Deny,
+            $subject,
+            $target,
+            array_map('strtolower', $attributes),
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Rule/Effect.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Rule/Effect.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Rule;
+
+enum Effect
+{
+    case Allow;
+    case Deny;
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Rule/OperationRule.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Rule/OperationRule.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Rule;
+
+use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Server\AccessControl\Subject\SubjectMatcherInterface;
+use FreeDSx\Ldap\Server\AccessControl\Target\AnyTargetMatcher;
+use FreeDSx\Ldap\Server\AccessControl\Target\TargetMatcherInterface;
+
+/**
+ * An ordered access control rule evaluated by authorize().
+ *
+ * An empty $operations list matches all operation types.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class OperationRule
+{
+    /**
+     * @param OperationType[] $operations Empty matches all operation types.
+     */
+    public function __construct(
+        public Effect $effect,
+        public SubjectMatcherInterface $subject,
+        public TargetMatcherInterface $target,
+        public array $operations,
+    ) {}
+
+    public static function allow(
+        SubjectMatcherInterface $subject,
+        TargetMatcherInterface $target = new AnyTargetMatcher(),
+        OperationType ...$operations,
+    ): self {
+        return new self(
+            Effect::Allow,
+            $subject,
+            $target,
+            $operations,
+        );
+    }
+
+    public static function deny(
+        SubjectMatcherInterface $subject,
+        TargetMatcherInterface $target = new AnyTargetMatcher(),
+        OperationType ...$operations,
+    ): self {
+        return new self(
+            Effect::Deny,
+            $subject,
+            $target,
+            $operations,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/RuleBasedAccessControl.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/RuleBasedAccessControl.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;
+use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * Evaluates an ordered list of rules; first match wins.
+ *
+ * When no operation rule matches, $defaultEffect is applied (default: Deny).
+ * When no attribute rule matches an attribute, the attribute is kept (default allow).
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class RuleBasedAccessControl implements AccessControlInterface, BackendAwareInterface
+{
+    /**
+     * @param OperationRule[] $operationRules Evaluated in order; first match wins.
+     * @param AttributeRule[] $attributeRules Evaluated per attribute in order; first match wins.
+     * @param Effect          $defaultEffect  Applied when no operation rule matches.
+     */
+    public function __construct(
+        private readonly array $operationRules = [],
+        private readonly array $attributeRules = [],
+        private readonly Effect $defaultEffect = Effect::Deny,
+    ) {}
+
+    public function setBackend(LdapBackendInterface $backend): void
+    {
+        foreach ($this->operationRules as $rule) {
+            if ($rule->subject instanceof BackendAwareInterface) {
+                $rule->subject->setBackend($backend);
+            }
+        }
+
+        foreach ($this->attributeRules as $rule) {
+            if ($rule->subject instanceof BackendAwareInterface) {
+                $rule->subject->setBackend($backend);
+            }
+        }
+    }
+
+    /**
+     * @throws OperationException
+     */
+    public function authorizeOperation(
+        OperationType $operation,
+        TokenInterface $token,
+        Dn $dn,
+    ): void {
+        if (!$this->isAllowed($operation, $token, $dn)) {
+            $this->deny();
+        }
+    }
+
+    /**
+     * @throws OperationException
+     */
+    public function authorizeAttribute(
+        TokenInterface $token,
+        Dn $dn,
+        string $attribute,
+    ): void {
+        $effect = $this->resolveAttributeEffect(
+            $token,
+            $dn,
+            strtolower($attribute),
+        );
+
+        if ($effect === Effect::Deny) {
+            $this->deny();
+        }
+    }
+
+    public function filterEntry(
+        TokenInterface $token,
+        Entry $entry,
+    ): ?Entry {
+        $dn = $entry->getDn();
+
+        if (!$this->isAllowed(OperationType::Search, $token, $dn)) {
+            return null;
+        }
+
+        if ($this->attributeRules === []) {
+            return $entry;
+        }
+
+        $allAttributes = $entry->getAttributes();
+        $kept = [];
+
+        foreach ($allAttributes as $attribute) {
+            $effect = $this->resolveAttributeEffect(
+                $token,
+                $dn,
+                strtolower($attribute->getName()),
+            );
+
+            if ($effect !== Effect::Deny) {
+                $kept[] = $attribute;
+            }
+        }
+
+        if (count($kept) === count($allAttributes)) {
+            return $entry;
+        }
+
+        return Entry::raw(
+            $dn,
+            $kept,
+        );
+    }
+
+    private function isAllowed(
+        OperationType $operation,
+        TokenInterface $token,
+        Dn $dn,
+    ): bool {
+        foreach ($this->operationRules as $rule) {
+            if (!$this->operationMatches($rule, $operation)) {
+                continue;
+            }
+
+            if (!$rule->target->matches($dn)) {
+                continue;
+            }
+
+            if (!$rule->subject->matches($token, $dn)) {
+                continue;
+            }
+
+            return $rule->effect === Effect::Allow;
+        }
+
+        return $this->defaultEffect === Effect::Allow;
+    }
+
+    private function operationMatches(
+        OperationRule $rule,
+        OperationType $operation,
+    ): bool {
+        return $rule->operations === []
+            || in_array($operation, $rule->operations, true);
+    }
+
+    private function resolveAttributeEffect(
+        TokenInterface $token,
+        Dn $dn,
+        string $attrName,
+    ): ?Effect {
+        foreach ($this->attributeRules as $rule) {
+            if (!$rule->target->matches($dn)) {
+                continue;
+            }
+
+            if (!$rule->subject->matches($token, $dn)) {
+                continue;
+            }
+
+            if ($rule->attributes !== [] && !in_array($attrName, $rule->attributes, true)) {
+                continue;
+            }
+
+            return $rule->effect;
+        }
+
+        return null;
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function deny(): never
+    {
+        throw new OperationException(
+            'Access denied.',
+            ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/SimpleAccessControl.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/SimpleAccessControl.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\Token\AnonToken;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * Default access control: deny all anonymous operations, allow all authenticated operations.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class SimpleAccessControl implements AccessControlInterface
+{
+    /**
+     * @throws OperationException
+     */
+    public function authorizeOperation(
+        OperationType $operation,
+        TokenInterface $token,
+        Dn $dn,
+    ): void {
+        if ($token instanceof AnonToken) {
+            throw new OperationException(
+                'Access denied.',
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+            );
+        }
+    }
+
+    public function authorizeAttribute(
+        TokenInterface $token,
+        Dn $dn,
+        string $attribute,
+    ): void {}
+
+    public function filterEntry(
+        TokenInterface $token,
+        Entry $entry,
+    ): Entry {
+        return $entry;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Subject/AnonymousSubjectMatcher.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Subject/AnonymousSubjectMatcher.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\Token\AnonToken;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * Matches unauthenticated (anonymous) identities only.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class AnonymousSubjectMatcher implements SubjectMatcherInterface
+{
+    public function matches(
+        TokenInterface $token,
+        Dn $targetDn,
+    ): bool {
+        return $token instanceof AnonToken;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Subject/AnySubjectMatcher.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Subject/AnySubjectMatcher.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * Matches any identity, authenticated or anonymous.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class AnySubjectMatcher implements SubjectMatcherInterface
+{
+    public function matches(
+        TokenInterface $token,
+        Dn $targetDn,
+    ): bool {
+        return true;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Subject/AuthenticatedSubjectMatcher.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Subject/AuthenticatedSubjectMatcher.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * Matches any successfully authenticated identity.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class AuthenticatedSubjectMatcher implements SubjectMatcherInterface
+{
+    public function matches(
+        TokenInterface $token,
+        Dn $targetDn,
+    ): bool {
+        return $token instanceof AuthenticatedTokenInterface;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Subject/CallbackSubjectMatcher.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Subject/CallbackSubjectMatcher.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use Closure;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+use Throwable;
+
+/**
+ * Delegates subject matching to a user-supplied closure.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class CallbackSubjectMatcher implements SubjectMatcherInterface
+{
+    public function __construct(
+        /** @var Closure(TokenInterface, Dn): bool */
+        private readonly Closure $callback,
+    ) {}
+
+    public function matches(
+        TokenInterface $token,
+        Dn $targetDn,
+    ): bool {
+        try {
+            return ($this->callback)($token, $targetDn);
+        } catch (Throwable) {
+            return false;
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Subject/DnSubjectMatcher.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Subject/DnSubjectMatcher.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * Matches a specific bound DN (case-insensitive).
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class DnSubjectMatcher implements SubjectMatcherInterface
+{
+    private readonly string $normalizedDn;
+
+    public function __construct(string $dn)
+    {
+        $this->normalizedDn = strtolower($dn);
+    }
+
+    public function matches(
+        TokenInterface $token,
+        Dn $targetDn,
+    ): bool {
+        if (!$token instanceof AuthenticatedTokenInterface) {
+            return false;
+        }
+
+        return strtolower($token->getResolvedDn()->toString()) === $this->normalizedDn;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Subject/DnSubtreeSubjectMatcher.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Subject/DnSubtreeSubjectMatcher.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+use Throwable;
+
+/**
+ * Matches when the bound DN is within a given subtree (case-insensitive).
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class DnSubtreeSubjectMatcher implements SubjectMatcherInterface
+{
+    private readonly Dn $subtreeDn;
+
+    public function __construct(string $dn)
+    {
+        $this->subtreeDn = new Dn($dn);
+    }
+
+    public function matches(
+        TokenInterface $token,
+        Dn $targetDn,
+    ): bool {
+        if (!$token instanceof AuthenticatedTokenInterface) {
+            return false;
+        }
+
+        try {
+            return $token->getResolvedDn()->isDescendantOf($this->subtreeDn);
+        } catch (Throwable) {
+            return false;
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Subject/GroupSubjectMatcher.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Subject/GroupSubjectMatcher.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Server\AccessControl\BackendAwareInterface;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+use LogicException;
+
+/**
+ * Matches when the bound DN is a member of the given LDAP group entry.
+ *
+ * The group entry is fetched from the backend once per token ID and cached.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class GroupSubjectMatcher implements SubjectMatcherInterface, BackendAwareInterface
+{
+    private readonly Dn $groupDn;
+
+    private readonly int $maxCacheSize;
+
+    private ?LdapBackendInterface $backend = null;
+
+    /**
+     * @var array<string, ?Entry>
+     */
+    private array $cache = [];
+
+    public function __construct(
+        string $groupDn,
+        private readonly string $memberAttribute = 'member',
+        int $maxCacheSize = 200,
+    ) {
+        $this->groupDn = new Dn($groupDn);
+        $this->maxCacheSize = $maxCacheSize;
+    }
+
+    public function setBackend(LdapBackendInterface $backend): void
+    {
+        $this->backend = $backend;
+    }
+
+    public function matches(
+        TokenInterface $token,
+        Dn $targetDn,
+    ): bool {
+        if ($this->backend === null) {
+            return false;
+        }
+
+        if (!$token instanceof AuthenticatedTokenInterface) {
+            return false;
+        }
+
+        $entry = $this->getGroupEntry($token);
+        if ($entry === null) {
+            return false;
+        }
+
+        $memberAttr = $entry->get($this->memberAttribute);
+        if ($memberAttr === null) {
+            return false;
+        }
+
+        $resolvedDn = self::normalizeDn($token->getResolvedDn()->toString());
+
+        foreach ($memberAttr->getValues() as $value) {
+            if (self::normalizeDn($value) === $resolvedDn) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function normalizeDn(string $dn): string
+    {
+        return strtolower(preg_replace('/\s*([,=])\s*/', '$1', $dn) ?? $dn);
+    }
+
+    private function getGroupEntry(TokenInterface $token): ?Entry
+    {
+        if ($this->maxCacheSize === 0) {
+            return $this->backend()->get($this->groupDn);
+        }
+
+        $id = $token->getId();
+        if (!array_key_exists($id, $this->cache)) {
+            $this->evictOldestIfFull();
+            $this->cache[$id] = $this->backend()->get($this->groupDn);
+        }
+
+        return $this->cache[$id];
+    }
+
+    private function backend(): LdapBackendInterface
+    {
+        if ($this->backend === null) {
+            throw new LogicException('No backend set on GroupSubjectMatcher; call setBackend() before use.');
+        }
+
+        return $this->backend;
+    }
+
+    private function evictOldestIfFull(): void
+    {
+        if (count($this->cache) < $this->maxCacheSize) {
+            return;
+        }
+
+        $oldest = array_key_first($this->cache);
+
+        if ($oldest === null) {
+            return;
+        }
+
+        unset($this->cache[$oldest]);
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Subject/SelfSubjectMatcher.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Subject/SelfSubjectMatcher.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * Matches when the bound DN equals the target entry DN (case-insensitive).
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class SelfSubjectMatcher implements SubjectMatcherInterface
+{
+    public function matches(
+        TokenInterface $token,
+        Dn $targetDn,
+    ): bool {
+        if (!$token instanceof AuthenticatedTokenInterface) {
+            return false;
+        }
+
+        return strtolower($token->getResolvedDn()->toString()) === strtolower($targetDn->toString());
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Subject/Subject.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Subject/Subject.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use Closure;
+
+/**
+ * Factory for common subject matchers.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class Subject
+{
+    private function __construct() {}
+
+    /**
+     * Matches any identity, authenticated or anonymous.
+     */
+    public static function anyone(): SubjectMatcherInterface
+    {
+        return new AnySubjectMatcher();
+    }
+
+    /**
+     * Matches unauthenticated (anonymous) identities only.
+     */
+    public static function anonymous(): SubjectMatcherInterface
+    {
+        return new AnonymousSubjectMatcher();
+    }
+
+    /**
+     * Matches any successfully authenticated identity.
+     */
+    public static function authenticated(): SubjectMatcherInterface
+    {
+        return new AuthenticatedSubjectMatcher();
+    }
+
+    /**
+     * Matches when the bound DN equals the target entry DN (case-insensitive).
+     */
+    public static function self(): SubjectMatcherInterface
+    {
+        return new SelfSubjectMatcher();
+    }
+
+    /**
+     * Matches a specific bound DN (case-insensitive).
+     */
+    public static function dn(string $dn): SubjectMatcherInterface
+    {
+        return new DnSubjectMatcher($dn);
+    }
+
+    /**
+     * Matches when the bound DN is within a given subtree (case-insensitive).
+     */
+    public static function dnSubtree(string $dn): SubjectMatcherInterface
+    {
+        return new DnSubtreeSubjectMatcher($dn);
+    }
+
+    /**
+     * Matches when the bound DN is a member of the given LDAP group entry.
+     *
+     * The backend is injected by the framework at server-start time.
+     * The group entry is cached per token ID. $maxCacheSize bounds the number of cached entries (FIFO).
+     *
+     * @param int $maxCacheSize Max cached entries; 0 disables caching (always fetches fresh from the backend).
+     */
+    public static function group(
+        string $groupDn,
+        string $memberAttribute = 'member',
+        int $maxCacheSize = 200,
+    ): SubjectMatcherInterface {
+        return new GroupSubjectMatcher(
+            $groupDn,
+            $memberAttribute,
+            $maxCacheSize,
+        );
+    }
+
+    /**
+     * Delegates subject matching to a user-supplied closure.
+     *
+     * @param Closure(mixed, mixed): bool $callback
+     */
+    public static function callback(Closure $callback): SubjectMatcherInterface
+    {
+        return new CallbackSubjectMatcher($callback);
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Subject/SubjectMatcherInterface.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Subject/SubjectMatcherInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * Determines whether a bound identity matches a rule subject.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface SubjectMatcherInterface
+{
+    /**
+     * @param Dn $targetDn The DN of the entry being operated on (needed for self-matching).
+     */
+    public function matches(
+        TokenInterface $token,
+        Dn $targetDn,
+    ): bool;
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Target/AnyTargetMatcher.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Target/AnyTargetMatcher.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Target;
+
+use FreeDSx\Ldap\Entry\Dn;
+
+/**
+ * Matches any target DN.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class AnyTargetMatcher implements TargetMatcherInterface
+{
+    public function matches(Dn $dn): bool
+    {
+        return true;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Target/DnTargetMatcher.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Target/DnTargetMatcher.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Target;
+
+use FreeDSx\Ldap\Entry\Dn;
+
+/**
+ * Matches a specific target DN (case-insensitive).
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class DnTargetMatcher implements TargetMatcherInterface
+{
+    private readonly string $normalizedDn;
+
+    public function __construct(string $dn)
+    {
+        $this->normalizedDn = strtolower($dn);
+    }
+
+    public function matches(Dn $dn): bool
+    {
+        return strtolower($dn->toString()) === $this->normalizedDn;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Target/SubtreeTargetMatcher.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Target/SubtreeTargetMatcher.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Target;
+
+use FreeDSx\Ldap\Entry\Dn;
+
+/**
+ * Matches any target DN within a given subtree (case-insensitive).
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class SubtreeTargetMatcher implements TargetMatcherInterface
+{
+    private readonly Dn $subtreeDn;
+
+    public function __construct(string $dn)
+    {
+        $this->subtreeDn = new Dn($dn);
+    }
+
+    public function matches(Dn $dn): bool
+    {
+        return $dn->isDescendantOf($this->subtreeDn);
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Target/Target.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Target/Target.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Target;
+
+/**
+ * Factory for common target matchers.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class Target
+{
+    private function __construct() {}
+
+    /**
+     * Matches any target DN.
+     */
+    public static function any(): TargetMatcherInterface
+    {
+        return new AnyTargetMatcher();
+    }
+
+    /**
+     * Matches a specific target DN (case-insensitive).
+     */
+    public static function dn(string $dn): TargetMatcherInterface
+    {
+        return new DnTargetMatcher($dn);
+    }
+
+    /**
+     * Matches any target DN within the given subtree (case-insensitive).
+     */
+    public static function subtree(string $dn): TargetMatcherInterface
+    {
+        return new SubtreeTargetMatcher($dn);
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Target/TargetMatcherInterface.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Target/TargetMatcherInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Target;
+
+use FreeDSx\Ldap\Entry\Dn;
+
+/**
+ * Determines whether a target DN matches a rule target.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface TargetMatcherInterface
+{
+    public function matches(Dn $dn): bool;
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticatableInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticatableInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Auth;
 
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 use FreeDSx\Sasl\Mechanism\MechanismName;
 use SensitiveParameter;
 
@@ -24,13 +26,15 @@ use SensitiveParameter;
 interface PasswordAuthenticatableInterface
 {
     /**
-     * Return true if $password is valid for $name; $name is the raw LDAP bind name and need not be a DN.
+     * Authenticate $name with $password and return a token representing the bound identity.
+     *
+     * @throws OperationException on invalid credentials or unresolvable bind name
      */
-    public function verifyPassword(
+    public function authenticate(
         string $name,
         #[SensitiveParameter]
         string $password,
-    ): bool;
+    ): AuthenticatedTokenInterface;
 
     /**
      * Return the plaintext password for $username (SCRAM/CRAM derive keys from plaintext), or null to reject the bind.

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticator.php
@@ -13,8 +13,12 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Auth;
 
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
+use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Sasl\Mechanism\MechanismName;
 use SensitiveParameter;
 
@@ -30,33 +34,45 @@ final class PasswordAuthenticator implements PasswordAuthenticatableInterface
         private readonly LdapBackendInterface $backend,
     ) {}
 
-    public function verifyPassword(
+    public function authenticate(
         string $name,
         #[SensitiveParameter]
         string $password,
-    ): bool {
+    ): AuthenticatedTokenInterface {
         $entry = $this->nameResolver->resolve(
             $name,
             $this->backend,
         );
 
         if ($entry === null) {
-            return false;
+            $this->denyCredentials();
         }
 
         $attr = $entry->get('userPassword');
 
         if ($attr === null) {
-            return false;
+            $this->denyCredentials();
         }
 
         foreach ($attr->getValues() as $stored) {
             if ($this->checkPassword($password, $stored)) {
-                return true;
+                return new BindToken(
+                    $name,
+                    $password,
+                    $entry->getDn(),
+                );
             }
         }
 
-        return false;
+        $this->denyCredentials();
+    }
+
+    private function denyCredentials(): never
+    {
+        throw new OperationException(
+            'Invalid credentials.',
+            ResultCode::INVALID_CREDENTIALS,
+        );
     }
 
     public function getPassword(

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/OperationalAttributeGenerator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/OperationalAttributeGenerator.php
@@ -19,16 +19,17 @@ use FreeDSx\Ldap\Schema\Definition\ObjectClass;
 use FreeDSx\Ldap\Schema\Definition\ObjectClassType;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
+use FreeDSx\Ldap\Server\Utility\Uuid;
 
 /**
  * Injects server-managed operational attributes into entries on write.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final class OperationalAttributeGenerator
+final readonly class OperationalAttributeGenerator
 {
     public function __construct(
-        private readonly ?Schema $schema = null,
+        private ?Schema $schema = null,
     ) {}
 
     /**
@@ -59,7 +60,7 @@ final class OperationalAttributeGenerator
         );
         $entry->set(
             AttributeTypeOid::NAME_ENTRY_UUID,
-            $this->generateUuid(),
+            Uuid::v4(),
         );
 
         $structuralOc = $this->resolveStructuralObjectClass($entry);
@@ -92,23 +93,6 @@ final class OperationalAttributeGenerator
     private function generateTimestamp(): string
     {
         return gmdate('YmdHis') . 'Z';
-    }
-
-    private function generateUuid(): string
-    {
-        $bytes = random_bytes(16);
-
-        // Set version 4 and RFC 4122 variant bits.
-        $bytes[6] = chr(ord($bytes[6]) & 0x0f | 0x40);
-        $bytes[8] = chr(ord($bytes[8]) & 0x3f | 0x80);
-
-        return vsprintf(
-            '%s%s-%s-%s-%s-%s%s%s',
-            str_split(
-                bin2hex($bytes),
-                4,
-            ),
-        );
     }
 
     private function resolveStructuralObjectClass(Entry $entry): ?string

--- a/src/FreeDSx/Ldap/Server/RequestHandler/ProxyBackend.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/ProxyBackend.php
@@ -30,6 +30,8 @@ use FreeDSx\Ldap\Server\Backend\Write\Command\MoveCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
+use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
+use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Write\WritableBackendTrait;
@@ -108,13 +110,18 @@ class ProxyBackend implements WritableLdapBackendInterface, PasswordAuthenticata
         );
     }
 
-    public function verifyPassword(
+    public function authenticate(
         string $name,
         #[SensitiveParameter]
         string $password,
-    ): bool {
+    ): AuthenticatedTokenInterface {
         try {
-            return (bool) $this->ldap()->bind($name, $password);
+            $this->ldap()->bind($name, $password);
+
+            return BindToken::fromDn(
+                $name,
+                $password,
+            );
         } catch (BindException $e) {
             throw new OperationException(
                 $e->getMessage(),

--- a/src/FreeDSx/Ldap/Server/Token/AnonToken.php
+++ b/src/FreeDSx/Ldap/Server/Token/AnonToken.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Token;
 
+use FreeDSx\Ldap\Server\Utility\Uuid;
+
 /**
  * Represents a token for an anonymous bind.
  *
@@ -20,6 +22,8 @@ namespace FreeDSx\Ldap\Server\Token;
  */
 class AnonToken implements TokenInterface
 {
+    private string $id;
+
     private ?string $username;
 
     private int $version;
@@ -28,8 +32,14 @@ class AnonToken implements TokenInterface
         ?string $username = null,
         int $version = 3,
     ) {
+        $this->id = Uuid::v4();
         $this->username = $username;
         $this->version = $version;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
     }
 
     public function getUsername(): ?string

--- a/src/FreeDSx/Ldap/Server/Token/AuthenticatedTokenInterface.php
+++ b/src/FreeDSx/Ldap/Server/Token/AuthenticatedTokenInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Token;
+
+use FreeDSx\Ldap\Entry\Dn;
+
+/**
+ * Implemented by tokens that represent a successfully authenticated identity with a resolved DN.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface AuthenticatedTokenInterface extends TokenInterface
+{
+    public function getResolvedDn(): Dn;
+}

--- a/src/FreeDSx/Ldap/Server/Token/BindToken.php
+++ b/src/FreeDSx/Ldap/Server/Token/BindToken.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Token;
 
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\Utility\Uuid;
 use SensitiveParameter;
 
 /**
@@ -20,9 +22,13 @@ use SensitiveParameter;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class BindToken implements TokenInterface
+class BindToken implements AuthenticatedTokenInterface
 {
+    private string $id;
+
     private string $username;
+
+    private readonly Dn $resolvedDn;
 
     private string $password;
 
@@ -32,11 +38,33 @@ class BindToken implements TokenInterface
         string $username,
         #[SensitiveParameter]
         string $password,
+        Dn $resolvedDn,
         int $version = 3,
     ) {
+        $this->id = Uuid::v4();
         $this->username = $username;
+        $this->resolvedDn = $resolvedDn;
         $this->password = $password;
         $this->version = $version;
+    }
+
+    public static function fromDn(
+        string $dn,
+        #[SensitiveParameter]
+        string $password,
+        int $version = 3,
+    ): self {
+        return new self(
+            $dn,
+            $password,
+            new Dn($dn),
+            $version,
+        );
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
     }
 
     public function getUsername(): ?string
@@ -47,6 +75,11 @@ class BindToken implements TokenInterface
     public function getPassword(): ?string
     {
         return $this->password;
+    }
+
+    public function getResolvedDn(): Dn
+    {
+        return $this->resolvedDn;
     }
 
     public function getVersion(): int

--- a/src/FreeDSx/Ldap/Server/Token/TokenInterface.php
+++ b/src/FreeDSx/Ldap/Server/Token/TokenInterface.php
@@ -20,6 +20,8 @@ namespace FreeDSx\Ldap\Server\Token;
  */
 interface TokenInterface
 {
+    public function getId(): string;
+
     public function getUsername(): ?string;
 
     public function getPassword(): ?string;

--- a/src/FreeDSx/Ldap/Server/Utility/Uuid.php
+++ b/src/FreeDSx/Ldap/Server/Utility/Uuid.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Utility;
+
+use function bin2hex;
+use function chr;
+use function ord;
+use function random_bytes;
+use function str_split;
+use function vsprintf;
+
+/**
+ * Generates RFC 4122 compliant UUIDs.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class Uuid
+{
+    private function __construct() {}
+
+    /**
+     * Generates a random UUID v4 string.
+     */
+    public static function v4(): string
+    {
+        $bytes = random_bytes(16);
+
+        // Set version 4 and RFC 4122 variant bits.
+        $bytes[6] = chr(ord($bytes[6]) & 0x0f | 0x40);
+        $bytes[8] = chr(ord($bytes[8]) & 0x3f | 0x80);
+
+        return vsprintf(
+            '%s%s-%s-%s-%s-%s%s%s',
+            str_split(
+                bin2hex($bytes),
+                4,
+            ),
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -22,6 +22,11 @@ use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;
+use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
+use FreeDSx\Ldap\Server\AccessControl\SimpleAccessControl;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
 use FreeDSx\Ldap\Server\SearchLimits;
@@ -132,6 +137,20 @@ final class ServerOptions
     private ?Schema $schema = null;
 
     private SchemaValidationMode $schemaValidationMode = SchemaValidationMode::Strict;
+
+    private ?AccessControlInterface $accessControl = null;
+
+    /**
+     * @var OperationRule[]
+     */
+    private array $operationRules = [];
+
+    /**
+     * @var AttributeRule[]
+     */
+    private array $attributeRules = [];
+
+    private Effect $defaultAccessRule = Effect::Deny;
 
     private ?LoggerInterface $logger = null;
 
@@ -450,6 +469,66 @@ final class ServerOptions
         $this->schemaValidationMode = $mode;
 
         return $this;
+    }
+
+    public function getAccessControl(): AccessControlInterface
+    {
+        return $this->accessControl ??= new SimpleAccessControl();
+    }
+
+    public function setAccessControl(AccessControlInterface $accessControl): self
+    {
+        $this->accessControl = $accessControl;
+
+        return $this;
+    }
+
+    /**
+     * @param OperationRule[] $rules
+     */
+    public function setOperationRules(array $rules): self
+    {
+        $this->operationRules = $rules;
+
+        return $this;
+    }
+
+    /**
+     * @return OperationRule[]
+     */
+    public function getOperationRules(): array
+    {
+        return $this->operationRules;
+    }
+
+    /**
+     * @param AttributeRule[] $rules
+     */
+    public function setAttributeRules(array $rules): self
+    {
+        $this->attributeRules = $rules;
+
+        return $this;
+    }
+
+    /**
+     * @return AttributeRule[]
+     */
+    public function getAttributeRules(): array
+    {
+        return $this->attributeRules;
+    }
+
+    public function setDefaultAccessRule(Effect $effect): self
+    {
+        $this->defaultAccessRule = $effect;
+
+        return $this;
+    }
+
+    public function getDefaultAccessRule(): Effect
+    {
+        return $this->defaultAccessRule;
     }
 
     public function getLogger(): ?LoggerInterface

--- a/tests/bin/ldap-acl.php
+++ b/tests/bin/ldap-acl.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Server bootstrap script for AclIntegrationTest.
+ *
+ * Usage: php ldap-acl.php [transport]
+ */
+
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
+use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
+use FreeDSx\Ldap\Server\AccessControl\Target\Target;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\ServerOptions;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$transport = $argv[1] ?? 'tcp';
+
+$adminPasswordHash = '{SHA}' . base64_encode(sha1('adminpass', true));
+$userPasswordHash = '{SHA}' . base64_encode(sha1('12345', true));
+$alicePasswordHash = '{SHA}' . base64_encode(sha1('alicepass', true));
+
+$entries = [
+    new Entry(
+        new Dn('dc=foo,dc=bar'),
+        new Attribute('dc', 'foo'),
+        new Attribute('objectClass', 'domain'),
+    ),
+    new Entry(
+        new Dn('cn=admins,dc=foo,dc=bar'),
+        new Attribute('cn', 'admins'),
+        new Attribute('objectClass', 'groupOfNames'),
+        new Attribute('member', 'cn=admin,dc=foo,dc=bar'),
+    ),
+    new Entry(
+        new Dn('cn=admin,dc=foo,dc=bar'),
+        new Attribute('cn', 'admin'),
+        new Attribute('sn', 'Admin'),
+        new Attribute('objectClass', 'inetOrgPerson'),
+        new Attribute('userPassword', $adminPasswordHash),
+    ),
+    new Entry(
+        new Dn('cn=user,dc=foo,dc=bar'),
+        new Attribute('cn', 'user'),
+        new Attribute('sn', 'User'),
+        new Attribute('objectClass', 'inetOrgPerson'),
+        new Attribute('userPassword', $userPasswordHash),
+    ),
+    new Entry(
+        new Dn('ou=people,dc=foo,dc=bar'),
+        new Attribute('ou', 'people'),
+        new Attribute('objectClass', 'organizationalUnit'),
+    ),
+    new Entry(
+        new Dn('cn=alice,ou=people,dc=foo,dc=bar'),
+        new Attribute('cn', 'alice'),
+        new Attribute('sn', 'Smith'),
+        new Attribute('objectClass', 'inetOrgPerson'),
+        new Attribute('userPassword', $alicePasswordHash),
+    ),
+];
+
+$server = new LdapServer(
+    (new ServerOptions())
+        ->setPort(10389)
+        ->setTransport($transport)
+        ->setSocketAcceptTimeout(0.1)
+        ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL))
+        ->setOperationRules([
+            OperationRule::allow(
+                Subject::group('cn=admins,dc=foo,dc=bar'),
+            ),
+            OperationRule::allow(
+                Subject::authenticated(),
+                Target::any(),
+                OperationType::Search,
+                OperationType::Compare,
+            ),
+            OperationRule::allow(
+                Subject::authenticated(),
+                Target::subtree('ou=people,dc=foo,dc=bar'),
+                OperationType::ModifyDn,
+            ),
+            OperationRule::allow(
+                Subject::self(),
+                Target::any(),
+                OperationType::Modify,
+            ),
+            OperationRule::deny(Subject::anyone()),
+        ])
+        ->setAttributeRules([
+            AttributeRule::allow(
+                Subject::self(),
+                Target::any(),
+                'userPassword',
+            ),
+            AttributeRule::allow(
+                Subject::group('cn=admins,dc=foo,dc=bar'),
+                Target::any(),
+                'userPassword',
+            ),
+            AttributeRule::deny(
+                Subject::anyone(),
+                Target::any(),
+                'userPassword',
+            ),
+        ]),
+);
+
+$server->useStorage(new InMemoryStorage($entries));
+$server->run();

--- a/tests/bin/ldap-server.php
+++ b/tests/bin/ldap-server.php
@@ -11,6 +11,8 @@ use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
+use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
+use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
@@ -100,17 +102,26 @@ class LdapServerBackend implements WritableLdapBackendInterface, PasswordAuthent
         return false;
     }
 
-    public function verifyPassword(
+    public function authenticate(
         string $name,
         string $password,
-    ): bool {
-
+    ): AuthenticatedTokenInterface {
         $this->logRequest(
             'bind',
             "username => $name, password => $password",
         );
 
-        return isset($this->users[$name]) && $this->users[$name] === $password;
+        if (!isset($this->users[$name]) || $this->users[$name] !== $password) {
+            throw new OperationException(
+                'Invalid credentials.',
+                ResultCode::INVALID_CREDENTIALS,
+            );
+        }
+
+        return BindToken::fromDn(
+            $name,
+            $password,
+        );
     }
 
     public function add(

--- a/tests/integration/Security/AclIntegrationTest.php
+++ b/tests/integration/Security/AclIntegrationTest.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Security;
+
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\Search\Filters;
+use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+
+/**
+ * End-to-end tests for RuleBasedAccessControl.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class AclIntegrationTest extends ServerTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        if (!extension_loaded('pcntl')) {
+            return;
+        }
+
+        static::initSharedServer(
+            'ldap-acl',
+            'tcp',
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        static::tearDownSharedServer();
+    }
+
+    public function setUp(): void
+    {
+        $this->setServerMode('ldap-acl');
+        parent::setUp();
+    }
+
+    public function testAnonymousSearchIsDenied(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+    }
+
+    public function testAuthenticatedUserCanSearch(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'))
+                ->base('dc=foo,dc=bar')
+                ->useBaseScope(),
+        );
+
+        self::assertCount(1, $entries);
+    }
+
+    public function testAuthenticatedUserCanCompare(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $result = $this->ldapClient()->compare(
+            'cn=alice,ou=people,dc=foo,dc=bar',
+            'sn',
+            'Smith',
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function testAuthenticatedUserAddIsDenied(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=denied-add,dc=foo,dc=bar',
+            ['cn' => 'denied-add', 'sn' => 'Denied', 'objectClass' => 'inetOrgPerson'],
+        ));
+    }
+
+    public function testAuthenticatedUserDeleteIsDenied(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->ldapClient()->delete('cn=alice,ou=people,dc=foo,dc=bar');
+    }
+
+    public function testAuthenticatedUserModifyDnIsDenied(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->ldapClient()->rename(
+            'cn=user,dc=foo,dc=bar',
+            'cn=user-renamed',
+            true,
+        );
+    }
+
+    public function testUserCanModifyOwnEntry(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $entry = Entry::fromArray('cn=user,dc=foo,dc=bar');
+        $entry->set('sn', 'UpdatedUser');
+        $this->ldapClient()->update($entry);
+
+        $results = $this->ldapClient()->search(
+            Operations::search(Filters::equal('sn', 'UpdatedUser'))
+                ->base('cn=user,dc=foo,dc=bar')
+                ->useBaseScope(),
+        );
+
+        self::assertCount(1, $results);
+    }
+
+    public function testUserCannotModifyOtherEntry(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $entry = Entry::fromArray('cn=alice,ou=people,dc=foo,dc=bar');
+        $entry->set('sn', 'ShouldNotWork');
+        $this->ldapClient()->update($entry);
+    }
+
+    public function testGroupMemberCanAddEntry(): void
+    {
+        $this->ldapClient()->bind('cn=admin,dc=foo,dc=bar', 'adminpass');
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=acl-temp-add,dc=foo,dc=bar',
+            ['cn' => 'acl-temp-add', 'sn' => 'Temp', 'objectClass' => 'inetOrgPerson'],
+        ));
+
+        $results = $this->ldapClient()->search(
+            Operations::search(Filters::equal('cn', 'acl-temp-add'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        self::assertCount(1, $results);
+
+        $this->ldapClient()->delete('cn=acl-temp-add,dc=foo,dc=bar');
+    }
+
+    public function testGroupMemberCanDeleteEntry(): void
+    {
+        $this->ldapClient()->bind('cn=admin,dc=foo,dc=bar', 'adminpass');
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=acl-temp-delete,dc=foo,dc=bar',
+            ['cn' => 'acl-temp-delete', 'sn' => 'Temp', 'objectClass' => 'inetOrgPerson'],
+        ));
+
+        $this->ldapClient()->delete('cn=acl-temp-delete,dc=foo,dc=bar');
+
+        $results = $this->ldapClient()->search(
+            Operations::search(Filters::equal('cn', 'acl-temp-delete'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        self::assertCount(0, $results);
+    }
+
+    public function testGroupMemberCanModifyAnyEntry(): void
+    {
+        $this->ldapClient()->bind('cn=admin,dc=foo,dc=bar', 'adminpass');
+
+        $entry = Entry::fromArray('cn=alice,ou=people,dc=foo,dc=bar');
+        $entry->set('sn', 'AdminModified');
+        $this->ldapClient()->update($entry);
+
+        $results = $this->ldapClient()->search(
+            Operations::search(Filters::equal('sn', 'AdminModified'))
+                ->base('ou=people,dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        self::assertCount(1, $results);
+
+        $revert = Entry::fromArray('cn=alice,ou=people,dc=foo,dc=bar');
+        $revert->set('sn', 'Smith');
+        $this->ldapClient()->update($revert);
+    }
+
+    public function testUserCanRenameWithinAllowedSubtree(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->ldapClient()->rename(
+            'cn=alice,ou=people,dc=foo,dc=bar',
+            'cn=alice-renamed',
+            true,
+        );
+
+        $results = $this->ldapClient()->search(
+            Operations::search(Filters::equal('cn', 'alice-renamed'))
+                ->base('ou=people,dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        self::assertCount(1, $results);
+
+        $this->ldapClient()->rename(
+            'cn=alice-renamed,ou=people,dc=foo,dc=bar',
+            'cn=alice',
+            true,
+        );
+    }
+
+    public function testUserCannotMoveEntryToRestrictedParent(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->ldapClient()->move(
+            'cn=alice,ou=people,dc=foo,dc=bar',
+            'dc=foo,dc=bar',
+        );
+    }
+
+    public function testUserPasswordHiddenFromOtherUsers(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $results = $this->ldapClient()->search(
+            Operations::search(Filters::equal('cn', 'alice'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope()
+                ->setAttributes('cn', 'sn', 'userPassword'),
+        );
+
+        $alice = $results->first();
+        self::assertNotNull($alice);
+        self::assertNull($alice->get('userPassword'));
+    }
+
+    public function testUserPasswordVisibleToSelf(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $results = $this->ldapClient()->search(
+            Operations::search(Filters::equal('cn', 'user'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope()
+                ->setAttributes('cn', 'userPassword'),
+        );
+
+        $user = $results->first();
+        self::assertNotNull($user);
+        self::assertNotNull($user->get('userPassword'));
+    }
+
+    public function testUserPasswordVisibleToGroupMember(): void
+    {
+        $this->ldapClient()->bind('cn=admin,dc=foo,dc=bar', 'adminpass');
+
+        $results = $this->ldapClient()->search(
+            Operations::search(Filters::equal('cn', 'alice'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope()
+                ->setAttributes('cn', 'userPassword'),
+        );
+
+        $alice = $results->first();
+        self::assertNotNull($alice);
+        self::assertNotNull($alice->get('userPassword'));
+    }
+}

--- a/tests/unit/Protocol/AuthenticatorTest.php
+++ b/tests/unit/Protocol/AuthenticatorTest.php
@@ -70,7 +70,7 @@ final class AuthenticatorTest extends TestCase
             $bindReq,
         );
 
-        $token = new BindToken(
+        $token = BindToken::fromDn(
             'foo',
             'bar',
         );

--- a/tests/unit/Protocol/Bind/AnonymousBindTest.php
+++ b/tests/unit/Protocol/Bind/AnonymousBindTest.php
@@ -69,12 +69,18 @@ final class AnonymousBindTest extends TestCase
             ))
             ->willReturnSelf();
 
-        self::assertEquals(
-            new AnonToken('foo'),
-            $this->subject->bind(new LdapMessageRequest(
-                1,
-                Operations::bindAnonymously('foo'),
-            )),
+        $token = $this->subject->bind(new LdapMessageRequest(
+            1,
+            Operations::bindAnonymously('foo'),
+        ));
+
+        self::assertInstanceOf(
+            AnonToken::class,
+            $token,
+        );
+        self::assertSame(
+            'foo',
+            $token->getUsername(),
         );
     }
 

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/PlainMechanismOptionsBuilderTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/PlainMechanismOptionsBuilderTest.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
 
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\PlainMechanismOptionsBuilder;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
+use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Sasl\Options\PlainOptions;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -40,13 +43,16 @@ final class PlainMechanismOptionsBuilderTest extends TestCase
         self::assertIsCallable($options->getValidate());
     }
 
-    public function test_the_validate_callable_delegates_to_backend_verify_password(): void
+    public function test_the_validate_callable_delegates_to_backend_authenticate(): void
     {
         $this->mockAuthenticator
             ->expects(self::once())
-            ->method('verifyPassword')
+            ->method('authenticate')
             ->with('cn=user,dc=foo,dc=bar', '12345')
-            ->willReturn(true);
+            ->willReturn(BindToken::fromDn(
+                'cn=user,dc=foo,dc=bar',
+                '12345',
+            ));
 
         $options = $this->subject->buildOptions(null, MechanismName::PLAIN);
         self::assertInstanceOf(PlainOptions::class, $options);
@@ -57,11 +63,14 @@ final class PlainMechanismOptionsBuilderTest extends TestCase
         self::assertTrue($result);
     }
 
-    public function test_the_validate_callable_returns_false_when_verify_password_fails(): void
+    public function test_the_validate_callable_returns_false_when_authenticate_throws(): void
     {
         $this->mockAuthenticator
-            ->method('verifyPassword')
-            ->willReturn(false);
+            ->method('authenticate')
+            ->willThrowException(new OperationException(
+                'Invalid credentials.',
+                ResultCode::INVALID_CREDENTIALS,
+            ));
 
         $options = $this->subject->buildOptions(null, MechanismName::PLAIN);
         self::assertInstanceOf(PlainOptions::class, $options);

--- a/tests/unit/Protocol/Bind/SaslBindTest.php
+++ b/tests/unit/Protocol/Bind/SaslBindTest.php
@@ -112,20 +112,29 @@ final class SaslBindTest extends TestCase
 
         $this->mockAuthenticator
             ->expects(self::once())
-            ->method('verifyPassword')
+            ->method('authenticate')
             ->with('cn=user,dc=foo,dc=bar', '12345')
-            ->willReturn(true);
+            ->willReturn(BindToken::fromDn(
+                'cn=user,dc=foo,dc=bar',
+                '12345',
+            ));
 
         $this->mockQueue
             ->expects(self::once())
             ->method('sendMessage');
 
-        self::assertEquals(
-            new BindToken('cn=user,dc=foo,dc=bar', ''),
-            $this->subject->bind(new LdapMessageRequest(
-                1,
-                new SaslBindRequest('PLAIN', $credentials),
-            )),
+        $token = $this->subject->bind(new LdapMessageRequest(
+            1,
+            new SaslBindRequest('PLAIN', $credentials),
+        ));
+
+        self::assertInstanceOf(
+            BindToken::class,
+            $token,
+        );
+        self::assertSame(
+            'cn=user,dc=foo,dc=bar',
+            $token->getUsername(),
         );
     }
 
@@ -135,9 +144,12 @@ final class SaslBindTest extends TestCase
 
         $this->mockAuthenticator
             ->expects(self::once())
-            ->method('verifyPassword')
+            ->method('authenticate')
             ->with('cn=user,dc=foo,dc=bar', 'wrong')
-            ->willReturn(false);
+            ->willThrowException(new OperationException(
+                'Invalid credentials.',
+                ResultCode::INVALID_CREDENTIALS,
+            ));
 
         $this->mockQueue
             ->expects(self::once())

--- a/tests/unit/Protocol/Bind/SimpleBindTest.php
+++ b/tests/unit/Protocol/Bind/SimpleBindTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind;
 
+use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\AnonBindRequest;
@@ -49,11 +50,17 @@ final class SimpleBindTest extends TestCase
 
     public function test_it_should_return_a_token_on_success(): void
     {
+        $expectedToken = new BindToken(
+            'foo@bar',
+            'bar',
+            new Dn('cn=foo,dc=bar'),
+        );
+
         $this->mockAuthenticator
             ->expects(self::once())
-            ->method('verifyPassword')
+            ->method('authenticate')
             ->with('foo@bar', 'bar')
-            ->willReturn(true);
+            ->willReturn($expectedToken);
 
         $this->mockQueue
             ->expects(self::once())
@@ -73,22 +80,24 @@ final class SimpleBindTest extends TestCase
             ),
         );
 
-        self::assertEquals(
-            new BindToken(
-                'foo@bar',
-                'bar',
-            ),
-            $this->subject->bind($bind),
+        $token = $this->subject->bind($bind);
+
+        self::assertSame(
+            $expectedToken,
+            $token,
         );
     }
 
-    public function test_it_should_throw_an_operations_exception_with_invalid_credentials_if_they_are_wrong(): void
+    public function test_it_should_propagate_exception_on_invalid_credentials(): void
     {
         $this->mockAuthenticator
             ->expects(self::once())
-            ->method('verifyPassword')
+            ->method('authenticate')
             ->with('foo@bar', 'bar')
-            ->willReturn(false);
+            ->willThrowException(new OperationException(
+                'Invalid credentials.',
+                ResultCode::INVALID_CREDENTIALS,
+            ));
 
         $this->mockQueue
             ->expects(self::never())

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
@@ -16,10 +16,14 @@ namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Operation\Request\CompareRequest;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyRequest;
+use FreeDSx\Ldap\Server\AccessControl\OperationType;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
@@ -30,6 +34,7 @@ use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\Backend\Write\WriteRequestInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -48,12 +53,15 @@ final class ServerDispatchHandlerTest extends TestCase
 
     private TokenInterface&MockObject $mockToken;
 
+    private AccessControlInterface&MockObject $mockAccessControl;
+
     protected function setUp(): void
     {
         $this->mockToken = $this->createMock(TokenInterface::class);
         $this->mockQueue = $this->createMock(ServerQueue::class);
         $this->mockBackend = $this->createMock(LdapBackendInterface::class);
         $this->mockWriteHandler = $this->createMock(WriteHandlerInterface::class);
+        $this->mockAccessControl = $this->createMock(AccessControlInterface::class);
 
         $this->mockQueue
             ->method('sendMessage')
@@ -67,6 +75,7 @@ final class ServerDispatchHandlerTest extends TestCase
             queue: $this->mockQueue,
             backend: $this->mockBackend,
             writeDispatcher: new WriteOperationDispatcher($this->mockWriteHandler),
+            accessControl: $this->mockAccessControl,
         );
     }
 
@@ -126,6 +135,42 @@ final class ServerDispatchHandlerTest extends TestCase
         $this->subject->handleRequest($compare, $this->mockToken);
     }
 
+    public function test_it_sends_error_response_when_authorizeAttribute_denies_compare(): void
+    {
+        $compare = new LdapMessageRequest(
+            1,
+            new CompareRequest(
+                'cn=foo,dc=bar',
+                Filters::equal(
+                    'userpassword',
+                    'secret',
+                ),
+            ),
+        );
+
+        $this->mockAccessControl
+            ->method('authorizeAttribute')
+            ->willThrowException(new OperationException(
+                'Access denied.',
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+            ));
+
+        $this->mockBackend
+            ->expects(self::never())
+            ->method('compare');
+
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('sendMessage')
+            ->with(self::callback(function (LdapMessageResponse $msg): bool {
+                return $msg->getResponse() instanceof LdapResult
+                    && $msg->getResponse()->getResultCode() === ResultCode::INSUFFICIENT_ACCESS_RIGHTS;
+            }))
+            ->willReturnSelf();
+
+        $this->subject->handleRequest($compare, $this->mockToken);
+    }
+
     public function test_it_sends_error_response_for_operation_exceptions_from_backend_compare(): void
     {
         $compare = new LdapMessageRequest(1, new CompareRequest('cn=foo,dc=bar', Filters::equal('foo', 'bar')));
@@ -155,6 +200,7 @@ final class ServerDispatchHandlerTest extends TestCase
             queue: $this->mockQueue,
             backend: $this->mockBackend,
             writeDispatcher: new WriteOperationDispatcher(),
+            accessControl: $this->mockAccessControl,
         );
 
         $add = new LdapMessageRequest(1, new AddRequest(Entry::create('cn=foo,dc=bar')));
@@ -193,5 +239,173 @@ final class ServerDispatchHandlerTest extends TestCase
             ->with(self::isInstanceOf(WriteRequestInterface::class));
 
         $this->subject->handleRequest($delete, $this->mockToken);
+    }
+
+    public function test_it_authorizes_modify_dn_against_source_dn_only_when_no_new_superior(): void
+    {
+        $request = new LdapMessageRequest(
+            1,
+            new ModifyDnRequest(
+                'cn=foo,dc=bar',
+                'cn=baz',
+                true,
+            ),
+        );
+
+        $this->mockAccessControl
+            ->expects(self::once())
+            ->method('authorizeOperation')
+            ->with(
+                OperationType::ModifyDn,
+                $this->mockToken,
+                self::isInstanceOf(Dn::class),
+            );
+
+        $this->subject->handleRequest(
+            $request,
+            $this->mockToken,
+        );
+    }
+
+    public function test_it_authorizes_modify_dn_against_both_source_and_new_superior(): void
+    {
+        $request = new LdapMessageRequest(
+            1,
+            new ModifyDnRequest(
+                'cn=foo,dc=bar',
+                'cn=baz',
+                true,
+                'ou=other,dc=bar',
+            ),
+        );
+
+        $this->mockAccessControl
+            ->expects(self::exactly(2))
+            ->method('authorizeOperation')
+            ->with(
+                OperationType::ModifyDn,
+                $this->mockToken,
+                self::isInstanceOf(Dn::class),
+            );
+
+        $this->subject->handleRequest(
+            $request,
+            $this->mockToken,
+        );
+    }
+
+    public function test_it_sends_error_response_when_authorizeAttribute_denies_add(): void
+    {
+        $add = new LdapMessageRequest(
+            1,
+            new AddRequest(
+                Entry::create(
+                    'cn=foo,dc=bar',
+                    ['userpassword' => 'secret'],
+                ),
+            ),
+        );
+
+        $this->mockAccessControl
+            ->method('authorizeAttribute')
+            ->willThrowException(new OperationException(
+                'Access denied.',
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+            ));
+
+        $this->mockWriteHandler
+            ->expects(self::never())
+            ->method('handle');
+
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('sendMessage')
+            ->with(self::callback(function (LdapMessageResponse $msg): bool {
+                return $msg->getResponse() instanceof LdapResult
+                    && $msg->getResponse()->getResultCode() === ResultCode::INSUFFICIENT_ACCESS_RIGHTS;
+            }))
+            ->willReturnSelf();
+
+        $this->subject->handleRequest(
+            $add,
+            $this->mockToken,
+        );
+    }
+
+    public function test_it_sends_error_response_when_authorizeAttribute_denies_modify(): void
+    {
+        $modify = new LdapMessageRequest(
+            1,
+            new ModifyRequest(
+                'cn=foo,dc=bar',
+                Change::replace(
+                    'userpassword',
+                    'newSecret',
+                ),
+            ),
+        );
+
+        $this->mockAccessControl
+            ->method('authorizeAttribute')
+            ->willThrowException(new OperationException(
+                'Access denied.',
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+            ));
+
+        $this->mockWriteHandler
+            ->expects(self::never())
+            ->method('handle');
+
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('sendMessage')
+            ->with(self::callback(function (LdapMessageResponse $msg): bool {
+                return $msg->getResponse() instanceof LdapResult
+                    && $msg->getResponse()->getResultCode() === ResultCode::INSUFFICIENT_ACCESS_RIGHTS;
+            }))
+            ->willReturnSelf();
+
+        $this->subject->handleRequest(
+            $modify,
+            $this->mockToken,
+        );
+    }
+
+    public function test_it_sends_error_response_when_access_control_denies_new_superior(): void
+    {
+        $request = new LdapMessageRequest(
+            1,
+            new ModifyDnRequest(
+                'cn=foo,dc=bar',
+                'cn=baz',
+                true,
+                'ou=restricted,dc=bar',
+            ),
+        );
+
+        $this->mockAccessControl
+            ->method('authorizeOperation')
+            ->willReturnCallback(function (OperationType $type, TokenInterface $token, Dn $dn): void {
+                if ($dn->toString() === 'ou=restricted,dc=bar') {
+                    throw new OperationException(
+                        'Access denied.',
+                        ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+                    );
+                }
+            });
+
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('sendMessage')
+            ->with(self::callback(function (LdapMessageResponse $msg): bool {
+                return $msg->getResponse() instanceof LdapResult
+                    && $msg->getResponse()->getResultCode() === ResultCode::INSUFFICIENT_ACCESS_RIGHTS;
+            }))
+            ->willReturnSelf();
+
+        $this->subject->handleRequest(
+            $request,
+            $this->mockToken,
+        );
     }
 }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
@@ -27,6 +27,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerPagingHandler;
 use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Paging\PagingRequest;
@@ -48,6 +49,8 @@ class ServerPagingHandlerTest extends TestCase
 
     private FilterEvaluatorInterface&MockObject $mockFilterEvaluator;
 
+    private AccessControlInterface&MockObject $mockAccessControl;
+
     private ServerPagingHandler $subject;
 
     private TokenInterface&MockObject $mockToken;
@@ -63,12 +66,17 @@ class ServerPagingHandlerTest extends TestCase
         $this->mockQueue = $this->createMock(ServerQueue::class);
         $this->mockBackend = $this->createMock(LdapBackendInterface::class);
         $this->mockFilterEvaluator = $this->createMock(FilterEvaluatorInterface::class);
+        $this->mockAccessControl = $this->createMock(AccessControlInterface::class);
         $this->requestHistory = new RequestHistory();
         $this->sentMessages = [];
 
         $this->mockFilterEvaluator
             ->method('evaluate')
             ->willReturn(true);
+
+        $this->mockAccessControl
+            ->method('filterEntry')
+            ->willReturnArgument(1);
 
         $this->mockQueue
             ->method('sendMessages')
@@ -88,6 +96,7 @@ class ServerPagingHandlerTest extends TestCase
             queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $this->mockFilterEvaluator,
+            accessControl: $this->mockAccessControl,
             requestHistory: $this->requestHistory,
         );
     }
@@ -409,6 +418,7 @@ class ServerPagingHandlerTest extends TestCase
             queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $this->mockFilterEvaluator,
+            accessControl: $this->mockAccessControl,
             requestHistory: $this->requestHistory,
             limits: new SearchLimits(maxSearchSize: 1),
         );
@@ -439,6 +449,7 @@ class ServerPagingHandlerTest extends TestCase
             queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $this->mockFilterEvaluator,
+            accessControl: $this->mockAccessControl,
             requestHistory: $this->requestHistory,
             limits: new SearchLimits(maxSearchPageSize: 1),
         );
@@ -470,6 +481,7 @@ class ServerPagingHandlerTest extends TestCase
             queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $this->mockFilterEvaluator,
+            accessControl: $this->mockAccessControl,
             requestHistory: $this->requestHistory,
             limits: new SearchLimits(maxSearchPageSize: 2),
         );
@@ -496,6 +508,7 @@ class ServerPagingHandlerTest extends TestCase
             queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $this->mockFilterEvaluator,
+            accessControl: $this->mockAccessControl,
             requestHistory: $this->requestHistory,
             limits: new SearchLimits(maxSearchPageSize: 5),
         );
@@ -507,6 +520,85 @@ class ServerPagingHandlerTest extends TestCase
             $this->entryMessages(),
         );
         self::assertNotSame('', $this->donePagingControl()->getCookie());
+    }
+
+    public function test_it_should_suppress_entry_when_filter_entry_returns_null(): void
+    {
+        $entry1 = Entry::create(
+            'cn=1,dc=foo,dc=bar',
+            ['cn' => '1'],
+        );
+        $entry2 = Entry::create(
+            'cn=2,dc=foo,dc=bar',
+            ['cn' => '2'],
+        );
+        $message = $this->makeSearchMessage(size: 10);
+
+        $mockAccessControl = $this->createMock(AccessControlInterface::class);
+        $mockAccessControl
+            ->method('filterEntry')
+            ->willReturnCallback(static function (TokenInterface $token, Entry $entry) use ($entry1): ?Entry {
+                return $entry === $entry1 ? null : $entry;
+            });
+
+        $this->mockBackend
+            ->method('search')
+            ->willReturn(new EntryStream($this->makeGenerator(
+                $entry1,
+                $entry2,
+            )));
+
+        $subject = new ServerPagingHandler(
+            queue: $this->mockQueue,
+            backend: $this->mockBackend,
+            filterEvaluator: $this->mockFilterEvaluator,
+            accessControl: $mockAccessControl,
+            requestHistory: $this->requestHistory,
+        );
+        $subject->handleRequest($message, $this->mockToken);
+
+        self::assertEquals(
+            [new LdapMessageResponse(2, new SearchResultEntry($entry2))],
+            $this->entryMessages(),
+        );
+    }
+
+    public function test_it_should_skip_entry_when_filter_no_longer_matches_after_acl_stripping(): void
+    {
+        $entry = Entry::create(
+            'cn=1,dc=foo,dc=bar',
+            ['cn' => '1', 'secret' => 'val'],
+        );
+        $stripped = Entry::create(
+            'cn=1,dc=foo,dc=bar',
+            ['cn' => '1'],
+        );
+        $message = $this->makeSearchMessage(size: 10);
+
+        $mockAccessControl = $this->createMock(AccessControlInterface::class);
+        $mockAccessControl
+            ->method('filterEntry')
+            ->willReturn($stripped);
+
+        $mockFilterEvaluator = $this->createMock(FilterEvaluatorInterface::class);
+        $mockFilterEvaluator
+            ->method('evaluate')
+            ->willReturnCallback(static fn(Entry $e): bool => $e === $entry);
+
+        $this->mockBackend
+            ->method('search')
+            ->willReturn(new EntryStream($this->makeGenerator($entry)));
+
+        $subject = new ServerPagingHandler(
+            queue: $this->mockQueue,
+            backend: $this->mockBackend,
+            filterEvaluator: $mockFilterEvaluator,
+            accessControl: $mockAccessControl,
+            requestHistory: $this->requestHistory,
+        );
+        $subject->handleRequest($message, $this->mockToken);
+
+        self::assertSame([], $this->entryMessages());
     }
 
     private function makeExistingPagingRequest(

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
@@ -24,6 +24,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerSearchHandler;
 use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
@@ -43,6 +44,8 @@ final class ServerSearchHandlerTest extends TestCase
 
     private FilterEvaluatorInterface&MockObject $mockFilterEvaluator;
 
+    private AccessControlInterface&MockObject $mockAccessControl;
+
     private TokenInterface&MockObject $mockToken;
 
     /**
@@ -56,7 +59,12 @@ final class ServerSearchHandlerTest extends TestCase
         $this->mockQueue = $this->createMock(ServerQueue::class);
         $this->mockBackend = $this->createMock(LdapBackendInterface::class);
         $this->mockFilterEvaluator = $this->createMock(FilterEvaluatorInterface::class);
+        $this->mockAccessControl = $this->createMock(AccessControlInterface::class);
         $this->sentMessages = [];
+
+        $this->mockAccessControl
+            ->method('filterEntry')
+            ->willReturnArgument(1);
 
         $this->mockQueue
             ->method('sendMessages')
@@ -76,6 +84,7 @@ final class ServerSearchHandlerTest extends TestCase
             queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $this->mockFilterEvaluator,
+            accessControl: $this->mockAccessControl,
         );
     }
 
@@ -285,6 +294,7 @@ final class ServerSearchHandlerTest extends TestCase
             queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $this->mockFilterEvaluator,
+            accessControl: $this->mockAccessControl,
             limits: new SearchLimits(maxSearchSize: 1),
         );
         $subject->handleRequest($search, $this->mockToken);
@@ -319,6 +329,7 @@ final class ServerSearchHandlerTest extends TestCase
             queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $this->mockFilterEvaluator,
+            accessControl: $this->mockAccessControl,
             limits: new SearchLimits(maxSearchSize: 5),
         );
         $subject->handleRequest($search, $this->mockToken);
@@ -353,6 +364,7 @@ final class ServerSearchHandlerTest extends TestCase
             queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $this->mockFilterEvaluator,
+            accessControl: $this->mockAccessControl,
             limits: new SearchLimits(maxSearchSize: 1),
         );
         $subject->handleRequest($search, $this->mockToken);
@@ -379,6 +391,102 @@ final class ServerSearchHandlerTest extends TestCase
             $search,
             $this->mockToken,
         );
+
+        $this->assertSentMessages([
+            new LdapMessageResponse(
+                2,
+                new SearchResultDone(0, 'dc=foo,dc=bar'),
+            ),
+        ]);
+    }
+
+    public function test_it_should_suppress_entry_when_filter_entry_returns_null(): void
+    {
+        $entry1 = Entry::create(
+            'dc=foo,dc=bar',
+            ['cn' => 'foo'],
+        );
+        $entry2 = Entry::create(
+            'dc=bar,dc=foo',
+            ['cn' => 'bar'],
+        );
+
+        $search = new LdapMessageRequest(
+            2,
+            (new SearchRequest(Filters::equal('foo', 'bar')))->base('dc=foo,dc=bar'),
+        );
+
+        $mockAccessControl = $this->createMock(AccessControlInterface::class);
+        $mockAccessControl
+            ->method('filterEntry')
+            ->willReturnCallback(static function (TokenInterface $token, Entry $entry) use ($entry1): ?Entry {
+                return $entry === $entry1 ? null : $entry;
+            });
+
+        $this->mockBackend
+            ->method('search')
+            ->willReturn(new EntryStream($this->makeGenerator(
+                $entry1,
+                $entry2,
+            )));
+
+        $this->mockFilterEvaluator
+            ->method('evaluate')
+            ->willReturn(true);
+
+        $subject = new ServerSearchHandler(
+            queue: $this->mockQueue,
+            backend: $this->mockBackend,
+            filterEvaluator: $this->mockFilterEvaluator,
+            accessControl: $mockAccessControl,
+        );
+        $subject->handleRequest($search, $this->mockToken);
+
+        $this->assertSentMessages([
+            new LdapMessageResponse(2, new SearchResultEntry($entry2)),
+            new LdapMessageResponse(
+                2,
+                new SearchResultDone(0, 'dc=foo,dc=bar'),
+            ),
+        ]);
+    }
+
+    public function test_it_should_skip_entry_when_filter_no_longer_matches_after_acl_stripping(): void
+    {
+        $entry = Entry::create(
+            'dc=foo,dc=bar',
+            ['cn' => 'foo', 'secret' => 'val'],
+        );
+        $stripped = Entry::create(
+            'dc=foo,dc=bar',
+            ['cn' => 'foo'],
+        );
+
+        $search = new LdapMessageRequest(
+            2,
+            (new SearchRequest(Filters::equal('secret', 'val')))->base('dc=foo,dc=bar'),
+        );
+
+        $mockAccessControl = $this->createMock(AccessControlInterface::class);
+        $mockAccessControl
+            ->method('filterEntry')
+            ->willReturn($stripped);
+
+        $this->mockBackend
+            ->method('search')
+            ->willReturn(new EntryStream($this->makeGenerator($entry)));
+
+        $this->mockFilterEvaluator
+            ->method('evaluate')
+            ->willReturnCallback(static fn(Entry $e): bool => $e === $entry);
+
+        $subject = new ServerSearchHandler(
+            queue: $this->mockQueue,
+            backend: $this->mockBackend,
+            filterEvaluator: $this->mockFilterEvaluator,
+            accessControl: $mockAccessControl,
+        );
+        $subject->handleRequest($search, $this->mockToken);
 
         $this->assertSentMessages([
             new LdapMessageResponse(

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
+use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
@@ -52,7 +53,39 @@ final class ServerWhoAmIHandlerTest extends TestCase
 
         $this->subject->handleRequest(
             $request,
-            new BindToken('cn=foo,dc=foo,dc=bar', '12345'),
+            BindToken::fromDn(
+                'cn=foo,dc=foo,dc=bar',
+                '12345',
+            ),
+        );
+    }
+
+    public function test_it_should_use_resolved_dn_when_it_differs_from_username(): void
+    {
+        $request = new LdapMessageRequest(
+            2,
+            new ExtendedRequest(ExtendedRequest::OID_WHOAMI),
+        );
+
+        $this->mockQueue
+            ->expects($this->once())
+            ->method('sendMessage')
+            ->with($this->equalTo(new LdapMessageResponse(
+                2,
+                new ExtendedResponse(
+                    new LdapResult(0),
+                    null,
+                    'dn:cn=Alice,dc=example,dc=com',
+                ),
+            )));
+
+        $this->subject->handleRequest(
+            $request,
+            new BindToken(
+                'uid=alice',
+                '12345',
+                new Dn('cn=Alice,dc=example,dc=com'),
+            ),
         );
     }
 
@@ -70,7 +103,10 @@ final class ServerWhoAmIHandlerTest extends TestCase
 
         $this->subject->handleRequest(
             $request,
-            new BindToken('foo@bar.local', '12345'),
+            BindToken::fromDn(
+                'foo@bar.local',
+                '12345',
+            ),
         );
     }
 

--- a/tests/unit/Protocol/ServerProtocolHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandlerTest.php
@@ -140,7 +140,10 @@ final class ServerProtocolHandlerTest extends TestCase
 
         $this->mockAuthenticator
             ->method('bind')
-            ->willReturn(new BindToken('foo', 'bar'));
+            ->willReturn(BindToken::fromDn(
+                'foo',
+                'bar',
+            ));
 
         $this->mockProtocolHandler
             ->expects($this->never())
@@ -302,7 +305,10 @@ final class ServerProtocolHandlerTest extends TestCase
         $this->mockAuthenticator
             ->expects($this->once())
             ->method('bind')
-            ->willReturn(new BindToken('foo@bar', 'bar'));
+            ->willReturn(BindToken::fromDn(
+                'foo@bar',
+                'bar',
+            ));
 
         $this->mockProtocolHandler
             ->expects($this->never())
@@ -334,7 +340,10 @@ final class ServerProtocolHandlerTest extends TestCase
         $this->mockAuthenticator
             ->expects($this->once())
             ->method('bind')
-            ->willReturn(new BindToken('foo@bar', 'bar'));
+            ->willReturn(BindToken::fromDn(
+                'foo@bar',
+                'bar',
+            ));
 
         $this->mockProtocolHandler
             ->expects($this->once())

--- a/tests/unit/Server/AccessControl/Rule/AttributeRuleTest.php
+++ b/tests/unit/Server/AccessControl/Rule/AttributeRuleTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl\Rule;
+
+use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;
+use FreeDSx\Ldap\Server\AccessControl\Subject\AnySubjectMatcher;
+use FreeDSx\Ldap\Server\AccessControl\Target\AnyTargetMatcher;
+use PHPUnit\Framework\TestCase;
+
+final class AttributeRuleTest extends TestCase
+{
+    public function test_allow_sets_effect_to_allow(): void
+    {
+        $rule = AttributeRule::allow(new AnySubjectMatcher());
+
+        self::assertSame(
+            Effect::Allow,
+            $rule->effect,
+        );
+    }
+
+    public function test_deny_sets_effect_to_deny(): void
+    {
+        $rule = AttributeRule::deny(new AnySubjectMatcher());
+
+        self::assertSame(
+            Effect::Deny,
+            $rule->effect,
+        );
+    }
+
+    public function test_empty_attributes_list_when_none_specified(): void
+    {
+        $rule = AttributeRule::deny(new AnySubjectMatcher());
+
+        self::assertSame(
+            [],
+            $rule->attributes,
+        );
+    }
+
+    public function test_attribute_names_are_stored_lowercase(): void
+    {
+        $rule = AttributeRule::deny(
+            new AnySubjectMatcher(),
+            new AnyTargetMatcher(),
+            'userPassword',
+            'CN',
+        );
+
+        self::assertSame(
+            ['userpassword', 'cn'],
+            $rule->attributes,
+        );
+    }
+
+    public function test_default_target_is_any_target_matcher(): void
+    {
+        $rule = AttributeRule::deny(new AnySubjectMatcher());
+
+        self::assertInstanceOf(
+            AnyTargetMatcher::class,
+            $rule->target,
+        );
+    }
+}

--- a/tests/unit/Server/AccessControl/Rule/OperationRuleTest.php
+++ b/tests/unit/Server/AccessControl/Rule/OperationRuleTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl\Rule;
+
+use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;
+use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
+use FreeDSx\Ldap\Server\AccessControl\Subject\AnySubjectMatcher;
+use FreeDSx\Ldap\Server\AccessControl\Target\AnyTargetMatcher;
+use PHPUnit\Framework\TestCase;
+
+final class OperationRuleTest extends TestCase
+{
+    public function test_allow_sets_effect_to_allow(): void
+    {
+        $rule = OperationRule::allow(new AnySubjectMatcher());
+
+        self::assertSame(
+            Effect::Allow,
+            $rule->effect,
+        );
+    }
+
+    public function test_deny_sets_effect_to_deny(): void
+    {
+        $rule = OperationRule::deny(new AnySubjectMatcher());
+
+        self::assertSame(
+            Effect::Deny,
+            $rule->effect,
+        );
+    }
+
+    public function test_empty_operations_list_when_none_specified(): void
+    {
+        $rule = OperationRule::allow(new AnySubjectMatcher());
+
+        self::assertSame(
+            [],
+            $rule->operations,
+        );
+    }
+
+    public function test_operations_are_stored_when_provided(): void
+    {
+        $rule = OperationRule::allow(
+            new AnySubjectMatcher(),
+            new AnyTargetMatcher(),
+            OperationType::Search,
+            OperationType::Compare,
+        );
+
+        self::assertSame(
+            [OperationType::Search, OperationType::Compare],
+            $rule->operations,
+        );
+    }
+
+    public function test_default_target_is_any_target_matcher(): void
+    {
+        $rule = OperationRule::allow(new AnySubjectMatcher());
+
+        self::assertInstanceOf(
+            AnyTargetMatcher::class,
+            $rule->target,
+        );
+    }
+}

--- a/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
+++ b/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
@@ -1,0 +1,431 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;
+use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
+use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
+use FreeDSx\Ldap\Server\AccessControl\BackendAwareInterface;
+use FreeDSx\Ldap\Server\AccessControl\Subject\AnySubjectMatcher;
+use FreeDSx\Ldap\Server\AccessControl\Subject\SubjectMatcherInterface;
+use FreeDSx\Ldap\Server\AccessControl\Target\AnyTargetMatcher;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class RuleBasedAccessControlTest extends TestCase
+{
+    private Dn $dn;
+
+    private TokenInterface $bindToken;
+
+    protected function setUp(): void
+    {
+        $this->dn = new Dn('dc=foo,dc=bar');
+        $this->bindToken = BindToken::fromDn(
+            'cn=admin,dc=foo,dc=bar',
+            'secret',
+        );
+    }
+
+    public function test_it_should_allow_when_first_matching_rule_is_allow(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $subject = new RuleBasedAccessControl(
+            operationRules: [
+                OperationRule::allow(new AnySubjectMatcher()),
+            ],
+        );
+
+        $subject->authorizeOperation(
+            OperationType::Search,
+            $this->bindToken,
+            $this->dn,
+        );
+    }
+
+    public function test_it_should_deny_when_first_matching_rule_is_deny(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $subject = new RuleBasedAccessControl(
+            operationRules: [
+                OperationRule::deny(new AnySubjectMatcher()),
+            ],
+        );
+
+        $subject->authorizeOperation(
+            OperationType::Search,
+            $this->bindToken,
+            $this->dn,
+        );
+    }
+
+    public function test_it_should_deny_when_no_rules_match_and_default_effect_is_deny(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $subject = new RuleBasedAccessControl(defaultEffect: Effect::Deny);
+
+        $subject->authorizeOperation(
+            OperationType::Search,
+            $this->bindToken,
+            $this->dn,
+        );
+    }
+
+    public function test_it_should_allow_when_no_rules_match_and_default_effect_is_allow(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $subject = new RuleBasedAccessControl(defaultEffect: Effect::Allow);
+
+        $subject->authorizeOperation(
+            OperationType::Search,
+            $this->bindToken,
+            $this->dn,
+        );
+    }
+
+    public function test_it_should_skip_rule_when_operation_type_does_not_match(): void
+    {
+        $this->expectException(OperationException::class);
+
+        $subject = new RuleBasedAccessControl(
+            operationRules: [
+                OperationRule::allow(
+                    new AnySubjectMatcher(),
+                    new AnyTargetMatcher(),
+                    OperationType::Add,
+                ),
+            ],
+            defaultEffect: Effect::Deny,
+        );
+
+        $subject->authorizeOperation(
+            OperationType::Search,
+            $this->bindToken,
+            $this->dn,
+        );
+    }
+
+    public function test_it_should_apply_rule_when_operation_type_matches(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $subject = new RuleBasedAccessControl(
+            operationRules: [
+                OperationRule::allow(
+                    new AnySubjectMatcher(),
+                    new AnyTargetMatcher(),
+                    OperationType::Search,
+                ),
+            ],
+        );
+
+        $subject->authorizeOperation(
+            OperationType::Search,
+            $this->bindToken,
+            $this->dn,
+        );
+    }
+
+    public function test_it_should_apply_rule_with_empty_operations_list_to_all_operation_types(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $subject = new RuleBasedAccessControl(
+            operationRules: [
+                OperationRule::allow(new AnySubjectMatcher()),
+            ],
+        );
+
+        foreach (OperationType::cases() as $type) {
+            $subject->authorizeOperation(
+                $type,
+                $this->bindToken,
+                $this->dn,
+            );
+        }
+    }
+
+    public function test_it_should_use_first_match_when_deny_rule_precedes_allow_rule(): void
+    {
+        $this->expectException(OperationException::class);
+
+        $subject = new RuleBasedAccessControl(
+            operationRules: [
+                OperationRule::deny(new AnySubjectMatcher()),
+                OperationRule::allow(new AnySubjectMatcher()),
+            ],
+        );
+
+        $subject->authorizeOperation(
+            OperationType::Search,
+            $this->bindToken,
+            $this->dn,
+        );
+    }
+
+    public function test_filter_entry_returns_same_instance_when_no_attribute_rules(): void
+    {
+        $entry = Entry::create('dc=foo,dc=bar', ['cn' => 'foo']);
+
+        $subject = new RuleBasedAccessControl(
+            operationRules: [OperationRule::allow(new AnySubjectMatcher())],
+        );
+
+        $result = $subject->filterEntry(
+            $this->bindToken,
+            $entry,
+        );
+
+        self::assertSame($entry, $result);
+    }
+
+    public function test_filter_entry_removes_attribute_when_deny_rule_matches(): void
+    {
+        $entry = Entry::create(
+            'dc=foo,dc=bar',
+            ['cn' => 'foo', 'userpassword' => 'secret'],
+        );
+
+        $subject = new RuleBasedAccessControl(
+            operationRules: [OperationRule::allow(new AnySubjectMatcher())],
+            attributeRules: [
+                AttributeRule::deny(
+                    new AnySubjectMatcher(),
+                    new AnyTargetMatcher(),
+                    'userPassword',
+                ),
+            ],
+        );
+
+        $result = $subject->filterEntry(
+            $this->bindToken,
+            $entry,
+        );
+
+        self::assertNotNull($result);
+        self::assertNull($result->get('userPassword'));
+        self::assertNotNull($result->get('cn'));
+    }
+
+    public function test_filter_entry_keeps_attribute_when_allow_rule_precedes_deny_rule(): void
+    {
+        $matchingSubject = $this->createMock(SubjectMatcherInterface::class);
+        $matchingSubject->method('matches')->willReturn(true);
+
+        $entry = Entry::create(
+            'dc=foo,dc=bar',
+            ['userpassword' => 'secret'],
+        );
+
+        $subject = new RuleBasedAccessControl(
+            operationRules: [OperationRule::allow(new AnySubjectMatcher())],
+            attributeRules: [
+                AttributeRule::allow(
+                    $matchingSubject,
+                    new AnyTargetMatcher(),
+                    'userPassword',
+                ),
+                AttributeRule::deny(
+                    new AnySubjectMatcher(),
+                    new AnyTargetMatcher(),
+                    'userPassword',
+                ),
+            ],
+        );
+
+        $result = $subject->filterEntry(
+            $this->bindToken,
+            $entry,
+        );
+
+        self::assertNotNull($result);
+        self::assertNotNull($result->get('userPassword'));
+    }
+
+    public function test_filter_entry_keeps_attribute_when_no_rule_matches(): void
+    {
+        $nonMatchingSubject = $this->createMock(SubjectMatcherInterface::class);
+        $nonMatchingSubject->method('matches')->willReturn(false);
+
+        $entry = Entry::create(
+            'dc=foo,dc=bar',
+            ['cn' => 'foo'],
+        );
+
+        $subject = new RuleBasedAccessControl(
+            operationRules: [OperationRule::allow(new AnySubjectMatcher())],
+            attributeRules: [
+                AttributeRule::deny(
+                    $nonMatchingSubject,
+                    new AnyTargetMatcher(),
+                    'cn',
+                ),
+            ],
+        );
+
+        $result = $subject->filterEntry(
+            $this->bindToken,
+            $entry,
+        );
+
+        self::assertNotNull($result);
+        self::assertNotNull($result->get('cn'));
+    }
+
+    public function test_filter_entry_returns_same_instance_when_all_attributes_kept(): void
+    {
+        $entry = Entry::create(
+            'dc=foo,dc=bar',
+            ['cn' => 'foo'],
+        );
+
+        $subject = new RuleBasedAccessControl(
+            operationRules: [OperationRule::allow(new AnySubjectMatcher())],
+            attributeRules: [
+                AttributeRule::allow(
+                    new AnySubjectMatcher(),
+                    new AnyTargetMatcher(),
+                    'cn',
+                ),
+            ],
+        );
+
+        $result = $subject->filterEntry(
+            $this->bindToken,
+            $entry,
+        );
+
+        self::assertSame($entry, $result);
+    }
+
+    public function test_filter_entry_empty_attributes_list_on_deny_rule_matches_all_attributes(): void
+    {
+        $entry = Entry::create(
+            'dc=foo,dc=bar',
+            ['cn' => 'foo', 'sn' => 'bar'],
+        );
+
+        $subject = new RuleBasedAccessControl(
+            operationRules: [OperationRule::allow(new AnySubjectMatcher())],
+            attributeRules: [
+                AttributeRule::deny(new AnySubjectMatcher()),
+            ],
+        );
+
+        $result = $subject->filterEntry(
+            $this->bindToken,
+            $entry,
+        );
+
+        self::assertNotNull($result);
+        self::assertEmpty($result->getAttributes());
+    }
+
+    public function test_filter_entry_returns_null_when_search_operation_is_denied_on_entry_dn(): void
+    {
+        $entry = Entry::create(
+            'dc=foo,dc=bar',
+            ['cn' => 'foo'],
+        );
+
+        $subject = new RuleBasedAccessControl(
+            operationRules: [
+                OperationRule::deny(
+                    new AnySubjectMatcher(),
+                    new AnyTargetMatcher(),
+                    OperationType::Search,
+                ),
+            ],
+        );
+
+        $result = $subject->filterEntry(
+            $this->bindToken,
+            $entry,
+        );
+
+        self::assertNull($result);
+    }
+
+    public function test_authorize_attribute_access_does_not_throw_when_no_deny_rule_matches(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $subject = new RuleBasedAccessControl();
+
+        $subject->authorizeAttribute(
+            $this->bindToken,
+            $this->dn,
+            'userPassword',
+        );
+    }
+
+    public function test_authorize_attribute_access_throws_when_deny_rule_matches(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $subject = new RuleBasedAccessControl(
+            attributeRules: [
+                AttributeRule::deny(
+                    new AnySubjectMatcher(),
+                    new AnyTargetMatcher(),
+                    'userPassword',
+                ),
+            ],
+        );
+
+        $subject->authorizeAttribute(
+            $this->bindToken,
+            $this->dn,
+            'userPassword',
+        );
+    }
+
+    public function test_set_backend_propagates_to_backend_aware_subjects(): void
+    {
+        $mockBackend = $this->createMock(LdapBackendInterface::class);
+
+        /** @var SubjectMatcherInterface&BackendAwareInterface&MockObject $mockBackendAwareSubject */
+        $mockBackendAwareSubject = $this->createMockForIntersectionOfInterfaces([
+            SubjectMatcherInterface::class,
+            BackendAwareInterface::class,
+        ]);
+
+        $mockBackendAwareSubject
+            ->expects(self::once())
+            ->method('setBackend')
+            ->with($mockBackend);
+
+        $subject = new RuleBasedAccessControl(
+            operationRules: [OperationRule::allow($mockBackendAwareSubject)],
+        );
+
+        $subject->setBackend($mockBackend);
+    }
+}

--- a/tests/unit/Server/AccessControl/SimpleAccessControlTest.php
+++ b/tests/unit/Server/AccessControl/SimpleAccessControlTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Server\AccessControl\SimpleAccessControl;
+use FreeDSx\Ldap\Server\Token\AnonToken;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use PHPUnit\Framework\TestCase;
+
+final class SimpleAccessControlTest extends TestCase
+{
+    private SimpleAccessControl $subject;
+
+    private Dn $dn;
+
+    protected function setUp(): void
+    {
+        $this->subject = new SimpleAccessControl();
+        $this->dn = new Dn('dc=foo,dc=bar');
+    }
+
+    public function test_it_should_deny_anonymous_search(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->subject->authorizeOperation(
+            OperationType::Search,
+            new AnonToken(),
+            $this->dn,
+        );
+    }
+
+    public function test_it_should_deny_anonymous_add(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->subject->authorizeOperation(
+            OperationType::Add,
+            new AnonToken(),
+            $this->dn,
+        );
+    }
+
+    public function test_it_should_deny_anonymous_modify(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->subject->authorizeOperation(
+            OperationType::Modify,
+            new AnonToken(),
+            $this->dn,
+        );
+    }
+
+    public function test_it_should_deny_anonymous_delete(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->subject->authorizeOperation(
+            OperationType::Delete,
+            new AnonToken(),
+            $this->dn,
+        );
+    }
+
+    public function test_it_should_deny_anonymous_modify_dn(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->subject->authorizeOperation(
+            OperationType::ModifyDn,
+            new AnonToken(),
+            $this->dn,
+        );
+    }
+
+    public function test_it_should_deny_anonymous_compare(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->subject->authorizeOperation(
+            OperationType::Compare,
+            new AnonToken(),
+            $this->dn,
+        );
+    }
+
+    public function test_it_should_allow_authenticated_search(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->subject->authorizeOperation(
+            OperationType::Search,
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->dn,
+        );
+    }
+
+    public function test_it_should_allow_authenticated_add(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->subject->authorizeOperation(
+            OperationType::Add,
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->dn,
+        );
+    }
+
+    public function test_it_should_return_entry_unchanged_from_filter_entry(): void
+    {
+        $entry = Entry::create('dc=foo,dc=bar', ['cn' => 'foo']);
+
+        $result = $this->subject->filterEntry(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $entry,
+        );
+
+        self::assertSame(
+            $entry,
+            $result,
+        );
+    }
+
+    public function test_filter_entry_returns_entry_unchanged_for_anonymous(): void
+    {
+        $entry = Entry::create('dc=foo,dc=bar', ['cn' => 'foo']);
+
+        $result = $this->subject->filterEntry(
+            new AnonToken(),
+            $entry,
+        );
+
+        self::assertSame(
+            $entry,
+            $result,
+        );
+    }
+
+    public function test_authorize_attribute_access_is_a_no_op(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->subject->authorizeAttribute(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->dn,
+            'userPassword',
+        );
+    }
+}

--- a/tests/unit/Server/AccessControl/Subject/AnonymousSubjectMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Subject/AnonymousSubjectMatcherTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\AccessControl\Subject\AnonymousSubjectMatcher;
+use FreeDSx\Ldap\Server\Token\AnonToken;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use PHPUnit\Framework\TestCase;
+
+final class AnonymousSubjectMatcherTest extends TestCase
+{
+    private AnonymousSubjectMatcher $subject;
+
+    private Dn $dn;
+
+    protected function setUp(): void
+    {
+        $this->subject = new AnonymousSubjectMatcher();
+        $this->dn = new Dn('dc=foo,dc=bar');
+    }
+
+    public function test_it_should_match_anonymous_token(): void
+    {
+        self::assertTrue($this->subject->matches(
+            new AnonToken(),
+            $this->dn,
+        ));
+    }
+
+    public function test_it_should_not_match_bind_token(): void
+    {
+        self::assertFalse($this->subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->dn,
+        ));
+    }
+}

--- a/tests/unit/Server/AccessControl/Subject/AuthenticatedSubjectMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Subject/AuthenticatedSubjectMatcherTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\AccessControl\Subject\AuthenticatedSubjectMatcher;
+use FreeDSx\Ldap\Server\Token\AnonToken;
+use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use PHPUnit\Framework\TestCase;
+
+final class AuthenticatedSubjectMatcherTest extends TestCase
+{
+    private AuthenticatedSubjectMatcher $subject;
+
+    private Dn $dn;
+
+    protected function setUp(): void
+    {
+        $this->subject = new AuthenticatedSubjectMatcher();
+        $this->dn = new Dn('dc=foo,dc=bar');
+    }
+
+    public function test_it_should_match_bind_token(): void
+    {
+        self::assertTrue($this->subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->dn,
+        ));
+    }
+
+    public function test_it_should_match_any_authenticated_token_interface_implementation(): void
+    {
+        $token = $this->createMock(AuthenticatedTokenInterface::class);
+
+        self::assertTrue($this->subject->matches(
+            $token,
+            $this->dn,
+        ));
+    }
+
+    public function test_it_should_not_match_anonymous_token(): void
+    {
+        self::assertFalse($this->subject->matches(
+            new AnonToken(),
+            $this->dn,
+        ));
+    }
+}

--- a/tests/unit/Server/AccessControl/Subject/CallbackSubjectMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Subject/CallbackSubjectMatcherTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\AccessControl\Subject\CallbackSubjectMatcher;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class CallbackSubjectMatcherTest extends TestCase
+{
+    public function test_it_should_delegate_to_callback_returning_true(): void
+    {
+        $subject = new CallbackSubjectMatcher(
+            fn(TokenInterface $token, Dn $dn): bool => true,
+        );
+
+        self::assertTrue($subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            new Dn('dc=foo,dc=bar'),
+        ));
+    }
+
+    public function test_it_should_delegate_to_callback_returning_false(): void
+    {
+        $subject = new CallbackSubjectMatcher(
+            fn(TokenInterface $token, Dn $dn): bool => false,
+        );
+
+        self::assertFalse($subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            new Dn('dc=foo,dc=bar'),
+        ));
+    }
+
+    public function test_it_should_pass_token_and_dn_to_callback(): void
+    {
+        $capturedToken = null;
+        $capturedDn = null;
+
+        $token = BindToken::fromDn(
+            'cn=admin,dc=foo,dc=bar',
+            'secret',
+        );
+        $dn = new Dn('dc=foo,dc=bar');
+
+        $subject = new CallbackSubjectMatcher(
+            function (TokenInterface $t, Dn $d) use (&$capturedToken, &$capturedDn): bool {
+                $capturedToken = $t;
+                $capturedDn = $d;
+
+                return true;
+            },
+        );
+
+        $subject->matches(
+            $token,
+            $dn,
+        );
+
+        self::assertSame(
+            $token,
+            $capturedToken,
+        );
+        self::assertSame(
+            $dn,
+            $capturedDn,
+        );
+    }
+
+    public function test_it_should_return_false_when_callback_throws(): void
+    {
+        $subject = new CallbackSubjectMatcher(
+            fn(TokenInterface $token, Dn $dn): bool => throw new RuntimeException('oh no!'),
+        );
+
+        self::assertFalse($subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            new Dn('dc=foo,dc=bar'),
+        ));
+    }
+}

--- a/tests/unit/Server/AccessControl/Subject/DnSubjectMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Subject/DnSubjectMatcherTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\AccessControl\Subject\DnSubjectMatcher;
+use FreeDSx\Ldap\Server\Token\AnonToken;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use PHPUnit\Framework\TestCase;
+
+final class DnSubjectMatcherTest extends TestCase
+{
+    private Dn $targetDn;
+
+    protected function setUp(): void
+    {
+        $this->targetDn = new Dn('dc=foo,dc=bar');
+    }
+
+    public function test_it_should_match_when_username_equals_configured_dn(): void
+    {
+        $subject = new DnSubjectMatcher('cn=admin,dc=foo,dc=bar');
+
+        self::assertTrue($subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_match_case_insensitively(): void
+    {
+        $subject = new DnSubjectMatcher('cn=admin,dc=foo,dc=bar');
+
+        self::assertTrue($subject->matches(
+            BindToken::fromDn(
+                'CN=Admin,DC=foo,DC=bar',
+                'secret',
+            ),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_not_match_when_username_differs(): void
+    {
+        $subject = new DnSubjectMatcher('cn=admin,dc=foo,dc=bar');
+
+        self::assertFalse($subject->matches(
+            BindToken::fromDn(
+                'cn=other,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_not_match_for_anonymous_token(): void
+    {
+        $subject = new DnSubjectMatcher('cn=admin,dc=foo,dc=bar');
+
+        self::assertFalse($subject->matches(
+            new AnonToken(),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_not_match_for_anonymous_token_even_with_matching_dn(): void
+    {
+        $subject = new DnSubjectMatcher('cn=admin,dc=foo,dc=bar');
+
+        self::assertFalse($subject->matches(
+            new AnonToken('cn=admin,dc=foo,dc=bar'),
+            $this->targetDn,
+        ));
+    }
+}

--- a/tests/unit/Server/AccessControl/Subject/DnSubtreeSubjectMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Subject/DnSubtreeSubjectMatcherTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\AccessControl\Subject\DnSubtreeSubjectMatcher;
+use FreeDSx\Ldap\Server\Token\AnonToken;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use PHPUnit\Framework\TestCase;
+
+final class DnSubtreeSubjectMatcherTest extends TestCase
+{
+    private Dn $targetDn;
+
+    protected function setUp(): void
+    {
+        $this->targetDn = new Dn('dc=foo,dc=bar');
+    }
+
+    public function test_it_should_match_when_bound_dn_is_within_subtree(): void
+    {
+        $subject = new DnSubtreeSubjectMatcher('dc=foo,dc=bar');
+
+        self::assertTrue($subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_not_match_when_bound_dn_is_in_sibling_subtree(): void
+    {
+        $subject = new DnSubtreeSubjectMatcher('dc=foo,dc=bar');
+
+        self::assertFalse($subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=other,dc=bar',
+                'secret',
+            ),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_not_match_for_anonymous_token(): void
+    {
+        $subject = new DnSubtreeSubjectMatcher('dc=foo,dc=bar');
+
+        self::assertFalse($subject->matches(
+            new AnonToken(),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_not_match_for_anonymous_token_even_with_dn_in_subtree(): void
+    {
+        $subject = new DnSubtreeSubjectMatcher('dc=foo,dc=bar');
+
+        self::assertFalse($subject->matches(
+            new AnonToken('cn=admin,dc=foo,dc=bar'),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_not_match_and_not_throw_when_resolved_dn_is_not_valid(): void
+    {
+        $subject = new DnSubtreeSubjectMatcher('dc=foo,dc=bar');
+
+        self::assertFalse($subject->matches(
+            BindToken::fromDn(
+                'jdoe',
+                'secret',
+            ),
+            $this->targetDn,
+        ));
+    }
+}

--- a/tests/unit/Server/AccessControl/Subject/GroupSubjectMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Subject/GroupSubjectMatcherTest.php
@@ -1,0 +1,377 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Server\AccessControl\Subject\GroupSubjectMatcher;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Token\AnonToken;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class GroupSubjectMatcherTest extends TestCase
+{
+    private LdapBackendInterface&MockObject $mockBackend;
+
+    private Dn $targetDn;
+
+    protected function setUp(): void
+    {
+        $this->mockBackend = $this->createMock(LdapBackendInterface::class);
+        $this->targetDn = new Dn('dc=foo,dc=bar');
+    }
+
+    public function test_it_should_match_when_bound_dn_is_a_group_member(): void
+    {
+        $groupEntry = Entry::create(
+            'cn=admins,dc=foo,dc=bar',
+            ['member' => ['cn=admin,dc=foo,dc=bar', 'cn=other,dc=foo,dc=bar']],
+        );
+
+        $this->mockBackend
+            ->method('get')
+            ->willReturn($groupEntry);
+
+        $subject = new GroupSubjectMatcher('cn=admins,dc=foo,dc=bar');
+        $subject->setBackend($this->mockBackend);
+
+        self::assertTrue($subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_match_case_insensitively(): void
+    {
+        $groupEntry = Entry::create(
+            'cn=admins,dc=foo,dc=bar',
+            ['member' => ['CN=Admin,DC=foo,DC=bar']],
+        );
+
+        $this->mockBackend
+            ->method('get')
+            ->willReturn($groupEntry);
+
+        $subject = new GroupSubjectMatcher('cn=admins,dc=foo,dc=bar');
+        $subject->setBackend($this->mockBackend);
+
+        self::assertTrue($subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_not_match_when_bound_dn_is_not_a_member(): void
+    {
+        $groupEntry = Entry::create(
+            'cn=admins,dc=foo,dc=bar',
+            ['member' => ['cn=other,dc=foo,dc=bar']],
+        );
+
+        $this->mockBackend
+            ->method('get')
+            ->willReturn($groupEntry);
+
+        $subject = new GroupSubjectMatcher('cn=admins,dc=foo,dc=bar');
+        $subject->setBackend($this->mockBackend);
+
+        self::assertFalse($subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_not_match_when_group_entry_is_not_found(): void
+    {
+        $this->mockBackend
+            ->method('get')
+            ->willReturn(null);
+
+        $subject = new GroupSubjectMatcher('cn=admins,dc=foo,dc=bar');
+        $subject->setBackend($this->mockBackend);
+
+        self::assertFalse($subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_not_match_when_backend_is_not_set(): void
+    {
+        $subject = new GroupSubjectMatcher('cn=admins,dc=foo,dc=bar');
+
+        self::assertFalse($subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_not_match_for_anonymous_token(): void
+    {
+        $this->mockBackend
+            ->expects(self::never())
+            ->method('get');
+
+        $subject = new GroupSubjectMatcher('cn=admins,dc=foo,dc=bar');
+        $subject->setBackend($this->mockBackend);
+
+        self::assertFalse($subject->matches(
+            new AnonToken(),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_not_match_for_anonymous_token_even_with_matching_dn(): void
+    {
+        $this->mockBackend
+            ->expects(self::never())
+            ->method('get');
+
+        $subject = new GroupSubjectMatcher('cn=admins,dc=foo,dc=bar');
+        $subject->setBackend($this->mockBackend);
+
+        self::assertFalse($subject->matches(
+            new AnonToken('cn=admin,dc=foo,dc=bar'),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_use_custom_member_attribute(): void
+    {
+        $groupEntry = Entry::create(
+            'cn=admins,dc=foo,dc=bar',
+            ['uniqueMember' => ['cn=admin,dc=foo,dc=bar']],
+        );
+
+        $this->mockBackend
+            ->method('get')
+            ->willReturn($groupEntry);
+
+        $subject = new GroupSubjectMatcher(
+            'cn=admins,dc=foo,dc=bar',
+            'uniqueMember',
+        );
+        $subject->setBackend($this->mockBackend);
+
+        self::assertTrue($subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_fetch_group_entry_only_once_across_multiple_calls(): void
+    {
+        $groupEntry = Entry::create(
+            'cn=admins,dc=foo,dc=bar',
+            ['member' => ['cn=admin,dc=foo,dc=bar']],
+        );
+
+        $this->mockBackend
+            ->expects(self::once())
+            ->method('get')
+            ->willReturn($groupEntry);
+
+        $subject = new GroupSubjectMatcher('cn=admins,dc=foo,dc=bar');
+        $subject->setBackend($this->mockBackend);
+
+        $token = BindToken::fromDn(
+            'cn=admin,dc=foo,dc=bar',
+            'secret',
+        );
+
+        $subject->matches(
+            $token,
+            $this->targetDn,
+        );
+        $subject->matches(
+            $token,
+            $this->targetDn,
+        );
+        $subject->matches(
+            $token,
+            $this->targetDn,
+        );
+    }
+
+    public function test_it_should_not_fetch_group_entry_for_anonymous_token(): void
+    {
+        $this->mockBackend
+            ->expects(self::never())
+            ->method('get');
+
+        $subject = new GroupSubjectMatcher('cn=admins,dc=foo,dc=bar');
+        $subject->setBackend($this->mockBackend);
+
+        $subject->matches(
+            new AnonToken(),
+            $this->targetDn,
+        );
+    }
+
+    public function test_it_should_fetch_group_entry_separately_per_token_id(): void
+    {
+        $groupEntry = Entry::create(
+            'cn=admins,dc=foo,dc=bar',
+            ['member' => ['cn=admin,dc=foo,dc=bar']],
+        );
+
+        $this->mockBackend
+            ->expects(self::exactly(2))
+            ->method('get')
+            ->willReturn($groupEntry);
+
+        $subject = new GroupSubjectMatcher('cn=admins,dc=foo,dc=bar');
+        $subject->setBackend($this->mockBackend);
+
+        $subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->targetDn,
+        );
+        $subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->targetDn,
+        );
+    }
+
+    public function test_it_should_bypass_cache_when_max_cache_size_is_zero(): void
+    {
+        $groupEntry = Entry::create(
+            'cn=admins,dc=foo,dc=bar',
+            ['member' => ['cn=admin,dc=foo,dc=bar']],
+        );
+
+        $this->mockBackend
+            ->expects(self::exactly(3))
+            ->method('get')
+            ->willReturn($groupEntry);
+
+        $subject = new GroupSubjectMatcher(
+            'cn=admins,dc=foo,dc=bar',
+            'member',
+            0,
+        );
+        $subject->setBackend($this->mockBackend);
+
+        $token = BindToken::fromDn(
+            'cn=admin,dc=foo,dc=bar',
+            'secret',
+        );
+
+        $subject->matches($token, $this->targetDn);
+        $subject->matches($token, $this->targetDn);
+        $subject->matches($token, $this->targetDn);
+    }
+
+    public function test_it_should_match_when_member_dn_has_surrounding_whitespace(): void
+    {
+        $groupEntry = Entry::create(
+            'cn=admins,dc=foo,dc=bar',
+            ['member' => ['CN=Admin, DC=foo, DC=bar']],
+        );
+
+        $this->mockBackend
+            ->method('get')
+            ->willReturn($groupEntry);
+
+        $subject = new GroupSubjectMatcher('cn=admins,dc=foo,dc=bar');
+        $subject->setBackend($this->mockBackend);
+
+        self::assertTrue($subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=foo,dc=bar',
+                'secret',
+            ),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_not_match_when_dn_is_different_after_normalization(): void
+    {
+        $groupEntry = Entry::create(
+            'cn=admins,dc=foo,dc=bar',
+            ['member' => ['cn=other,dc=foo,dc=bar']],
+        );
+
+        $this->mockBackend
+            ->method('get')
+            ->willReturn($groupEntry);
+
+        $subject = new GroupSubjectMatcher('cn=admins,dc=foo,dc=bar');
+        $subject->setBackend($this->mockBackend);
+
+        self::assertFalse($subject->matches(
+            BindToken::fromDn(
+                'cn=admin, dc=foo, dc=bar',
+                'secret',
+            ),
+            $this->targetDn,
+        ));
+    }
+
+    public function test_it_should_evict_oldest_entry_when_cache_is_full(): void
+    {
+        $groupEntry = Entry::create(
+            'cn=admins,dc=foo,dc=bar',
+            ['member' => ['cn=admin,dc=foo,dc=bar']],
+        );
+
+        $this->mockBackend
+            ->expects(self::exactly(4))
+            ->method('get')
+            ->willReturn($groupEntry);
+
+        $subject = new GroupSubjectMatcher(
+            'cn=admins,dc=foo,dc=bar',
+            'member',
+            2,
+        );
+        $subject->setBackend($this->mockBackend);
+
+        $token1 = BindToken::fromDn('cn=admin,dc=foo,dc=bar', 'secret');
+        $token2 = BindToken::fromDn('cn=admin,dc=foo,dc=bar', 'secret');
+        $token3 = BindToken::fromDn('cn=admin,dc=foo,dc=bar', 'secret');
+
+        $subject->matches($token1, $this->targetDn);
+        $subject->matches($token2, $this->targetDn);
+        $subject->matches($token3, $this->targetDn);
+        $subject->matches($token2, $this->targetDn);
+        $subject->matches($token1, $this->targetDn);
+    }
+}

--- a/tests/unit/Server/AccessControl/Subject/SelfSubjectMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Subject/SelfSubjectMatcherTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl\Subject;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\AccessControl\Subject\SelfSubjectMatcher;
+use FreeDSx\Ldap\Server\Token\AnonToken;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use PHPUnit\Framework\TestCase;
+
+final class SelfSubjectMatcherTest extends TestCase
+{
+    private SelfSubjectMatcher $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new SelfSubjectMatcher();
+    }
+
+    public function test_it_should_match_when_username_equals_target_dn(): void
+    {
+        self::assertTrue($this->subject->matches(
+            BindToken::fromDn(
+                'cn=foo,dc=bar',
+                'secret',
+            ),
+            new Dn('cn=foo,dc=bar'),
+        ));
+    }
+
+    public function test_it_should_match_case_insensitively(): void
+    {
+        self::assertTrue($this->subject->matches(
+            BindToken::fromDn(
+                'CN=Foo,DC=bar',
+                'secret',
+            ),
+            new Dn('cn=foo,dc=bar'),
+        ));
+    }
+
+    public function test_it_should_not_match_when_username_differs_from_target_dn(): void
+    {
+        self::assertFalse($this->subject->matches(
+            BindToken::fromDn(
+                'cn=admin,dc=bar',
+                'secret',
+            ),
+            new Dn('cn=foo,dc=bar'),
+        ));
+    }
+
+    public function test_it_should_not_match_for_anonymous_token(): void
+    {
+        self::assertFalse($this->subject->matches(
+            new AnonToken(),
+            new Dn('cn=foo,dc=bar'),
+        ));
+    }
+
+    public function test_it_should_not_match_for_anonymous_token_even_with_matching_dn(): void
+    {
+        self::assertFalse($this->subject->matches(
+            new AnonToken('cn=foo,dc=bar'),
+            new Dn('cn=foo,dc=bar'),
+        ));
+    }
+}

--- a/tests/unit/Server/AccessControl/Target/DnTargetMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Target/DnTargetMatcherTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl\Target;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\AccessControl\Target\DnTargetMatcher;
+use PHPUnit\Framework\TestCase;
+
+final class DnTargetMatcherTest extends TestCase
+{
+    public function test_it_should_match_exact_dn(): void
+    {
+        $subject = new DnTargetMatcher('cn=foo,dc=bar');
+
+        self::assertTrue($subject->matches(new Dn('cn=foo,dc=bar')));
+    }
+
+    public function test_it_should_match_case_insensitively(): void
+    {
+        $subject = new DnTargetMatcher('cn=foo,dc=bar');
+
+        self::assertTrue($subject->matches(new Dn('CN=Foo,DC=bar')));
+    }
+
+    public function test_it_should_not_match_different_dn(): void
+    {
+        $subject = new DnTargetMatcher('cn=foo,dc=bar');
+
+        self::assertFalse($subject->matches(new Dn('cn=other,dc=bar')));
+    }
+}

--- a/tests/unit/Server/AccessControl/Target/SubtreeTargetMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Target/SubtreeTargetMatcherTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl\Target;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\AccessControl\Target\SubtreeTargetMatcher;
+use PHPUnit\Framework\TestCase;
+
+final class SubtreeTargetMatcherTest extends TestCase
+{
+    public function test_it_should_match_descendant_dn(): void
+    {
+        $subject = new SubtreeTargetMatcher('dc=foo,dc=bar');
+
+        self::assertTrue($subject->matches(new Dn('cn=admin,dc=foo,dc=bar')));
+    }
+
+    public function test_it_should_match_deeply_nested_descendant(): void
+    {
+        $subject = new SubtreeTargetMatcher('dc=foo,dc=bar');
+
+        self::assertTrue($subject->matches(new Dn('uid=user,ou=people,dc=foo,dc=bar')));
+    }
+
+    public function test_it_should_match_root_dn_of_subtree_itself(): void
+    {
+        $subject = new SubtreeTargetMatcher('dc=foo,dc=bar');
+
+        // isDescendantOf uses inclusive subtree semantics — the root matches itself.
+        self::assertTrue($subject->matches(new Dn('dc=foo,dc=bar')));
+    }
+
+    public function test_it_should_not_match_sibling_subtree(): void
+    {
+        $subject = new SubtreeTargetMatcher('dc=foo,dc=bar');
+
+        self::assertFalse($subject->matches(new Dn('cn=admin,dc=other,dc=bar')));
+    }
+}

--- a/tests/unit/Server/Backend/Auth/NameResolver/PasswordAuthenticatorTest.php
+++ b/tests/unit/Server/Backend/Auth/NameResolver/PasswordAuthenticatorTest.php
@@ -16,9 +16,12 @@ namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Auth\NameResolver;
 use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticator;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Sasl\Mechanism\MechanismName;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -48,50 +51,55 @@ final class PasswordAuthenticatorTest extends TestCase
         );
     }
 
-    public function test_returns_false_when_entry_not_found(): void
+    public function test_throws_when_entry_not_found(): void
     {
-        self::assertFalse(
-            $this->subject(null)->verifyPassword('cn=Unknown,dc=example,dc=com', 'secret'),
-        );
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        $this->subject(null)->authenticate('cn=Unknown,dc=example,dc=com', 'secret');
     }
 
-    public function test_returns_false_when_entry_has_no_user_password(): void
+    public function test_throws_when_entry_has_no_user_password(): void
     {
         $entry = new Entry(
             new Dn('cn=Alice,dc=example,dc=com'),
             new Attribute('cn', 'Alice'),
         );
 
-        self::assertFalse(
-            $this->subject($entry)->verifyPassword('cn=Alice,dc=example,dc=com', 'secret'),
-        );
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        $this->subject($entry)->authenticate('cn=Alice,dc=example,dc=com', 'secret');
     }
 
-    public function test_returns_true_for_correct_plain_text_password(): void
+    public function test_returns_token_for_correct_plain_text_password(): void
     {
         $entry = new Entry(
             new Dn('cn=Alice,dc=example,dc=com'),
             new Attribute('userPassword', 'secret'),
         );
 
-        self::assertTrue(
-            $this->subject($entry)->verifyPassword('cn=Alice,dc=example,dc=com', 'secret'),
-        );
+        $token = $this->subject($entry)->authenticate('cn=Alice,dc=example,dc=com', 'secret');
+
+        self::assertInstanceOf(BindToken::class, $token);
+        self::assertSame('cn=Alice,dc=example,dc=com', $token->getUsername());
+        self::assertSame('cn=Alice,dc=example,dc=com', $token->getResolvedDn()->toString());
     }
 
-    public function test_returns_false_for_wrong_plain_text_password(): void
+    public function test_throws_for_wrong_plain_text_password(): void
     {
         $entry = new Entry(
             new Dn('cn=Alice,dc=example,dc=com'),
             new Attribute('userPassword', 'secret'),
         );
 
-        self::assertFalse(
-            $this->subject($entry)->verifyPassword('cn=Alice,dc=example,dc=com', 'wrong'),
-        );
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        $this->subject($entry)->authenticate('cn=Alice,dc=example,dc=com', 'wrong');
     }
 
-    public function test_returns_true_for_correct_sha_password(): void
+    public function test_returns_token_for_correct_sha_password(): void
     {
         $hashed = '{SHA}' . base64_encode(sha1('mypassword', true));
         $entry = new Entry(
@@ -99,12 +107,12 @@ final class PasswordAuthenticatorTest extends TestCase
             new Attribute('userPassword', $hashed),
         );
 
-        self::assertTrue(
-            $this->subject($entry)->verifyPassword('cn=Test,dc=example,dc=com', 'mypassword'),
-        );
+        $token = $this->subject($entry)->authenticate('cn=Test,dc=example,dc=com', 'mypassword');
+
+        self::assertInstanceOf(BindToken::class, $token);
     }
 
-    public function test_returns_false_for_wrong_sha_password(): void
+    public function test_throws_for_wrong_sha_password(): void
     {
         $hashed = '{SHA}' . base64_encode(sha1('mypassword', true));
         $entry = new Entry(
@@ -112,12 +120,13 @@ final class PasswordAuthenticatorTest extends TestCase
             new Attribute('userPassword', $hashed),
         );
 
-        self::assertFalse(
-            $this->subject($entry)->verifyPassword('cn=Test,dc=example,dc=com', 'wrong'),
-        );
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        $this->subject($entry)->authenticate('cn=Test,dc=example,dc=com', 'wrong');
     }
 
-    public function test_returns_true_for_correct_ssha_password(): void
+    public function test_returns_token_for_correct_ssha_password(): void
     {
         $salt = 'salt';
         $hashed = '{SSHA}' . base64_encode(sha1('mypassword' . $salt, true) . $salt);
@@ -126,12 +135,12 @@ final class PasswordAuthenticatorTest extends TestCase
             new Attribute('userPassword', $hashed),
         );
 
-        self::assertTrue(
-            $this->subject($entry)->verifyPassword('cn=Test,dc=example,dc=com', 'mypassword'),
-        );
+        $token = $this->subject($entry)->authenticate('cn=Test,dc=example,dc=com', 'mypassword');
+
+        self::assertInstanceOf(BindToken::class, $token);
     }
 
-    public function test_returns_false_for_wrong_ssha_password(): void
+    public function test_throws_for_wrong_ssha_password(): void
     {
         $salt = 'salt';
         $hashed = '{SSHA}' . base64_encode(sha1('mypassword' . $salt, true) . $salt);
@@ -140,12 +149,13 @@ final class PasswordAuthenticatorTest extends TestCase
             new Attribute('userPassword', $hashed),
         );
 
-        self::assertFalse(
-            $this->subject($entry)->verifyPassword('cn=Test,dc=example,dc=com', 'wrong'),
-        );
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        $this->subject($entry)->authenticate('cn=Test,dc=example,dc=com', 'wrong');
     }
 
-    public function test_returns_true_for_correct_md5_password(): void
+    public function test_returns_token_for_correct_md5_password(): void
     {
         $hashed = '{MD5}' . base64_encode(md5('mypassword', true));
         $entry = new Entry(
@@ -153,12 +163,12 @@ final class PasswordAuthenticatorTest extends TestCase
             new Attribute('userPassword', $hashed),
         );
 
-        self::assertTrue(
-            $this->subject($entry)->verifyPassword('cn=Test,dc=example,dc=com', 'mypassword'),
-        );
+        $token = $this->subject($entry)->authenticate('cn=Test,dc=example,dc=com', 'mypassword');
+
+        self::assertInstanceOf(BindToken::class, $token);
     }
 
-    public function test_returns_false_for_wrong_md5_password(): void
+    public function test_throws_for_wrong_md5_password(): void
     {
         $hashed = '{MD5}' . base64_encode(md5('mypassword', true));
         $entry = new Entry(
@@ -166,12 +176,13 @@ final class PasswordAuthenticatorTest extends TestCase
             new Attribute('userPassword', $hashed),
         );
 
-        self::assertFalse(
-            $this->subject($entry)->verifyPassword('cn=Test,dc=example,dc=com', 'wrong'),
-        );
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        $this->subject($entry)->authenticate('cn=Test,dc=example,dc=com', 'wrong');
     }
 
-    public function test_returns_true_for_correct_smd5_password(): void
+    public function test_returns_token_for_correct_smd5_password(): void
     {
         $salt = 'salt';
         $hashed = '{SMD5}' . base64_encode(md5('mypassword' . $salt, true) . $salt);
@@ -180,12 +191,12 @@ final class PasswordAuthenticatorTest extends TestCase
             new Attribute('userPassword', $hashed),
         );
 
-        self::assertTrue(
-            $this->subject($entry)->verifyPassword('cn=Test,dc=example,dc=com', 'mypassword'),
-        );
+        $token = $this->subject($entry)->authenticate('cn=Test,dc=example,dc=com', 'mypassword');
+
+        self::assertInstanceOf(BindToken::class, $token);
     }
 
-    public function test_returns_false_for_wrong_smd5_password(): void
+    public function test_throws_for_wrong_smd5_password(): void
     {
         $salt = 'salt';
         $hashed = '{SMD5}' . base64_encode(md5('mypassword' . $salt, true) . $salt);
@@ -194,9 +205,23 @@ final class PasswordAuthenticatorTest extends TestCase
             new Attribute('userPassword', $hashed),
         );
 
-        self::assertFalse(
-            $this->subject($entry)->verifyPassword('cn=Test,dc=example,dc=com', 'wrong'),
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        $this->subject($entry)->authenticate('cn=Test,dc=example,dc=com', 'wrong');
+    }
+
+    public function test_resolved_dn_is_the_entry_dn_not_the_raw_bind_name(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('userPassword', 'secret'),
         );
+
+        $token = $this->subject($entry)->authenticate('uid=alice', 'secret');
+
+        self::assertSame('uid=alice', $token->getUsername());
+        self::assertSame('cn=Alice,dc=example,dc=com', $token->getResolvedDn()->toString());
     }
 
     public function test_get_password_returns_null_when_entry_not_found(): void

--- a/tests/unit/Server/Backend/Storage/OperationalAttributeGeneratorTest.php
+++ b/tests/unit/Server/Backend/Storage/OperationalAttributeGeneratorTest.php
@@ -52,7 +52,10 @@ final class OperationalAttributeGeneratorTest extends TestCase
     private function boundContext(string $dn): WriteContext
     {
         return new WriteContext(
-            new BindToken($dn, ''),
+            BindToken::fromDn(
+                $dn,
+                '',
+            ),
             new ControlBag(),
         );
     }

--- a/tests/unit/Server/RequestContextTest.php
+++ b/tests/unit/Server/RequestContextTest.php
@@ -22,18 +22,21 @@ final class RequestContextTest extends TestCase
 {
     private RequestContext $subject;
 
+    private AnonToken $token;
+
     protected function setUp(): void
     {
+        $this->token = new AnonToken(null);
         $this->subject = new RequestContext(
             new ControlBag(),
-            new AnonToken(null),
+            $this->token,
         );
     }
 
     public function test_it_should_get_the_token(): void
     {
-        self::assertEquals(
-            new AnonToken(null),
+        self::assertSame(
+            $this->token,
             $this->subject->token(),
         );
     }

--- a/tests/unit/Server/RequestHandler/ProxyBackendTest.php
+++ b/tests/unit/Server/RequestHandler/ProxyBackendTest.php
@@ -38,6 +38,7 @@ use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Rdn;
 use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Server\Token\AnonToken;
+use FreeDSx\Ldap\Server\Token\BindToken;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use FreeDSx\Ldap\Server\RequestHandler\ProxyBackend;
@@ -186,7 +187,7 @@ final class ProxyBackendTest extends TestCase
         self::assertSame($entry, $this->subject->get(new Dn('cn=Alice,dc=example,dc=com')));
     }
 
-    public function test_verify_password_returns_true_on_successful_bind(): void
+    public function test_authenticate_returns_token_on_successful_bind(): void
     {
         $this->mockLdap
             ->expects(self::once())
@@ -194,19 +195,31 @@ final class ProxyBackendTest extends TestCase
             ->with('cn=Alice,dc=example,dc=com', 'secret')
             ->willReturn($this->createMock(LdapMessageResponse::class));
 
-        self::assertTrue($this->subject->verifyPassword('cn=Alice,dc=example,dc=com', 'secret'));
+        $token = $this->subject->authenticate(
+            'cn=Alice,dc=example,dc=com',
+            'secret',
+        );
+
+        self::assertInstanceOf(BindToken::class, $token);
+        self::assertSame('cn=Alice,dc=example,dc=com', $token->getUsername());
     }
 
-    public function test_verify_password_rethrows_bind_exception_as_operation_exception(): void
+    public function test_authenticate_rethrows_bind_exception_as_operation_exception(): void
     {
         $this->mockLdap
             ->method('bind')
-            ->willThrowException(new BindException('Invalid credentials.', ResultCode::INVALID_CREDENTIALS));
+            ->willThrowException(new BindException(
+                'Invalid credentials.',
+                ResultCode::INVALID_CREDENTIALS,
+            ));
 
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
 
-        $this->subject->verifyPassword('cn=Alice,dc=example,dc=com', 'wrong');
+        $this->subject->authenticate(
+            'cn=Alice,dc=example,dc=com',
+            'wrong',
+        );
     }
 
     public function test_add_sends_add_request_to_upstream(): void

--- a/tests/unit/Server/RequestHandler/ProxyHandlerTest.php
+++ b/tests/unit/Server/RequestHandler/ProxyHandlerTest.php
@@ -43,7 +43,10 @@ final class ProxyHandlerTest extends TestCase
             ->willReturn(new ControlBag());
         $this->mockContext
             ->method('token')
-            ->willReturn(new BindToken('foo', 'bar'));
+            ->willReturn(BindToken::fromDn(
+                'foo',
+                'bar',
+            ));
 
         $this->subject = new ProxyHandler($this->mockClient);
         ;

--- a/tests/unit/Server/Token/AnonTokenTest.php
+++ b/tests/unit/Server/Token/AnonTokenTest.php
@@ -46,4 +46,22 @@ final class AnonTokenTest extends TestCase
             $this->subject->getVersion(),
         );
     }
+
+    public function test_it_should_return_a_uuid_as_its_id(): void
+    {
+        self::assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+            $this->subject->getId(),
+        );
+    }
+
+    public function test_it_should_return_a_unique_id_per_instance(): void
+    {
+        $other = new AnonToken('foo');
+
+        self::assertNotSame(
+            $this->subject->getId(),
+            $other->getId(),
+        );
+    }
 }

--- a/tests/unit/Server/Token/BindTokenTest.php
+++ b/tests/unit/Server/Token/BindTokenTest.php
@@ -22,7 +22,7 @@ final class BindTokenTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->subject = new BindToken(
+        $this->subject = BindToken::fromDn(
             'foo',
             'bar',
         );
@@ -49,6 +49,40 @@ final class BindTokenTest extends TestCase
         self::assertSame(
             3,
             $this->subject->getVersion(),
+        );
+    }
+
+    public function test_it_should_return_a_uuid_as_its_id(): void
+    {
+        self::assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+            $this->subject->getId(),
+        );
+    }
+
+    public function test_it_should_return_a_unique_id_per_instance(): void
+    {
+        $other = BindToken::fromDn(
+            'foo',
+            'bar',
+        );
+
+        self::assertNotSame(
+            $this->subject->getId(),
+            $other->getId(),
+        );
+    }
+
+    public function test_it_should_return_the_resolved_dn(): void
+    {
+        $token = BindToken::fromDn(
+            'cn=foo,dc=bar',
+            'secret',
+        );
+
+        self::assertSame(
+            'cn=foo,dc=bar',
+            $token->getResolvedDn()->toString(),
         );
     }
 }

--- a/tests/unit/Server/Utility/UuidTest.php
+++ b/tests/unit/Server/Utility/UuidTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Utility;
+
+use FreeDSx\Ldap\Server\Utility\Uuid;
+use PHPUnit\Framework\TestCase;
+
+final class UuidTest extends TestCase
+{
+    public function test_it_should_return_a_valid_uuid_v4_string(): void
+    {
+        self::assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+            Uuid::v4(),
+        );
+    }
+
+    public function test_it_should_return_a_unique_value_on_each_call(): void
+    {
+        self::assertNotSame(
+            Uuid::v4(),
+            Uuid::v4(),
+        );
+    }
+}


### PR DESCRIPTION
Add a configurable ACL system. This allows a rule-based ordered approach to what operations a client can perform and which entries / attributes they can access. This positions the server to handle the password modify operation in a sane way, and closes a huge security gap for using the server on any normal setting.

There are some slight performance trade-offs here, but having some sort of ACL system is needed to add actual restrictions to clients. This is more important now that the server has an actual backend storage adapter setup and controls basically the whole flow.

There will be some follow-ups to this, this gets the main logic in place. Unfortunately SASL doesn't fit cleanly into this whole situation. I need to refactor the backend flow to fit the DN resolution logic needed for the ACL system.