### PR TITLE
[1.0.0] Return the proper response code for unsupported critical controls.

### DIFF
--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerCancelHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerCancelHandler.php
@@ -29,6 +29,8 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  */
 readonly class ServerCancelHandler implements ServerProtocolHandlerInterface
 {
+    use ServerCriticalControlTrait;
+
     public function __construct(private ServerQueue $queue) {}
 
     /**
@@ -39,6 +41,7 @@ readonly class ServerCancelHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
     ): void {
+        $this->assertNoCriticalUnsupportedControls($message->controls());
         $this->queue->sendMessage(new LdapMessageResponse(
             $message->getMessageId(),
             new ExtendedResponse(new LdapResult(ResultCode::NO_SUCH_OPERATION)),

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerCriticalControlTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerCriticalControlTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+
+use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+
+trait ServerCriticalControlTrait
+{
+    /**
+     * OIDs of controls this handler supports.
+     *
+     * @return string[]
+     */
+    private function supportedControls(): array
+    {
+        return [];
+    }
+
+    /**
+     * Throws if any critical control in $controls is unsupported by this handler.
+     *
+     * @throws OperationException
+     */
+    private function assertNoCriticalUnsupportedControls(ControlBag $controls): void
+    {
+        $supported = $this->supportedControls();
+
+        foreach ($controls as $control) {
+            if (!$control->getCriticality()) {
+                continue;
+            }
+
+            if (!in_array($control->getTypeOid(), $supported, true)) {
+                throw new OperationException(
+                    sprintf('Critical control %s is not supported.', $control->getTypeOid()),
+                    ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
+                );
+            }
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -36,6 +36,8 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  */
 readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
 {
+    use ServerCriticalControlTrait;
+
     public function __construct(
         private ServerQueue $queue,
         private LdapBackendInterface $backend,
@@ -55,6 +57,7 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
         TokenInterface $token,
     ): void {
         try {
+            $this->assertNoCriticalUnsupportedControls($message->controls());
             $request = $message->getRequest();
             $this->authorizeRequest(
                 $request,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
+use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\PagingControl;
 use FreeDSx\Ldap\Entry\Entries;
 use FreeDSx\Ldap\Entry\Entry;
@@ -43,6 +44,7 @@ use Throwable;
 class ServerPagingHandler implements ServerProtocolHandlerInterface
 {
     use ServerSearchTrait;
+    use ServerCriticalControlTrait;
 
     public function __construct(
         private readonly ServerQueue $queue,
@@ -68,6 +70,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         $response = null;
         $controls = [];
         try {
+            $this->assertNoCriticalUnsupportedControls($message->controls());
             $baseDn = $this->assertBaseDnProvided($searchRequest);
             $this->accessControl->authorizeOperation(
                 OperationType::Search,
@@ -130,6 +133,14 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
             $this->queue,
             ...$controls,
         );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function supportedControls(): array
+    {
+        return [Control::OID_PAGING];
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordModifyHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordModifyHandler.php
@@ -46,6 +46,8 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  */
 readonly class ServerPasswordModifyHandler implements ServerProtocolHandlerInterface
 {
+    use ServerCriticalControlTrait;
+
     public function __construct(
         private ServerQueue $queue,
         private LdapBackendInterface $backend,
@@ -67,6 +69,7 @@ readonly class ServerPasswordModifyHandler implements ServerProtocolHandlerInter
         TokenInterface $token,
     ): void {
         try {
+            $this->assertNoCriticalUnsupportedControls($message->controls());
             $this->process(
                 $message,
                 $token,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
@@ -38,6 +38,8 @@ use function count;
  */
 class ServerRootDseHandler implements ServerProtocolHandlerInterface
 {
+    use ServerCriticalControlTrait;
+
     public function __construct(
         private readonly ServerOptions $options,
         private readonly ServerQueue $queue,
@@ -52,6 +54,7 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
     ): void {
+        $this->assertNoCriticalUnsupportedControls($message->controls());
         $entry = Entry::fromArray('', [
             'namingContexts' => $this->options->getDseNamingContexts(),
             'subschemaSubentry' => [$this->options->getSubschemaEntry()->toString()],

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -38,6 +38,8 @@ use Generator;
 class ServerSearchHandler implements ServerProtocolHandlerInterface
 {
     use ServerSearchTrait;
+    use ServerCriticalControlTrait;
+
 
     private const CANCEL_CHECK_INTERVAL = 50;
 
@@ -59,6 +61,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         $request = $this->getSearchRequestFromMessage($message);
 
         try {
+            $this->assertNoCriticalUnsupportedControls($message->controls());
             $baseDn = $this->assertBaseDnProvided($request);
             $this->accessControl->authorizeOperation(
                 OperationType::Search,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
@@ -34,6 +34,8 @@ use function extension_loaded;
  */
 class ServerStartTlsHandler implements ServerProtocolHandlerInterface
 {
+    use ServerCriticalControlTrait;
+
     private static ?bool $hasOpenssl = null;
 
     public function __construct(
@@ -54,6 +56,7 @@ class ServerStartTlsHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
     ): void {
+        $this->assertNoCriticalUnsupportedControls($message->controls());
         # If we don't have a SSL cert or the OpenSSL extension is not available, then we can do nothing...
         if ($this->options->getSslCert() === null || !self::$hasOpenssl) {
             $this->queue->sendMessage(new LdapMessageResponse($message->getMessageId(), new ExtendedResponse(

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSubschemaHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSubschemaHandler.php
@@ -33,6 +33,8 @@ use FreeDSx\Ldap\ServerOptions;
  */
 class ServerSubschemaHandler implements ServerProtocolHandlerInterface
 {
+    use ServerCriticalControlTrait;
+
     public function __construct(
         private readonly ServerOptions $options,
         private readonly ServerQueue $queue,
@@ -42,6 +44,7 @@ class ServerSubschemaHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
     ): void {
+        $this->assertNoCriticalUnsupportedControls($message->controls());
         $schemaDn = $this->options->getSubschemaEntry();
         $rdn = $schemaDn->getRdn();
         $schema = $this->options->getSchema();

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
@@ -31,6 +31,8 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  */
 class ServerWhoAmIHandler implements ServerProtocolHandlerInterface
 {
+    use ServerCriticalControlTrait;
+
     public function __construct(private readonly ServerQueue $queue) {}
 
     /**
@@ -41,6 +43,7 @@ class ServerWhoAmIHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
     ): void {
+        $this->assertNoCriticalUnsupportedControls($message->controls());
         $userId = null;
 
         if ($token instanceof AuthenticatedTokenInterface) {

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
@@ -13,10 +13,11 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
-use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Operation\Request\CompareRequest;
@@ -402,6 +403,47 @@ final class ServerDispatchHandlerTest extends TestCase
                     && $msg->getResponse()->getResultCode() === ResultCode::INSUFFICIENT_ACCESS_RIGHTS;
             }))
             ->willReturnSelf();
+
+        $this->subject->handleRequest(
+            $request,
+            $this->mockToken,
+        );
+    }
+
+    public function test_critical_unsupported_control_returns_unavailable_critical_extension(): void
+    {
+        $request = new LdapMessageRequest(
+            1,
+            new DeleteRequest('cn=foo,dc=bar'),
+            new Control('1.2.3.4.5', criticality: true),
+        );
+
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('sendMessage')
+            ->with(self::callback(function (LdapMessageResponse $msg): bool {
+                return $msg->getResponse() instanceof LdapResult
+                    && $msg->getResponse()->getResultCode() === ResultCode::UNAVAILABLE_CRITICAL_EXTENSION;
+            }))
+            ->willReturnSelf();
+
+        $this->subject->handleRequest(
+            $request,
+            $this->mockToken,
+        );
+    }
+
+    public function test_non_critical_unsupported_control_does_not_cause_an_error(): void
+    {
+        $request = new LdapMessageRequest(
+            1,
+            new DeleteRequest('cn=foo,dc=bar'),
+            new Control('1.2.3.4.5', criticality: false),
+        );
+
+        $this->mockWriteHandler
+            ->expects(self::once())
+            ->method('handle');
 
         $this->subject->handleRequest(
             $request,

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
+use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\LdapResult;
@@ -590,5 +591,60 @@ final class ServerSearchHandlerTest extends TestCase
             ],
             $nonEntryMessages,
         );
+    }
+
+    public function test_critical_unsupported_control_returns_unavailable_critical_extension(): void
+    {
+        $search = new LdapMessageRequest(
+            2,
+            (new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar'),
+            new Control('1.2.3.4.5', criticality: true),
+        );
+
+        $this->mockBackend
+            ->expects(self::never())
+            ->method('search');
+
+        $this->subject->handleRequest(
+            $search,
+            $this->mockToken,
+        );
+
+        $this->assertSentMessages([
+            new LdapMessageResponse(
+                2,
+                new SearchResultDone(
+                    ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
+                    'dc=foo,dc=bar',
+                    'Critical control 1.2.3.4.5 is not supported.',
+                ),
+            ),
+        ]);
+    }
+
+    public function test_non_critical_unsupported_control_does_not_cause_an_error(): void
+    {
+        $search = new LdapMessageRequest(
+            2,
+            (new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar'),
+            new Control('1.2.3.4.5', criticality: false),
+        );
+
+        $this->mockBackend
+            ->expects(self::once())
+            ->method('search')
+            ->willReturn(new EntryStream($this->makeGenerator()));
+
+        $this->subject->handleRequest(
+            $search,
+            $this->mockToken,
+        );
+
+        $this->assertSentMessages([
+            new LdapMessageResponse(
+                2,
+                new SearchResultDone(ResultCode::SUCCESS, 'dc=foo,dc=bar'),
+            ),
+        ]);
     }
 }


### PR DESCRIPTION
Currently the server silently ignores many controls it doesn't support, even when marked as critical. Per the RFC, we should be returning a proper response code in that case. This updates the handlers. The only real supported backend control at the moment is for pagination. However, I will add server side sorting in a PR follow-up. And adding VLV support will be a future effort.