### PR TITLE
[1.0.0] Correctly handle matchedDN in error responses.

### DIFF
--- a/src/FreeDSx/Ldap/Exception/OperationException.php
+++ b/src/FreeDSx/Ldap/Exception/OperationException.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Exception;
 
 use Exception;
+use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Operation\ResultCode;
 use Throwable;
 
@@ -30,6 +31,7 @@ class OperationException extends Exception
         string $message = '',
         int $code = ResultCode::OPERATIONS_ERROR,
         ?Throwable $previous = null,
+        private readonly ?Dn $matchedDn = null,
     ) {
         $message = empty($message)
             ? $this->generateMessage($code)
@@ -40,6 +42,14 @@ class OperationException extends Exception
             $code,
             $previous,
         );
+    }
+
+    /**
+     * The deepest DIT ancestor found when the noSuchObject result code was returned; null if no ancestor exists.
+     */
+    public function getMatchedDn(): ?Dn
+    {
+        return $this->matchedDn;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/Factory/ResponseFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ResponseFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\Factory;
 
+use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Operation\Request\BindRequest;
@@ -43,32 +44,71 @@ class ResponseFactory
 {
     /**
      * Retrieve the expected response type for the request that was given.
+     *
+     * @param Dn|null $matchedDn Matched ancestor; emitted as matchedDN when non-null.
      */
     public function getStandardResponse(
         LdapMessageRequest $message,
         int $resultCode = ResultCode::SUCCESS,
         string $diagnostic = '',
+        ?Dn $matchedDn = null,
     ): LdapMessageResponse {
         $request = $message->getRequest();
+        $dn = $matchedDn?->toString() ?? '';
 
-        if ($request instanceof BindRequest) {
-            $response = new BindResponse(new LdapResult($resultCode, '', $diagnostic));
-        } elseif ($request instanceof SearchRequest) {
-            $response = new SearchResultDone($resultCode, '', $diagnostic);
-        } elseif ($request instanceof AddRequest) {
-            $response = new AddResponse($resultCode, $request->getEntry()->getDn()->toString(), $diagnostic);
-        } elseif ($request instanceof CompareRequest) {
-            $response = new CompareResponse($resultCode, $request->getDn()->toString(), $diagnostic);
-        } elseif ($request instanceof DeleteRequest) {
-            $response = new DeleteResponse($resultCode, $request->getDn()->toString(), $diagnostic);
-        } elseif ($request instanceof ModifyDnRequest) {
-            $response = new ModifyDnResponse($resultCode, $request->getDn()->toString(), $diagnostic);
-        } elseif ($request instanceof ModifyRequest) {
-            $response = new ModifyResponse($resultCode, $request->getDn()->toString(), $diagnostic);
-        } elseif ($request instanceof ExtendedRequest) {
-            $response = new ExtendedResponse(new LdapResult($resultCode, '', $diagnostic));
-        } else {
-            return $this->getExtendedError('Invalid request.', ResultCode::OPERATIONS_ERROR);
+        $response = match (true) {
+            $request instanceof BindRequest => new BindResponse(
+                new LdapResult(
+                    $resultCode,
+                    $dn,
+                    $diagnostic,
+                ),
+            ),
+            $request instanceof SearchRequest => new SearchResultDone(
+                $resultCode,
+                $dn,
+                $diagnostic,
+            ),
+            $request instanceof AddRequest => new AddResponse(
+                $resultCode,
+                $dn,
+                $diagnostic,
+            ),
+            $request instanceof CompareRequest => new CompareResponse(
+                $resultCode,
+                $dn,
+                $diagnostic,
+            ),
+            $request instanceof DeleteRequest => new DeleteResponse(
+                $resultCode,
+                $dn,
+                $diagnostic,
+            ),
+            $request instanceof ModifyDnRequest => new ModifyDnResponse(
+                $resultCode,
+                $dn,
+                $diagnostic,
+            ),
+            $request instanceof ModifyRequest => new ModifyResponse(
+                $resultCode,
+                $dn,
+                $diagnostic,
+            ),
+            $request instanceof ExtendedRequest => new ExtendedResponse(
+                new LdapResult(
+                    $resultCode,
+                    $dn,
+                    $diagnostic,
+                ),
+            ),
+            default => null,
+        };
+
+        if ($response === null) {
+            return $this->getExtendedError(
+                'Invalid request.',
+                ResultCode::OPERATIONS_ERROR,
+            );
         }
 
         return new LdapMessageResponse(
@@ -87,7 +127,14 @@ class ResponseFactory
     ): LdapMessageResponse {
         return new LdapMessageResponse(
             0,
-            new ExtendedResponse(new LdapResult($errorCode, '', $message), $responseName),
+            new ExtendedResponse(
+                new LdapResult(
+                    $errorCode,
+                    '',
+                    $message,
+                ),
+                $responseName,
+            ),
         );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/MatchedDnAccessFilterTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/MatchedDnAccessFilterTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * Applies the RFC 4511 §4.1.9 "subject to access controls" rule to a candidate matchedDN.
+ */
+trait MatchedDnAccessFilterTrait
+{
+    /**
+     * Returns $matchedDn when the token may see the ancestor entry.
+     */
+    private function filterMatchedDn(
+        ?Dn $matchedDn,
+        TokenInterface $token,
+        LdapBackendInterface $backend,
+        AccessControlInterface $accessControl,
+    ): ?Dn {
+        if ($matchedDn === null) {
+            return null;
+        }
+
+        try {
+            $entry = $backend->get($matchedDn);
+        } catch (OperationException) {
+            return new Dn('');
+        }
+
+        if ($entry === null) {
+            return new Dn('');
+        }
+
+        return $accessControl->filterEntry($token, $entry) === null
+            ? new Dn('')
+            : $matchedDn;
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -37,6 +37,7 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
 readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
 {
     use ServerCriticalControlTrait;
+    use MatchedDnAccessFilterTrait;
 
     public function __construct(
         private ServerQueue $queue,
@@ -99,6 +100,12 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
                 $message,
                 $e->getCode(),
                 $e->getMessage(),
+                $this->filterMatchedDn(
+                    $e->getMatchedDn(),
+                    $token,
+                    $this->backend,
+                    $this->accessControl,
+                ),
             ));
         }
     }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -46,6 +46,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
 {
     use ServerSearchTrait;
     use ServerCriticalControlTrait;
+    use MatchedDnAccessFilterTrait;
 
     public function __construct(
         private readonly ServerQueue $queue,
@@ -102,9 +103,17 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
                 );
             }
         } catch (OperationException $e) {
+            $matchedDn = $this->filterMatchedDn(
+                $e->getMatchedDn(),
+                $token,
+                $this->backend,
+                $this->accessControl,
+            );
             $searchResult = SearchResult::makeErrorResult(
                 $e->getCode(),
-                (string) $searchRequest->getBaseDn(),
+                $matchedDn !== null
+                    ? $matchedDn->toString()
+                    : '',
                 $e->getMessage(),
             );
             $controls[] = new PagingControl(0, '');

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -41,6 +41,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
 {
     use ServerSearchTrait;
     use ServerCriticalControlTrait;
+    use MatchedDnAccessFilterTrait;
 
 
     private const CANCEL_CHECK_INTERVAL = 50;
@@ -89,9 +90,17 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
                 $state,
             );
         } catch (OperationException $e) {
+            $matchedDn = $this->filterMatchedDn(
+                $e->getMatchedDn(),
+                $token,
+                $this->backend,
+                $this->accessControl,
+            );
             $searchResult = SearchResult::makeErrorResult(
                 $e->getCode(),
-                (string) $request->getBaseDn(),
+                $matchedDn !== null
+                    ? $matchedDn->toString()
+                    : '',
                 $e->getMessage(),
             );
         }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Control\Sorting\SortingControl;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
@@ -97,7 +98,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         $entry = $this->get($dn);
 
         if ($entry === null) {
-            $this->throwNoSuchObject($dn);
+            $this->throwNoSuchObject(
+                $this->storage,
+                $dn,
+            );
         }
 
         $attribute = $entry->get($filter->getAttribute());
@@ -129,7 +133,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             $entry = $this->storage->find($normBase);
 
             if ($entry === null) {
-                $this->throwNoSuchObject($baseDn);
+                $this->throwNoSuchObject(
+                    $this->storage,
+                    $baseDn,
+                );
             }
 
             return $this->searchStream->buildForBaseObject(
@@ -140,7 +147,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
 
         // no chance to be confused with the RootDSE, which is handled special elsewhere.
         if ($normBase->toString() !== '' && !$this->storage->exists($normBase)) {
-            $this->throwNoSuchObject($baseDn);
+            $this->throwNoSuchObject(
+                $this->storage,
+                $baseDn,
+            );
         }
 
         $subtree = $request->getScope() === SearchRequest::SCOPE_WHOLE_SUBTREE;
@@ -314,7 +324,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         $entry = $storage->find($dn);
 
         if ($entry === null) {
-            $this->throwNoSuchObject($dn);
+            $this->throwNoSuchObject(
+                $storage,
+                $dn,
+            );
         }
 
         return $entry;
@@ -334,7 +347,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         }
 
         if (!$storage->exists($parent)) {
-            $this->throwNoSuchObject($parent);
+            $this->throwNoSuchObject(
+                $storage,
+                $parent,
+            );
         }
     }
 
@@ -350,7 +366,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         $normNewParent = $command->newParent->normalize();
 
         if ($normNewParent->getParent() !== null && !$storage->exists($normNewParent)) {
-            $this->throwNoSuchObject($command->newParent);
+            $this->throwNoSuchObject(
+                $storage,
+                $command->newParent,
+            );
         }
     }
 
@@ -375,12 +394,43 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
     /**
      * @throws OperationException
      */
-    private function throwNoSuchObject(Dn $dn): never
-    {
+    private function throwNoSuchObject(
+        EntryStorageInterface $storage,
+        Dn $dn,
+    ): never {
         throw new OperationException(
             sprintf('No such object: %s', $dn->toString()),
             ResultCode::NO_SUCH_OBJECT,
+            null,
+            $this->findMatchedDn(
+                $storage,
+                $dn,
+            ),
         );
+    }
+
+    /**
+     * Walks up the parent chain to find the deepest ancestor that exists in the DIT (RFC 4511 §4.1.9).
+     */
+    private function findMatchedDn(
+        EntryStorageInterface $storage,
+        Dn $dn,
+    ): ?Dn {
+        try {
+            $current = $dn->getParent();
+
+            while ($current !== null) {
+                if ($storage->exists($current->normalize())) {
+                    return $current;
+                }
+
+                $current = $current->getParent();
+            }
+        } catch (InvalidArgumentException) {
+            // DN has malformed components — no matched ancestor can be determined.
+        }
+
+        return null;
     }
 
     /**

--- a/tests/unit/Exception/OperationExceptionTest.php
+++ b/tests/unit/Exception/OperationExceptionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Exception;
 
+use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use PHPUnit\Framework\TestCase;
@@ -55,6 +56,27 @@ final class OperationExceptionTest extends TestCase
         self::assertSame(
             'The result code 1 was thrown (operationsError). Indicates that the operation is not properly sequenced with relation to other operations (of same or different type).',
             $this->subject->getMessage(),
+        );
+    }
+
+    public function test_matched_dn_is_null_by_default(): void
+    {
+        self::assertNull($this->subject->getMatchedDn());
+    }
+
+    public function test_matched_dn_is_returned_when_provided(): void
+    {
+        $dn = new Dn('dc=example,dc=com');
+        $exception = new OperationException(
+            'No such object',
+            ResultCode::NO_SUCH_OBJECT,
+            null,
+            $dn,
+        );
+
+        self::assertSame(
+            $dn,
+            $exception->getMatchedDn(),
         );
     }
 }

--- a/tests/unit/Protocol/Factory/ResponseFactoryTest.php
+++ b/tests/unit/Protocol/Factory/ResponseFactoryTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Protocol\Factory;
 
 use FreeDSx\Ldap\Entry\Change;
+use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
@@ -31,12 +32,14 @@ use FreeDSx\Ldap\Operation\Response\DeleteResponse;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\Response\ModifyDnResponse;
 use FreeDSx\Ldap\Operation\Response\ModifyResponse;
+use FreeDSx\Ldap\Operation\Response\ResponseInterface;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Search\Filters;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class ResponseFactoryTest extends TestCase
@@ -71,7 +74,7 @@ final class ResponseFactoryTest extends TestCase
         self::assertEquals(
             new LdapMessageResponse(
                 1,
-                new AddResponse(0, 'foo'),
+                new AddResponse(0, ''),
             ),
             $this->subject->getStandardResponse(
                 new LdapMessageRequest(
@@ -89,7 +92,7 @@ final class ResponseFactoryTest extends TestCase
                 1,
                 new CompareResponse(
                     ResultCode::COMPARE_TRUE,
-                    'foo',
+                    '',
                     'foo',
                 ),
             ),
@@ -112,7 +115,7 @@ final class ResponseFactoryTest extends TestCase
         self::assertEquals(
             new LdapMessageResponse(
                 1,
-                new ModifyResponse(0, 'foo', 'foo'),
+                new ModifyResponse(0, '', 'foo'),
             ),
             $this->subject->getStandardResponse(
                 new LdapMessageRequest(
@@ -130,7 +133,7 @@ final class ResponseFactoryTest extends TestCase
         self::assertEquals(
             new LdapMessageResponse(
                 1,
-                new ModifyDnResponse(0, 'foo', 'foo'),
+                new ModifyDnResponse(0, '', 'foo'),
             ),
             $this->subject->getStandardResponse(
                 new LdapMessageRequest(
@@ -163,7 +166,7 @@ final class ResponseFactoryTest extends TestCase
         self::assertEquals(
             new LdapMessageResponse(
                 1,
-                new DeleteResponse(0, 'foo', 'foo'),
+                new DeleteResponse(0, '', 'foo'),
             ),
             $this->subject->getStandardResponse(
                 new LdapMessageRequest(
@@ -185,6 +188,70 @@ final class ResponseFactoryTest extends TestCase
                 0,
                 'foo',
             ),
+        );
+    }
+
+    #[DataProvider('provideMatchedDnWriteResponseCases')]
+    public function test_matched_dn_overrides_request_dn_for_write_responses(
+        LdapMessageRequest $message,
+        ResponseInterface $expectedResponse,
+    ): void {
+        $actual = $this->subject->getStandardResponse(
+            $message,
+            ResultCode::NO_SUCH_OBJECT,
+            '',
+            new Dn('dc=example,dc=com'),
+        );
+
+        self::assertEquals(
+            $expectedResponse,
+            $actual->getResponse(),
+        );
+    }
+
+    /**
+     * @return array<string, array{LdapMessageRequest, ResponseInterface}>
+     */
+    public static function provideMatchedDnWriteResponseCases(): array
+    {
+        return [
+            'delete' => [
+                new LdapMessageRequest(1, new DeleteRequest('cn=Missing,dc=example,dc=com')),
+                new DeleteResponse(ResultCode::NO_SUCH_OBJECT, 'dc=example,dc=com', ''),
+            ],
+            'modify' => [
+                new LdapMessageRequest(
+                    1,
+                    new ModifyRequest('cn=Missing,dc=example,dc=com', Change::replace('cn', 'x')),
+                ),
+                new ModifyResponse(ResultCode::NO_SUCH_OBJECT, 'dc=example,dc=com', ''),
+            ],
+            'modifyDn' => [
+                new LdapMessageRequest(
+                    1,
+                    new ModifyDnRequest('cn=Missing,dc=example,dc=com', 'cn=other', true),
+                ),
+                new ModifyDnResponse(ResultCode::NO_SUCH_OBJECT, 'dc=example,dc=com', ''),
+            ],
+        ];
+    }
+
+    public function test_matched_dn_is_passed_through_for_any_result_code(): void
+    {
+        $actual = $this->subject->getStandardResponse(
+            new LdapMessageRequest(1, new DeleteRequest('cn=foo,dc=example,dc=com')),
+            ResultCode::ENTRY_ALREADY_EXISTS,
+            '',
+            new Dn('dc=example,dc=com'),
+        );
+
+        self::assertEquals(
+            new DeleteResponse(
+                ResultCode::ENTRY_ALREADY_EXISTS,
+                'dc=example,dc=com',
+                '',
+            ),
+            $actual->getResponse(),
         );
     }
 

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Operation\Response\DeleteResponse;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
@@ -430,6 +431,128 @@ final class ServerDispatchHandlerTest extends TestCase
         $this->subject->handleRequest(
             $request,
             $this->mockToken,
+        );
+    }
+
+    public function test_matched_dn_from_exception_is_used_in_write_response(): void
+    {
+        $matchedDn = new Dn('dc=bar');
+        $matchedEntry = Entry::create('dc=bar');
+        $delete = new LdapMessageRequest(1, new DeleteRequest('cn=Missing,dc=bar'));
+
+        $this->mockWriteHandler
+            ->method('handle')
+            ->willThrowException(new OperationException(
+                'No such object.',
+                ResultCode::NO_SUCH_OBJECT,
+                null,
+                $matchedDn,
+            ));
+
+        $this->mockBackend
+            ->method('get')
+            ->willReturn($matchedEntry);
+        $this->mockAccessControl
+            ->method('filterEntry')
+            ->willReturn($matchedEntry);
+
+        $captured = null;
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('sendMessage')
+            ->willReturnCallback(function (LdapMessageResponse $msg) use (&$captured): LdapMessageResponse {
+                $captured = $msg;
+
+                return $msg;
+            });
+
+        $this->subject->handleRequest($delete, $this->mockToken);
+
+        $response = $captured?->getResponse();
+        self::assertInstanceOf(DeleteResponse::class, $response);
+        self::assertSame(
+            'dc=bar',
+            $response->getDn()->toString(),
+        );
+    }
+
+    public function test_matched_dn_is_dropped_when_access_control_hides_ancestor(): void
+    {
+        $matchedDn = new Dn('dc=bar');
+        $matchedEntry = Entry::create('dc=bar');
+        $delete = new LdapMessageRequest(1, new DeleteRequest('cn=Missing,dc=bar'));
+
+        $this->mockWriteHandler
+            ->method('handle')
+            ->willThrowException(new OperationException(
+                'No such object.',
+                ResultCode::NO_SUCH_OBJECT,
+                null,
+                $matchedDn,
+            ));
+
+        $this->mockBackend
+            ->method('get')
+            ->willReturn($matchedEntry);
+        $this->mockAccessControl
+            ->method('filterEntry')
+            ->willReturn(null);
+
+        $captured = null;
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('sendMessage')
+            ->willReturnCallback(function (LdapMessageResponse $msg) use (&$captured): LdapMessageResponse {
+                $captured = $msg;
+
+                return $msg;
+            });
+
+        $this->subject->handleRequest($delete, $this->mockToken);
+
+        $response = $captured?->getResponse();
+        self::assertInstanceOf(DeleteResponse::class, $response);
+        self::assertSame(
+            '',
+            $response->getDn()->toString(),
+        );
+    }
+
+    public function test_matched_dn_is_dropped_when_backend_returns_no_entry_for_ancestor(): void
+    {
+        $matchedDn = new Dn('dc=bar');
+        $delete = new LdapMessageRequest(1, new DeleteRequest('cn=Missing,dc=bar'));
+
+        $this->mockWriteHandler
+            ->method('handle')
+            ->willThrowException(new OperationException(
+                'No such object.',
+                ResultCode::NO_SUCH_OBJECT,
+                null,
+                $matchedDn,
+            ));
+
+        $this->mockBackend
+            ->method('get')
+            ->willReturn(null);
+
+        $captured = null;
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('sendMessage')
+            ->willReturnCallback(function (LdapMessageResponse $msg) use (&$captured): LdapMessageResponse {
+                $captured = $msg;
+
+                return $msg;
+            });
+
+        $this->subject->handleRequest($delete, $this->mockToken);
+
+        $response = $captured?->getResponse();
+        self::assertInstanceOf(DeleteResponse::class, $response);
+        self::assertSame(
+            '',
+            $response->getDn()->toString(),
         );
     }
 

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Control\PagingControl;
 use FreeDSx\Ldap\Control\Sorting\SortKey;
 use FreeDSx\Ldap\Control\Sorting\SortingControl;
 use FreeDSx\Ldap\Control\Sorting\SortingResponseControl;
+use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
@@ -269,7 +270,7 @@ class ServerPagingHandlerTest extends TestCase
                     $message->getMessageId(),
                     new SearchResultDone(
                         ResultCode::OPERATIONS_ERROR,
-                        'dc=foo,dc=bar',
+                        '',
                         "The search request and controls must be identical between paging requests.",
                     ),
                     new PagingControl(0, ''),
@@ -671,6 +672,91 @@ class ServerPagingHandlerTest extends TestCase
 
         self::assertNull(
             $this->doneMessage()->controls()->get(Control::OID_SORTING_RESPONSE),
+        );
+    }
+
+    public function test_matched_dn_from_exception_is_used_in_SearchResultDone_when_access_control_allows(): void
+    {
+        $matchedDn = new Dn('dc=foo,dc=bar');
+        $matchedEntry = Entry::create('dc=foo,dc=bar');
+
+        $message = $this->makeSearchMessage(size: 10);
+
+        $this->mockBackend
+            ->method('search')
+            ->willThrowException(new OperationException(
+                'No such object.',
+                ResultCode::NO_SUCH_OBJECT,
+                null,
+                $matchedDn,
+            ));
+        $this->mockBackend
+            ->method('get')
+            ->willReturn($matchedEntry);
+
+        $this->subject->handleRequest(
+            $message,
+            $this->mockToken,
+        );
+
+        $done = $this->doneMessage()->getResponse();
+        self::assertInstanceOf(SearchResultDone::class, $done);
+        self::assertSame(
+            ResultCode::NO_SUCH_OBJECT,
+            $done->getResultCode(),
+        );
+        self::assertSame(
+            'dc=foo,dc=bar',
+            $done->getDn()->toString(),
+        );
+    }
+
+    public function test_matched_dn_is_dropped_when_access_control_hides_ancestor_on_paged_search(): void
+    {
+        $matchedDn = new Dn('dc=foo,dc=bar');
+        $matchedEntry = Entry::create('dc=foo,dc=bar');
+
+        $message = $this->makeSearchMessage(size: 10);
+
+        $this->mockBackend
+            ->method('search')
+            ->willThrowException(new OperationException(
+                'No such object.',
+                ResultCode::NO_SUCH_OBJECT,
+                null,
+                $matchedDn,
+            ));
+        $this->mockBackend
+            ->method('get')
+            ->willReturn($matchedEntry);
+
+        $mockAccessControl = $this->createMock(AccessControlInterface::class);
+        $mockAccessControl
+            ->method('filterEntry')
+            ->willReturn(null);
+
+        $subject = new ServerPagingHandler(
+            queue: $this->mockQueue,
+            backend: $this->mockBackend,
+            filterEvaluator: $this->mockFilterEvaluator,
+            accessControl: $mockAccessControl,
+            requestHistory: $this->requestHistory,
+        );
+
+        $subject->handleRequest(
+            $message,
+            $this->mockToken,
+        );
+
+        $done = $this->doneMessage()->getResponse();
+        self::assertInstanceOf(SearchResultDone::class, $done);
+        self::assertSame(
+            ResultCode::NO_SUCH_OBJECT,
+            $done->getResultCode(),
+        );
+        self::assertSame(
+            '',
+            $done->getDn()->toString(),
         );
     }
 

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\Sorting\SortKey;
 use FreeDSx\Ldap\Control\Sorting\SortingControl;
 use FreeDSx\Ldap\Control\Sorting\SortingResponseControl;
+use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\LdapResult;
@@ -217,7 +218,7 @@ final class ServerSearchHandlerTest extends TestCase
                 2,
                 new SearchResultDone(
                     ResultCode::OPERATIONS_ERROR,
-                    'dc=foo,dc=bar',
+                    '',
                     "Fail",
                 ),
             ),
@@ -618,7 +619,7 @@ final class ServerSearchHandlerTest extends TestCase
                 2,
                 new SearchResultDone(
                     ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
-                    'dc=foo,dc=bar',
+                    '',
                     'Critical control 1.2.3.4.5 is not supported.',
                 ),
             ),
@@ -679,6 +680,99 @@ final class ServerSearchHandlerTest extends TestCase
             0,
             $sortControl->getResult(),
         );
+    }
+
+    public function test_matched_dn_from_exception_is_used_in_SearchResultDone_on_error(): void
+    {
+        $matchedDn = new Dn('dc=foo,dc=bar');
+        $matchedEntry = Entry::create('dc=foo,dc=bar');
+
+        $search = new LdapMessageRequest(
+            2,
+            (new SearchRequest(Filters::equal('foo', 'bar')))->base('cn=Missing,dc=foo,dc=bar'),
+        );
+
+        $this->mockBackend
+            ->method('search')
+            ->willThrowException(new OperationException(
+                'No such object.',
+                ResultCode::NO_SUCH_OBJECT,
+                null,
+                $matchedDn,
+            ));
+        $this->mockBackend
+            ->method('get')
+            ->willReturn($matchedEntry);
+        $this->mockAccessControl
+            ->method('filterEntry')
+            ->willReturn($matchedEntry);
+
+        $this->subject->handleRequest(
+            $search,
+            $this->mockToken,
+        );
+
+        $this->assertSentMessages([
+            new LdapMessageResponse(
+                2,
+                new SearchResultDone(
+                    ResultCode::NO_SUCH_OBJECT,
+                    'dc=foo,dc=bar',
+                    'No such object.',
+                ),
+            ),
+        ]);
+    }
+
+    public function test_matched_dn_is_dropped_when_access_control_hides_ancestor_on_search(): void
+    {
+        $matchedDn = new Dn('dc=foo,dc=bar');
+        $matchedEntry = Entry::create('dc=foo,dc=bar');
+
+        $search = new LdapMessageRequest(
+            2,
+            (new SearchRequest(Filters::equal('foo', 'bar')))->base('cn=Missing,dc=foo,dc=bar'),
+        );
+
+        $this->mockBackend
+            ->method('search')
+            ->willThrowException(new OperationException(
+                'No such object.',
+                ResultCode::NO_SUCH_OBJECT,
+                null,
+                $matchedDn,
+            ));
+        $this->mockBackend
+            ->method('get')
+            ->willReturn($matchedEntry);
+
+        $mockAccessControl = $this->createMock(AccessControlInterface::class);
+        $mockAccessControl
+            ->method('filterEntry')
+            ->willReturn(null);
+
+        $subject = new ServerSearchHandler(
+            queue: $this->mockQueue,
+            backend: $this->mockBackend,
+            filterEvaluator: $this->mockFilterEvaluator,
+            accessControl: $mockAccessControl,
+        );
+
+        $subject->handleRequest(
+            $search,
+            $this->mockToken,
+        );
+
+        $this->assertSentMessages([
+            new LdapMessageResponse(
+                2,
+                new SearchResultDone(
+                    ResultCode::NO_SUCH_OBJECT,
+                    '',
+                    'No such object.',
+                ),
+            ),
+        ]);
     }
 
     public function test_no_sort_control_does_not_append_sorting_response_control(): void

--- a/tests/unit/Protocol/ServerProtocolHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandlerTest.php
@@ -189,7 +189,7 @@ final class ServerProtocolHandlerTest extends TestCase
                 1,
                 new ModifyDnResponse(
                     ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
-                    'cn=foo,dc=bar',
+                    '',
                     'Authentication required.',
                 ),
             )))
@@ -361,7 +361,7 @@ final class ServerProtocolHandlerTest extends TestCase
                     2,
                     new ModifyResponse(
                         ResultCode::CONFIDENTIALITY_REQUIRED,
-                        'cn=foo,dc=bar',
+                        '',
                         'Foo.',
                     ),
                 ),

--- a/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
@@ -21,6 +21,7 @@ use FreeDSx\Ldap\Entry\Rdn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Search\Filter\PresentFilter;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Schema\StandardSchemaProvider;
@@ -1099,6 +1100,128 @@ final class WritableStorageBackendTest extends TestCase
         $stored = $this->subject->get(new Dn('dc=example,dc=com'));
 
         self::assertNull($stored?->get('hasSubordinates'));
+    }
+
+    public function test_no_such_object_on_search_base_carries_matched_dn(): void
+    {
+        // dc=example,dc=com exists; cn=Missing does not — matchedDn should be dc=example,dc=com
+        $request = (new SearchRequest(new PresentFilter('objectClass')))
+            ->base('cn=Missing,dc=example,dc=com')
+            ->useBaseScope();
+
+        try {
+            $this->subject->search($request);
+            self::fail('Expected OperationException was not thrown.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                'dc=example,dc=com',
+                $e->getMatchedDn()?->toString(),
+            );
+        }
+    }
+
+    public function test_no_such_object_on_search_subtree_carries_matched_dn(): void
+    {
+        $request = (new SearchRequest(new PresentFilter('objectClass')))
+            ->base('cn=Missing,dc=example,dc=com')
+            ->useSubtreeScope();
+
+        try {
+            $this->subject->search($request);
+            self::fail('Expected OperationException was not thrown.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                'dc=example,dc=com',
+                $e->getMatchedDn()?->toString(),
+            );
+        }
+    }
+
+    public function test_no_such_object_on_delete_carries_matched_dn(): void
+    {
+        try {
+            $this->subject->delete(
+                new DeleteCommand(new Dn('cn=Nobody,dc=example,dc=com')),
+                $this->context(),
+            );
+            self::fail('Expected OperationException was not thrown.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                'dc=example,dc=com',
+                $e->getMatchedDn()?->toString(),
+            );
+        }
+    }
+
+    public function test_no_such_object_on_update_carries_matched_dn(): void
+    {
+        try {
+            $this->subject->update(
+                new UpdateCommand(
+                    new Dn('cn=Nobody,dc=example,dc=com'),
+                    [new Change(Change::TYPE_REPLACE, 'cn', 'Nobody')],
+                ),
+                $this->context(),
+            );
+            self::fail('Expected OperationException was not thrown.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                'dc=example,dc=com',
+                $e->getMatchedDn()?->toString(),
+            );
+        }
+    }
+
+    public function test_no_such_object_on_compare_carries_matched_dn(): void
+    {
+        try {
+            $this->subject->compare(
+                new Dn('cn=Nobody,dc=example,dc=com'),
+                new EqualityFilter('cn', 'Nobody'),
+            );
+            self::fail('Expected OperationException was not thrown.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                'dc=example,dc=com',
+                $e->getMatchedDn()?->toString(),
+            );
+        }
+    }
+
+    public function test_no_such_object_on_add_with_missing_parent_carries_matched_dn(): void
+    {
+        // ou=Missing does not exist; dc=example,dc=com does — matchedDn should be dc=example,dc=com
+        try {
+            $this->subject->add(
+                new AddCommand(new Entry(
+                    new Dn('cn=New,ou=Missing,dc=example,dc=com'),
+                    new Attribute('cn', 'New'),
+                )),
+                $this->context(),
+            );
+            self::fail('Expected OperationException was not thrown.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                'dc=example,dc=com',
+                $e->getMatchedDn()?->toString(),
+            );
+        }
+    }
+
+    public function test_no_such_object_with_no_existing_ancestor_has_null_matched_dn(): void
+    {
+        $backend = new WritableStorageBackend(new InMemoryStorage());
+
+        $request = (new SearchRequest(new PresentFilter('objectClass')))
+            ->base('cn=Missing,dc=example,dc=com')
+            ->useBaseScope();
+
+        try {
+            $backend->search($request);
+            self::fail('Expected OperationException was not thrown.');
+        } catch (OperationException $e) {
+            self::assertNull($e->getMatchedDn());
+        }
     }
 
     /**


### PR DESCRIPTION
I was not returning the correct matchedDN in error responses. It is defined as:

> the matchedDN field is set (subject to
> access controls) to the name of the last entry (object or alias) used
> in finding the target (or base) object.  This will be a truncated
> form of the provided name or, if an alias was dereferenced while
> attempting to locate the entry, of the resulting name.  Otherwise,
> the matchedDN field is empty.

This makes sure we set it correctly on the various operations.