### PR TITLE
[1.0.0] Support abandoned and canceled requests on the server. Fix max search size.

### DIFF
--- a/src/FreeDSx/Ldap/Operation/Request/ExtendedRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/ExtendedRequest.php
@@ -138,9 +138,18 @@ class ExtendedRequest implements RequestInterface
      *
      * @param AbstractType<mixed> $type
      */
-    public static function fromAsn1(AbstractType $type): static
+    public static function fromAsn1(AbstractType $type): self
     {
-        return new static(...self::parseAsn1ExtendedRequest($type));
+        [$oid, $value] = self::parseAsn1ExtendedRequest($type);
+
+        if ($oid === self::OID_CANCEL) {
+            return CancelRequest::fromAsn1($type);
+        }
+
+        return new static(
+            $oid,
+            $value,
+        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Protocol\Factory;
 
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
@@ -44,7 +45,11 @@ class ServerProtocolHandlerFactory
         RequestInterface $request,
         ControlBag $controls,
     ): ServerProtocolHandlerInterface {
-        if ($request instanceof ExtendedRequest && $request->getName() === ExtendedRequest::OID_WHOAMI) {
+        if ($request instanceof AbandonRequest) {
+            return new ServerProtocolHandler\ServerAbandonHandler();
+        } elseif ($request instanceof ExtendedRequest && $request->getName() === ExtendedRequest::OID_CANCEL) {
+            return new ServerProtocolHandler\ServerCancelHandler($this->queue);
+        } elseif ($request instanceof ExtendedRequest && $request->getName() === ExtendedRequest::OID_WHOAMI) {
             return new ServerProtocolHandler\ServerWhoAmIHandler($this->queue);
         } elseif ($request instanceof ExtendedRequest && $request->getName() === ExtendedRequest::OID_PWD_MODIFY) {
             return new ServerProtocolHandler\ServerPasswordModifyHandler(

--- a/src/FreeDSx/Ldap/Protocol/LdapMessage.php
+++ b/src/FreeDSx/Ldap/Protocol/LdapMessage.php
@@ -200,6 +200,7 @@ abstract class LdapMessage implements ProtocolElementInterface, PduInterface
             13 => Response\ModifyDnResponse::fromAsn1($opAsn1),
             14 => Request\CompareRequest::fromAsn1($opAsn1),
             15 => Response\CompareResponse::fromAsn1($opAsn1),
+            16 => Request\AbandonRequest::fromAsn1($opAsn1),
             19 => Response\SearchResultReference::fromAsn1($opAsn1),
             23 => Request\ExtendedRequest::fromAsn1($opAsn1),
             24 => Response\ExtendedResponse::fromAsn1($opAsn1),

--- a/src/FreeDSx/Ldap/Protocol/LdapQueue.php
+++ b/src/FreeDSx/Ldap/Protocol/LdapQueue.php
@@ -150,6 +150,25 @@ class LdapQueue extends Asn1MessageQueue
     }
 
     /**
+     * True if data is already buffered or available on the socket without blocking.
+     */
+    protected function hasPendingData(): bool
+    {
+        if ($this->hasBuffer()) {
+            return true;
+        }
+
+        $data = $this->socket->read(false);
+        if ($data === false || $data === '') {
+            return false;
+        }
+
+        $this->buffer .= $data;
+
+        return true;
+    }
+
+    /**
      * @throws ConnectionException
      * @throws ProtocolException
      * @throws UnsolicitedNotificationException

--- a/src/FreeDSx/Ldap/Protocol/Queue/ServerQueue.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/ServerQueue.php
@@ -19,6 +19,9 @@ use FreeDSx\Asn1\Type\AbstractType;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Exception\UnsolicitedNotificationException;
+use FreeDSx\Ldap\Operation\Request\AbandonRequest;
+use FreeDSx\Ldap\Operation\Request\CancelRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\LdapQueue;
@@ -33,12 +36,21 @@ use FreeDSx\Socket\Queue\Message;
 class ServerQueue extends LdapQueue
 {
     /**
+     * @var LdapMessageRequest[]
+     */
+    private array $pendingMessages = [];
+
+    /**
      * @throws ProtocolException
      * @throws UnsolicitedNotificationException
      * @throws ConnectionException
      */
     public function getMessage(?int $id = null): LdapMessageRequest
     {
+        if ($id === null && $this->pendingMessages !== []) {
+            return array_shift($this->pendingMessages);
+        }
+
         $message = $this->getAndValidateMessage($id);
 
         if (!$message instanceof LdapMessageRequest) {
@@ -49,6 +61,29 @@ class ServerQueue extends LdapQueue
         }
 
         return $message;
+    }
+
+    /**
+     * Checks whether an Abandon or Cancel targeting a message ID has arrived.
+     *
+     * Other messages received while peeking are buffered.
+     */
+    public function peekForCancelSignal(int $inFlightMessageId): ?LdapMessageRequest
+    {
+        if (!$this->hasPendingData()) {
+            return null;
+        }
+
+        $message = $this->getMessage();
+        $request = $message->getRequest();
+
+        if ($this->isAbandonOrCancelRequest($request, $inFlightMessageId)) {
+            return $message;
+        }
+
+        $this->pendingMessages[] = $message;
+
+        return null;
     }
 
     /**
@@ -72,6 +107,19 @@ class ServerQueue extends LdapQueue
         $this->sendLdapMessage($responses);
 
         return $this;
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @param int $inFlightMessageId
+     * @return bool
+     */
+    private function isAbandonOrCancelRequest(
+        RequestInterface $request,
+        int $inFlightMessageId,
+    ): bool {
+        return ($request instanceof AbandonRequest || $request instanceof CancelRequest)
+            && $request->getMessageId() === $inFlightMessageId;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAbandonHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAbandonHandler.php
@@ -13,20 +13,18 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
-use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
- * Late-bound result code / diagnostic for a streaming search.
+ * Handles AbandonRequest — RFC 4511 §4.11 requires no response.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final class SearchResultState
+final class ServerAbandonHandler implements ServerProtocolHandlerInterface
 {
-    public bool $isAbandoned = false;
-
-    public ?LdapMessageRequest $cancelSignal = null;
-
-    public function __construct(
-        public int $resultCode = ResultCode::SUCCESS,
-        public string $diagnosticMessage = '',
-    ) {}
+    public function handleRequest(
+        LdapMessageRequest $message,
+        TokenInterface $token,
+    ): void {}
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerCancelHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerCancelHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+
+use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Ldap\Operation\LdapResult;
+use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * Handles a CancelRequest (RFC 3909) that arrives after the target operation has already completed.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+readonly class ServerCancelHandler implements ServerProtocolHandlerInterface
+{
+    public function __construct(private ServerQueue $queue) {}
+
+    /**
+     * {@inheritDoc}
+     * @throws EncoderException
+     */
+    public function handleRequest(
+        LdapMessageRequest $message,
+        TokenInterface $token,
+    ): void {
+        $this->queue->sendMessage(new LdapMessageResponse(
+            $message->getMessageId(),
+            new ExtendedResponse(new LdapResult(ResultCode::NO_SUCH_OPERATION)),
+        ));
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -173,7 +173,6 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
             $generator,
             $pagingRequest->getSize(),
             $searchRequest,
-            0,
             $token,
         );
 
@@ -223,7 +222,6 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
             $generator,
             $pagingRequest->getSize(),
             $pagingRequest->getSearchRequest(),
-            $pagingRequest->getTotalSent(),
             $token,
         );
 
@@ -253,7 +251,6 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
             return PagingResponse::makeFinal(new Entries(...$collected->entries));
         }
 
-        $pagingRequest->incrementTotalSent(count($collected->entries));
         $this->requestHistory->storePagingGenerator(
             $nextCookie,
             $generator,
@@ -274,7 +271,6 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         Generator $generator,
         int $pageSize,
         SearchRequest $request,
-        int $totalAlreadySent,
         TokenInterface $token,
     ): CollectedPage {
         $page = [];
@@ -316,7 +312,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
                     $request->getAttributesOnly(),
                 );
 
-                if ($sizeLimit > 0 && ($totalAlreadySent + count($page)) >= $sizeLimit) {
+                if ($sizeLimit > 0 && count($page) >= $sizeLimit) {
                     $generator->next();
                     break;
                 }
@@ -328,7 +324,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         $generatorExhausted = !$generator->valid();
         $sizeLimitExceeded = !$generatorExhausted
             && $sizeLimit > 0
-            && ($totalAlreadySent + count($page)) >= $sizeLimit;
+            && count($page) >= $sizeLimit;
 
         return new CollectedPage(
             $page,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
@@ -61,6 +61,7 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
             'supportedExtension' => [
                 ExtendedRequest::OID_WHOAMI,
                 ExtendedRequest::OID_PWD_MODIFY,
+                ExtendedRequest::OID_CANCEL,
             ],
             'supportedLDAPVersion' => ['3'],
             'vendorName' => $this->options->getDseVendorName(),

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -15,6 +15,8 @@ namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\AbandonRequest;
+use FreeDSx\Ldap\Operation\Request\CancelRequest;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
@@ -36,6 +38,8 @@ use Generator;
 class ServerSearchHandler implements ServerProtocolHandlerInterface
 {
     use ServerSearchTrait;
+
+    private const CANCEL_CHECK_INTERVAL = 50;
 
     public function __construct(
         private readonly ServerQueue $queue,
@@ -74,6 +78,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
                     $request,
                     $state,
                     $token,
+                    $message->getMessageId(),
                 ),
                 (string) $request->getBaseDn(),
                 $state,
@@ -96,6 +101,8 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
     /**
      * Streams filtered + attribute-projected entries from the backend.
      *
+     * Checks for cancel signals periodically.
+     *
      * @return Generator<Entry>
      */
     private function filteredEntryStream(
@@ -103,6 +110,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         SearchRequest $request,
         SearchResultState $state,
         TokenInterface $token,
+        int $messageId,
     ): Generator {
         $sizeLimit = $this->effectiveSizeLimit(
             $request->getSizeLimit(),
@@ -112,6 +120,10 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         $emitted = 0;
 
         foreach ($backend->entries as $entry) {
+            if ($this->shouldCancelSearch($emitted, $messageId, $state)) {
+                return;
+            }
+
             $filtered = $this->accessControl->filterEntry(
                 $token,
                 $entry,
@@ -138,5 +150,33 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
                 return;
             }
         }
+    }
+
+    private function shouldCancelSearch(
+        int $emitted,
+        int $messageId,
+        SearchResultState $state,
+    ): bool {
+        if ($emitted === 0 || $emitted % self::CANCEL_CHECK_INTERVAL !== 0) {
+            return false;
+        }
+
+        $signal = $this->queue->peekForCancelSignal($messageId);
+        if ($signal === null) {
+            return false;
+        }
+
+        $request = $signal->getRequest();
+        if ($request instanceof AbandonRequest) {
+            $state->isAbandoned = true;
+
+            return true;
+        }
+
+        if ($request instanceof CancelRequest) {
+            $state->cancelSignal = $signal;
+        }
+
+        return true;
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
@@ -21,7 +21,10 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Operation\LdapResult;
+use FreeDSx\Ldap\Operation\Request\CancelRequest;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\ResultCode;
@@ -47,6 +50,7 @@ trait ServerSearchTrait
 
     /**
      * Yields a SearchResultEntry per backend entry followed by the terminal SearchResultDone.
+     * Yields nothing for abandoned requests; yields CANCELED + SUCCESS for cancelled requests.
      *
      * @return Generator<LdapMessageResponse>
      */
@@ -63,6 +67,27 @@ trait ServerSearchTrait
         }
 
         $state = $searchResult->getState();
+
+        if ($state->isAbandoned) {
+            return;
+        }
+        $cancelSignal = $state->cancelSignal;
+
+        if ($cancelSignal !== null && $cancelSignal->getRequest() instanceof CancelRequest) {
+            yield new LdapMessageResponse(
+                $messageId,
+                new SearchResultDone(
+                    ResultCode::CANCELED,
+                    $searchResult->getBaseDn(),
+                ),
+            );
+            yield new LdapMessageResponse(
+                $cancelSignal->getMessageId(),
+                new ExtendedResponse(new LdapResult(ResultCode::SUCCESS)),
+            );
+
+            return;
+        }
 
         yield new LdapMessageResponse(
             $messageId,

--- a/src/FreeDSx/Ldap/Server/Paging/PagingRequest.php
+++ b/src/FreeDSx/Ldap/Server/Paging/PagingRequest.php
@@ -34,8 +34,6 @@ final class PagingRequest
 
     private bool $hasProcessed = false;
 
-    private int $totalSent = 0;
-
     public function __construct(
         private PagingControl $control,
         private readonly SearchRequest $request,
@@ -154,22 +152,6 @@ final class PagingRequest
     public function updateNextCookie(string $cookie): void
     {
         $this->nextCookie = $cookie;
-    }
-
-    /**
-     * Total entries sent to the client across all completed pages of this paging session.
-     */
-    public function getTotalSent(): int
-    {
-        return $this->totalSent;
-    }
-
-    /**
-     * @internal
-     */
-    public function incrementTotalSent(int $count): void
-    {
-        $this->totalSent += $count;
     }
 
     /**

--- a/tests/bin/ldap-server.php
+++ b/tests/bin/ldap-server.php
@@ -202,7 +202,7 @@ class LdapServerPagingBackend extends LdapServerBackend
 
     private function yieldPagingResults(): Generator
     {
-        for ($i = 1; $i <= 300; $i++) {
+        for ($i = 1; $i <= 5000; $i++) {
             yield Entry::fromArray(
                 "cn=foo$i,dc=foo,dc=bar",
                 [

--- a/tests/integration/LdapCancelServerTest.php
+++ b/tests/integration/LdapCancelServerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap;
+
+use FreeDSx\Ldap\Exception\CancelRequestException;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Response\SearchResponse;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Search\Result\EntryResult;
+
+final class LdapCancelServerTest extends ServerTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createServerProcess(
+            'tcp',
+            'paging',
+        );
+        $this->authenticate();
+    }
+
+    public function testMidStreamCancelStopsSearchAndReturnsSuccess(): void
+    {
+        $entriesReceived = 0;
+
+        $request = Operations::search(Filters::present('foo'))
+            ->base('dc=foo,dc=bar')
+            ->useEntryHandler(function (EntryResult $result) use (&$entriesReceived): void {
+                $entriesReceived++;
+
+                if ($entriesReceived >= 100) {
+                    throw new CancelRequestException();
+                }
+            });
+
+        $response = $this->ldapClient()->sendAndReceive($request);
+
+        /** @var SearchResponse $searchResponse */
+        $searchResponse = $response->getResponse();
+
+        self::assertInstanceOf(
+            SearchResponse::class,
+            $searchResponse,
+        );
+        self::assertSame(
+            ResultCode::SUCCESS,
+            $searchResponse->getResultCode(),
+        );
+        self::assertLessThan(
+            5000,
+            $entriesReceived,
+        );
+    }
+
+    public function testPostCompletionCancelReturnsNoSuchOperation(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::NO_SUCH_OPERATION);
+
+        $this->ldapClient()->sendAndReceive(Operations::cancel(999));
+    }
+}

--- a/tests/integration/LdapServerTest.php
+++ b/tests/integration/LdapServerTest.php
@@ -218,6 +218,7 @@ class LdapServerTest extends ServerTestCase
                 'supportedExtension' => [
                     '1.3.6.1.4.1.4203.1.11.3',
                     '1.3.6.1.4.1.4203.1.11.1',
+                    '1.3.6.1.1.8',
                     '1.3.6.1.4.1.1466.20037',
                 ],
                 'supportedLDAPVersion' => [
@@ -318,8 +319,8 @@ class LdapServerTest extends ServerTestCase
             );
         }
 
-        $this->assertSame(3, $iterations);
-        $this->assertCount(300, $allEntries);
+        $this->assertSame(50, $iterations);
+        $this->assertCount(5000, $allEntries);
     }
 
     public function testItDoesASearchWhenPagingIsNotMarkedAsCritical(): void

--- a/tests/unit/Protocol/Queue/ServerQueueTest.php
+++ b/tests/unit/Protocol/Queue/ServerQueueTest.php
@@ -17,8 +17,12 @@ use FreeDSx\Asn1\Asn1;
 use FreeDSx\Asn1\Encoder\EncoderInterface;
 use FreeDSx\Asn1\Type\IncompleteType;
 use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Operation\Request\AbandonRequest;
+use FreeDSx\Ldap\Operation\Request\CancelRequest;
+use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Operation\Response\DeleteResponse;
 use FreeDSx\Ldap\Protocol\LdapEncoder;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\MessageWrapperInterface;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
@@ -149,5 +153,118 @@ final class ServerQueueTest extends TestCase
         $this->subject->setMessageWrapper($mockWrapper);
 
         $this->subject->getMessage();
+    }
+
+    public function test_peek_returns_null_when_no_socket_data(): void
+    {
+        $socket = $this->createMock(Socket::class);
+        $socket->method('read')->willReturn(false);
+
+        $queue = new ServerQueue($socket, new LdapEncoder());
+
+        self::assertNull($queue->peekForCancelSignal(2));
+    }
+
+    public function test_peek_returns_abandon_request_targeting_in_flight_message(): void
+    {
+        $queue = $this->makeQueueWithEncodedRequest(
+            new LdapMessageRequest(3, new AbandonRequest(2)),
+        );
+
+        $result = $queue->peekForCancelSignal(2);
+
+        self::assertNotNull($result);
+        self::assertInstanceOf(
+            AbandonRequest::class,
+            $result->getRequest(),
+        );
+    }
+
+    public function test_peek_returns_cancel_request_targeting_in_flight_message(): void
+    {
+        $queue = $this->makeQueueWithEncodedRequest(
+            new LdapMessageRequest(3, new CancelRequest(2)),
+        );
+
+        $result = $queue->peekForCancelSignal(2);
+
+        self::assertNotNull($result);
+        self::assertInstanceOf(
+            CancelRequest::class,
+            $result->getRequest(),
+        );
+    }
+
+    public function test_peek_buffers_non_cancel_message_and_returns_null(): void
+    {
+        $queue = $this->makeQueueWithEncodedRequest(
+            new LdapMessageRequest(5, new DeleteRequest('dc=foo,dc=bar')),
+        );
+
+        self::assertNull($queue->peekForCancelSignal(2));
+
+        $buffered = $queue->getMessage();
+
+        self::assertSame(
+            5,
+            $buffered->getMessageId(),
+        );
+        self::assertInstanceOf(
+            DeleteRequest::class,
+            $buffered->getRequest(),
+        );
+    }
+
+    public function test_peek_buffers_abandon_targeting_different_message_and_returns_null(): void
+    {
+        $queue = $this->makeQueueWithEncodedRequest(
+            new LdapMessageRequest(3, new AbandonRequest(99)),
+        );
+
+        self::assertNull($queue->peekForCancelSignal(2));
+
+        $buffered = $queue->getMessage();
+
+        self::assertInstanceOf(
+            AbandonRequest::class,
+            $buffered->getRequest(),
+        );
+    }
+
+    public function test_get_message_drains_pending_before_reading_socket(): void
+    {
+        $encoder = new LdapEncoder();
+        $bytes = $encoder->encode(
+            (new LdapMessageRequest(5, new DeleteRequest('dc=foo,dc=bar')))->toAsn1(),
+        );
+
+        $socket = $this->createMock(Socket::class);
+        $socket->expects(self::once())
+            ->method('read')
+            ->willReturn($bytes);
+
+        $queue = new ServerQueue($socket, $encoder);
+
+        // Peek decodes and buffers the DeleteRequest into pendingMessages
+        $queue->peekForCancelSignal(2);
+
+        // getMessage() must drain pendingMessages — no second socket read
+        $result = $queue->getMessage();
+
+        self::assertInstanceOf(
+            DeleteRequest::class,
+            $result->getRequest(),
+        );
+    }
+
+    private function makeQueueWithEncodedRequest(LdapMessageRequest $message): ServerQueue
+    {
+        $encoder = new LdapEncoder();
+        $bytes = $encoder->encode($message->toAsn1());
+
+        $socket = $this->createMock(Socket::class);
+        $socket->method('read')->willReturn($bytes);
+
+        return new ServerQueue($socket, $encoder);
     }
 }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerAbandonHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerAbandonHandlerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+
+use FreeDSx\Ldap\Operation\Request\AbandonRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerAbandonHandler;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class ServerAbandonHandlerTest extends TestCase
+{
+    private ServerQueue&MockObject $mockQueue;
+
+    private TokenInterface&MockObject $mockToken;
+
+    private ServerAbandonHandler $subject;
+
+    protected function setUp(): void
+    {
+        $this->mockQueue = $this->createMock(ServerQueue::class);
+        $this->mockToken = $this->createMock(TokenInterface::class);
+        $this->subject = new ServerAbandonHandler();
+    }
+
+    public function test_it_sends_no_response_per_rfc4511(): void
+    {
+        $this->mockQueue
+            ->expects(self::never())
+            ->method('sendMessage');
+
+        $this->subject->handleRequest(
+            new LdapMessageRequest(
+                2,
+                new AbandonRequest(1),
+            ),
+            $this->mockToken,
+        );
+    }
+}

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerCancelHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerCancelHandlerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+
+use FreeDSx\Ldap\Operation\LdapResult;
+use FreeDSx\Ldap\Operation\Request\CancelRequest;
+use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerCancelHandler;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class ServerCancelHandlerTest extends TestCase
+{
+    private ServerQueue&MockObject $mockQueue;
+
+    private TokenInterface&MockObject $mockToken;
+
+    private ServerCancelHandler $subject;
+
+    protected function setUp(): void
+    {
+        $this->mockQueue = $this->createMock(ServerQueue::class);
+        $this->mockToken = $this->createMock(TokenInterface::class);
+        $this->subject = new ServerCancelHandler($this->mockQueue);
+    }
+
+    public function test_it_sends_no_such_operation_when_target_already_completed(): void
+    {
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('sendMessage')
+            ->with(self::equalTo(new LdapMessageResponse(
+                3,
+                new ExtendedResponse(new LdapResult(ResultCode::NO_SUCH_OPERATION)),
+            )));
+
+        $this->subject->handleRequest(
+            new LdapMessageRequest(3, new CancelRequest(2)),
+            $this->mockToken,
+        );
+    }
+}

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
@@ -356,7 +356,7 @@ class ServerPagingHandlerTest extends TestCase
         self::assertSame('', $this->donePagingControl()->getCookie());
     }
 
-    public function test_it_should_accumulate_size_limit_across_pages(): void
+    public function test_size_limit_applies_per_page_not_cumulatively(): void
     {
         $searchRequest = (new SearchRequest(Filters::raw('(foo=bar)')))
             ->base('dc=foo,dc=bar')
@@ -365,11 +365,12 @@ class ServerPagingHandlerTest extends TestCase
         $entry1 = Entry::create('cn=1,dc=foo,dc=bar', ['cn' => '1']);
         $entry2 = Entry::create('cn=2,dc=foo,dc=bar', ['cn' => '2']);
         $entry3 = Entry::create('cn=3,dc=foo,dc=bar', ['cn' => '3']);
+        $entry4 = Entry::create('cn=4,dc=foo,dc=bar', ['cn' => '4']);
 
         $this->mockBackend
             ->expects(self::once())
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2, $entry3)));
+            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2, $entry3, $entry4)));
 
         // First page: pageSize=1, sizeLimit=2 — gets entry1, stores generator
         $this->subject->handleRequest(
@@ -380,7 +381,7 @@ class ServerPagingHandlerTest extends TestCase
         $capturedCookie = $this->donePagingControl()->getCookie();
         self::assertNotSame('', $capturedCookie, 'Expected a non-empty cookie after the first page.');
 
-        // Second page: totalSent=1, gets entry2 — hits sizeLimit(2), returns SIZE_LIMIT_EXCEEDED
+        // Second page: pageSize=10, sizeLimit=2 — gets entry2+entry3 (hits limit), entry4 still in generator → SIZE_LIMIT_EXCEEDED
         $pagingReq = $this->requestHistory->pagingRequest()->findByNextCookie($capturedCookie);
         $this->subject->handleRequest(
             $this->makeSearchMessage(size: 10, cookie: $capturedCookie, searchRequest: $pagingReq->getSearchRequest()),

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerRootDseHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerRootDseHandlerTest.php
@@ -81,6 +81,7 @@ final class ServerRootDseHandlerTest extends TestCase
                     'supportedExtension' => [
                         ExtendedRequest::OID_WHOAMI,
                         ExtendedRequest::OID_PWD_MODIFY,
+                        ExtendedRequest::OID_CANCEL,
                     ],
                     'supportedLDAPVersion' => ['3'],
                     'vendorName' => 'Foo',
@@ -146,6 +147,7 @@ final class ServerRootDseHandlerTest extends TestCase
             'supportedExtension' => [
                 ExtendedRequest::OID_WHOAMI,
                 ExtendedRequest::OID_PWD_MODIFY,
+                ExtendedRequest::OID_CANCEL,
             ],
             'supportedLDAPVersion' => ['3'],
             'vendorName' => 'Foo',

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
@@ -15,7 +15,11 @@ namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\LdapResult;
+use FreeDSx\Ldap\Operation\Request\AbandonRequest;
+use FreeDSx\Ldap\Operation\Request\CancelRequest;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\ResultCode;
@@ -502,5 +506,89 @@ final class ServerSearchHandlerTest extends TestCase
                 new SearchResultDone(0, 'dc=foo,dc=bar'),
             ),
         ]);
+    }
+
+    public function test_abandon_mid_stream_stops_entries_and_sends_no_response(): void
+    {
+        $entries = array_map(
+            static fn(int $i): Entry => Entry::create("cn=$i,dc=foo,dc=bar"),
+            range(1, 51),
+        );
+
+        $abandonSignal = new LdapMessageRequest(3, new AbandonRequest(2));
+
+        $search = new LdapMessageRequest(
+            2,
+            (new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar'),
+        );
+
+        $this->mockBackend
+            ->method('search')
+            ->willReturn(new EntryStream($this->makeGenerator(...$entries)));
+
+        $this->mockFilterEvaluator
+            ->method('evaluate')
+            ->willReturn(true);
+
+        $this->mockQueue
+            ->method('peekForCancelSignal')
+            ->willReturn($abandonSignal);
+
+        $this->subject->handleRequest($search, $this->mockToken);
+
+        $sentDone = array_filter(
+            $this->sentMessages,
+            static fn(LdapMessageResponse $r): bool => $r->getResponse() instanceof SearchResultDone,
+        );
+
+        self::assertEmpty($sentDone);
+    }
+
+    public function test_cancel_mid_stream_stops_entries_and_sends_canceled_plus_success(): void
+    {
+        $entries = array_map(
+            static fn(int $i): Entry => Entry::create("cn=$i,dc=foo,dc=bar"),
+            range(1, 51),
+        );
+
+        $cancelSignal = new LdapMessageRequest(3, new CancelRequest(2));
+
+        $search = new LdapMessageRequest(
+            2,
+            (new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar'),
+        );
+
+        $this->mockBackend
+            ->method('search')
+            ->willReturn(new EntryStream($this->makeGenerator(...$entries)));
+
+        $this->mockFilterEvaluator
+            ->method('evaluate')
+            ->willReturn(true);
+
+        $this->mockQueue
+            ->method('peekForCancelSignal')
+            ->willReturn($cancelSignal);
+
+        $this->subject->handleRequest($search, $this->mockToken);
+
+        $nonEntryMessages = array_values(array_filter(
+            $this->sentMessages,
+            static fn(LdapMessageResponse $r): bool => !$r->getResponse() instanceof SearchResultEntry,
+        ));
+
+        self::assertEquals(
+            [
+                new LdapMessageResponse(
+                    2,
+                    new SearchResultDone(ResultCode::CANCELED, 'dc=foo,dc=bar'),
+                ),
+                new LdapMessageResponse(
+                    3,
+                    new ExtendedResponse(new LdapResult(ResultCode::SUCCESS)),
+                ),
+            ],
+            $nonEntryMessages,
+        );
     }
 }


### PR DESCRIPTION
This adds support for abandoned / canceled searches at the server level. The cancel logic may be revisited at some point. Currently it will check every 50 entries so it makes less syscalls, which can be expensive. I could maybe be more aggressive by default and bump it to 25 or make it configurable or something.

This also fixes a bug in the initial max search size logic as it applied to pagination.