### PR TITLE
[1.0.0] Lay the foundation for server-side password policy support (draft-behera-10)

### DIFF
--- a/src/FreeDSx/Ldap/Exception/PasswordPolicyException.php
+++ b/src/FreeDSx/Ldap/Exception/PasswordPolicyException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Exception;
+
+use Exception;
+
+/**
+ * Raised when a password-policy related error occurs.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class PasswordPolicyException extends Exception {}

--- a/src/FreeDSx/Ldap/Schema/Definition/GeneralizedTime.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/GeneralizedTime.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Definition;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+
+/**
+ * Parser and formatter for the GeneralizedTime LDAP syntax (RFC 4517 §3.3.13).
+ *
+ * Format always emits the canonical "YYYYMMDDHHMMSSZ" UTC form.
+ */
+final class GeneralizedTime
+{
+    private const PATTERN = '/^
+        (?<year>\d{4})
+        (?<month>\d{2})
+        (?<day>\d{2})
+        (?<hour>\d{2})
+        (?:(?<minute>\d{2})
+            (?:(?<second>\d{2}))?
+        )?
+        (?:[.,](?<fraction>\d+))?
+        (?<zone>Z|[+\-]\d{2}(?:\d{2})?)
+    $/x';
+
+    private function __construct() {}
+
+    /**
+     * @throws InvalidArgumentException when the value is not a valid GeneralizedTime.
+     */
+    public static function parse(string $value): DateTimeImmutable
+    {
+        if (preg_match(self::PATTERN, $value, $matches) !== 1) {
+            throw new InvalidArgumentException(sprintf(
+                'Value "%s" is not a valid GeneralizedTime.',
+                $value,
+            ));
+        }
+
+        $iso = self::componentsToIso8601($matches);
+        $parsed = DateTimeImmutable::createFromFormat(
+            self::isoFormat($matches),
+            $iso,
+        );
+        $errors = DateTimeImmutable::getLastErrors();
+        $hasOverflow = $errors !== false
+            && ($errors['warning_count'] > 0 || $errors['error_count'] > 0);
+        if ($parsed === false || $hasOverflow) {
+            throw new InvalidArgumentException(sprintf(
+                'Value "%s" contains an invalid date or time component.',
+                $value,
+            ));
+        }
+
+        return $parsed->setTimezone(new DateTimeZone('UTC'));
+    }
+
+    /**
+     * Render as the canonical UTC GeneralizedTime form: YYYYMMDDHHMMSSZ.
+     */
+    public static function format(DateTimeImmutable $instant): string
+    {
+        return $instant
+            ->setTimezone(new DateTimeZone('UTC'))
+            ->format('YmdHis') . 'Z';
+    }
+
+    /**
+     * @param array<int|string, string> $components named capture groups
+     */
+    private static function componentsToIso8601(array $components): string
+    {
+        $minute = ($components['minute'] ?? '') !== '' ? $components['minute'] : '00';
+        $second = ($components['second'] ?? '') !== '' ? $components['second'] : '00';
+        $fraction = ($components['fraction'] ?? '') !== '' ? '.' . $components['fraction'] : '';
+        $zone = $components['zone'] === 'Z'
+            ? '+0000'
+            : self::normalizeZone($components['zone']);
+
+        return sprintf(
+            '%s-%s-%sT%s:%s:%s%s%s',
+            $components['year'],
+            $components['month'],
+            $components['day'],
+            $components['hour'],
+            $minute,
+            $second,
+            $fraction,
+            $zone,
+        );
+    }
+
+    /**
+     * @param array<int|string, string> $components named capture groups
+     */
+    private static function isoFormat(array $components): string
+    {
+        $fraction = ($components['fraction'] ?? '') !== '' ? '.u' : '';
+
+        return 'Y-m-d\\TH:i:s' . $fraction . 'O';
+    }
+
+    private static function normalizeZone(string $zone): string
+    {
+        return strlen($zone) === 3
+            ? $zone . '00'
+            : $zone;
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Definition/PasswordPolicyOid.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/PasswordPolicyOid.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Definition;
+
+/**
+ * OIDs, names, and descriptions for draft-behera-ldap-password-policy-10 attributes and object classes.
+ */
+final class PasswordPolicyOid
+{
+    public const OID_PWD_ATTRIBUTE = '1.3.6.1.4.1.42.2.27.8.1.1';
+    public const NAME_PWD_ATTRIBUTE = 'pwdAttribute';
+    public const DESC_PWD_ATTRIBUTE = 'attribute to which the policy applies';
+
+    public const OID_PWD_MIN_AGE = '1.3.6.1.4.1.42.2.27.8.1.2';
+    public const NAME_PWD_MIN_AGE = 'pwdMinAge';
+    public const DESC_PWD_MIN_AGE = 'minimum seconds between password changes';
+
+    public const OID_PWD_MAX_AGE = '1.3.6.1.4.1.42.2.27.8.1.3';
+    public const NAME_PWD_MAX_AGE = 'pwdMaxAge';
+    public const DESC_PWD_MAX_AGE = 'maximum seconds a password remains valid';
+
+    public const OID_PWD_IN_HISTORY = '1.3.6.1.4.1.42.2.27.8.1.4';
+    public const NAME_PWD_IN_HISTORY = 'pwdInHistory';
+    public const DESC_PWD_IN_HISTORY = 'number of prior passwords retained for history checks';
+
+    public const OID_PWD_CHECK_QUALITY = '1.3.6.1.4.1.42.2.27.8.1.5';
+    public const NAME_PWD_CHECK_QUALITY = 'pwdCheckQuality';
+    public const DESC_PWD_CHECK_QUALITY = 'quality enforcement level (0=off, 1=lenient, 2=strict)';
+
+    public const OID_PWD_MIN_LENGTH = '1.3.6.1.4.1.42.2.27.8.1.6';
+    public const NAME_PWD_MIN_LENGTH = 'pwdMinLength';
+    public const DESC_PWD_MIN_LENGTH = 'minimum password length in characters';
+
+    public const OID_PWD_EXPIRE_WARNING = '1.3.6.1.4.1.42.2.27.8.1.7';
+    public const NAME_PWD_EXPIRE_WARNING = 'pwdExpireWarning';
+    public const DESC_PWD_EXPIRE_WARNING = 'seconds before expiration at which to warn the user';
+
+    public const OID_PWD_GRACE_AUTHN_LIMIT = '1.3.6.1.4.1.42.2.27.8.1.8';
+    public const NAME_PWD_GRACE_AUTHN_LIMIT = 'pwdGraceAuthNLimit';
+    public const DESC_PWD_GRACE_AUTHN_LIMIT = 'number of grace logins permitted after expiration';
+
+    public const OID_PWD_LOCKOUT = '1.3.6.1.4.1.42.2.27.8.1.9';
+    public const NAME_PWD_LOCKOUT = 'pwdLockout';
+    public const DESC_PWD_LOCKOUT = 'whether failed bind attempts can lock the account';
+
+    public const OID_PWD_LOCKOUT_DURATION = '1.3.6.1.4.1.42.2.27.8.1.10';
+    public const NAME_PWD_LOCKOUT_DURATION = 'pwdLockoutDuration';
+    public const DESC_PWD_LOCKOUT_DURATION = 'seconds an account stays locked (0 = until reset)';
+
+    public const OID_PWD_MAX_FAILURE = '1.3.6.1.4.1.42.2.27.8.1.11';
+    public const NAME_PWD_MAX_FAILURE = 'pwdMaxFailure';
+    public const DESC_PWD_MAX_FAILURE = 'failed bind threshold that triggers lockout';
+
+    public const OID_PWD_FAILURE_COUNT_INTERVAL = '1.3.6.1.4.1.42.2.27.8.1.12';
+    public const NAME_PWD_FAILURE_COUNT_INTERVAL = 'pwdFailureCountInterval';
+    public const DESC_PWD_FAILURE_COUNT_INTERVAL = 'seconds before old failure counts are forgotten';
+
+    public const OID_PWD_MUST_CHANGE = '1.3.6.1.4.1.42.2.27.8.1.13';
+    public const NAME_PWD_MUST_CHANGE = 'pwdMustChange';
+    public const DESC_PWD_MUST_CHANGE = 'whether the user must change password after admin reset';
+
+    public const OID_PWD_ALLOW_USER_CHANGE = '1.3.6.1.4.1.42.2.27.8.1.14';
+    public const NAME_PWD_ALLOW_USER_CHANGE = 'pwdAllowUserChange';
+    public const DESC_PWD_ALLOW_USER_CHANGE = 'whether the user may change their own password';
+
+    public const OID_PWD_SAFE_MODIFY = '1.3.6.1.4.1.42.2.27.8.1.15';
+    public const NAME_PWD_SAFE_MODIFY = 'pwdSafeModify';
+    public const DESC_PWD_SAFE_MODIFY = 'whether password change requires the existing password';
+
+    public const OID_PWD_CHANGED_TIME = '1.3.6.1.4.1.42.2.27.8.1.16';
+    public const NAME_PWD_CHANGED_TIME = 'pwdChangedTime';
+    public const DESC_PWD_CHANGED_TIME = 'time the password was last changed';
+
+    public const OID_PWD_ACCOUNT_LOCKED_TIME = '1.3.6.1.4.1.42.2.27.8.1.17';
+    public const NAME_PWD_ACCOUNT_LOCKED_TIME = 'pwdAccountLockedTime';
+    public const DESC_PWD_ACCOUNT_LOCKED_TIME = 'time the account became locked';
+
+    public const OID_PWD_FAILURE_TIME = '1.3.6.1.4.1.42.2.27.8.1.19';
+    public const NAME_PWD_FAILURE_TIME = 'pwdFailureTime';
+    public const DESC_PWD_FAILURE_TIME = 'timestamps of recent consecutive bind failures';
+
+    public const OID_PWD_HISTORY = '1.3.6.1.4.1.42.2.27.8.1.20';
+    public const NAME_PWD_HISTORY = 'pwdHistory';
+    public const DESC_PWD_HISTORY = 'history of prior password values';
+
+    public const OID_PWD_GRACE_USE_TIME = '1.3.6.1.4.1.42.2.27.8.1.21';
+    public const NAME_PWD_GRACE_USE_TIME = 'pwdGraceUseTime';
+    public const DESC_PWD_GRACE_USE_TIME = 'timestamps of grace logins consumed after expiration';
+
+    public const OID_PWD_RESET = '1.3.6.1.4.1.42.2.27.8.1.22';
+    public const NAME_PWD_RESET = 'pwdReset';
+    public const DESC_PWD_RESET = 'whether the password was reset and must be changed';
+
+    public const OID_PWD_POLICY_SUBENTRY = '1.3.6.1.4.1.42.2.27.8.1.23';
+    public const NAME_PWD_POLICY_SUBENTRY = 'pwdPolicySubentry';
+    public const DESC_PWD_POLICY_SUBENTRY = 'DN of the pwdPolicy entry that governs this user';
+
+    public const OID_PWD_MIN_DELAY = '1.3.6.1.4.1.42.2.27.8.1.24';
+    public const NAME_PWD_MIN_DELAY = 'pwdMinDelay';
+    public const DESC_PWD_MIN_DELAY = 'minimum seconds to delay after each failed bind';
+
+    public const OID_PWD_MAX_DELAY = '1.3.6.1.4.1.42.2.27.8.1.25';
+    public const NAME_PWD_MAX_DELAY = 'pwdMaxDelay';
+    public const DESC_PWD_MAX_DELAY = 'maximum seconds to delay after each failed bind';
+
+    public const OID_PWD_MAX_IDLE = '1.3.6.1.4.1.42.2.27.8.1.26';
+    public const NAME_PWD_MAX_IDLE = 'pwdMaxIdle';
+    public const DESC_PWD_MAX_IDLE = 'seconds without successful bind before lockout';
+
+    public const OID_PWD_START_TIME = '1.3.6.1.4.1.42.2.27.8.1.27';
+    public const NAME_PWD_START_TIME = 'pwdStartTime';
+    public const DESC_PWD_START_TIME = 'time the password becomes valid for authentication';
+
+    public const OID_PWD_END_TIME = '1.3.6.1.4.1.42.2.27.8.1.28';
+    public const NAME_PWD_END_TIME = 'pwdEndTime';
+    public const DESC_PWD_END_TIME = 'time the password stops being valid for authentication';
+
+    public const OID_PWD_LAST_SUCCESS = '1.3.6.1.4.1.42.2.27.8.1.29';
+    public const NAME_PWD_LAST_SUCCESS = 'pwdLastSuccess';
+    public const DESC_PWD_LAST_SUCCESS = 'time of the last successful bind';
+
+    public const OID_PWD_GRACE_EXPIRY = '1.3.6.1.4.1.42.2.27.8.1.30';
+    public const NAME_PWD_GRACE_EXPIRY = 'pwdGraceExpiry';
+    public const DESC_PWD_GRACE_EXPIRY = 'seconds after expiration during which grace logins remain valid';
+
+    public const OID_PWD_MAX_LENGTH = '1.3.6.1.4.1.42.2.27.8.1.31';
+    public const NAME_PWD_MAX_LENGTH = 'pwdMaxLength';
+    public const DESC_PWD_MAX_LENGTH = 'maximum password length in characters';
+
+    public const OID_PWD_POLICY = '1.3.6.1.4.1.42.2.27.8.2.1';
+    public const NAME_PWD_POLICY = 'pwdPolicy';
+    public const DESC_PWD_POLICY = 'auxiliary class for entries that define a password policy';
+
+    /**
+     * Sentinel for pwdAccountLockedTime indicating a permanent administrative lockout.
+     */
+    public const PERMANENT_LOCK_SENTINEL = '000001010000Z';
+
+    private function __construct() {}
+}

--- a/src/FreeDSx/Ldap/Schema/PasswordPolicySchemaProvider.php
+++ b/src/FreeDSx/Ldap/Schema/PasswordPolicySchemaProvider.php
@@ -1,0 +1,335 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema;
+
+use FreeDSx\Ldap\Schema\Definition\AttributeType;
+use FreeDSx\Ldap\Schema\Definition\AttributeUsage;
+use FreeDSx\Ldap\Schema\Definition\MatchingRuleOid;
+use FreeDSx\Ldap\Schema\Definition\ObjectClass;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassType;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Schema\Definition\SyntaxOid;
+
+/**
+ * Builds the draft-behera-ldap-password-policy-10 attribute types and the pwdPolicy auxiliary class.
+ */
+final class PasswordPolicySchemaProvider
+{
+    public static function build(): Schema
+    {
+        $schema = new Schema();
+
+        foreach (self::attributeTypes() as $type) {
+            $schema->addAttributeType($type);
+        }
+        foreach (self::objectClasses() as $class) {
+            $schema->addObjectClass($class);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * @return list<AttributeType>
+     */
+    private static function attributeTypes(): array
+    {
+        return [
+            ...self::policyConfigAttributes(),
+            ...self::userStateAttributes(),
+        ];
+    }
+
+    /**
+     * @return list<AttributeType>
+     */
+    private static function policyConfigAttributes(): array
+    {
+        return [
+            new AttributeType(
+                PasswordPolicyOid::OID_PWD_ATTRIBUTE,
+                [PasswordPolicyOid::NAME_PWD_ATTRIBUTE],
+                equalityOid: MatchingRuleOid::OID_OBJECT_IDENTIFIER_MATCH,
+                syntaxOid: SyntaxOid::OID_OID,
+                singleValue: true,
+                desc: PasswordPolicyOid::DESC_PWD_ATTRIBUTE,
+            ),
+            self::integer(
+                PasswordPolicyOid::OID_PWD_MIN_AGE,
+                PasswordPolicyOid::NAME_PWD_MIN_AGE,
+                PasswordPolicyOid::DESC_PWD_MIN_AGE,
+            ),
+            self::integer(
+                PasswordPolicyOid::OID_PWD_MAX_AGE,
+                PasswordPolicyOid::NAME_PWD_MAX_AGE,
+                PasswordPolicyOid::DESC_PWD_MAX_AGE,
+            ),
+            self::integer(
+                PasswordPolicyOid::OID_PWD_IN_HISTORY,
+                PasswordPolicyOid::NAME_PWD_IN_HISTORY,
+                PasswordPolicyOid::DESC_PWD_IN_HISTORY,
+            ),
+            self::integer(
+                PasswordPolicyOid::OID_PWD_CHECK_QUALITY,
+                PasswordPolicyOid::NAME_PWD_CHECK_QUALITY,
+                PasswordPolicyOid::DESC_PWD_CHECK_QUALITY,
+            ),
+            self::integer(
+                PasswordPolicyOid::OID_PWD_MIN_LENGTH,
+                PasswordPolicyOid::NAME_PWD_MIN_LENGTH,
+                PasswordPolicyOid::DESC_PWD_MIN_LENGTH,
+            ),
+            self::integer(
+                PasswordPolicyOid::OID_PWD_EXPIRE_WARNING,
+                PasswordPolicyOid::NAME_PWD_EXPIRE_WARNING,
+                PasswordPolicyOid::DESC_PWD_EXPIRE_WARNING,
+            ),
+            self::integer(
+                PasswordPolicyOid::OID_PWD_GRACE_AUTHN_LIMIT,
+                PasswordPolicyOid::NAME_PWD_GRACE_AUTHN_LIMIT,
+                PasswordPolicyOid::DESC_PWD_GRACE_AUTHN_LIMIT,
+            ),
+            self::boolean(
+                PasswordPolicyOid::OID_PWD_LOCKOUT,
+                PasswordPolicyOid::NAME_PWD_LOCKOUT,
+                PasswordPolicyOid::DESC_PWD_LOCKOUT,
+            ),
+            self::integer(
+                PasswordPolicyOid::OID_PWD_LOCKOUT_DURATION,
+                PasswordPolicyOid::NAME_PWD_LOCKOUT_DURATION,
+                PasswordPolicyOid::DESC_PWD_LOCKOUT_DURATION,
+            ),
+            self::integer(
+                PasswordPolicyOid::OID_PWD_MAX_FAILURE,
+                PasswordPolicyOid::NAME_PWD_MAX_FAILURE,
+                PasswordPolicyOid::DESC_PWD_MAX_FAILURE,
+            ),
+            self::integer(
+                PasswordPolicyOid::OID_PWD_FAILURE_COUNT_INTERVAL,
+                PasswordPolicyOid::NAME_PWD_FAILURE_COUNT_INTERVAL,
+                PasswordPolicyOid::DESC_PWD_FAILURE_COUNT_INTERVAL,
+            ),
+            self::boolean(
+                PasswordPolicyOid::OID_PWD_MUST_CHANGE,
+                PasswordPolicyOid::NAME_PWD_MUST_CHANGE,
+                PasswordPolicyOid::DESC_PWD_MUST_CHANGE,
+            ),
+            self::boolean(
+                PasswordPolicyOid::OID_PWD_ALLOW_USER_CHANGE,
+                PasswordPolicyOid::NAME_PWD_ALLOW_USER_CHANGE,
+                PasswordPolicyOid::DESC_PWD_ALLOW_USER_CHANGE,
+            ),
+            self::boolean(
+                PasswordPolicyOid::OID_PWD_SAFE_MODIFY,
+                PasswordPolicyOid::NAME_PWD_SAFE_MODIFY,
+                PasswordPolicyOid::DESC_PWD_SAFE_MODIFY,
+            ),
+            self::integer(
+                PasswordPolicyOid::OID_PWD_MIN_DELAY,
+                PasswordPolicyOid::NAME_PWD_MIN_DELAY,
+                PasswordPolicyOid::DESC_PWD_MIN_DELAY,
+            ),
+            self::integer(
+                PasswordPolicyOid::OID_PWD_MAX_DELAY,
+                PasswordPolicyOid::NAME_PWD_MAX_DELAY,
+                PasswordPolicyOid::DESC_PWD_MAX_DELAY,
+            ),
+            self::integer(
+                PasswordPolicyOid::OID_PWD_MAX_IDLE,
+                PasswordPolicyOid::NAME_PWD_MAX_IDLE,
+                PasswordPolicyOid::DESC_PWD_MAX_IDLE,
+            ),
+            self::integer(
+                PasswordPolicyOid::OID_PWD_GRACE_EXPIRY,
+                PasswordPolicyOid::NAME_PWD_GRACE_EXPIRY,
+                PasswordPolicyOid::DESC_PWD_GRACE_EXPIRY,
+            ),
+            self::integer(
+                PasswordPolicyOid::OID_PWD_MAX_LENGTH,
+                PasswordPolicyOid::NAME_PWD_MAX_LENGTH,
+                PasswordPolicyOid::DESC_PWD_MAX_LENGTH,
+            ),
+        ];
+    }
+
+    /**
+     * @return list<AttributeType>
+     */
+    private static function userStateAttributes(): array
+    {
+        return [
+            self::operationalGeneralizedTime(
+                PasswordPolicyOid::OID_PWD_CHANGED_TIME,
+                PasswordPolicyOid::NAME_PWD_CHANGED_TIME,
+                PasswordPolicyOid::DESC_PWD_CHANGED_TIME,
+                singleValue: true,
+            ),
+            self::operationalGeneralizedTime(
+                PasswordPolicyOid::OID_PWD_ACCOUNT_LOCKED_TIME,
+                PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME,
+                PasswordPolicyOid::DESC_PWD_ACCOUNT_LOCKED_TIME,
+                singleValue: true,
+            ),
+            self::operationalGeneralizedTime(
+                PasswordPolicyOid::OID_PWD_FAILURE_TIME,
+                PasswordPolicyOid::NAME_PWD_FAILURE_TIME,
+                PasswordPolicyOid::DESC_PWD_FAILURE_TIME,
+                singleValue: false,
+            ),
+            new AttributeType(
+                PasswordPolicyOid::OID_PWD_HISTORY,
+                [PasswordPolicyOid::NAME_PWD_HISTORY],
+                equalityOid: MatchingRuleOid::OID_OCTET_STRING_MATCH,
+                syntaxOid: SyntaxOid::OID_OCTET_STRING,
+                noUserModification: true,
+                usage: AttributeUsage::DirectoryOperation,
+                desc: PasswordPolicyOid::DESC_PWD_HISTORY,
+            ),
+            new AttributeType(
+                PasswordPolicyOid::OID_PWD_GRACE_USE_TIME,
+                [PasswordPolicyOid::NAME_PWD_GRACE_USE_TIME],
+                equalityOid: MatchingRuleOid::OID_GENERALIZED_TIME_MATCH,
+                syntaxOid: SyntaxOid::OID_GENERALIZED_TIME,
+                noUserModification: true,
+                usage: AttributeUsage::DirectoryOperation,
+                desc: PasswordPolicyOid::DESC_PWD_GRACE_USE_TIME,
+            ),
+            self::operationalGeneralizedTime(
+                PasswordPolicyOid::OID_PWD_START_TIME,
+                PasswordPolicyOid::NAME_PWD_START_TIME,
+                PasswordPolicyOid::DESC_PWD_START_TIME,
+                singleValue: true,
+            ),
+            self::operationalGeneralizedTime(
+                PasswordPolicyOid::OID_PWD_END_TIME,
+                PasswordPolicyOid::NAME_PWD_END_TIME,
+                PasswordPolicyOid::DESC_PWD_END_TIME,
+                singleValue: true,
+            ),
+            self::operationalGeneralizedTime(
+                PasswordPolicyOid::OID_PWD_LAST_SUCCESS,
+                PasswordPolicyOid::NAME_PWD_LAST_SUCCESS,
+                PasswordPolicyOid::DESC_PWD_LAST_SUCCESS,
+                singleValue: true,
+            ),
+            new AttributeType(
+                PasswordPolicyOid::OID_PWD_RESET,
+                [PasswordPolicyOid::NAME_PWD_RESET],
+                equalityOid: MatchingRuleOid::OID_BOOLEAN_MATCH,
+                syntaxOid: SyntaxOid::OID_BOOLEAN,
+                singleValue: true,
+                noUserModification: true,
+                usage: AttributeUsage::DirectoryOperation,
+                desc: PasswordPolicyOid::DESC_PWD_RESET,
+            ),
+            new AttributeType(
+                PasswordPolicyOid::OID_PWD_POLICY_SUBENTRY,
+                [PasswordPolicyOid::NAME_PWD_POLICY_SUBENTRY],
+                equalityOid: MatchingRuleOid::OID_DISTINGUISHED_NAME_MATCH,
+                syntaxOid: SyntaxOid::OID_DISTINGUISHED_NAME,
+                singleValue: true,
+                noUserModification: true,
+                usage: AttributeUsage::DirectoryOperation,
+                desc: PasswordPolicyOid::DESC_PWD_POLICY_SUBENTRY,
+            ),
+        ];
+    }
+
+    /**
+     * @return list<ObjectClass>
+     */
+    private static function objectClasses(): array
+    {
+        return [
+            new ObjectClass(
+                PasswordPolicyOid::OID_PWD_POLICY,
+                [PasswordPolicyOid::NAME_PWD_POLICY],
+                type: ObjectClassType::AuxiliaryClass,
+                must: [PasswordPolicyOid::NAME_PWD_ATTRIBUTE],
+                may: [
+                    PasswordPolicyOid::NAME_PWD_MIN_AGE,
+                    PasswordPolicyOid::NAME_PWD_MAX_AGE,
+                    PasswordPolicyOid::NAME_PWD_IN_HISTORY,
+                    PasswordPolicyOid::NAME_PWD_CHECK_QUALITY,
+                    PasswordPolicyOid::NAME_PWD_MIN_LENGTH,
+                    PasswordPolicyOid::NAME_PWD_MAX_LENGTH,
+                    PasswordPolicyOid::NAME_PWD_EXPIRE_WARNING,
+                    PasswordPolicyOid::NAME_PWD_GRACE_AUTHN_LIMIT,
+                    PasswordPolicyOid::NAME_PWD_GRACE_EXPIRY,
+                    PasswordPolicyOid::NAME_PWD_LOCKOUT,
+                    PasswordPolicyOid::NAME_PWD_LOCKOUT_DURATION,
+                    PasswordPolicyOid::NAME_PWD_MAX_FAILURE,
+                    PasswordPolicyOid::NAME_PWD_FAILURE_COUNT_INTERVAL,
+                    PasswordPolicyOid::NAME_PWD_MUST_CHANGE,
+                    PasswordPolicyOid::NAME_PWD_ALLOW_USER_CHANGE,
+                    PasswordPolicyOid::NAME_PWD_SAFE_MODIFY,
+                    PasswordPolicyOid::NAME_PWD_MIN_DELAY,
+                    PasswordPolicyOid::NAME_PWD_MAX_DELAY,
+                    PasswordPolicyOid::NAME_PWD_MAX_IDLE,
+                ],
+                desc: PasswordPolicyOid::DESC_PWD_POLICY,
+            ),
+        ];
+    }
+
+    private static function integer(
+        string $oid,
+        string $name,
+        string $desc,
+    ): AttributeType {
+        return new AttributeType(
+            $oid,
+            [$name],
+            equalityOid: MatchingRuleOid::OID_INTEGER_MATCH,
+            orderingOid: MatchingRuleOid::OID_INTEGER_ORDERING_MATCH,
+            syntaxOid: SyntaxOid::OID_INTEGER,
+            singleValue: true,
+            desc: $desc,
+        );
+    }
+
+    private static function boolean(
+        string $oid,
+        string $name,
+        string $desc,
+    ): AttributeType {
+        return new AttributeType(
+            $oid,
+            [$name],
+            equalityOid: MatchingRuleOid::OID_BOOLEAN_MATCH,
+            syntaxOid: SyntaxOid::OID_BOOLEAN,
+            singleValue: true,
+            desc: $desc,
+        );
+    }
+
+    private static function operationalGeneralizedTime(
+        string $oid,
+        string $name,
+        string $desc,
+        bool $singleValue,
+    ): AttributeType {
+        return new AttributeType(
+            $oid,
+            [$name],
+            equalityOid: MatchingRuleOid::OID_GENERALIZED_TIME_MATCH,
+            orderingOid: MatchingRuleOid::OID_GENERALIZED_TIME_ORDERING_MATCH,
+            syntaxOid: SyntaxOid::OID_GENERALIZED_TIME,
+            singleValue: $singleValue,
+            noUserModification: true,
+            usage: AttributeUsage::DirectoryOperation,
+            desc: $desc,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Clock/ClockInterface.php
+++ b/src/FreeDSx/Ldap/Server/Clock/ClockInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Clock;
+
+use DateTimeImmutable;
+
+/**
+ * Abstraction over the current wall-clock time.
+ */
+interface ClockInterface
+{
+    public function now(): DateTimeImmutable;
+}

--- a/src/FreeDSx/Ldap/Server/Clock/SystemClock.php
+++ b/src/FreeDSx/Ldap/Server/Clock/SystemClock.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Clock;
+
+use DateTimeImmutable;
+use DateTimeZone;
+
+/**
+ * Production clock backed by the system time, normalized to UTC.
+ */
+final class SystemClock implements ClockInterface
+{
+    public function now(): DateTimeImmutable
+    {
+        return new DateTimeImmutable(
+            'now',
+            new DateTimeZone('UTC'),
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/HistoryEntry.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/HistoryEntry.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy;
+
+use DateTimeImmutable;
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Exception\PasswordPolicyException;
+use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
+use FreeDSx\Ldap\Schema\Definition\SyntaxOid;
+
+/**
+ * One pwdHistory value (draft-behera-10 §5.3.7): time#syntaxOID#length#data.
+ */
+final readonly class HistoryEntry
+{
+    public function __construct(
+        public DateTimeImmutable $changedAt,
+        public string $syntaxOid,
+        public string $data,
+    ) {}
+
+    /**
+     * Decode a pwdHistory attribute value.
+     *
+     * @throws PasswordPolicyException when the value does not conform to the spec.
+     */
+    public static function decode(string $value): self
+    {
+        $timeEnd = self::expectDelimiter(
+            $value,
+            0,
+            'time',
+        );
+        $syntaxEnd = self::expectDelimiter(
+            $value,
+            $timeEnd + 1,
+            'syntax',
+        );
+        $lengthEnd = self::expectDelimiter(
+            $value,
+            $syntaxEnd + 1,
+            'length',
+        );
+
+        $timeRaw = substr(
+            $value,
+            0,
+            $timeEnd,
+        );
+        $syntaxOid = substr(
+            $value,
+            $timeEnd + 1,
+            $syntaxEnd - $timeEnd - 1,
+        );
+        $lengthRaw = substr(
+            $value,
+            $syntaxEnd + 1,
+            $lengthEnd - $syntaxEnd - 1,
+        );
+        $data = substr(
+            $value,
+            $lengthEnd + 1,
+        );
+
+        self::assertSyntaxOid($syntaxOid);
+        $length = self::parseLength($lengthRaw);
+        self::assertDataLength(
+            $length,
+            $data,
+        );
+
+        return new self(
+            self::parseTime($timeRaw),
+            $syntaxOid,
+            $data,
+        );
+    }
+
+    /**
+     * Build a history entry for a stored password value, defaulting the syntax to Octet String per RFC 4517.
+     */
+    public static function forStoredPassword(
+        DateTimeImmutable $changedAt,
+        string $storedPassword,
+        string $syntaxOid = SyntaxOid::OID_OCTET_STRING,
+    ): self {
+        return new self(
+            $changedAt,
+            $syntaxOid,
+            $storedPassword,
+        );
+    }
+
+    /**
+     * Encode as the pwdHistory attribute value.
+     */
+    public function encode(): string
+    {
+        return sprintf(
+            '%s#%s#%d#%s',
+            GeneralizedTime::format($this->changedAt),
+            $this->syntaxOid,
+            strlen($this->data),
+            $this->data,
+        );
+    }
+
+    /**
+     * @throws PasswordPolicyException
+     */
+    private static function expectDelimiter(
+        string $value,
+        int $from,
+        string $segmentLabel,
+    ): int {
+        $position = strpos(
+            $value,
+            '#',
+            $from,
+        );
+        if ($position === false) {
+            throw new PasswordPolicyException(sprintf(
+                'Invalid pwdHistory value: missing %s delimiter.',
+                $segmentLabel,
+            ));
+        }
+
+        return $position;
+    }
+
+    /**
+     * @throws PasswordPolicyException
+     */
+    private static function assertSyntaxOid(string $syntaxOid): void
+    {
+        if ($syntaxOid === '') {
+            throw new PasswordPolicyException(
+                'Invalid pwdHistory value: empty syntax OID.',
+            );
+        }
+    }
+
+    /**
+     * @throws PasswordPolicyException
+     */
+    private static function parseLength(string $raw): int
+    {
+        if ($raw === '' || !ctype_digit($raw)) {
+            throw new PasswordPolicyException(
+                'Invalid pwdHistory value: length is not a non-negative integer.',
+            );
+        }
+
+        return (int) $raw;
+    }
+
+    /**
+     * @throws PasswordPolicyException
+     */
+    private static function assertDataLength(
+        int $declared,
+        string $data,
+    ): void {
+        $actual = strlen($data);
+        if ($actual !== $declared) {
+            throw new PasswordPolicyException(sprintf(
+                'Invalid pwdHistory value: declared length %d does not match data length %d.',
+                $declared,
+                $actual,
+            ));
+        }
+    }
+
+    /**
+     * @throws PasswordPolicyException
+     */
+    private static function parseTime(string $raw): DateTimeImmutable
+    {
+        try {
+            return GeneralizedTime::parse($raw);
+        } catch (InvalidArgumentException $cause) {
+            throw new PasswordPolicyException(
+                sprintf(
+                    'Invalid pwdHistory value: time "%s" is not a valid GeneralizedTime.',
+                    $raw,
+                ),
+                previous: $cause,
+            );
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicy.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicy.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy;
+
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\PasswordPolicyException;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordChangeRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordExpirationRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
+
+/**
+ * Decoded view of a pwdPolicy entry per draft-behera-ldap-password-policy-10 §5.2.
+ *
+ * Nullable fields on the rule DTOs mean "policy unspecified" and are interpreted as "no limit" by the engine.
+ */
+final readonly class PasswordPolicy
+{
+    public function __construct(
+        public string $pwdAttribute = AttributeTypeOid::NAME_USER_PASSWORD,
+        public PasswordQualityRules $quality = new PasswordQualityRules(),
+        public PasswordChangeRules $change = new PasswordChangeRules(),
+        public PasswordExpirationRules $expiration = new PasswordExpirationRules(),
+        public PasswordLockoutRules $lockout = new PasswordLockoutRules(),
+    ) {}
+
+    /**
+     * @throws PasswordPolicyException when pwdAttribute is missing or any value fails to parse.
+     */
+    public static function fromEntry(Entry $entry): self
+    {
+        $pwdAttribute = $entry
+            ->get(PasswordPolicyOid::NAME_PWD_ATTRIBUTE)
+            ?->firstValue();
+        if ($pwdAttribute === null || $pwdAttribute === '') {
+            throw new PasswordPolicyException(sprintf(
+                'pwdPolicy entry "%s" is missing the required pwdAttribute.',
+                $entry->getDn()->toString(),
+            ));
+        }
+
+        return new self(
+            $pwdAttribute,
+            quality: self::readQuality($entry),
+            change: self::readChange($entry),
+            expiration: self::readExpiration($entry),
+            lockout: self::readLockout($entry),
+        );
+    }
+
+    private static function readQuality(Entry $entry): PasswordQualityRules
+    {
+        return new PasswordQualityRules(
+            minLength: self::readInt(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_MIN_LENGTH,
+            ),
+            maxLength: self::readInt(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_MAX_LENGTH,
+            ),
+            inHistory: self::readInt(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_IN_HISTORY,
+            ),
+            checkQuality: self::readInt(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_CHECK_QUALITY,
+            ),
+        );
+    }
+
+    private static function readChange(Entry $entry): PasswordChangeRules
+    {
+        return new PasswordChangeRules(
+            minAge: self::readInt(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_MIN_AGE,
+            ),
+            mustChange: self::readBool(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_MUST_CHANGE,
+            ),
+            allowUserChange: self::readBool(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_ALLOW_USER_CHANGE,
+            ),
+            safeModify: self::readBool(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_SAFE_MODIFY,
+            ),
+        );
+    }
+
+    private static function readExpiration(Entry $entry): PasswordExpirationRules
+    {
+        return new PasswordExpirationRules(
+            maxAge: self::readInt(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_MAX_AGE,
+            ),
+            expireWarning: self::readInt(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_EXPIRE_WARNING,
+            ),
+            graceAuthnLimit: self::readInt(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_GRACE_AUTHN_LIMIT,
+            ),
+            graceExpiry: self::readInt(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_GRACE_EXPIRY,
+            ),
+            maxIdle: self::readInt(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_MAX_IDLE,
+            ),
+        );
+    }
+
+    private static function readLockout(Entry $entry): PasswordLockoutRules
+    {
+        return new PasswordLockoutRules(
+            enabled: self::readBool(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_LOCKOUT,
+            ),
+            duration: self::readInt(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_LOCKOUT_DURATION,
+            ),
+            maxFailure: self::readInt(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_MAX_FAILURE,
+            ),
+            failureCountInterval: self::readInt(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_FAILURE_COUNT_INTERVAL,
+            ),
+            minDelay: self::readInt(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_MIN_DELAY,
+            ),
+            maxDelay: self::readInt(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_MAX_DELAY,
+            ),
+        );
+    }
+
+    /**
+     * @return int<0, max>|null
+     * @throws PasswordPolicyException
+     */
+    private static function readInt(
+        Entry $entry,
+        string $name,
+    ): ?int {
+        $value = $entry->get($name)?->firstValue();
+        if ($value === null) {
+            return null;
+        }
+
+        if (!ctype_digit($value)) {
+            throw new PasswordPolicyException(sprintf(
+                'pwdPolicy entry "%s" has invalid value "%s" for %s; expected a non-negative integer.',
+                $entry->getDn()->toString(),
+                $value,
+                $name,
+            ));
+        }
+
+        return max(
+            0,
+            (int) $value,
+        );
+    }
+
+    private static function readBool(
+        Entry $entry,
+        string $name,
+    ): ?bool {
+        $value = $entry->get($name)?->firstValue();
+        if ($value === null) {
+            return null;
+        }
+
+        return match (strtoupper($value)) {
+            'TRUE' => true,
+            'FALSE' => false,
+            default => throw new PasswordPolicyException(sprintf(
+                'pwdPolicy entry "%s" has non-boolean value "%s" for %s.',
+                $entry->getDn()->toString(),
+                $value,
+                $name,
+            )),
+        };
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Rules/PasswordChangeRules.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Rules/PasswordChangeRules.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Rules;
+
+/**
+ * Constraints on when and by whom a password may be changed (draft-behera-10 §5.2.2, §5.2.12-5.2.15).
+ */
+final readonly class PasswordChangeRules
+{
+    /**
+     * @param int<0, max>|null $minAge
+     */
+    public function __construct(
+        public ?int $minAge = null,
+        public ?bool $mustChange = null,
+        public ?bool $allowUserChange = null,
+        public ?bool $safeModify = null,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Rules/PasswordExpirationRules.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Rules/PasswordExpirationRules.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Rules;
+
+/**
+ * Rules governing password expiration / any grace window (draft-behera-10 §5.2.3, §5.2.7-5.2.8, §5.2.16, §5.2.19).
+ */
+final readonly class PasswordExpirationRules
+{
+    /**
+     * @param int<0, max>|null $maxAge
+     * @param int<0, max>|null $expireWarning
+     * @param int<0, max>|null $graceAuthnLimit
+     * @param int<0, max>|null $graceExpiry
+     * @param int<0, max>|null $maxIdle
+     */
+    public function __construct(
+        public ?int $maxAge = null,
+        public ?int $expireWarning = null,
+        public ?int $graceAuthnLimit = null,
+        public ?int $graceExpiry = null,
+        public ?int $maxIdle = null,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Rules/PasswordLockoutRules.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Rules/PasswordLockoutRules.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Rules;
+
+/**
+ * Rules governing account lockout from failed binds (draft-behera-10 §5.2.9-5.2.10, §5.2.17-5.2.18).
+ */
+final readonly class PasswordLockoutRules
+{
+    /**
+     * @param int<0, max>|null $duration
+     * @param int<0, max>|null $maxFailure
+     * @param int<0, max>|null $failureCountInterval
+     * @param int<0, max>|null $minDelay
+     * @param int<0, max>|null $maxDelay
+     */
+    public function __construct(
+        public ?bool $enabled = null,
+        public ?int $duration = null,
+        public ?int $maxFailure = null,
+        public ?int $failureCountInterval = null,
+        public ?int $minDelay = null,
+        public ?int $maxDelay = null,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Rules/PasswordQualityRules.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Rules/PasswordQualityRules.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Rules;
+
+/**
+ * Constraints on what a new password is allowed to contain (draft-behera-10 §5.2.4-5.2.6, §5.2.11).
+ */
+final readonly class PasswordQualityRules
+{
+    /**
+     * @param int<0, max>|null $minLength
+     * @param int<0, max>|null $maxLength
+     * @param int<0, max>|null $inHistory
+     * @param int<0, max>|null $checkQuality
+     */
+    public function __construct(
+        public ?int $minLength = null,
+        public ?int $maxLength = null,
+        public ?int $inHistory = null,
+        public ?int $checkQuality = null,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/UserPasswordState.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/UserPasswordState.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy;
+
+use DateTimeImmutable;
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Exception\PasswordPolicyException;
+use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+
+/**
+ * Immutable snapshot of a user entry's draft-behera password-policy operational attributes.
+ */
+final readonly class UserPasswordState
+{
+    /**
+     * @param list<DateTimeImmutable> $failureTimes
+     * @param list<HistoryEntry> $history
+     * @param list<DateTimeImmutable> $graceUseTimes
+     */
+    public function __construct(
+        public ?DateTimeImmutable $changedAt = null,
+        public ?DateTimeImmutable $accountLockedAt = null,
+        public bool $permanentlyLocked = false,
+        public array $failureTimes = [],
+        public array $history = [],
+        public array $graceUseTimes = [],
+        public bool $mustChange = false,
+        public ?Dn $policySubentry = null,
+    ) {}
+
+    /**
+     * @throws PasswordPolicyException when any operational attribute value fails to parse.
+     */
+    public static function fromEntry(Entry $entry): self
+    {
+        return new self(
+            changedAt: self::readGeneralizedTime(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_CHANGED_TIME,
+            ),
+            accountLockedAt: self::readLockedAt($entry),
+            permanentlyLocked: self::isPermanentLockSentinel($entry),
+            failureTimes: self::readGeneralizedTimeList(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_FAILURE_TIME,
+            ),
+            history: self::readHistory($entry),
+            graceUseTimes: self::readGeneralizedTimeList(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_GRACE_USE_TIME,
+            ),
+            mustChange: self::readBoolean(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_RESET,
+            ) ?? false,
+            policySubentry: self::readDn(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_POLICY_SUBENTRY,
+            ),
+        );
+    }
+
+    public function isLocked(): bool
+    {
+        return $this->accountLockedAt !== null
+            || $this->permanentlyLocked;
+    }
+
+    /**
+     * Count failures recorded at or after $threshold; used to honor pwdFailureCountInterval.
+     *
+     * @return int<0, max>
+     */
+    public function failureCountSince(DateTimeImmutable $threshold): int
+    {
+        $count = 0;
+
+        foreach ($this->failureTimes as $time) {
+            if ($time >= $threshold) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    private static function readLockedAt(Entry $entry): ?DateTimeImmutable
+    {
+        $raw = $entry
+            ->get(PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME)
+            ?->firstValue();
+        if ($raw === null || $raw === PasswordPolicyOid::PERMANENT_LOCK_SENTINEL) {
+            return null;
+        }
+
+        return self::parseGeneralizedTime(
+            $raw,
+            $entry,
+            PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME,
+        );
+    }
+
+    private static function isPermanentLockSentinel(Entry $entry): bool
+    {
+        $raw = $entry
+            ->get(PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME)
+            ?->firstValue();
+
+        return $raw === PasswordPolicyOid::PERMANENT_LOCK_SENTINEL;
+    }
+
+    private static function readGeneralizedTime(
+        Entry $entry,
+        string $name,
+    ): ?DateTimeImmutable {
+        $raw = $entry->get($name)?->firstValue();
+        if ($raw === null) {
+            return null;
+        }
+
+        return self::parseGeneralizedTime(
+            $raw,
+            $entry,
+            $name,
+        );
+    }
+
+    /**
+     * @return list<DateTimeImmutable>
+     */
+    private static function readGeneralizedTimeList(
+        Entry $entry,
+        string $name,
+    ): array {
+        $attr = $entry->get($name);
+        if (!$attr instanceof Attribute) {
+            return [];
+        }
+
+        $values = [];
+        foreach ($attr->getValues() as $raw) {
+            $values[] = self::parseGeneralizedTime(
+                $raw,
+                $entry,
+                $name,
+            );
+        }
+
+        return $values;
+    }
+
+    /**
+     * @return list<HistoryEntry>
+     */
+    private static function readHistory(Entry $entry): array
+    {
+        $attr = $entry->get(PasswordPolicyOid::NAME_PWD_HISTORY);
+        if (!$attr instanceof Attribute) {
+            return [];
+        }
+
+        $values = [];
+        foreach ($attr->getValues() as $raw) {
+            $values[] = HistoryEntry::decode($raw);
+        }
+
+        return $values;
+    }
+
+    private static function readBoolean(
+        Entry $entry,
+        string $name,
+    ): ?bool {
+        $raw = $entry->get($name)?->firstValue();
+        if ($raw === null) {
+            return null;
+        }
+
+        return match (strtoupper($raw)) {
+            'TRUE' => true,
+            'FALSE' => false,
+            default => throw new PasswordPolicyException(sprintf(
+                'Entry "%s" has non-boolean value "%s" for %s.',
+                $entry->getDn()->toString(),
+                $raw,
+                $name,
+            )),
+        };
+    }
+
+    private static function readDn(
+        Entry $entry,
+        string $name,
+    ): ?Dn {
+        $raw = $entry->get($name)?->firstValue();
+        if ($raw === null || $raw === '') {
+            return null;
+        }
+
+        return new Dn($raw);
+    }
+
+    /**
+     * @throws PasswordPolicyException
+     */
+    private static function parseGeneralizedTime(
+        string $raw,
+        Entry $entry,
+        string $name,
+    ): DateTimeImmutable {
+        try {
+            return GeneralizedTime::parse($raw);
+        } catch (InvalidArgumentException $cause) {
+            throw new PasswordPolicyException(
+                sprintf(
+                    'Entry "%s" has non-GeneralizedTime value "%s" for %s.',
+                    $entry->getDn()->toString(),
+                    $raw,
+                    $name,
+                ),
+                previous: $cause,
+            );
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -15,9 +15,11 @@ namespace FreeDSx\Ldap;
 
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Schema\PasswordPolicySchemaProvider;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Schema\StandardSchemaProvider;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
@@ -152,6 +154,10 @@ final class ServerOptions
     private array $attributeRules = [];
 
     private Effect $defaultAccessRule = Effect::Deny;
+
+    private ?PasswordPolicy $passwordPolicy = null;
+
+    private ?Dn $defaultPasswordPolicyDn = null;
 
     private ?LoggerInterface $logger = null;
 
@@ -452,7 +458,16 @@ final class ServerOptions
 
     public function getSchema(): Schema
     {
-        return $this->schema ??= StandardSchemaProvider::buildCore();
+        if ($this->schema !== null) {
+            return $this->schema;
+        }
+
+        $base = StandardSchemaProvider::buildCore();
+        $this->schema = $this->isPasswordPolicyEnabled()
+            ? $base->merge(PasswordPolicySchemaProvider::build())
+            : $base;
+
+        return $this->schema;
     }
 
     public function setSchema(Schema $schema): self
@@ -532,6 +547,45 @@ final class ServerOptions
     public function getDefaultAccessRule(): Effect
     {
         return $this->defaultAccessRule;
+    }
+
+    /**
+     * In-memory fallback policy applied to users that do not resolve a pwdPolicy entry from the DIT.
+     */
+    public function getPasswordPolicy(): ?PasswordPolicy
+    {
+        return $this->passwordPolicy;
+    }
+
+    public function setPasswordPolicy(?PasswordPolicy $policy): self
+    {
+        $this->passwordPolicy = $policy;
+
+        return $this;
+    }
+
+    /**
+     * DN of the default pwdPolicy entry used when a user has no pwdPolicySubentry pointer.
+     */
+    public function getDefaultPasswordPolicyDn(): ?Dn
+    {
+        return $this->defaultPasswordPolicyDn;
+    }
+
+    public function setDefaultPasswordPolicyDn(?Dn $dn): self
+    {
+        $this->defaultPasswordPolicyDn = $dn;
+
+        return $this;
+    }
+
+    /**
+     * Whether any password-policy source is configured.
+     */
+    public function isPasswordPolicyEnabled(): bool
+    {
+        return $this->passwordPolicy !== null
+            || $this->defaultPasswordPolicyDn !== null;
     }
 
     public function getLogger(): ?LoggerInterface

--- a/tests/support/Clock/FrozenClock.php
+++ b/tests/support/Clock/FrozenClock.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Support\FreeDSx\Ldap\Clock;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use FreeDSx\Ldap\Server\Clock\ClockInterface;
+
+/**
+ * Test clock with manually controlled time. Always returns UTC instants.
+ */
+final class FrozenClock implements ClockInterface
+{
+    private DateTimeImmutable $instant;
+
+    public function __construct(DateTimeImmutable $instant)
+    {
+        $this->setTo($instant);
+    }
+
+    public static function fromString(string $instant): self
+    {
+        return new self(new DateTimeImmutable(
+            $instant,
+            new DateTimeZone('UTC'),
+        ));
+    }
+
+    public function now(): DateTimeImmutable
+    {
+        return $this->instant;
+    }
+
+    public function setTo(DateTimeImmutable $instant): void
+    {
+        $this->instant = $instant->setTimezone(new DateTimeZone('UTC'));
+    }
+
+    public function advance(string $interval): void
+    {
+        $this->instant = $this->instant->add(new DateInterval($interval));
+    }
+}

--- a/tests/unit/Schema/Definition/GeneralizedTimeTest.php
+++ b/tests/unit/Schema/Definition/GeneralizedTimeTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Definition;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class GeneralizedTimeTest extends TestCase
+{
+    public function test_parses_canonical_utc_form(): void
+    {
+        $parsed = GeneralizedTime::parse('20250415103000Z');
+
+        self::assertEquals(
+            new DateTimeImmutable(
+                '2025-04-15T10:30:00Z',
+                new DateTimeZone('UTC'),
+            ),
+            $parsed,
+        );
+        self::assertSame(
+            'UTC',
+            $parsed->getTimezone()->getName(),
+        );
+    }
+
+    public function test_parses_hour_only_precision(): void
+    {
+        $parsed = GeneralizedTime::parse('2025041510Z');
+
+        self::assertSame(
+            '2025-04-15T10:00:00+00:00',
+            $parsed->format('c'),
+        );
+    }
+
+    public function test_parses_hour_and_minute_precision(): void
+    {
+        $parsed = GeneralizedTime::parse('202504151030Z');
+
+        self::assertSame(
+            '2025-04-15T10:30:00+00:00',
+            $parsed->format('c'),
+        );
+    }
+
+    public function test_parses_fractional_seconds_with_dot(): void
+    {
+        $parsed = GeneralizedTime::parse('20250415103000.500Z');
+
+        self::assertSame(
+            '500000',
+            $parsed->format('u'),
+        );
+    }
+
+    public function test_parses_fractional_seconds_with_comma(): void
+    {
+        $parsed = GeneralizedTime::parse('20250415103000,250Z');
+
+        self::assertSame(
+            '250000',
+            $parsed->format('u'),
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function zoneFormProvider(): array
+    {
+        return [
+            'Z UTC' => ['20250415100000Z', '2025-04-15T10:00:00+00:00'],
+            'plus hours only' => ['20250415100000+05', '2025-04-15T05:00:00+00:00'],
+            'plus hours+minutes' => ['20250415100000+0530', '2025-04-15T04:30:00+00:00'],
+            'minus hours only' => ['20250415100000-08', '2025-04-15T18:00:00+00:00'],
+            'minus hours+minutes' => ['20250415100000-0800', '2025-04-15T18:00:00+00:00'],
+        ];
+    }
+
+    #[DataProvider('zoneFormProvider')]
+    public function test_parses_all_rfc4517_zone_forms_and_normalizes_to_utc(
+        string $input,
+        string $expectedUtcIso,
+    ): void {
+        $parsed = GeneralizedTime::parse($input);
+
+        self::assertSame(
+            $expectedUtcIso,
+            $parsed->format('c'),
+        );
+    }
+
+    public function test_parse_normalizes_to_utc(): void
+    {
+        $parsed = GeneralizedTime::parse('20250415100000-0500');
+
+        self::assertSame(
+            'UTC',
+            $parsed->getTimezone()->getName(),
+        );
+        self::assertSame(
+            '2025-04-15T15:00:00+00:00',
+            $parsed->format('c'),
+        );
+    }
+
+    public function test_format_emits_canonical_utc_form(): void
+    {
+        $instant = new DateTimeImmutable(
+            '2025-04-15T10:30:00+05:00',
+            new DateTimeZone('+05:00'),
+        );
+
+        self::assertSame(
+            '20250415053000Z',
+            GeneralizedTime::format($instant),
+        );
+    }
+
+    public function test_round_trip_canonical(): void
+    {
+        $original = '20250415103000Z';
+
+        self::assertSame(
+            $original,
+            GeneralizedTime::format(GeneralizedTime::parse($original)),
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function invalidInputProvider(): array
+    {
+        return [
+            'empty string' => [''],
+            'missing zone' => ['20250415103000'],
+            'too short for hour' => ['202504'],
+            'invalid month 13' => ['20251315103000Z'],
+            'invalid day Feb 30' => ['20250230103000Z'],
+            'invalid hour 25' => ['20250415253000Z'],
+            'extra characters' => ['20250415103000Zfoo'],
+            'lowercase zone z' => ['20250415103000z'],
+            'colon in zone' => ['20250415103000+05:00'],
+            'date separators' => ['2025-04-15T10:30:00Z'],
+            'non-digit garbage' => ['not-a-time'],
+        ];
+    }
+
+    #[DataProvider('invalidInputProvider')]
+    public function test_rejects_invalid_input(string $value): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        GeneralizedTime::parse($value);
+    }
+}

--- a/tests/unit/Schema/PasswordPolicySchemaProviderTest.php
+++ b/tests/unit/Schema/PasswordPolicySchemaProviderTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema;
+
+use FreeDSx\Ldap\Schema\Definition\AttributeUsage;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassType;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Schema\Definition\SyntaxOid;
+use FreeDSx\Ldap\Schema\PasswordPolicySchemaProvider;
+use FreeDSx\Ldap\Schema\Schema;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PasswordPolicySchemaProviderTest extends TestCase
+{
+    private Schema $schema;
+
+    protected function setUp(): void
+    {
+        $this->schema = PasswordPolicySchemaProvider::build();
+    }
+
+    public function test_registers_all_30_attribute_types(): void
+    {
+        self::assertCount(
+            30,
+            $this->schema->getAttributeTypes(),
+        );
+    }
+
+    public function test_registers_pwd_policy_object_class(): void
+    {
+        $oc = $this->schema->getObjectClass(PasswordPolicyOid::NAME_PWD_POLICY);
+
+        self::assertNotNull($oc);
+        self::assertSame(
+            ObjectClassType::AuxiliaryClass,
+            $oc->type,
+        );
+        self::assertContains(
+            PasswordPolicyOid::NAME_PWD_ATTRIBUTE,
+            $oc->must,
+        );
+        self::assertCount(
+            19,
+            $oc->may,
+        );
+    }
+
+    #[DataProvider('userStateAttributeProvider')]
+    public function test_user_state_attributes_are_operational_and_no_user_modification(string $name): void
+    {
+        $type = $this->schema->getAttributeType($name);
+
+        self::assertNotNull($type);
+        self::assertTrue($type->noUserModification);
+        self::assertSame(
+            AttributeUsage::DirectoryOperation,
+            $type->usage,
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function userStateAttributeProvider(): array
+    {
+        return [
+            'pwdChangedTime' => [PasswordPolicyOid::NAME_PWD_CHANGED_TIME],
+            'pwdAccountLockedTime' => [PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME],
+            'pwdFailureTime' => [PasswordPolicyOid::NAME_PWD_FAILURE_TIME],
+            'pwdHistory' => [PasswordPolicyOid::NAME_PWD_HISTORY],
+            'pwdGraceUseTime' => [PasswordPolicyOid::NAME_PWD_GRACE_USE_TIME],
+            'pwdReset' => [PasswordPolicyOid::NAME_PWD_RESET],
+            'pwdPolicySubentry' => [PasswordPolicyOid::NAME_PWD_POLICY_SUBENTRY],
+            'pwdStartTime' => [PasswordPolicyOid::NAME_PWD_START_TIME],
+            'pwdEndTime' => [PasswordPolicyOid::NAME_PWD_END_TIME],
+            'pwdLastSuccess' => [PasswordPolicyOid::NAME_PWD_LAST_SUCCESS],
+        ];
+    }
+
+    #[DataProvider('policyConfigAttributeProvider')]
+    public function test_policy_config_attributes_are_user_application(string $name): void
+    {
+        $type = $this->schema->getAttributeType($name);
+
+        self::assertNotNull($type);
+        self::assertFalse($type->noUserModification);
+        self::assertSame(
+            AttributeUsage::UserApplications,
+            $type->usage,
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function policyConfigAttributeProvider(): array
+    {
+        return [
+            'pwdAttribute' => [PasswordPolicyOid::NAME_PWD_ATTRIBUTE],
+            'pwdMinAge' => [PasswordPolicyOid::NAME_PWD_MIN_AGE],
+            'pwdMaxAge' => [PasswordPolicyOid::NAME_PWD_MAX_AGE],
+            'pwdInHistory' => [PasswordPolicyOid::NAME_PWD_IN_HISTORY],
+            'pwdCheckQuality' => [PasswordPolicyOid::NAME_PWD_CHECK_QUALITY],
+            'pwdMinLength' => [PasswordPolicyOid::NAME_PWD_MIN_LENGTH],
+            'pwdMaxLength' => [PasswordPolicyOid::NAME_PWD_MAX_LENGTH],
+            'pwdExpireWarning' => [PasswordPolicyOid::NAME_PWD_EXPIRE_WARNING],
+            'pwdGraceAuthNLimit' => [PasswordPolicyOid::NAME_PWD_GRACE_AUTHN_LIMIT],
+            'pwdGraceExpiry' => [PasswordPolicyOid::NAME_PWD_GRACE_EXPIRY],
+            'pwdLockout' => [PasswordPolicyOid::NAME_PWD_LOCKOUT],
+            'pwdLockoutDuration' => [PasswordPolicyOid::NAME_PWD_LOCKOUT_DURATION],
+            'pwdMaxFailure' => [PasswordPolicyOid::NAME_PWD_MAX_FAILURE],
+            'pwdFailureCountInterval' => [PasswordPolicyOid::NAME_PWD_FAILURE_COUNT_INTERVAL],
+            'pwdMustChange' => [PasswordPolicyOid::NAME_PWD_MUST_CHANGE],
+            'pwdAllowUserChange' => [PasswordPolicyOid::NAME_PWD_ALLOW_USER_CHANGE],
+            'pwdSafeModify' => [PasswordPolicyOid::NAME_PWD_SAFE_MODIFY],
+            'pwdMinDelay' => [PasswordPolicyOid::NAME_PWD_MIN_DELAY],
+            'pwdMaxDelay' => [PasswordPolicyOid::NAME_PWD_MAX_DELAY],
+            'pwdMaxIdle' => [PasswordPolicyOid::NAME_PWD_MAX_IDLE],
+        ];
+    }
+
+    public function test_pwd_history_uses_octet_string_syntax(): void
+    {
+        $type = $this->schema->getAttributeType(PasswordPolicyOid::NAME_PWD_HISTORY);
+
+        self::assertNotNull($type);
+        self::assertSame(
+            SyntaxOid::OID_OCTET_STRING,
+            $type->syntaxOid,
+        );
+        self::assertFalse($type->singleValue);
+    }
+
+    public function test_pwd_failure_time_is_multi_valued(): void
+    {
+        $type = $this->schema->getAttributeType(PasswordPolicyOid::NAME_PWD_FAILURE_TIME);
+
+        self::assertNotNull($type);
+        self::assertFalse($type->singleValue);
+    }
+
+    public function test_pwd_changed_time_is_single_valued(): void
+    {
+        $type = $this->schema->getAttributeType(PasswordPolicyOid::NAME_PWD_CHANGED_TIME);
+
+        self::assertNotNull($type);
+        self::assertTrue($type->singleValue);
+    }
+
+    public function test_pwd_grace_use_time_has_no_ordering_rule(): void
+    {
+        $type = $this->schema->getAttributeType(PasswordPolicyOid::NAME_PWD_GRACE_USE_TIME);
+
+        self::assertNotNull($type);
+        self::assertNull($type->orderingOid);
+    }
+
+    public function test_pwd_change_time_has_ordering_rule(): void
+    {
+        $type = $this->schema->getAttributeType(PasswordPolicyOid::NAME_PWD_CHANGED_TIME);
+
+        self::assertNotNull($type);
+        self::assertNotNull($type->orderingOid);
+    }
+}

--- a/tests/unit/Server/Clock/SystemClockTest.php
+++ b/tests/unit/Server/Clock/SystemClockTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Clock;
+
+use FreeDSx\Ldap\Server\Clock\SystemClock;
+use PHPUnit\Framework\TestCase;
+
+final class SystemClockTest extends TestCase
+{
+    public function test_now_returns_utc(): void
+    {
+        $clock = new SystemClock();
+
+        self::assertSame(
+            'UTC',
+            $clock->now()->getTimezone()->getName(),
+        );
+    }
+
+    public function test_now_is_monotonically_non_decreasing(): void
+    {
+        $clock = new SystemClock();
+
+        $first = $clock->now();
+        $second = $clock->now();
+
+        self::assertGreaterThanOrEqual(
+            $first,
+            $second,
+        );
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/HistoryEntryTest.php
+++ b/tests/unit/Server/PasswordPolicy/HistoryEntryTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use FreeDSx\Ldap\Exception\PasswordPolicyException;
+use FreeDSx\Ldap\Schema\Definition\SyntaxOid;
+use FreeDSx\Ldap\Server\PasswordPolicy\HistoryEntry;
+use PHPUnit\Framework\TestCase;
+
+final class HistoryEntryTest extends TestCase
+{
+    public function test_encode_then_decode_round_trips(): void
+    {
+        $entry = new HistoryEntry(
+            new DateTimeImmutable(
+                '2025-04-15T10:30:00Z',
+                new DateTimeZone('UTC'),
+            ),
+            SyntaxOid::OID_OCTET_STRING,
+            '{SSHA}1234567890abcdef',
+        );
+
+        $decoded = HistoryEntry::decode($entry->encode());
+
+        self::assertEquals(
+            $entry->changedAt,
+            $decoded->changedAt,
+        );
+        self::assertSame(
+            $entry->syntaxOid,
+            $decoded->syntaxOid,
+        );
+        self::assertSame(
+            $entry->data,
+            $decoded->data,
+        );
+    }
+
+    public function test_decode_handles_data_containing_hash(): void
+    {
+        $data = '{SSHA}aaa#bbb#ccc';
+        $wire = sprintf(
+            '20250101000000Z#%s#%d#%s',
+            SyntaxOid::OID_OCTET_STRING,
+            strlen($data),
+            $data,
+        );
+
+        $decoded = HistoryEntry::decode($wire);
+
+        self::assertSame(
+            $data,
+            $decoded->data,
+        );
+    }
+
+    public function test_encode_formats_time_as_generalized_time_utc(): void
+    {
+        $entry = new HistoryEntry(
+            new DateTimeImmutable(
+                '2025-04-15T10:30:00+05:00',
+                new DateTimeZone('+05:00'),
+            ),
+            SyntaxOid::OID_OCTET_STRING,
+            'x',
+        );
+
+        self::assertStringStartsWith(
+            '20250415053000Z#',
+            $entry->encode(),
+        );
+    }
+
+    public function test_for_stored_password_defaults_to_octet_string(): void
+    {
+        $entry = HistoryEntry::forStoredPassword(
+            new DateTimeImmutable(
+                '2025-01-01T00:00:00Z',
+                new DateTimeZone('UTC'),
+            ),
+            '{SSHA}abc',
+        );
+
+        self::assertSame(
+            SyntaxOid::OID_OCTET_STRING,
+            $entry->syntaxOid,
+        );
+    }
+
+    public function test_decode_rejects_missing_time_delimiter(): void
+    {
+        $this->expectException(PasswordPolicyException::class);
+        $this->expectExceptionMessage('missing time delimiter');
+
+        HistoryEntry::decode('20250101000000Z');
+    }
+
+    public function test_decode_rejects_missing_syntax_delimiter(): void
+    {
+        $this->expectException(PasswordPolicyException::class);
+        $this->expectExceptionMessage('missing syntax delimiter');
+
+        HistoryEntry::decode('20250101000000Z#1.2.3.4');
+    }
+
+    public function test_decode_rejects_missing_length_delimiter(): void
+    {
+        $this->expectException(PasswordPolicyException::class);
+        $this->expectExceptionMessage('missing length delimiter');
+
+        HistoryEntry::decode('20250101000000Z#1.2.3.4#3');
+    }
+
+    public function test_decode_rejects_empty_syntax(): void
+    {
+        $this->expectException(PasswordPolicyException::class);
+        $this->expectExceptionMessage('empty syntax OID');
+
+        HistoryEntry::decode('20250101000000Z##3#abc');
+    }
+
+    public function test_decode_rejects_non_numeric_length(): void
+    {
+        $this->expectException(PasswordPolicyException::class);
+        $this->expectExceptionMessage('length is not a non-negative integer');
+
+        HistoryEntry::decode('20250101000000Z#1.2.3.4#abc#abc');
+    }
+
+    public function test_decode_rejects_length_mismatch(): void
+    {
+        $this->expectException(PasswordPolicyException::class);
+        $this->expectExceptionMessage('declared length 10 does not match data length 3');
+
+        HistoryEntry::decode('20250101000000Z#1.2.3.4#10#abc');
+    }
+
+    public function test_decode_rejects_invalid_time(): void
+    {
+        $this->expectException(PasswordPolicyException::class);
+        $this->expectExceptionMessage('is not a valid GeneralizedTime');
+
+        HistoryEntry::decode('not-a-time#1.2.3.4#3#abc');
+    }
+
+    public function test_decode_accepts_non_canonical_generalized_time_forms(): void
+    {
+        $decoded = HistoryEntry::decode('20250415080000-0500#1.3.6.1.4.1.1466.115.121.1.40#3#abc');
+
+        self::assertSame(
+            '2025-04-15T13:00:00+00:00',
+            $decoded->changedAt->format('c'),
+        );
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/PasswordPolicyTest.php
+++ b/tests/unit/Server/PasswordPolicy/PasswordPolicyTest.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy;
+
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\PasswordPolicyException;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
+use PHPUnit\Framework\TestCase;
+
+final class PasswordPolicyTest extends TestCase
+{
+    public function test_defaults_apply_for_an_empty_policy(): void
+    {
+        $policy = new PasswordPolicy();
+
+        self::assertSame(
+            AttributeTypeOid::NAME_USER_PASSWORD,
+            $policy->pwdAttribute,
+        );
+        self::assertNull($policy->quality->minLength);
+        self::assertNull($policy->lockout->enabled);
+        self::assertNull($policy->lockout->maxFailure);
+        self::assertNull($policy->change->mustChange);
+        self::assertNull($policy->expiration->maxAge);
+    }
+
+    public function test_named_args_construction_via_sub_dtos(): void
+    {
+        $policy = new PasswordPolicy(
+            quality: new PasswordQualityRules(minLength: 8),
+            lockout: new PasswordLockoutRules(
+                enabled: true,
+                duration: 300,
+                maxFailure: 5,
+            ),
+        );
+
+        self::assertSame(
+            8,
+            $policy->quality->minLength,
+        );
+        self::assertTrue($policy->lockout->enabled);
+        self::assertSame(
+            5,
+            $policy->lockout->maxFailure,
+        );
+        self::assertSame(
+            300,
+            $policy->lockout->duration,
+        );
+    }
+
+    public function test_from_entry_decodes_full_policy(): void
+    {
+        $entry = Entry::fromArray(
+            'cn=default,ou=policies,dc=example,dc=com',
+            [
+                'pwdAttribute' => 'userPassword',
+                'pwdMinAge' => '60',
+                'pwdMaxAge' => '7776000',
+                'pwdInHistory' => '5',
+                'pwdCheckQuality' => '2',
+                'pwdMinLength' => '8',
+                'pwdMaxLength' => '128',
+                'pwdExpireWarning' => '604800',
+                'pwdGraceAuthNLimit' => '3',
+                'pwdGraceExpiry' => '86400',
+                'pwdLockout' => 'TRUE',
+                'pwdLockoutDuration' => '900',
+                'pwdMaxFailure' => '5',
+                'pwdFailureCountInterval' => '300',
+                'pwdMustChange' => 'TRUE',
+                'pwdAllowUserChange' => 'TRUE',
+                'pwdSafeModify' => 'FALSE',
+                'pwdMinDelay' => '1',
+                'pwdMaxDelay' => '60',
+                'pwdMaxIdle' => '2592000',
+            ],
+        );
+
+        $policy = PasswordPolicy::fromEntry($entry);
+
+        self::assertSame(
+            'userPassword',
+            $policy->pwdAttribute,
+        );
+
+        self::assertSame(
+            8,
+            $policy->quality->minLength,
+        );
+        self::assertSame(
+            128,
+            $policy->quality->maxLength,
+        );
+        self::assertSame(
+            5,
+            $policy->quality->inHistory,
+        );
+        self::assertSame(
+            2,
+            $policy->quality->checkQuality,
+        );
+
+        self::assertSame(
+            60,
+            $policy->change->minAge,
+        );
+        self::assertTrue($policy->change->mustChange);
+        self::assertTrue($policy->change->allowUserChange);
+        self::assertFalse($policy->change->safeModify);
+
+        self::assertSame(
+            7776000,
+            $policy->expiration->maxAge,
+        );
+        self::assertSame(
+            604800,
+            $policy->expiration->expireWarning,
+        );
+        self::assertSame(
+            3,
+            $policy->expiration->graceAuthnLimit,
+        );
+        self::assertSame(
+            86400,
+            $policy->expiration->graceExpiry,
+        );
+        self::assertSame(
+            2592000,
+            $policy->expiration->maxIdle,
+        );
+
+        self::assertTrue($policy->lockout->enabled);
+        self::assertSame(
+            900,
+            $policy->lockout->duration,
+        );
+        self::assertSame(
+            5,
+            $policy->lockout->maxFailure,
+        );
+        self::assertSame(
+            300,
+            $policy->lockout->failureCountInterval,
+        );
+        self::assertSame(
+            1,
+            $policy->lockout->minDelay,
+        );
+        self::assertSame(
+            60,
+            $policy->lockout->maxDelay,
+        );
+    }
+
+    public function test_from_entry_leaves_absent_fields_null(): void
+    {
+        $entry = Entry::fromArray(
+            'cn=minimal,ou=policies,dc=example,dc=com',
+            ['pwdAttribute' => 'userPassword'],
+        );
+
+        $policy = PasswordPolicy::fromEntry($entry);
+
+        self::assertNull($policy->change->minAge);
+        self::assertNull($policy->lockout->enabled);
+        self::assertNull($policy->change->safeModify);
+        self::assertNull($policy->quality->maxLength);
+        self::assertNull($policy->expiration->maxIdle);
+    }
+
+    public function test_from_entry_accepts_lowercase_boolean(): void
+    {
+        $entry = Entry::fromArray(
+            'cn=lower,ou=policies,dc=example,dc=com',
+            [
+                'pwdAttribute' => 'userPassword',
+                'pwdLockout' => 'true',
+            ],
+        );
+
+        $policy = PasswordPolicy::fromEntry($entry);
+
+        self::assertTrue($policy->lockout->enabled);
+    }
+
+    public function test_default_sub_dtos_have_all_null_fields(): void
+    {
+        $policy = new PasswordPolicy();
+
+        self::assertNull($policy->quality->maxLength);
+        self::assertNull($policy->quality->inHistory);
+        self::assertNull($policy->change->mustChange);
+        self::assertNull($policy->change->safeModify);
+        self::assertNull($policy->expiration->maxAge);
+        self::assertNull($policy->expiration->graceAuthnLimit);
+        self::assertNull($policy->lockout->duration);
+        self::assertNull($policy->lockout->minDelay);
+    }
+
+    public function test_from_entry_rejects_missing_pwd_attribute(): void
+    {
+        $entry = Entry::fromArray(
+            'cn=bad,ou=policies,dc=example,dc=com',
+            ['pwdMinLength' => '8'],
+        );
+
+        $this->expectException(PasswordPolicyException::class);
+        $this->expectExceptionMessage('missing the required pwdAttribute');
+
+        PasswordPolicy::fromEntry($entry);
+    }
+
+    public function test_from_entry_rejects_non_integer_value(): void
+    {
+        $entry = Entry::fromArray(
+            'cn=bad,ou=policies,dc=example,dc=com',
+            [
+                'pwdAttribute' => 'userPassword',
+                'pwdMinLength' => 'eight',
+            ],
+        );
+
+        $this->expectException(PasswordPolicyException::class);
+        $this->expectExceptionMessage('expected a non-negative integer');
+
+        PasswordPolicy::fromEntry($entry);
+    }
+
+    public function test_from_entry_rejects_negative_integer_value(): void
+    {
+        $entry = Entry::fromArray(
+            'cn=bad,ou=policies,dc=example,dc=com',
+            [
+                'pwdAttribute' => 'userPassword',
+                'pwdMaxAge' => '-1',
+            ],
+        );
+
+        $this->expectException(PasswordPolicyException::class);
+        $this->expectExceptionMessage('expected a non-negative integer');
+
+        PasswordPolicy::fromEntry($entry);
+    }
+
+    public function test_from_entry_rejects_non_boolean_value(): void
+    {
+        $entry = Entry::fromArray(
+            'cn=bad,ou=policies,dc=example,dc=com',
+            [
+                'pwdAttribute' => 'userPassword',
+                'pwdLockout' => 'maybe',
+            ],
+        );
+
+        $this->expectException(PasswordPolicyException::class);
+        $this->expectExceptionMessage('non-boolean value');
+
+        PasswordPolicy::fromEntry($entry);
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/UserPasswordStateTest.php
+++ b/tests/unit/Server/PasswordPolicy/UserPasswordStateTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\PasswordPolicyException;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
+use PHPUnit\Framework\TestCase;
+
+final class UserPasswordStateTest extends TestCase
+{
+    public function test_from_empty_entry_returns_defaults(): void
+    {
+        $state = UserPasswordState::fromEntry(Entry::fromArray('uid=alice,dc=example,dc=com'));
+
+        self::assertNull($state->changedAt);
+        self::assertNull($state->accountLockedAt);
+        self::assertFalse($state->permanentlyLocked);
+        self::assertSame(
+            [],
+            $state->failureTimes,
+        );
+        self::assertSame(
+            [],
+            $state->history,
+        );
+        self::assertSame(
+            [],
+            $state->graceUseTimes,
+        );
+        self::assertFalse($state->mustChange);
+        self::assertNull($state->policySubentry);
+        self::assertFalse($state->isLocked());
+    }
+
+    public function test_from_entry_decodes_all_state(): void
+    {
+        $entry = Entry::fromArray(
+            'uid=alice,dc=example,dc=com',
+            [
+                'pwdChangedTime' => '20250101120000Z',
+                'pwdAccountLockedTime' => '20250105080000Z',
+                'pwdFailureTime' => ['20250105075800Z', '20250105075900Z', '20250105080000Z'],
+                'pwdHistory' => [
+                    '20240101000000Z#1.3.6.1.4.1.1466.115.121.1.40#9#{SSHA}old',
+                ],
+                'pwdGraceUseTime' => ['20250102000000Z'],
+                'pwdReset' => 'TRUE',
+                'pwdPolicySubentry' => 'cn=default,ou=policies,dc=example,dc=com',
+            ],
+        );
+
+        $state = UserPasswordState::fromEntry($entry);
+
+        self::assertEquals(
+            new DateTimeImmutable(
+                '2025-01-01T12:00:00Z',
+                new DateTimeZone('UTC'),
+            ),
+            $state->changedAt,
+        );
+        self::assertEquals(
+            new DateTimeImmutable(
+                '2025-01-05T08:00:00Z',
+                new DateTimeZone('UTC'),
+            ),
+            $state->accountLockedAt,
+        );
+        self::assertFalse($state->permanentlyLocked);
+        self::assertTrue($state->isLocked());
+        self::assertCount(
+            3,
+            $state->failureTimes,
+        );
+        self::assertCount(
+            1,
+            $state->history,
+        );
+        self::assertSame(
+            '{SSHA}old',
+            $state->history[0]->data,
+        );
+        self::assertCount(
+            1,
+            $state->graceUseTimes,
+        );
+        self::assertTrue($state->mustChange);
+        self::assertSame(
+            'cn=default,ou=policies,dc=example,dc=com',
+            $state->policySubentry?->toString(),
+        );
+    }
+
+    public function test_permanent_lock_sentinel_is_recognized(): void
+    {
+        $entry = Entry::fromArray(
+            'uid=alice,dc=example,dc=com',
+            ['pwdAccountLockedTime' => PasswordPolicyOid::PERMANENT_LOCK_SENTINEL],
+        );
+
+        $state = UserPasswordState::fromEntry($entry);
+
+        self::assertTrue($state->permanentlyLocked);
+        self::assertTrue($state->isLocked());
+        self::assertNull($state->accountLockedAt);
+    }
+
+    public function test_failure_count_since_filters_old_entries(): void
+    {
+        $entry = Entry::fromArray(
+            'uid=alice,dc=example,dc=com',
+            [
+                'pwdFailureTime' => [
+                    '20250101000000Z',
+                    '20250105000000Z',
+                    '20250110000000Z',
+                ],
+            ],
+        );
+
+        $state = UserPasswordState::fromEntry($entry);
+
+        $threshold = new DateTimeImmutable(
+            '2025-01-04T00:00:00Z',
+            new DateTimeZone('UTC'),
+        );
+
+        self::assertSame(
+            2,
+            $state->failureCountSince($threshold),
+        );
+    }
+
+    public function test_from_entry_rejects_invalid_generalized_time(): void
+    {
+        $entry = Entry::fromArray(
+            'uid=alice,dc=example,dc=com',
+            ['pwdChangedTime' => 'not-a-time'],
+        );
+
+        $this->expectException(PasswordPolicyException::class);
+        $this->expectExceptionMessage('non-GeneralizedTime value');
+
+        UserPasswordState::fromEntry($entry);
+    }
+
+    public function test_from_entry_rejects_invalid_boolean(): void
+    {
+        $entry = Entry::fromArray(
+            'uid=alice,dc=example,dc=com',
+            ['pwdReset' => 'maybe'],
+        );
+
+        $this->expectException(PasswordPolicyException::class);
+        $this->expectExceptionMessage('non-boolean value');
+
+        UserPasswordState::fromEntry($entry);
+    }
+
+    public function test_from_entry_accepts_non_canonical_generalized_time(): void
+    {
+        $entry = Entry::fromArray(
+            'uid=alice,dc=example,dc=com',
+            ['pwdChangedTime' => '20250101120000+0530'],
+        );
+
+        $state = UserPasswordState::fromEntry($entry);
+
+        self::assertSame(
+            '2025-01-01T06:30:00+00:00',
+            $state->changedAt?->format('c'),
+        );
+    }
+}

--- a/tests/unit/ServerOptionsTest.php
+++ b/tests/unit/ServerOptionsTest.php
@@ -15,6 +15,9 @@ namespace Tests\Unit\FreeDSx\Ldap;
 
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
@@ -605,6 +608,57 @@ final class ServerOptionsTest extends TestCase
             ),
             $this->subject->makeSearchLimits(),
         );
+    }
+
+    public function test_password_policy_is_disabled_by_default(): void
+    {
+        self::assertFalse($this->subject->isPasswordPolicyEnabled());
+        self::assertNull($this->subject->getPasswordPolicy());
+        self::assertNull($this->subject->getDefaultPasswordPolicyDn());
+    }
+
+    public function test_setting_in_memory_policy_enables_the_feature(): void
+    {
+        $policy = new PasswordPolicy(quality: new PasswordQualityRules(minLength: 8));
+
+        $this->subject->setPasswordPolicy($policy);
+
+        self::assertTrue($this->subject->isPasswordPolicyEnabled());
+        self::assertSame(
+            $policy,
+            $this->subject->getPasswordPolicy(),
+        );
+    }
+
+    public function test_setting_default_policy_dn_enables_the_feature(): void
+    {
+        $dn = new Dn('cn=default,ou=policies,dc=example,dc=com');
+
+        $this->subject->setDefaultPasswordPolicyDn($dn);
+
+        self::assertTrue($this->subject->isPasswordPolicyEnabled());
+        self::assertSame(
+            $dn,
+            $this->subject->getDefaultPasswordPolicyDn(),
+        );
+    }
+
+    public function test_schema_omits_password_policy_attributes_when_feature_disabled(): void
+    {
+        $schema = $this->subject->getSchema();
+
+        self::assertNull($schema->getAttributeType(PasswordPolicyOid::NAME_PWD_MIN_LENGTH));
+        self::assertNull($schema->getObjectClass(PasswordPolicyOid::NAME_PWD_POLICY));
+    }
+
+    public function test_schema_includes_password_policy_attributes_when_feature_enabled(): void
+    {
+        $this->subject->setPasswordPolicy(new PasswordPolicy());
+
+        $schema = $this->subject->getSchema();
+
+        self::assertNotNull($schema->getAttributeType(PasswordPolicyOid::NAME_PWD_MIN_LENGTH));
+        self::assertNotNull($schema->getObjectClass(PasswordPolicyOid::NAME_PWD_POLICY));
     }
 
     public function test_it_accepts_all_defined_mechanism_constants(): void


### PR DESCRIPTION
This starts the lay the foundation for what's needed to support password policy on the server side. Specifically:

https://datatracker.ietf.org/doc/html/draft-behera-ldap-password-policy-10

This lays out the needed server options, schema definitions, and the models / parsing needed for the various state. I'm splitting this across several PRs because it's a lot of work. Easier for me to digest / review / tweak by doing each individually.