### PR TITLE
[1.0.0] More plumbing needed for server-side password policy support.

### DIFF
--- a/src/FreeDSx/Ldap/Protocol/Factory/ResponseFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ResponseFactory.php
@@ -32,6 +32,7 @@ use FreeDSx\Ldap\Operation\Response\ModifyDnResponse;
 use FreeDSx\Ldap\Operation\Response\ModifyResponse;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 
@@ -46,12 +47,14 @@ class ResponseFactory
      * Retrieve the expected response type for the request that was given.
      *
      * @param Dn|null $matchedDn Matched ancestor; emitted as matchedDN when non-null.
+     * @param Control ...$controls Response controls to attach to the resulting message.
      */
     public function getStandardResponse(
         LdapMessageRequest $message,
         int $resultCode = ResultCode::SUCCESS,
         string $diagnostic = '',
         ?Dn $matchedDn = null,
+        Control ...$controls,
     ): LdapMessageResponse {
         $request = $message->getRequest();
         $dn = $matchedDn?->toString() ?? '';
@@ -115,16 +118,20 @@ class ResponseFactory
         return new LdapMessageResponse(
             $message->getMessageId(),
             $response,
+            ...$controls,
         );
     }
 
     /**
      * Retrieve an extended error, which has a message ID of zero.
+     *
+     * @param Control ...$controls Response controls to attach to the resulting message.
      */
     public function getExtendedError(
         string $message,
         int $errorCode,
         ?string $responseName = null,
+        Control ...$controls,
     ): LdapMessageResponse {
         return new LdapMessageResponse(
             0,
@@ -136,6 +143,7 @@ class ResponseFactory
                 ),
                 $responseName,
             ),
+            ...$controls,
         );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Operation\Request\UnbindRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerProtocolHandlerInterface;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordHasher;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\RequestHistory;
@@ -61,6 +62,7 @@ class ServerProtocolHandlerFactory
                 accessControl: $this->options->getAccessControl(),
                 identityResolver: $this->handlerFactory->makeIdentityResolverChain(),
                 eventLogger: $this->eventLogger,
+                hasher: new PasswordHasher($this->options->getPasswordHashScheme()),
             );
         } elseif ($request instanceof ExtendedRequest && $request->getName() === ExtendedRequest::OID_START_TLS) {
             return new ServerProtocolHandler\ServerStartTlsHandler(

--- a/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
@@ -41,32 +41,41 @@ final class SchemaValidator
     /**
      * Validates an entry before it is added to storage.
      *
+     * @param bool $isSystem Skip the NO-USER-MODIFICATION check for server-initiated writes.
      * @throws OperationException
      */
-    public function validateAdd(Entry $entry): void
-    {
+    public function validateAdd(
+        Entry $entry,
+        bool $isSystem = false,
+    ): void {
         if ($this->mode === SchemaValidationMode::Off) {
             return;
         }
 
-        $this->checkNoUserModificationInEntry($entry);
+        if (!$isSystem) {
+            $this->checkNoUserModificationInEntry($entry);
+        }
         $this->validateStructure($entry);
     }
 
     /**
      * Validates the changes and resulting entry from an update operation.
      *
+     * @param bool $isSystem Skip the NO-USER-MODIFICATION check for server-initiated writes.
      * @throws OperationException
      */
     public function validateModify(
         UpdateCommand $command,
         Entry $result,
+        bool $isSystem = false,
     ): void {
         if ($this->mode === SchemaValidationMode::Off) {
             return;
         }
 
-        $this->checkNoUserModificationInChanges($command->changes);
+        if (!$isSystem) {
+            $this->checkNoUserModificationInChanges($command->changes);
+        }
         $this->validateStructure($result);
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordHashScheme.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordHashScheme.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Auth;
+
+/**
+ * Output scheme used by {@see PasswordHasher} when hashing a new password.
+ */
+enum PasswordHashScheme: string
+{
+    case Ssha = '{SSHA}';
+    case Bcrypt = '{BCRYPT}';
+    case Argon2 = '{ARGON2}';
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordHashVerifier.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordHashVerifier.php
@@ -16,7 +16,7 @@ namespace FreeDSx\Ldap\Server\Backend\Auth;
 use SensitiveParameter;
 
 /**
- * Verifies a plaintext password against a stored value that may be hashed ({SHA}, {SSHA}, {MD5}, {SMD5}).
+ * Verifies a plaintext password against a stored value that may be hashed ({SHA}, {SSHA}, {MD5}, {SMD5}, {BCRYPT}, {ARGON2}).
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -32,6 +32,8 @@ final class PasswordHashVerifier
             str_starts_with($stored, '{SSHA}') => $this->verifySsha($plain, substr($stored, 6)),
             str_starts_with($stored, '{MD5}') => $this->verifyMd5($plain, substr($stored, 5)),
             str_starts_with($stored, '{SMD5}') => $this->verifySmd5($plain, substr($stored, 6)),
+            str_starts_with($stored, '{BCRYPT}') => password_verify($plain, substr($stored, 8)),
+            str_starts_with($stored, '{ARGON2}') => password_verify($plain, substr($stored, 8)),
             default => $plain === $stored,
         };
     }

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordHasher.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordHasher.php
@@ -16,22 +16,36 @@ namespace FreeDSx\Ldap\Server\Backend\Auth;
 use SensitiveParameter;
 
 /**
- * Hashes plaintext passwords into the SSHA format understood by {@see PasswordHashVerifier}.
+ * Hashes plaintext passwords into the format understood by {@see PasswordHashVerifier}.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final class PasswordHasher
+final readonly class PasswordHasher
 {
+    public function __construct(
+        private PasswordHashScheme $scheme = PasswordHashScheme::Bcrypt,
+    ) {}
+
     /**
-     * Hash a plaintext password using salted SHA-1 (SSHA), compatible with OpenLDAP defaults.
+     * Hash a plaintext password using the configured scheme.
      */
     public function hash(
         #[SensitiveParameter]
         string $plain,
     ): string {
-        $salt = random_bytes(8);
-
-        return '{SSHA}' . base64_encode(sha1($plain . $salt, true) . $salt);
+        return match ($this->scheme) {
+            PasswordHashScheme::Ssha => $this->hashSsha($plain),
+            PasswordHashScheme::Bcrypt => $this->hashWithPhpAlgo(
+                $plain,
+                PASSWORD_BCRYPT,
+                PasswordHashScheme::Bcrypt,
+            ),
+            PasswordHashScheme::Argon2 => $this->hashWithPhpAlgo(
+                $plain,
+                PASSWORD_ARGON2ID,
+                PasswordHashScheme::Argon2,
+            ),
+        };
     }
 
     /**
@@ -40,5 +54,29 @@ final class PasswordHasher
     public function generate(): string
     {
         return bin2hex(random_bytes(8));
+    }
+
+    private function hashSsha(
+        #[SensitiveParameter]
+        string $plain,
+    ): string {
+        $salt = random_bytes(8);
+
+        return PasswordHashScheme::Ssha->value
+            . base64_encode(sha1($plain . $salt, true) . $salt);
+    }
+
+    private function hashWithPhpAlgo(
+        #[SensitiveParameter]
+        string $plain,
+        string $algo,
+        PasswordHashScheme $scheme,
+    ): string {
+        $hash = password_hash(
+            $plain,
+            $algo,
+        );
+
+        return $scheme->value . $hash;
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -197,7 +197,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
                 $this->throwEntryAlreadyExists($command->entry->getDn());
             }
 
-            $this->validator?->validateAdd($command->entry);
+            $this->validator?->validateAdd(
+                $command->entry,
+                $context->isSystem(),
+            );
             $this->operationalAttrs->applyForAdd(
                 $command->entry,
                 $context,
@@ -244,7 +247,11 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             $dn = $command->dn->normalize();
             $entry = $this->findOrFail($storage, $dn);
             $updated = $this->entryHandler->apply($entry, $command);
-            $this->validator?->validateModify($command, $updated);
+            $this->validator?->validateModify(
+                $command,
+                $updated,
+                $context->isSystem(),
+            );
             $this->operationalAttrs->applyForModify(
                 $updated,
                 $context,

--- a/src/FreeDSx/Ldap/Server/Backend/Write/WriteContext.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/WriteContext.php
@@ -26,7 +26,22 @@ final readonly class WriteContext
     public function __construct(
         private TokenInterface $token,
         private ControlBag $controls,
+        private bool $isSystem = false,
     ) {}
+
+    /**
+     * Build a context for a server-initiated write that bypasses {@see SchemaValidator}.
+     */
+    public static function system(
+        TokenInterface $token,
+        ControlBag $controls,
+    ): self {
+        return new self(
+            $token,
+            $controls,
+            isSystem: true,
+        );
+    }
 
     /**
      * Bound DN of the authenticated user, or null for anonymous.
@@ -39,6 +54,11 @@ final readonly class WriteContext
     public function isAnonymous(): bool
     {
         return $this->token->getUsername() === null;
+    }
+
+    public function isSystem(): bool
+    {
+        return $this->isSystem;
     }
 
     public function getLdapVersion(): int

--- a/src/FreeDSx/Ldap/Server/Logging/EventLogPolicy.php
+++ b/src/FreeDSx/Ldap/Server/Logging/EventLogPolicy.php
@@ -57,6 +57,12 @@ final readonly class EventLogPolicy
             ServerEvent::CriticalControlRejected,
             ServerEvent::SchemaViolation,
             ServerEvent::NoticeOfDisconnectSent,
+            ServerEvent::PasswordPolicyAccountLocked,
+            ServerEvent::PasswordPolicyAccountUnlocked,
+            ServerEvent::PasswordPolicyExpired,
+            ServerEvent::PasswordPolicyMustChange,
+            ServerEvent::PasswordPolicyGraceLogin,
+            ServerEvent::PasswordPolicyChangeRejected,
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/Logging/ServerEvent.php
+++ b/src/FreeDSx/Ldap/Server/Logging/ServerEvent.php
@@ -25,28 +25,35 @@ use Psr\Log\LogLevel;
  */
 enum ServerEvent: string
 {
-    case BindSuccess              = 'bind.success';
-    case BindFailure              = 'bind.failure';
-    case BindAnonymous            = 'bind.anonymous';
-    case StartTlsSucceeded        = 'starttls.succeeded';
-    case StartTlsFailed           = 'starttls.failed';
-    case EntryAdded               = 'entry.added';
-    case EntryModified            = 'entry.modified';
-    case EntryDeleted             = 'entry.deleted';
-    case EntryRenamed             = 'entry.renamed';
-    case SearchAuthorized         = 'search.authorized';
-    case CompareCompleted         = 'compare.completed';
-    case PasswordModifySuccess    = 'password_modify.success';
-    case PasswordModifyFailed     = 'password_modify.failed';
-    case AuthorizationDeniedWrite = 'authz.denied.write';
-    case AuthorizationDeniedRead  = 'authz.denied.read';
-    case CriticalControlRejected  = 'control.critical.rejected';
-    case SchemaViolation          = 'schema.violation';
-    case NoticeOfDisconnectSent   = 'session.disconnect_notice';
+    case BindSuccess                    = 'bind.success';
+    case BindFailure                    = 'bind.failure';
+    case BindAnonymous                  = 'bind.anonymous';
+    case StartTlsSucceeded              = 'starttls.succeeded';
+    case StartTlsFailed                 = 'starttls.failed';
+    case EntryAdded                     = 'entry.added';
+    case EntryModified                  = 'entry.modified';
+    case EntryDeleted                   = 'entry.deleted';
+    case EntryRenamed                   = 'entry.renamed';
+    case SearchAuthorized               = 'search.authorized';
+    case CompareCompleted               = 'compare.completed';
+    case PasswordModifySuccess          = 'password_modify.success';
+    case PasswordModifyFailed           = 'password_modify.failed';
+    case AuthorizationDeniedWrite       = 'authz.denied.write';
+    case AuthorizationDeniedRead        = 'authz.denied.read';
+    case CriticalControlRejected        = 'control.critical.rejected';
+    case SchemaViolation                = 'schema.violation';
+    case NoticeOfDisconnectSent         = 'session.disconnect_notice';
+    case PasswordPolicyAccountLocked    = 'password_policy.account_locked';
+    case PasswordPolicyAccountUnlocked  = 'password_policy.account_unlocked';
+    case PasswordPolicyExpired          = 'password_policy.expired';
+    case PasswordPolicyMustChange       = 'password_policy.must_change';
+    case PasswordPolicyGraceLogin       = 'password_policy.grace_login';
+    case PasswordPolicyChangeRejected   = 'password_policy.change_rejected';
 
     public function level(): string
     {
         return match ($this) {
+            self::PasswordPolicyAccountLocked => LogLevel::WARNING,
             self::BindFailure,
             self::StartTlsFailed,
             self::PasswordModifyFailed,
@@ -54,7 +61,9 @@ enum ServerEvent: string
             self::AuthorizationDeniedRead,
             self::CriticalControlRejected,
             self::SchemaViolation,
-            self::NoticeOfDisconnectSent => LogLevel::NOTICE,
+            self::NoticeOfDisconnectSent,
+            self::PasswordPolicyExpired,
+            self::PasswordPolicyChangeRejected => LogLevel::NOTICE,
             default => LogLevel::INFO,
         };
     }

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -22,6 +22,7 @@ use FreeDSx\Ldap\Schema\StandardSchemaProvider;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashScheme;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
@@ -158,6 +159,8 @@ final class ServerOptions
     private ?PasswordPolicy $passwordPolicy = null;
 
     private ?Dn $defaultPasswordPolicyDn = null;
+
+    private PasswordHashScheme $passwordHashScheme = PasswordHashScheme::Bcrypt;
 
     private ?LoggerInterface $logger = null;
 
@@ -586,6 +589,21 @@ final class ServerOptions
     {
         return $this->passwordPolicy !== null
             || $this->defaultPasswordPolicyDn !== null;
+    }
+
+    /**
+     * Output scheme used by the password hasher when writing a new password.
+     */
+    public function getPasswordHashScheme(): PasswordHashScheme
+    {
+        return $this->passwordHashScheme;
+    }
+
+    public function setPasswordHashScheme(PasswordHashScheme $scheme): self
+    {
+        $this->passwordHashScheme = $scheme;
+
+        return $this;
     }
 
     public function getLogger(): ?LoggerInterface

--- a/tests/integration/LdapPasswordModifyServerTest.php
+++ b/tests/integration/LdapPasswordModifyServerTest.php
@@ -68,7 +68,7 @@ final class LdapPasswordModifyServerTest extends ServerTestCase
 
         $this->assertNotNull($entry);
         $this->assertStringStartsWith(
-            '{SSHA}',
+            '{BCRYPT}',
             (string) $entry->get('userPassword')?->firstValue(),
         );
     }
@@ -111,7 +111,7 @@ final class LdapPasswordModifyServerTest extends ServerTestCase
 
         $this->assertNotNull($entry);
         $this->assertStringStartsWith(
-            '{SSHA}',
+            '{BCRYPT}',
             (string) $entry->get('userPassword')?->firstValue(),
         );
     }
@@ -140,7 +140,7 @@ final class LdapPasswordModifyServerTest extends ServerTestCase
 
         $this->assertNotNull($entry);
         $this->assertStringStartsWith(
-            '{SSHA}',
+            '{BCRYPT}',
             (string) $entry->get('userPassword')?->firstValue(),
         );
     }

--- a/tests/unit/Protocol/Factory/ResponseFactoryTest.php
+++ b/tests/unit/Protocol/Factory/ResponseFactoryTest.php
@@ -34,6 +34,7 @@ use FreeDSx\Ldap\Operation\Response\ModifyDnResponse;
 use FreeDSx\Ldap\Operation\Response\ModifyResponse;
 use FreeDSx\Ldap\Operation\Response\ResponseInterface;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
+use FreeDSx\Ldap\Control\PagingControl;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
@@ -276,6 +277,47 @@ final class ResponseFactoryTest extends TestCase
                 'foo',
                 ResultCode::PROTOCOL_ERROR,
             ),
+        );
+    }
+
+    public function test_standard_response_threads_through_response_controls(): void
+    {
+        $control = new PagingControl(
+            42,
+            'cookie',
+        );
+
+        $actual = $this->subject->getStandardResponse(
+            new LdapMessageRequest(1, new DeleteRequest('cn=foo,dc=example,dc=com')),
+            ResultCode::SUCCESS,
+            '',
+            null,
+            $control,
+        );
+
+        self::assertSame(
+            [$control],
+            $actual->controls()->toArray(),
+        );
+    }
+
+    public function test_extended_error_threads_through_response_controls(): void
+    {
+        $control = new PagingControl(
+            42,
+            'cookie',
+        );
+
+        $actual = $this->subject->getExtendedError(
+            'foo',
+            ResultCode::PROTOCOL_ERROR,
+            null,
+            $control,
+        );
+
+        self::assertSame(
+            [$control],
+            $actual->controls()->toArray(),
         );
     }
 }

--- a/tests/unit/Schema/Validation/SchemaValidatorTest.php
+++ b/tests/unit/Schema/Validation/SchemaValidatorTest.php
@@ -199,4 +199,79 @@ final class SchemaValidatorTest extends TestCase
         $this->expectNotToPerformAssertions();
         $subject->validateAdd($entry);
     }
+
+    public function test_system_add_skips_no_user_modification_but_keeps_structure_checks(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'top', 'person'),
+            new Attribute('cn', 'Alice'),
+            new Attribute('sn', 'Smith'),
+            new Attribute('createTimestamp', '20240101000000Z'),
+        );
+
+        $this->expectNotToPerformAssertions();
+
+        $this->subject->validateAdd(
+            $entry,
+            isSystem: true,
+        );
+    }
+
+    public function test_system_add_still_enforces_structural_class(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'top'),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
+
+        $this->subject->validateAdd(
+            $entry,
+            isSystem: true,
+        );
+    }
+
+    public function test_system_modify_skips_no_user_modification_check(): void
+    {
+        $command = new UpdateCommand(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            [Change::replace(new Attribute('createTimestamp', '20240101000000Z'))],
+        );
+        $result = $this->personEntry();
+
+        $this->expectNotToPerformAssertions();
+
+        $this->subject->validateModify(
+            $command,
+            $result,
+            isSystem: true,
+        );
+    }
+
+    public function test_system_modify_still_enforces_single_valued_attribute(): void
+    {
+        $command = new UpdateCommand(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            [Change::replace(new Attribute('createTimestamp', '20240101000000Z', '20240202000000Z'))],
+        );
+        $result = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'top', 'person'),
+            new Attribute('cn', 'Alice'),
+            new Attribute('sn', 'Smith'),
+            new Attribute('createTimestamp', '20240101000000Z', '20240202000000Z'),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::CONSTRAINT_VIOLATION);
+
+        $this->subject->validateModify(
+            $command,
+            $result,
+            isSystem: true,
+        );
+    }
 }

--- a/tests/unit/Server/Backend/Auth/PasswordHashVerifierTest.php
+++ b/tests/unit/Server/Backend/Auth/PasswordHashVerifierTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Auth;
+
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashVerifier;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PasswordHashVerifierTest extends TestCase
+{
+    private PasswordHashVerifier $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new PasswordHashVerifier();
+    }
+
+    public function test_plaintext_verifies_when_equal(): void
+    {
+        self::assertTrue($this->subject->verify('secret', 'secret'));
+    }
+
+    public function test_plaintext_does_not_verify_when_different(): void
+    {
+        self::assertFalse($this->subject->verify('secret', 'other'));
+    }
+
+    public function test_sha_format_verifies(): void
+    {
+        $hashed = '{SHA}' . base64_encode(sha1('mypassword', true));
+
+        self::assertTrue($this->subject->verify('mypassword', $hashed));
+    }
+
+    public function test_ssha_format_verifies(): void
+    {
+        $salt = random_bytes(8);
+        $hashed = '{SSHA}' . base64_encode(sha1('mypassword' . $salt, true) . $salt);
+
+        self::assertTrue($this->subject->verify('mypassword', $hashed));
+    }
+
+    public function test_md5_format_verifies(): void
+    {
+        $hashed = '{MD5}' . base64_encode(md5('mypassword', true));
+
+        self::assertTrue($this->subject->verify('mypassword', $hashed));
+    }
+
+    public function test_smd5_format_verifies(): void
+    {
+        $salt = random_bytes(8);
+        $hashed = '{SMD5}' . base64_encode(md5('mypassword' . $salt, true) . $salt);
+
+        self::assertTrue($this->subject->verify('mypassword', $hashed));
+    }
+
+    public function test_bcrypt_format_verifies(): void
+    {
+        $hashed = '{BCRYPT}' . password_hash('mypassword', PASSWORD_BCRYPT);
+
+        self::assertTrue($this->subject->verify('mypassword', $hashed));
+    }
+
+    public function test_argon2_format_verifies(): void
+    {
+        $hashed = '{ARGON2}' . password_hash('mypassword', PASSWORD_ARGON2ID);
+
+        self::assertTrue($this->subject->verify('mypassword', $hashed));
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function hashedPrefixProvider(): array
+    {
+        return [
+            '{SHA}'    => ['{SHA}' . base64_encode(sha1('mypassword', true))],
+            '{MD5}'    => ['{MD5}' . base64_encode(md5('mypassword', true))],
+            '{BCRYPT}' => ['{BCRYPT}' . password_hash('mypassword', PASSWORD_BCRYPT)],
+            '{ARGON2}' => ['{ARGON2}' . password_hash('mypassword', PASSWORD_ARGON2ID)],
+        ];
+    }
+
+    #[DataProvider('hashedPrefixProvider')]
+    public function test_wrong_password_does_not_verify(string $hashed): void
+    {
+        self::assertFalse($this->subject->verify('wrong', $hashed));
+    }
+}

--- a/tests/unit/Server/Backend/Auth/PasswordHasherTest.php
+++ b/tests/unit/Server/Backend/Auth/PasswordHasherTest.php
@@ -14,50 +14,80 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Auth;
 
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHasher;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashScheme;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashVerifier;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class PasswordHasherTest extends TestCase
 {
-    private PasswordHasher $subject;
-
-    protected function setUp(): void
+    public function test_default_scheme_is_bcrypt(): void
     {
-        $this->subject = new PasswordHasher();
-    }
-
-    public function test_hash_produces_ssha_string(): void
-    {
-        $hashed = $this->subject->hash('secret');
+        $hashed = (new PasswordHasher())->hash('secret');
 
         self::assertStringStartsWith(
-            '{SSHA}',
+            '{BCRYPT}',
             $hashed,
         );
     }
 
-    public function test_hash_is_verified_by_password_hash_verifier(): void
+    /**
+     * @return array<string, array{0: PasswordHashScheme, 1: non-empty-string}>
+     */
+    public static function schemeProvider(): array
     {
-        $hashed = $this->subject->hash('mypassword');
+        return [
+            'ssha' => [PasswordHashScheme::Ssha, '{SSHA}'],
+            'bcrypt' => [PasswordHashScheme::Bcrypt, '{BCRYPT}'],
+            'argon2' => [PasswordHashScheme::Argon2, '{ARGON2}'],
+        ];
+    }
+
+    /**
+     * @param non-empty-string $expectedPrefix
+     */
+    #[DataProvider('schemeProvider')]
+    public function test_each_scheme_produces_its_prefix(
+        PasswordHashScheme $scheme,
+        string $expectedPrefix,
+    ): void {
+        $hashed = (new PasswordHasher($scheme))->hash('secret');
+
+        self::assertStringStartsWith(
+            $expectedPrefix,
+            $hashed,
+        );
+    }
+
+    #[DataProvider('schemeProvider')]
+    public function test_each_scheme_round_trips_through_verifier(
+        PasswordHashScheme $scheme,
+    ): void {
+        $hashed = (new PasswordHasher($scheme))->hash('mypassword');
 
         self::assertTrue(
             (new PasswordHashVerifier())->verify('mypassword', $hashed),
         );
     }
 
-    public function test_wrong_password_does_not_verify(): void
-    {
-        $hashed = $this->subject->hash('mypassword');
+    #[DataProvider('schemeProvider')]
+    public function test_wrong_password_does_not_verify(
+        PasswordHashScheme $scheme,
+    ): void {
+        $hashed = (new PasswordHasher($scheme))->hash('mypassword');
 
         self::assertFalse(
             (new PasswordHashVerifier())->verify('wrong', $hashed),
         );
     }
 
-    public function test_two_hashes_of_same_input_differ_due_to_random_salt(): void
-    {
-        $first = $this->subject->hash('password');
-        $second = $this->subject->hash('password');
+    #[DataProvider('schemeProvider')]
+    public function test_two_hashes_of_same_input_differ_due_to_random_salt(
+        PasswordHashScheme $scheme,
+    ): void {
+        $hasher = new PasswordHasher($scheme);
+        $first = $hasher->hash('password');
+        $second = $hasher->hash('password');
 
         self::assertNotSame(
             $first,
@@ -67,22 +97,19 @@ final class PasswordHasherTest extends TestCase
 
     public function test_generate_returns_16_character_string(): void
     {
-        $generated = $this->subject->generate();
-
         self::assertSame(
             16,
-            strlen($generated),
+            strlen((new PasswordHasher())->generate()),
         );
     }
 
     public function test_generate_produces_different_values_on_each_call(): void
     {
-        $first = $this->subject->generate();
-        $second = $this->subject->generate();
+        $hasher = new PasswordHasher();
 
         self::assertNotSame(
-            $first,
-            $second,
+            $hasher->generate(),
+            $hasher->generate(),
         );
     }
 }

--- a/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
@@ -990,6 +990,72 @@ final class WritableStorageBackendTest extends TestCase
         );
     }
 
+    public function test_system_update_bypasses_no_user_modification_check(): void
+    {
+        $valid = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'top', 'person'),
+            new Attribute('cn', 'Alice'),
+            new Attribute('sn', 'Smith'),
+        );
+        $backend = new WritableStorageBackend(
+            storage: new InMemoryStorage([$this->base, $valid]),
+            validator: new SchemaValidator(
+                StandardSchemaProvider::buildCore(),
+                SchemaValidationMode::Strict,
+            ),
+        );
+
+        $backend->update(
+            new UpdateCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                [Change::replace(new Attribute('createTimestamp', '20240101000000Z'))],
+            ),
+            WriteContext::system(
+                new AnonToken(),
+                new ControlBag(),
+            ),
+        );
+
+        $stored = $backend->get(new Dn('cn=Alice,dc=example,dc=com'));
+
+        self::assertSame(
+            '20240101000000Z',
+            $stored?->get('createTimestamp')?->firstValue(),
+        );
+    }
+
+    public function test_system_update_still_enforces_single_valued_attribute(): void
+    {
+        $valid = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'top', 'person'),
+            new Attribute('cn', 'Alice'),
+            new Attribute('sn', 'Smith'),
+        );
+        $backend = new WritableStorageBackend(
+            storage: new InMemoryStorage([$this->base, $valid]),
+            validator: new SchemaValidator(
+                StandardSchemaProvider::buildCore(),
+                SchemaValidationMode::Strict,
+            ),
+        );
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::CONSTRAINT_VIOLATION);
+
+        $backend->update(
+            new UpdateCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                [Change::replace(new Attribute('createTimestamp', '20240101000000Z', '20240202000000Z'))],
+            ),
+            WriteContext::system(
+                new AnonToken(),
+                new ControlBag(),
+            ),
+        );
+    }
+
     public function test_add_sets_operational_attributes_on_entry(): void
     {
         $entry = new Entry(

--- a/tests/unit/Server/Logging/EventLogPolicyTest.php
+++ b/tests/unit/Server/Logging/EventLogPolicyTest.php
@@ -32,6 +32,12 @@ final class EventLogPolicyTest extends TestCase
         ServerEvent::CriticalControlRejected,
         ServerEvent::SchemaViolation,
         ServerEvent::NoticeOfDisconnectSent,
+        ServerEvent::PasswordPolicyAccountLocked,
+        ServerEvent::PasswordPolicyAccountUnlocked,
+        ServerEvent::PasswordPolicyExpired,
+        ServerEvent::PasswordPolicyMustChange,
+        ServerEvent::PasswordPolicyGraceLogin,
+        ServerEvent::PasswordPolicyChangeRejected,
     ];
 
     private const AUDIT_TRAIL_ENABLED = [

--- a/tests/unit/Server/Logging/ServerEventTest.php
+++ b/tests/unit/Server/Logging/ServerEventTest.php
@@ -54,6 +54,32 @@ final class ServerEventTest extends TestCase
         }
     }
 
+    /**
+     * @return array<string, array{0: ServerEvent, 1: string}>
+     */
+    public static function passwordPolicyEventLevels(): array
+    {
+        return [
+            'account_locked is a warning' => [ServerEvent::PasswordPolicyAccountLocked, LogLevel::WARNING],
+            'expired is a notice' => [ServerEvent::PasswordPolicyExpired, LogLevel::NOTICE],
+            'change_rejected is a notice' => [ServerEvent::PasswordPolicyChangeRejected, LogLevel::NOTICE],
+            'account_unlocked is informational' => [ServerEvent::PasswordPolicyAccountUnlocked, LogLevel::INFO],
+            'must_change is informational' => [ServerEvent::PasswordPolicyMustChange, LogLevel::INFO],
+            'grace_login is informational' => [ServerEvent::PasswordPolicyGraceLogin, LogLevel::INFO],
+        ];
+    }
+
+    #[DataProvider('passwordPolicyEventLevels')]
+    public function test_password_policy_event_log_level(
+        ServerEvent $event,
+        string $expected,
+    ): void {
+        self::assertSame(
+            $expected,
+            $event->level(),
+        );
+    }
+
     #[DataProvider('provideExceptionDiscriminationCases')]
     public function test_from_operation_exception_with_fallback_maps_codes_to_events(
         int $resultCode,

--- a/tests/unit/ServerOptionsTest.php
+++ b/tests/unit/ServerOptionsTest.php
@@ -16,6 +16,7 @@ namespace Tests\Unit\FreeDSx\Ldap;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashScheme;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
@@ -659,6 +660,24 @@ final class ServerOptionsTest extends TestCase
 
         self::assertNotNull($schema->getAttributeType(PasswordPolicyOid::NAME_PWD_MIN_LENGTH));
         self::assertNotNull($schema->getObjectClass(PasswordPolicyOid::NAME_PWD_POLICY));
+    }
+
+    public function test_password_hash_scheme_defaults_to_bcrypt(): void
+    {
+        self::assertSame(
+            PasswordHashScheme::Bcrypt,
+            $this->subject->getPasswordHashScheme(),
+        );
+    }
+
+    public function test_setting_password_hash_scheme_is_round_tripped(): void
+    {
+        $this->subject->setPasswordHashScheme(PasswordHashScheme::Argon2);
+
+        self::assertSame(
+            PasswordHashScheme::Argon2,
+            $this->subject->getPasswordHashScheme(),
+        );
     }
 
     public function test_it_accepts_all_defined_mechanism_constants(): void


### PR DESCRIPTION
More of the plumbing needed to support the password policy process:

* Backend writes need to be aware when we are dealing with system level attributes.
* The logging event system needs the password policy related events in place.
* We need to be able to pass controls in standard responses / errors.
* Support modern password hashing (argon2, bcrypt)