### PR TITLE
[1.0.0] Add server-side-sort control support to the server.

### DIFF
--- a/src/FreeDSx/Ldap/Protocol/LdapMessage.php
+++ b/src/FreeDSx/Ldap/Protocol/LdapMessage.php
@@ -160,6 +160,7 @@ abstract class LdapMessage implements ProtocolElementInterface, PduInterface
                         }
                         $controls[] = match ($control->getChild(0)->getValue()) {
                             Control\Control::OID_PAGING => Control\PagingControl::fromAsn1($control),
+                            Control\Control::OID_SORTING => Control\Sorting\SortingControl::fromAsn1($control),
                             Control\Control::OID_SORTING_RESPONSE => Control\Sorting\SortingResponseControl::fromAsn1($control),
                             Control\Control::OID_VLV_RESPONSE => Control\Vlv\VlvResponseControl::fromAsn1($control),
                             Control\Control::OID_DIR_SYNC => Control\Ad\DirSyncResponseControl::fromAsn1($control),

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\PagingControl;
+use FreeDSx\Ldap\Control\Sorting\SortingResponseControl;
 use FreeDSx\Ldap\Entry\Entries;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -109,6 +110,11 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
             $controls[] = new PagingControl(0, '');
         }
 
+        $sortControl = $this->sortingControl($message);
+        if ($sortControl !== null) {
+            $controls[] = new SortingResponseControl(0);
+        }
+
         $pagingRequest->markProcessed();
 
         /**
@@ -140,7 +146,10 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
      */
     private function supportedControls(): array
     {
-        return [Control::OID_PAGING];
+        return [
+            Control::OID_PAGING,
+            Control::OID_SORTING,
+        ];
     }
 
     /**
@@ -373,7 +382,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         return new PagingRequest(
             $pagingControl,
             $request,
-            $this->nonPagingControls($message),
+            $this->controlsForBackend($message),
             $this->generateCookie(),
         );
     }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
@@ -60,6 +60,7 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
             'subschemaSubentry' => [$this->options->getSubschemaEntry()->toString()],
             'supportedControl' => [
                 Control::OID_PAGING,
+                Control::OID_SORTING,
             ],
             'supportedExtension' => [
                 ExtendedRequest::OID_WHOAMI,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\Sorting\SortingResponseControl;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\AbandonRequest;
@@ -71,7 +73,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
 
             $backendResult = $this->backend->search(
                 $request,
-                $this->nonPagingControls($message),
+                $this->controlsForBackend($message),
             );
 
             $state = new SearchResultState();
@@ -94,11 +96,25 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
             );
         }
 
+        $sortControl = $this->sortingControl($message);
+        $responseControls = $sortControl !== null
+            ? [new SortingResponseControl(0)]
+            : [];
+
         $this->sendEntriesToClient(
             $searchResult,
             $message,
             $this->queue,
+            ...$responseControls,
         );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function supportedControls(): array
+    {
+        return [Control::OID_SORTING];
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Control\PagingControl;
+use FreeDSx\Ldap\Control\Sorting\SortingControl;
 use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
@@ -169,10 +170,9 @@ trait ServerSearchTrait
     }
 
     /**
-     * Returns a ControlBag containing the message controls minus the paging control,
-     * which the server consumes itself and must not forward to backends.
+     * Returns a ControlBag with server-consumed controls stripped; only paging is excluded (sort passes through to backends).
      */
-    private function nonPagingControls(LdapMessageRequest $message): ControlBag
+    private function controlsForBackend(LdapMessageRequest $message): ControlBag
     {
         $filtered = array_filter(
             $message->controls()->toArray(),
@@ -180,6 +180,18 @@ trait ServerSearchTrait
         );
 
         return new ControlBag(...$filtered);
+    }
+
+    /**
+     * Extracts the sorting control from the message, or returns null if absent.
+     */
+    private function sortingControl(LdapMessageRequest $message): ?SortingControl
+    {
+        $control = $message->controls()->get(Control::OID_SORTING);
+
+        return $control instanceof SortingControl
+            ? $control
+            : null;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectInterface.php
@@ -122,4 +122,9 @@ interface PdoDialectInterface
      * Maximum DN byte-length allowed by the storage backend, or null if there is no practical limit.
      */
     public function maxDnLength(): ?int;
+
+    /**
+     * Returns a single ORDER BY term for one sort key; caller provides $direction ("ASC" or "DESC") and appends "?" for the attribute name param.
+     */
+    public function sortKeyClause(string $direction): string;
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
@@ -119,4 +119,14 @@ trait PdoDialectTrait
     {
         return 'INSERT INTO entry_attribute_values (entry_lc_dn, attr_name_lower, value_lower, value_original) VALUES ';
     }
+
+    public function sortKeyClause(string $direction): string
+    {
+        return <<<SQL
+            (SELECT MIN(eav.value_lower)
+             FROM entry_attribute_values eav
+             WHERE eav.entry_lc_dn = LOWER(dn)
+               AND eav.attr_name_lower = ?) $direction
+        SQL;
+    }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SqliteDialect.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SqliteDialect.php
@@ -96,4 +96,14 @@ final class SqliteDialect implements PdoDialectInterface
     {
         return null;
     }
+
+    public function sortKeyClause(string $direction): string
+    {
+        return <<<SQL
+            (SELECT MIN(eav.value_lower)
+             FROM entry_attribute_values eav
+             WHERE eav.entry_lc_dn = LOWER(dn)
+               AND eav.attr_name_lower = ?) $direction NULLS LAST
+        SQL;
+    }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
@@ -56,13 +56,9 @@ final class InMemoryStorage implements EntryStorageInterface
 
     public function list(StorageListOptions $options): EntryStream
     {
-        return new EntryStream(
-            $this->yieldByScope(
-                $this->entries,
-                $options->baseDn,
-                $options->subtree,
-                $options->timeLimit,
-            ),
+        return $this->listFromArray(
+            $options,
+            $this->entries,
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonFileStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonFileStorage.php
@@ -80,13 +80,9 @@ final class JsonFileStorage implements EntryStorageInterface
 
     public function list(StorageListOptions $options): EntryStream
     {
-        return new EntryStream(
-            $this->yieldByScope(
-                $this->read(),
-                $options->baseDn,
-                $options->subtree,
-                $options->timeLimit,
-            ),
+        return $this->listFromArray(
+            $options,
+            $this->read(),
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilder.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo;
+
+use FreeDSx\Ldap\Control\Sorting\SortKey;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterResult;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterUtility;
+
+/**
+ * Builds the SQL query for PdoStorage::list().
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class PdoListQueryBuilder
+{
+    public function __construct(
+        private PdoDialectInterface $dialect,
+    ) {}
+
+    /**
+     * @param SortKey[] $sortKeys
+     */
+    public function build(
+        string $base,
+        bool $subtree,
+        ?SqlFilterResult $filterResult,
+        ?int $sizeLimit,
+        array $sortKeys,
+    ): SqlQuery {
+        $query = match (true) {
+            !$subtree => $this->buildChildQuery($base, $filterResult),
+            $base === '' => $this->buildRootQuery($filterResult),
+            default => $this->buildSubtreeQuery($base, $filterResult),
+        };
+
+        if ($sortKeys !== []) {
+            $query = $this->appendSortClause(
+                $query,
+                $sortKeys,
+            );
+        }
+
+        if ($sizeLimit !== null) {
+            $query = $query->appending(' LIMIT ' . $sizeLimit);
+        }
+
+        return $query;
+    }
+
+    private function buildChildQuery(
+        string $base,
+        ?SqlFilterResult $filterResult,
+    ): SqlQuery {
+        $query = new SqlQuery(
+            $this->dialect->queryFetchChildren(),
+            [$base],
+        );
+
+        if ($filterResult === null) {
+            return $query;
+        }
+
+        return $query->appending(
+            ' AND (' . $filterResult->sql . ')',
+            $filterResult->params,
+        );
+    }
+
+    private function buildRootQuery(?SqlFilterResult $filterResult): SqlQuery
+    {
+        if ($filterResult === null) {
+            return new SqlQuery($this->dialect->queryFetchAll());
+        }
+
+        return new SqlQuery(
+            $this->dialect->queryFetchAll() . ' WHERE (' . $filterResult->sql . ')',
+            $filterResult->params,
+        );
+    }
+
+    private function buildSubtreeQuery(
+        string $base,
+        ?SqlFilterResult $filterResult,
+    ): SqlQuery {
+        if ($filterResult === null) {
+            return new SqlQuery(
+                $this->dialect->querySubtree(),
+                [$base],
+            );
+        }
+
+        return $this->buildFilteredSubtreeQuery(
+            $base,
+            $filterResult,
+        );
+    }
+
+    /**
+     * Filter drives via the sidecar index; scope suffix is LIKE-checked per candidate.
+     */
+    private function buildFilteredSubtreeQuery(
+        string $base,
+        SqlFilterResult $filterResult,
+    ): SqlQuery {
+        $fetchAll = $this->dialect->queryFetchAll();
+        $filterSql = $filterResult->sql;
+        $sql = <<<SQL
+            $fetchAll WHERE ($filterSql)
+            AND (lc_dn = ? OR lc_dn LIKE ? ESCAPE '!')
+            SQL;
+
+        $params = $filterResult->params;
+        $params[] = $base;
+        $params[] = '%,' . SqlFilterUtility::escape($base);
+
+        return new SqlQuery(
+            $sql,
+            $params,
+        );
+    }
+
+    /**
+     * @param SortKey[] $sortKeys
+     */
+    private function appendSortClause(
+        SqlQuery $query,
+        array $sortKeys,
+    ): SqlQuery {
+        $clauses = [];
+        $params = [];
+
+        foreach ($sortKeys as $sortKey) {
+            $direction = $sortKey->getUseReverseOrder() ? 'DESC' : 'ASC';
+            $clauses[] = $this->dialect->sortKeyClause($direction);
+            $params[] = strtolower($sortKey->getAttribute());
+        }
+
+        return $query->appending(
+            ' ORDER BY ' . implode(', ', $clauses),
+            $params,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/SqlQuery.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/SqlQuery.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo;
+
+/**
+ * Immutable SQL + bound parameters pair.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class SqlQuery
+{
+    /**
+     * @param list<string> $params
+     */
+    public function __construct(
+        public string $sql,
+        public array $params = [],
+    ) {}
+
+    /**
+     * Returns a new instance with the given SQL appended and params merged.
+     *
+     * @param list<string> $additionalParams
+     */
+    public function appending(
+        string $sql,
+        array $additionalParams = [],
+    ): self {
+        return new self(
+            $this->sql . $sql,
+            array_merge(
+                $this->params,
+                $additionalParams,
+            ),
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -18,11 +18,11 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConnectionProviderInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoListQueryBuilder;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PooledStatement;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\DnTooLongException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\FilterTranslatorInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterResult;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterUtility;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
@@ -50,11 +50,15 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
      */
     private array $statementCache = [];
 
+    private readonly PdoListQueryBuilder $queryBuilder;
+
     public function __construct(
         private readonly PdoConnectionProviderInterface $provider,
         private readonly FilterTranslatorInterface $translator,
         private readonly PdoDialectInterface $dialect,
-    ) {}
+    ) {
+        $this->queryBuilder = new PdoListQueryBuilder($dialect);
+    }
 
     public function reset(): void
     {
@@ -121,11 +125,12 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
             ? $options->sizeLimit
             : null;
 
-        $stmt = $this->buildListStatement(
+        $query = $this->queryBuilder->build(
             $options->baseDn->toString(),
             $options->subtree,
             $filterResult,
             $sqlLimit,
+            $options->sortKeys,
         );
 
         $deadline = $options->timeLimit > 0
@@ -133,7 +138,10 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
             : null;
 
         return new EntryStream(
-            $this->generateRows($stmt, $deadline),
+            $this->generateRows(
+                $this->prepareAndExecute($query->sql, $query->params),
+                $deadline,
+            ),
             $isPreFiltered,
         );
     }
@@ -339,127 +347,6 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
                 $txState->broken = false;
             }
         }
-    }
-
-    private function buildListStatement(
-        string $base,
-        bool $subtree,
-        ?SqlFilterResult $filterResult,
-        ?int $sizeLimit,
-    ): PooledStatement {
-        if (!$subtree) {
-            return $this->buildChildQuery(
-                $base,
-                $filterResult,
-                $sizeLimit,
-            );
-        }
-
-        if ($base === '') {
-            return $this->buildRootQuery(
-                $filterResult,
-                $sizeLimit,
-            );
-        }
-
-        return $this->buildSubtreeQuery(
-            $base,
-            $filterResult,
-            $sizeLimit,
-        );
-    }
-
-    private function buildChildQuery(
-        string $base,
-        ?SqlFilterResult $filterResult,
-        ?int $sizeLimit,
-    ): PooledStatement {
-        $sql = $this->dialect->queryFetchChildren();
-        $params = [$base];
-
-        if ($filterResult !== null) {
-            $sql .= ' AND (' . $filterResult->sql . ')';
-            $params = array_merge(
-                $params,
-                $filterResult->params,
-            );
-        }
-
-        return $this->prepareAndExecute(
-            $sql . $this->buildLimitClause($sizeLimit),
-            $params,
-        );
-    }
-
-    private function buildRootQuery(
-        ?SqlFilterResult $filterResult,
-        ?int $sizeLimit,
-    ): PooledStatement {
-        $sql = $this->dialect->queryFetchAll();
-        $params = [];
-
-        if ($filterResult !== null) {
-            $sql .= ' WHERE (' . $filterResult->sql . ')';
-            $params = $filterResult->params;
-        }
-
-        return $this->prepareAndExecute(
-            $sql . $this->buildLimitClause($sizeLimit),
-            $params,
-        );
-    }
-
-    private function buildSubtreeQuery(
-        string $base,
-        ?SqlFilterResult $filterResult,
-        ?int $sizeLimit,
-    ): PooledStatement {
-        if ($filterResult !== null) {
-            return $this->buildFilteredSubtreeQuery(
-                $base,
-                $filterResult,
-                $sizeLimit,
-            );
-        }
-
-        return $this->prepareAndExecute(
-            $this->dialect->querySubtree() . $this->buildLimitClause($sizeLimit),
-            [$base],
-        );
-    }
-
-    /**
-     * Filter drives via the sidecar index; scope suffix is LIKE-checked per candidate.
-     */
-    private function buildFilteredSubtreeQuery(
-        string $base,
-        SqlFilterResult $filterResult,
-        ?int $sizeLimit,
-    ): PooledStatement {
-        $fetchAll = $this->dialect->queryFetchAll();
-        $filterSql = $filterResult->sql;
-        $sql = <<<SQL
-            $fetchAll WHERE ($filterSql)
-            AND (lc_dn = ? OR lc_dn LIKE ? ESCAPE '!')
-            SQL;
-
-        $params = $filterResult->params;
-        $params[] = $base;
-        $params[] = '%,' . SqlFilterUtility::escape($base);
-
-        return $this->prepareAndExecute(
-            $sql . $this->buildLimitClause($sizeLimit),
-            $params,
-        );
-    }
-
-    private function buildLimitClause(?int $sizeLimit): string
-    {
-        if ($sizeLimit === null) {
-            return '';
-        }
-
-        return ' LIMIT ' . $sizeLimit;
     }
 
     private function encodeAttributes(Entry $entry): string

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/ArrayEntryStorageTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/ArrayEntryStorageTrait.php
@@ -15,7 +15,9 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Support;
 
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
+use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 use Generator;
 
 /**
@@ -26,6 +28,55 @@ use Generator;
 trait ArrayEntryStorageTrait
 {
     use DefaultHasChildrenTrait;
+
+    /**
+     * @param array<string, Entry> $entries Entries keyed by normalised DN string
+     */
+    private function listFromArray(
+        StorageListOptions $options,
+        array $entries,
+    ): EntryStream {
+        if ($options->sortKeys === []) {
+            return new EntryStream(
+                $this->yieldByScope(
+                    $entries,
+                    $options->baseDn,
+                    $options->subtree,
+                    $options->timeLimit,
+                ),
+            );
+        }
+
+        return new EntryStream($this->sortedStreamFromArray(
+            $options,
+            $entries,
+        ));
+    }
+
+    /**
+     * @param array<string, Entry> $entries Entries keyed by normalised DN string
+     * @return Generator<Entry>
+     */
+    private function sortedStreamFromArray(
+        StorageListOptions $options,
+        array $entries,
+    ): Generator {
+        /** @var list<Entry> $collected */
+        $collected = iterator_to_array(
+            $this->yieldByScope(
+                $entries,
+                $options->baseDn,
+                $options->subtree,
+                $options->timeLimit,
+            ),
+            false,
+        );
+
+        yield from (new SortKeyComparator())->sort(
+            $collected,
+            $options->sortKeys,
+        );
+    }
 
     /**
      * @param array<string, Entry> $entries Entries keyed by normalised DN string

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/SortKeyComparator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/SortKeyComparator.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Support;
+
+use FreeDSx\Ldap\Control\Sorting\SortKey;
+use FreeDSx\Ldap\Entry\Entry;
+
+/**
+ * Sorts a list of entries in-place by an ordered list of SortKeys.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class SortKeyComparator
+{
+    /**
+     * Returns a new sorted array.
+     *
+     * @param list<Entry> $entries
+     * @param SortKey[] $sortKeys
+     * @return list<Entry>
+     */
+    public function sort(
+        array $entries,
+        array $sortKeys,
+    ): array {
+        usort(
+            $entries,
+            fn(Entry $a, Entry $b): int => $this->compare(
+                $a,
+                $b,
+                $sortKeys,
+            ),
+        );
+
+        return $entries;
+    }
+
+    /**
+     * @param SortKey[] $sortKeys
+     */
+    private function compare(
+        Entry $a,
+        Entry $b,
+        array $sortKeys,
+    ): int {
+        foreach ($sortKeys as $sortKey) {
+            $result = $this->compareByKey(
+                $a,
+                $b,
+                $sortKey,
+            );
+
+            if ($result !== 0) {
+                return $result;
+            }
+        }
+
+        return 0;
+    }
+
+    private function compareByKey(
+        Entry $a,
+        Entry $b,
+        SortKey $sortKey,
+    ): int {
+        $aValue = $this->minValue(
+            $a,
+            $sortKey->getAttribute(),
+        );
+        $bValue = $this->minValue(
+            $b,
+            $sortKey->getAttribute(),
+        );
+
+        if ($aValue === null && $bValue === null) {
+            return 0;
+        }
+
+        if ($aValue === null) {
+            return 1;
+        }
+
+        if ($bValue === null) {
+            return -1;
+        }
+
+        $cmp = strcasecmp(
+            $aValue,
+            $bValue,
+        );
+
+        return $sortKey->getUseReverseOrder() ? -$cmp : $cmp;
+    }
+
+    /**
+     * Returns the case-insensitive minimum value, consistent with the SQL backend's MIN(value_lower).
+     * Null when the attribute is absent or empty.
+     */
+    private function minValue(
+        Entry $entry,
+        string $attribute,
+    ): ?string {
+        $attr = $entry->get($attribute);
+
+        if ($attr === null) {
+            return null;
+        }
+
+        $values = $attr->getValues();
+
+        if ($values === []) {
+            return null;
+        }
+
+        return array_reduce(
+            $values,
+            self::caseInsensitiveMin(...),
+        );
+    }
+
+    private static function caseInsensitiveMin(
+        ?string $min,
+        string $value,
+    ): string {
+        return $min === null || strcasecmp($value, $min) < 0
+            ? $value
+            : $min;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage;
 
+use FreeDSx\Ldap\Control\Sorting\SortKey;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Search\Filter\AndFilter;
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
@@ -24,12 +25,16 @@ use FreeDSx\Ldap\Search\Filter\FilterInterface;
  */
 final class StorageListOptions
 {
+    /**
+     * @param SortKey[] $sortKeys
+     */
     public function __construct(
         public readonly Dn $baseDn,
         public readonly bool $subtree,
         public readonly FilterInterface $filter,
         public readonly int $timeLimit = 0,
         public readonly int $sizeLimit = 0,
+        public readonly array $sortKeys = [],
     ) {}
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage;
 
+use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Control\Sorting\SortingControl;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -142,12 +144,16 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         }
 
         $subtree = $request->getScope() === SearchRequest::SCOPE_WHOLE_SUBTREE;
+        $sortingControl = $controls->get(Control::OID_SORTING);
         $options = new StorageListOptions(
             baseDn: $normBase,
             subtree: $subtree,
             filter: $request->getFilter(),
             timeLimit: $this->searchStream->effectiveTimeLimit($request->getTimeLimit()),
             sizeLimit: $request->getSizeLimit(),
+            sortKeys: $sortingControl instanceof SortingControl
+                ? $sortingControl->getSortKeys()
+                : [],
         );
 
         try {

--- a/tests/integration/LdapServerTest.php
+++ b/tests/integration/LdapServerTest.php
@@ -186,6 +186,7 @@ final class LdapServerTest extends ServerTestCase
                 ],
                 'supportedControl' => [
                     '1.2.840.113556.1.4.319',
+                    '1.2.840.113556.1.4.473',
                 ],
                 'supportedExtension' => [
                     '1.3.6.1.4.1.4203.1.11.3',

--- a/tests/integration/Storage/LdapBackendStorageTest.php
+++ b/tests/integration/Storage/LdapBackendStorageTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Tests\Integration\FreeDSx\Ldap\Storage;
 
+use FreeDSx\Ldap\Control\Sorting\SortingControl;
+use FreeDSx\Ldap\Control\Sorting\SortKey;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -442,5 +444,51 @@ class LdapBackendStorageTest extends ServerTestCase
 
         // Under ou=people only alice exists in the seed; NOT-equal alice leaves zero matches.
         self::assertCount(0, $entries);
+    }
+
+    public function testSortControlAscendingOrdersResults(): void
+    {
+        $this->authenticateUser();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::present('sn'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+            new SortingControl(SortKey::ascending('sn')),
+        );
+
+        $sns = array_map(
+            static fn(Entry $e): string => $e->get('sn')?->getValues()[0] ?? '',
+            $entries->toArray(),
+        );
+
+        // Seed: cn=user (sn=Admin), cn=alice (sn=Smith). Admin < Smith ascending.
+        self::assertSame(
+            ['Admin', 'Smith'],
+            $sns,
+        );
+    }
+
+    public function testSortControlDescendingOrdersResults(): void
+    {
+        $this->authenticateUser();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::present('sn'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+            new SortingControl(SortKey::descending('sn')),
+        );
+
+        $sns = array_map(
+            static fn(Entry $e): string => $e->get('sn')?->getValues()[0] ?? '',
+            $entries->toArray(),
+        );
+
+        // Seed: cn=user (sn=Admin), cn=alice (sn=Smith). Smith > Admin descending.
+        self::assertSame(
+            ['Smith', 'Admin'],
+            $sns,
+        );
     }
 }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
@@ -16,6 +16,9 @@ namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Control\PagingControl;
+use FreeDSx\Ldap\Control\Sorting\SortKey;
+use FreeDSx\Ldap\Control\Sorting\SortingControl;
+use FreeDSx\Ldap\Control\Sorting\SortingResponseControl;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
@@ -622,6 +625,53 @@ class ServerPagingHandlerTest extends TestCase
         $this->requestHistory->storePagingGenerator($nextCookie, $this->makeGenerator());
 
         return $pagingReq;
+    }
+
+    public function test_sort_control_appends_sorting_response_control_to_done_message(): void
+    {
+        $message = new LdapMessageRequest(
+            2,
+            $this->makeSearchRequest(),
+            new PagingControl(10, ''),
+            new SortingControl(SortKey::ascending('cn')),
+        );
+
+        $this->mockBackend
+            ->method('search')
+            ->willReturn(new EntryStream($this->makeGenerator()));
+
+        $this->subject->handleRequest(
+            $message,
+            $this->mockToken,
+        );
+
+        $sortControl = $this->doneMessage()->controls()->get(Control::OID_SORTING_RESPONSE);
+        self::assertInstanceOf(
+            SortingResponseControl::class,
+            $sortControl,
+        );
+        self::assertSame(
+            0,
+            $sortControl->getResult(),
+        );
+    }
+
+    public function test_no_sort_control_does_not_append_sorting_response_control(): void
+    {
+        $message = $this->makeSearchMessage(size: 10);
+
+        $this->mockBackend
+            ->method('search')
+            ->willReturn(new EntryStream($this->makeGenerator()));
+
+        $this->subject->handleRequest(
+            $message,
+            $this->mockToken,
+        );
+
+        self::assertNull(
+            $this->doneMessage()->controls()->get(Control::OID_SORTING_RESPONSE),
+        );
     }
 
     private function makeSearchMessage(

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerRootDseHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerRootDseHandlerTest.php
@@ -77,7 +77,10 @@ final class ServerRootDseHandlerTest extends TestCase
                 self::equalTo(new LdapMessageResponse(1, new SearchResultEntry(Entry::create('', [
                     'namingContexts' => 'dc=Foo,dc=Bar',
                     'subschemaSubentry' => ['cn=Subschema'],
-                    'supportedControl' => [Control::OID_PAGING],
+                    'supportedControl' => [
+                        Control::OID_PAGING,
+                        Control::OID_SORTING,
+                    ],
                     'supportedExtension' => [
                         ExtendedRequest::OID_WHOAMI,
                         ExtendedRequest::OID_PWD_MODIFY,
@@ -143,7 +146,10 @@ final class ServerRootDseHandlerTest extends TestCase
         $rootDse = Entry::create('', [
             'namingContexts' => 'dc=Foo,dc=Bar',
             'subschemaSubentry' => ['cn=Subschema'],
-            'supportedControl' => [Control::OID_PAGING],
+            'supportedControl' => [
+                Control::OID_PAGING,
+                Control::OID_SORTING,
+            ],
             'supportedExtension' => [
                 ExtendedRequest::OID_WHOAMI,
                 ExtendedRequest::OID_PWD_MODIFY,

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\Sorting\SortKey;
+use FreeDSx\Ldap\Control\Sorting\SortingControl;
+use FreeDSx\Ldap\Control\Sorting\SortingResponseControl;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\LdapResult;
@@ -646,5 +649,56 @@ final class ServerSearchHandlerTest extends TestCase
                 new SearchResultDone(ResultCode::SUCCESS, 'dc=foo,dc=bar'),
             ),
         ]);
+    }
+
+    public function test_sort_control_appends_sorting_response_control_to_done_message(): void
+    {
+        $search = new LdapMessageRequest(
+            2,
+            (new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar'),
+            new SortingControl(SortKey::ascending('cn')),
+        );
+
+        $this->mockBackend
+            ->method('search')
+            ->willReturn(new EntryStream($this->makeGenerator()));
+
+        $this->subject->handleRequest(
+            $search,
+            $this->mockToken,
+        );
+
+        $done = end($this->sentMessages);
+        self::assertInstanceOf(LdapMessageResponse::class, $done);
+        $sortControl = $done->controls()->get(Control::OID_SORTING_RESPONSE);
+        self::assertInstanceOf(
+            SortingResponseControl::class,
+            $sortControl,
+        );
+        self::assertSame(
+            0,
+            $sortControl->getResult(),
+        );
+    }
+
+    public function test_no_sort_control_does_not_append_sorting_response_control(): void
+    {
+        $search = new LdapMessageRequest(
+            2,
+            (new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar'),
+        );
+
+        $this->mockBackend
+            ->method('search')
+            ->willReturn(new EntryStream($this->makeGenerator()));
+
+        $this->subject->handleRequest(
+            $search,
+            $this->mockToken,
+        );
+
+        $done = end($this->sentMessages);
+        self::assertInstanceOf(LdapMessageResponse::class, $done);
+        self::assertNull($done->controls()->get(Control::OID_SORTING_RESPONSE));
     }
 }

--- a/tests/unit/Server/Backend/Storage/Adapter/Support/SortKeyComparatorTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Support/SortKeyComparatorTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Adapter\Support;
+
+use FreeDSx\Ldap\Control\Sorting\SortKey;
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Support\SortKeyComparator;
+use PHPUnit\Framework\TestCase;
+
+final class SortKeyComparatorTest extends TestCase
+{
+    private SortKeyComparator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new SortKeyComparator();
+    }
+
+    private function entry(
+        string $dn,
+        string ...$cnValues,
+    ): Entry {
+        return new Entry(
+            new Dn($dn),
+            new Attribute('cn', ...$cnValues),
+        );
+    }
+
+    /**
+     * @param list<Entry> $sorted
+     * @return list<string>
+     */
+    private function cnValues(array $sorted): array
+    {
+        return array_map(
+            static fn(Entry $e): string => $e->get('cn')?->getValues()[0] ?? '',
+            $sorted,
+        );
+    }
+
+    public function test_sort_ascending_by_single_key(): void
+    {
+        $alice = $this->entry('cn=Alice,dc=example,dc=com', 'Alice');
+        $bob = $this->entry('cn=Bob,dc=example,dc=com', 'Bob');
+        $charlie = $this->entry('cn=Charlie,dc=example,dc=com', 'Charlie');
+
+        $sorted = $this->subject->sort(
+            [$charlie, $alice, $bob],
+            [SortKey::ascending('cn')],
+        );
+
+        self::assertSame(
+            ['Alice', 'Bob', 'Charlie'],
+            $this->cnValues($sorted),
+        );
+    }
+
+    public function test_sort_descending_by_single_key(): void
+    {
+        $alice = $this->entry('cn=Alice,dc=example,dc=com', 'Alice');
+        $bob = $this->entry('cn=Bob,dc=example,dc=com', 'Bob');
+        $charlie = $this->entry('cn=Charlie,dc=example,dc=com', 'Charlie');
+
+        $sorted = $this->subject->sort(
+            [$alice, $charlie, $bob],
+            [SortKey::descending('cn')],
+        );
+
+        self::assertSame(
+            ['Charlie', 'Bob', 'Alice'],
+            $this->cnValues($sorted),
+        );
+    }
+
+    public function test_sort_is_case_insensitive(): void
+    {
+        $lower = $this->entry('cn=alpha,dc=example,dc=com', 'alpha');
+        $upper = $this->entry('cn=BETA,dc=example,dc=com', 'BETA');
+
+        $sorted = $this->subject->sort(
+            [$upper, $lower],
+            [SortKey::ascending('cn')],
+        );
+
+        self::assertSame(
+            ['alpha', 'BETA'],
+            $this->cnValues($sorted),
+        );
+    }
+
+    public function test_multi_valued_attribute_sorts_by_minimum_value(): void
+    {
+        $aEntry = new Entry(
+            new Dn('cn=A,dc=example,dc=com'),
+            new Attribute('cn', 'Zebra', 'Apple'),
+        );
+        $bEntry = new Entry(
+            new Dn('cn=B,dc=example,dc=com'),
+            new Attribute('cn', 'Mango'),
+        );
+
+        $sorted = $this->subject->sort(
+            [$bEntry, $aEntry],
+            [SortKey::ascending('cn')],
+        );
+
+        self::assertSame(
+            $aEntry,
+            $sorted[0],
+            'Entry whose minimum value (Apple) is less than Mango should sort first',
+        );
+    }
+
+    public function test_entries_missing_attribute_sort_last_for_ascending(): void
+    {
+        $alice = $this->entry('cn=Alice,dc=example,dc=com', 'Alice');
+        $noAttr = new Entry(new Dn('cn=NoAttr,dc=example,dc=com'));
+
+        $sorted = $this->subject->sort(
+            [$noAttr, $alice],
+            [SortKey::ascending('cn')],
+        );
+
+        self::assertSame(
+            'Alice',
+            $sorted[0]->get('cn')?->getValues()[0],
+        );
+        self::assertNull($sorted[1]->get('cn'));
+    }
+
+    public function test_entries_missing_attribute_sort_last_for_descending(): void
+    {
+        $alice = $this->entry('cn=Alice,dc=example,dc=com', 'Alice');
+        $noAttr = new Entry(new Dn('cn=NoAttr,dc=example,dc=com'));
+
+        $sorted = $this->subject->sort(
+            [$noAttr, $alice],
+            [SortKey::descending('cn')],
+        );
+
+        self::assertSame(
+            'Alice',
+            $sorted[0]->get('cn')?->getValues()[0],
+        );
+        self::assertNull($sorted[1]->get('cn'));
+    }
+
+    public function test_sort_cascades_through_multiple_keys(): void
+    {
+        $alice1 = new Entry(
+            new Dn('uid=a1,dc=example,dc=com'),
+            new Attribute('sn', 'Smith'),
+            new Attribute('cn', 'Alice'),
+        );
+        $alice2 = new Entry(
+            new Dn('uid=a2,dc=example,dc=com'),
+            new Attribute('sn', 'Smith'),
+            new Attribute('cn', 'Alice2'),
+        );
+        $bob = new Entry(
+            new Dn('uid=b,dc=example,dc=com'),
+            new Attribute('sn', 'Jones'),
+            new Attribute('cn', 'Bob'),
+        );
+
+        $sorted = $this->subject->sort(
+            [$alice2, $bob, $alice1],
+            [SortKey::ascending('sn'), SortKey::ascending('cn')],
+        );
+
+        self::assertSame(
+            'Bob',
+            $sorted[0]->get('cn')?->getValues()[0],
+        );
+        self::assertSame(
+            'Alice',
+            $sorted[1]->get('cn')?->getValues()[0],
+        );
+        self::assertSame(
+            'Alice2',
+            $sorted[2]->get('cn')?->getValues()[0],
+        );
+    }
+
+    public function test_sort_does_not_modify_original_array(): void
+    {
+        $alice = $this->entry('cn=Alice,dc=example,dc=com', 'Alice');
+        $bob = $this->entry('cn=Bob,dc=example,dc=com', 'Bob');
+        $original = [$bob, $alice];
+
+        $this->subject->sort(
+            $original,
+            [SortKey::ascending('cn')],
+        );
+
+        self::assertSame(
+            $bob,
+            $original[0],
+        );
+    }
+}


### PR DESCRIPTION
This adds support for the server-side-sort control to the server. This leverages the existing storage backends, so we sort in PHP with the in-memory / json file storage, and for PDO we delegate to the dialect so SQL does the sorting.