### PR TITLE
[1.0.0] Add more foundational code for server-side password policy support.

### DIFF
--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/OperationalChanges.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/OperationalChanges.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy;
+
+use FreeDSx\Ldap\Entry\Change;
+
+/**
+ * Bookkeeping deltas emitted by {@see PasswordPolicyEngine} "record" methods.
+ */
+final readonly class OperationalChanges
+{
+    /**
+     * @param list<Change> $changes
+     */
+    public function __construct(public array $changes = []) {}
+
+    public static function none(): self
+    {
+        return new self();
+    }
+
+    public static function of(Change ...$changes): self
+    {
+        return new self(array_values($changes));
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->changes === [];
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyContext.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyContext.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy;
+
+use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
+
+/**
+ * Per-connection holder that bridges the engine and the protocol handler.
+ */
+final class PasswordPolicyContext
+{
+    private ?PasswordPolicyOutcome $outcome = null;
+
+    public function setOutcome(PasswordPolicyOutcome $outcome): void
+    {
+        $this->outcome = $outcome;
+    }
+
+    public function clear(): void
+    {
+        $this->outcome = null;
+    }
+
+    public function getOutcome(): ?PasswordPolicyOutcome
+    {
+        return $this->outcome;
+    }
+
+    /**
+     * Convert the stashed outcome into a response control; null when there is nothing to communicate.
+     */
+    public function buildResponseControl(): ?PwdPolicyResponseControl
+    {
+        if ($this->outcome === null || !$this->outcome->hasResponseControlPayload()) {
+            return null;
+        }
+
+        return new PwdPolicyResponseControl(
+            timeBeforeExpiration: $this->outcome->timeBeforeExpiration,
+            graceAuthRemaining: $this->outcome->graceRemaining,
+            error: $this->outcome->errorCode,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyOutcome.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyOutcome.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy;
+
+use FreeDSx\Ldap\Operation\ResultCode;
+
+/**
+ * Decision returned by {@see PasswordPolicyEngine} methods.
+ */
+final readonly class PasswordPolicyOutcome
+{
+    /**
+     * @param ?int $errorCode A {@see \FreeDSx\Ldap\Control\PwdPolicyError} constant, or null when no error.
+     * @param ?int $timeBeforeExpiration Seconds until expiration; mutually exclusive with $graceRemaining.
+     * @param ?int $graceRemaining Grace logins left
+     */
+    public function __construct(
+        public bool $denied,
+        public int $ldapResultCode = ResultCode::SUCCESS,
+        public ?int $errorCode = null,
+        public ?int $timeBeforeExpiration = null,
+        public ?int $graceRemaining = null,
+        public string $diagnostic = '',
+    ) {}
+
+    public static function allow(): self
+    {
+        return new self(denied: false);
+    }
+
+    public static function allowWithExpirationWarning(int $seconds): self
+    {
+        return new self(
+            denied: false,
+            timeBeforeExpiration: $seconds,
+        );
+    }
+
+    public static function allowWithGraceWarning(int $remaining): self
+    {
+        return new self(
+            denied: false,
+            graceRemaining: $remaining,
+        );
+    }
+
+    public static function allowWithError(
+        int $errorCode,
+        string $diagnostic = '',
+    ): self {
+        return new self(
+            denied: false,
+            errorCode: $errorCode,
+            diagnostic: $diagnostic,
+        );
+    }
+
+    public static function deny(
+        int $errorCode,
+        int $ldapResultCode,
+        string $diagnostic,
+    ): self {
+        return new self(
+            denied: true,
+            ldapResultCode: $ldapResultCode,
+            errorCode: $errorCode,
+            diagnostic: $diagnostic,
+        );
+    }
+
+    public function hasResponseControlPayload(): bool
+    {
+        return $this->errorCode !== null
+            || $this->timeBeforeExpiration !== null
+            || $this->graceRemaining !== null;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyResolver.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyResolver.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+
+/**
+ * Locates the {@see PasswordPolicy} that governs a given user entry.
+ *
+ * One instance is constructed per request so the internal cache lives request-scoped.
+ */
+final class PasswordPolicyResolver
+{
+    /**
+     * @var array<string, ?PasswordPolicy> normalized DN string to decoded policy (null = not found in DIT)
+     */
+    private array $cache = [];
+
+    public function __construct(
+        private readonly LdapBackendInterface $backend,
+        private readonly ?Dn $defaultPolicyDn,
+        private readonly ?PasswordPolicy $inMemoryFallback,
+    ) {}
+
+    public function resolveFor(Entry $user): ?PasswordPolicy
+    {
+        return $this->fromUserSubentry($user)
+            ?? $this->fromDefaultDn()
+            ?? $this->inMemoryFallback;
+    }
+
+    private function fromUserSubentry(Entry $user): ?PasswordPolicy
+    {
+        $value = $user
+            ->get(PasswordPolicyOid::NAME_PWD_POLICY_SUBENTRY)
+            ?->firstValue();
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return $this->loadFromDit(new Dn($value));
+    }
+
+    private function fromDefaultDn(): ?PasswordPolicy
+    {
+        if ($this->defaultPolicyDn === null) {
+            return null;
+        }
+
+        return $this->loadFromDit($this->defaultPolicyDn);
+    }
+
+    private function loadFromDit(Dn $dn): ?PasswordPolicy
+    {
+        $key = $dn->normalize()->toString();
+
+        if (array_key_exists($key, $this->cache)) {
+            return $this->cache[$key];
+        }
+
+        $entry = $this->backend->get($dn);
+        $policy = $entry !== null ? PasswordPolicy::fromEntry($entry) : null;
+
+        return $this->cache[$key] = $policy;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/QualityCheck/DefaultPasswordQualityChecker.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/QualityCheck/DefaultPasswordQualityChecker.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
+use SensitiveParameter;
+
+/**
+ * Default checker enforcing pwdMinLength and pwdMaxLength. Operators wanting composition / strength
+ * rules should plug their own {@see PasswordQualityCheckerInterface} via {@see \FreeDSx\Ldap\ServerOptions}.
+ */
+final class DefaultPasswordQualityChecker implements PasswordQualityCheckerInterface
+{
+    public function check(
+        #[SensitiveParameter]
+        string $plain,
+        PasswordQualityRules $rules,
+    ): ?int {
+        $length = mb_strlen($plain);
+
+        if ($rules->minLength !== null && $length < $rules->minLength) {
+            return PwdPolicyError::PASSWORD_TOO_SHORT;
+        }
+        if ($rules->maxLength !== null && $length > $rules->maxLength) {
+            return PwdPolicyError::INSUFFICIENT_PASSWORD_QUALITY;
+        }
+
+        return null;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/QualityCheck/PasswordQualityCheckerInterface.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/QualityCheck/PasswordQualityCheckerInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck;
+
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
+use SensitiveParameter;
+
+/**
+ * Pluggable check applied to a new password before it is hashed and written.
+ */
+interface PasswordQualityCheckerInterface
+{
+    /**
+     * @return ?int A {@see \FreeDSx\Ldap\Control\PwdPolicyError} code on violation; null when acceptable.
+     */
+    public function check(
+        #[SensitiveParameter]
+        string $plain,
+        PasswordQualityRules $rules,
+    ): ?int;
+}

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -23,6 +23,8 @@ use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashScheme;
+use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\DefaultPasswordQualityChecker;
+use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\PasswordQualityCheckerInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
@@ -161,6 +163,8 @@ final class ServerOptions
     private ?Dn $defaultPasswordPolicyDn = null;
 
     private PasswordHashScheme $passwordHashScheme = PasswordHashScheme::Bcrypt;
+
+    private ?PasswordQualityCheckerInterface $passwordQualityChecker = null;
 
     private ?LoggerInterface $logger = null;
 
@@ -602,6 +606,21 @@ final class ServerOptions
     public function setPasswordHashScheme(PasswordHashScheme $scheme): self
     {
         $this->passwordHashScheme = $scheme;
+
+        return $this;
+    }
+
+    /**
+     * Quality check applied to new passwords before they are hashed and stored.
+     */
+    public function getPasswordQualityChecker(): PasswordQualityCheckerInterface
+    {
+        return $this->passwordQualityChecker ??= new DefaultPasswordQualityChecker();
+    }
+
+    public function setPasswordQualityChecker(PasswordQualityCheckerInterface $checker): self
+    {
+        $this->passwordQualityChecker = $checker;
 
         return $this;
     }

--- a/tests/support/Backend/RecordingLdapBackend.php
+++ b/tests/support/Backend/RecordingLdapBackend.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Support\FreeDSx\Ldap\Backend;
+
+use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Search\Filter\EqualityFilter;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
+use Generator;
+
+/**
+ * Stub backend keyed by DN string. Records how many times each DN is fetched so tests can assert caching.
+ */
+final class RecordingLdapBackend implements LdapBackendInterface
+{
+    /**
+     * @var array<string, int>
+     */
+    private array $getCalls = [];
+
+    /**
+     * @param array<string, Entry> $entries DN string → entry
+     */
+    public function __construct(private readonly array $entries = []) {}
+
+    public function get(Dn $dn): ?Entry
+    {
+        $key = $dn->toString();
+        $this->getCalls[$key] = ($this->getCalls[$key] ?? 0) + 1;
+
+        return $this->entries[$key] ?? null;
+    }
+
+    public function getCallCount(string $dn): int
+    {
+        return $this->getCalls[$dn] ?? 0;
+    }
+
+    public function search(
+        SearchRequest $request,
+        ControlBag $controls = new ControlBag(),
+    ): EntryStream {
+        return new EntryStream((static function (): Generator {
+            yield from [];
+        })());
+    }
+
+    public function compare(
+        Dn $dn,
+        EqualityFilter $filter,
+    ): bool {
+        return false;
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/OperationalChangesTest.php
+++ b/tests/unit/Server/PasswordPolicy/OperationalChangesTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy;
+
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Change;
+use FreeDSx\Ldap\Server\PasswordPolicy\OperationalChanges;
+use PHPUnit\Framework\TestCase;
+
+final class OperationalChangesTest extends TestCase
+{
+    public function test_none_is_empty(): void
+    {
+        $changes = OperationalChanges::none();
+
+        self::assertTrue($changes->isEmpty());
+        self::assertSame(
+            [],
+            $changes->changes,
+        );
+    }
+
+    public function test_of_carries_changes(): void
+    {
+        $a = Change::replace(new Attribute('pwdChangedTime', '20250101000000Z'));
+        $b = Change::reset(new Attribute('pwdFailureTime'));
+
+        $changes = OperationalChanges::of(
+            $a,
+            $b,
+        );
+
+        self::assertFalse($changes->isEmpty());
+        self::assertSame(
+            [$a, $b],
+            $changes->changes,
+        );
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/PasswordPolicyContextTest.php
+++ b/tests/unit/Server/PasswordPolicy/PasswordPolicyContextTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyOutcome;
+use PHPUnit\Framework\TestCase;
+
+final class PasswordPolicyContextTest extends TestCase
+{
+    public function test_starts_with_no_outcome(): void
+    {
+        $context = new PasswordPolicyContext();
+
+        self::assertNull($context->getOutcome());
+        self::assertNull($context->buildResponseControl());
+    }
+
+    public function test_set_then_get_round_trips(): void
+    {
+        $context = new PasswordPolicyContext();
+        $outcome = PasswordPolicyOutcome::allowWithGraceWarning(2);
+
+        $context->setOutcome($outcome);
+
+        self::assertSame(
+            $outcome,
+            $context->getOutcome(),
+        );
+    }
+
+    public function test_clear_removes_stashed_outcome(): void
+    {
+        $context = new PasswordPolicyContext();
+        $context->setOutcome(PasswordPolicyOutcome::allowWithGraceWarning(2));
+
+        $context->clear();
+
+        self::assertNull($context->getOutcome());
+        self::assertNull($context->buildResponseControl());
+    }
+
+    public function test_build_response_control_omits_payload_free_outcome(): void
+    {
+        $context = new PasswordPolicyContext();
+        $context->setOutcome(PasswordPolicyOutcome::allow());
+
+        self::assertNull($context->buildResponseControl());
+    }
+
+    public function test_build_response_control_includes_grace_remaining(): void
+    {
+        $context = new PasswordPolicyContext();
+        $context->setOutcome(PasswordPolicyOutcome::allowWithGraceWarning(3));
+
+        $control = $context->buildResponseControl();
+
+        self::assertNotNull($control);
+        self::assertSame(
+            3,
+            $control->getGraceAttemptsRemaining(),
+        );
+        self::assertNull($control->getTimeBeforeExpiration());
+        self::assertNull($control->getError());
+    }
+
+    public function test_build_response_control_includes_time_before_expiration(): void
+    {
+        $context = new PasswordPolicyContext();
+        $context->setOutcome(PasswordPolicyOutcome::allowWithExpirationWarning(86400));
+
+        $control = $context->buildResponseControl();
+
+        self::assertNotNull($control);
+        self::assertSame(
+            86400,
+            $control->getTimeBeforeExpiration(),
+        );
+        self::assertNull($control->getGraceAttemptsRemaining());
+    }
+
+    public function test_build_response_control_includes_error_code(): void
+    {
+        $context = new PasswordPolicyContext();
+        $context->setOutcome(PasswordPolicyOutcome::allowWithError(PwdPolicyError::CHANGE_AFTER_RESET));
+
+        $control = $context->buildResponseControl();
+
+        self::assertNotNull($control);
+        self::assertSame(
+            PwdPolicyError::CHANGE_AFTER_RESET,
+            $control->getError(),
+        );
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/PasswordPolicyOutcomeTest.php
+++ b/tests/unit/Server/PasswordPolicy/PasswordPolicyOutcomeTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyOutcome;
+use PHPUnit\Framework\TestCase;
+
+final class PasswordPolicyOutcomeTest extends TestCase
+{
+    public function test_allow_has_no_payload(): void
+    {
+        $outcome = PasswordPolicyOutcome::allow();
+
+        self::assertFalse($outcome->denied);
+        self::assertSame(
+            ResultCode::SUCCESS,
+            $outcome->ldapResultCode,
+        );
+        self::assertNull($outcome->errorCode);
+        self::assertNull($outcome->timeBeforeExpiration);
+        self::assertNull($outcome->graceRemaining);
+        self::assertFalse($outcome->hasResponseControlPayload());
+    }
+
+    public function test_allow_with_expiration_warning(): void
+    {
+        $outcome = PasswordPolicyOutcome::allowWithExpirationWarning(3600);
+
+        self::assertFalse($outcome->denied);
+        self::assertSame(
+            3600,
+            $outcome->timeBeforeExpiration,
+        );
+        self::assertNull($outcome->graceRemaining);
+        self::assertTrue($outcome->hasResponseControlPayload());
+    }
+
+    public function test_allow_with_grace_warning(): void
+    {
+        $outcome = PasswordPolicyOutcome::allowWithGraceWarning(2);
+
+        self::assertFalse($outcome->denied);
+        self::assertSame(
+            2,
+            $outcome->graceRemaining,
+        );
+        self::assertNull($outcome->timeBeforeExpiration);
+        self::assertTrue($outcome->hasResponseControlPayload());
+    }
+
+    public function test_allow_with_error_signals_change_after_reset(): void
+    {
+        $outcome = PasswordPolicyOutcome::allowWithError(
+            PwdPolicyError::CHANGE_AFTER_RESET,
+            'reset required',
+        );
+
+        self::assertFalse($outcome->denied);
+        self::assertSame(
+            PwdPolicyError::CHANGE_AFTER_RESET,
+            $outcome->errorCode,
+        );
+        self::assertSame(
+            'reset required',
+            $outcome->diagnostic,
+        );
+        self::assertTrue($outcome->hasResponseControlPayload());
+    }
+
+    public function test_deny_carries_error_code_and_result_code(): void
+    {
+        $outcome = PasswordPolicyOutcome::deny(
+            PwdPolicyError::ACCOUNT_LOCKED,
+            ResultCode::INVALID_CREDENTIALS,
+            'account locked',
+        );
+
+        self::assertTrue($outcome->denied);
+        self::assertSame(
+            ResultCode::INVALID_CREDENTIALS,
+            $outcome->ldapResultCode,
+        );
+        self::assertSame(
+            PwdPolicyError::ACCOUNT_LOCKED,
+            $outcome->errorCode,
+        );
+        self::assertSame(
+            'account locked',
+            $outcome->diagnostic,
+        );
+        self::assertTrue($outcome->hasResponseControlPayload());
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/PasswordPolicyResolverTest.php
+++ b/tests/unit/Server/PasswordPolicy/PasswordPolicyResolverTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Backend\RecordingLdapBackend;
+
+final class PasswordPolicyResolverTest extends TestCase
+{
+    private const USER_DN = 'uid=alice,dc=example,dc=com';
+    private const SUBENTRY_DN = 'cn=subentry-policy,ou=policies,dc=example,dc=com';
+    private const DEFAULT_DN = 'cn=default,ou=policies,dc=example,dc=com';
+
+    public function test_returns_null_when_no_source_configured(): void
+    {
+        $resolver = new PasswordPolicyResolver(
+            new RecordingLdapBackend(),
+            defaultPolicyDn: null,
+            inMemoryFallback: null,
+        );
+
+        self::assertNull($resolver->resolveFor($this->userEntry()));
+    }
+
+    public function test_falls_back_to_in_memory_policy_when_no_dn_configured(): void
+    {
+        $fallback = new PasswordPolicy(quality: new PasswordQualityRules(minLength: 8));
+
+        $resolver = new PasswordPolicyResolver(
+            new RecordingLdapBackend(),
+            defaultPolicyDn: null,
+            inMemoryFallback: $fallback,
+        );
+
+        self::assertSame(
+            $fallback,
+            $resolver->resolveFor($this->userEntry()),
+        );
+    }
+
+    public function test_resolves_from_default_dn_when_user_has_no_subentry(): void
+    {
+        $defaultEntry = $this->policyEntry(
+            self::DEFAULT_DN,
+            ['pwdMinLength' => '10'],
+        );
+        $backend = new RecordingLdapBackend([self::DEFAULT_DN => $defaultEntry]);
+
+        $resolver = new PasswordPolicyResolver(
+            $backend,
+            defaultPolicyDn: new Dn(self::DEFAULT_DN),
+            inMemoryFallback: null,
+        );
+
+        $resolved = $resolver->resolveFor($this->userEntry());
+
+        self::assertNotNull($resolved);
+        self::assertSame(
+            10,
+            $resolved->quality->minLength,
+        );
+    }
+
+    public function test_resolves_from_user_subentry_when_present(): void
+    {
+        $subentryEntry = $this->policyEntry(
+            self::SUBENTRY_DN,
+            ['pwdMinLength' => '12'],
+        );
+        $defaultEntry = $this->policyEntry(
+            self::DEFAULT_DN,
+            ['pwdMinLength' => '6'],
+        );
+        $backend = new RecordingLdapBackend([
+            self::SUBENTRY_DN => $subentryEntry,
+            self::DEFAULT_DN => $defaultEntry,
+        ]);
+
+        $resolver = new PasswordPolicyResolver(
+            $backend,
+            defaultPolicyDn: new Dn(self::DEFAULT_DN),
+            inMemoryFallback: null,
+        );
+
+        $resolved = $resolver->resolveFor(
+            $this->userEntry(['pwdPolicySubentry' => self::SUBENTRY_DN]),
+        );
+
+        self::assertNotNull($resolved);
+        self::assertSame(
+            12,
+            $resolved->quality->minLength,
+        );
+    }
+
+    public function test_missing_subentry_dn_falls_through_to_default(): void
+    {
+        $defaultEntry = $this->policyEntry(
+            self::DEFAULT_DN,
+            ['pwdMinLength' => '6'],
+        );
+        $backend = new RecordingLdapBackend([
+            self::DEFAULT_DN => $defaultEntry,
+        ]);
+
+        $resolver = new PasswordPolicyResolver(
+            $backend,
+            defaultPolicyDn: new Dn(self::DEFAULT_DN),
+            inMemoryFallback: null,
+        );
+
+        $resolved = $resolver->resolveFor(
+            $this->userEntry(['pwdPolicySubentry' => 'cn=missing,ou=policies,dc=example,dc=com']),
+        );
+
+        self::assertNotNull($resolved);
+        self::assertSame(
+            6,
+            $resolved->quality->minLength,
+        );
+    }
+
+    public function test_repeated_lookups_hit_the_cache(): void
+    {
+        $defaultEntry = $this->policyEntry(
+            self::DEFAULT_DN,
+            ['pwdMinLength' => '6'],
+        );
+        $backend = new RecordingLdapBackend([self::DEFAULT_DN => $defaultEntry]);
+
+        $resolver = new PasswordPolicyResolver(
+            $backend,
+            defaultPolicyDn: new Dn(self::DEFAULT_DN),
+            inMemoryFallback: null,
+        );
+
+        $resolver->resolveFor($this->userEntry());
+        $resolver->resolveFor($this->userEntry());
+        $resolver->resolveFor($this->userEntry());
+
+        self::assertSame(
+            1,
+            $backend->getCallCount(self::DEFAULT_DN),
+        );
+    }
+
+    /**
+     * @param array<string, string> $extra
+     */
+    private function userEntry(array $extra = []): Entry
+    {
+        return Entry::fromArray(
+            self::USER_DN,
+            ['uid' => 'alice'] + $extra,
+        );
+    }
+
+    /**
+     * @param array<string, string> $extra
+     */
+    private function policyEntry(
+        string $dn,
+        array $extra,
+    ): Entry {
+        return Entry::fromArray(
+            $dn,
+            ['pwdAttribute' => 'userPassword'] + $extra,
+        );
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/QualityCheck/DefaultPasswordQualityCheckerTest.php
+++ b/tests/unit/Server/PasswordPolicy/QualityCheck/DefaultPasswordQualityCheckerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\DefaultPasswordQualityChecker;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DefaultPasswordQualityCheckerTest extends TestCase
+{
+    private DefaultPasswordQualityChecker $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new DefaultPasswordQualityChecker();
+    }
+
+    public function test_unconstrained_rules_accept_any_value(): void
+    {
+        self::assertNull(
+            $this->subject->check(
+                'whatever',
+                new PasswordQualityRules(),
+            ),
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: PasswordQualityRules, 2: ?int}>
+     */
+    public static function checkProvider(): array
+    {
+        return [
+            'min length pass' => [
+                'longenough',
+                new PasswordQualityRules(minLength: 8),
+                null,
+            ],
+            'min length exact boundary' => [
+                'eightchr',
+                new PasswordQualityRules(minLength: 8),
+                null,
+            ],
+            'min length fail' => [
+                'short',
+                new PasswordQualityRules(minLength: 8),
+                PwdPolicyError::PASSWORD_TOO_SHORT,
+            ],
+            'max length pass' => [
+                'fits',
+                new PasswordQualityRules(maxLength: 10),
+                null,
+            ],
+            'max length exact boundary' => [
+                'tencharsok',
+                new PasswordQualityRules(maxLength: 10),
+                null,
+            ],
+            'max length fail' => [
+                'thispasswordistoolong',
+                new PasswordQualityRules(maxLength: 10),
+                PwdPolicyError::INSUFFICIENT_PASSWORD_QUALITY,
+            ],
+            'both bounds satisfied' => [
+                'fitsperfectly',
+                new PasswordQualityRules(minLength: 8, maxLength: 20),
+                null,
+            ],
+            'min checked before max' => [
+                'short',
+                new PasswordQualityRules(minLength: 8, maxLength: 3),
+                PwdPolicyError::PASSWORD_TOO_SHORT,
+            ],
+        ];
+    }
+
+    #[DataProvider('checkProvider')]
+    public function test_check_maps_each_rule_violation(
+        string $plain,
+        PasswordQualityRules $rules,
+        ?int $expected,
+    ): void {
+        self::assertSame(
+            $expected,
+            $this->subject->check(
+                $plain,
+                $rules,
+            ),
+        );
+    }
+
+    public function test_check_uses_multibyte_length_not_byte_length(): void
+    {
+        // 4 multi-byte chars; 12 bytes in UTF-8.
+        $rules = new PasswordQualityRules(minLength: 8);
+
+        self::assertSame(
+            PwdPolicyError::PASSWORD_TOO_SHORT,
+            $this->subject->check(
+                '日本語版',
+                $rules,
+            ),
+        );
+    }
+}

--- a/tests/unit/ServerOptionsTest.php
+++ b/tests/unit/ServerOptionsTest.php
@@ -18,6 +18,8 @@ use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashScheme;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\DefaultPasswordQualityChecker;
+use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\PasswordQualityCheckerInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
@@ -677,6 +679,33 @@ final class ServerOptionsTest extends TestCase
         self::assertSame(
             PasswordHashScheme::Argon2,
             $this->subject->getPasswordHashScheme(),
+        );
+    }
+
+    public function test_password_quality_checker_defaults_to_the_built_in_checker(): void
+    {
+        self::assertInstanceOf(
+            DefaultPasswordQualityChecker::class,
+            $this->subject->getPasswordQualityChecker(),
+        );
+    }
+
+    public function test_setting_password_quality_checker_is_round_tripped(): void
+    {
+        $custom = new class implements PasswordQualityCheckerInterface {
+            public function check(
+                string $plain,
+                PasswordQualityRules $rules,
+            ): ?int {
+                return null;
+            }
+        };
+
+        $this->subject->setPasswordQualityChecker($custom);
+
+        self::assertSame(
+            $custom,
+            $this->subject->getPasswordQualityChecker(),
         );
     }
 


### PR DESCRIPTION
Add the quality checker / result outcome / policy resolver and other models needed by what will be the actual policy engine where the bulk of the logic will live. Just getting these various pieces out of the way still.