### PR TITLE
[1.0.0] Add the core password policy engine

### DIFF
--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -20,7 +20,16 @@ use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\Queue\ClientQueueInstantiator;
 use FreeDSx\Ldap\Protocol\RootDseLoader;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
+use FreeDSx\Ldap\Server\Clock\SystemClock;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\AllowUserChangeConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\HistoryConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\MinAgeConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\QualityConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\SafeModifyConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashVerifier;
 use FreeDSx\Ldap\Server\RequestHandler\HandlerFactory;
 use FreeDSx\Ldap\Server\ServerProtocolFactory;
 use FreeDSx\Ldap\Server\ServerRunner\PcntlServerRunner;
@@ -155,6 +164,29 @@ class Container
         $this->registerFactory(
             className: ServerAuthorization::class,
             factory: $this->makeServerAuthorizer(...),
+        );
+        $this->registerFactory(
+            className: PasswordPolicyEngine::class,
+            factory: $this->makePasswordPolicyEngine(...),
+        );
+    }
+
+    private function makePasswordPolicyEngine(): PasswordPolicyEngine
+    {
+        $options = $this->get(ServerOptions::class);
+        $clock = new SystemClock();
+
+        $chain = new PasswordChangeConstraintChain([
+            new AllowUserChangeConstraint(),
+            new SafeModifyConstraint(),
+            new MinAgeConstraint($clock),
+            new QualityConstraint($options->getPasswordQualityChecker()),
+            new HistoryConstraint(new PasswordHashVerifier()),
+        ]);
+
+        return new PasswordPolicyEngine(
+            clock: $clock,
+            changeConstraints: $chain,
         );
     }
 

--- a/src/FreeDSx/Ldap/Control/PwdPolicyResponseControl.php
+++ b/src/FreeDSx/Ldap/Control/PwdPolicyResponseControl.php
@@ -76,26 +76,29 @@ class PwdPolicyResponseControl extends Control
         $response = Asn1::sequence();
         $warning = null;
 
-        if ($this->graceAuthRemaining !== null && $this->timeBeforeExpiration !== null) {
+        $timeBefore = $this->timeBeforeExpiration;
+        $graceRemaining = $this->graceAuthRemaining;
+
+        if ($timeBefore !== null && $graceRemaining !== null) {
             throw new ProtocolException('The password policy response cannot have both a time expiration and a grace auth value.');
         }
-        if ($this->timeBeforeExpiration !== null) {
+        if ($timeBefore !== null) {
             $warning = Asn1::context(
                 tagNumber: 0,
                 type: Asn1::sequence(
                     Asn1::context(
                         tagNumber: 0,
-                        type: Asn1::integer($this->timeBeforeExpiration),
+                        type: Asn1::integer($timeBefore),
                     ),
                 ),
             );
         }
-        if ($this->graceAuthRemaining !== null) {
+        if ($graceRemaining !== null) {
             $warning = Asn1::context(
                 tagNumber: 0,
                 type: Asn1::sequence(Asn1::context(
                     tagNumber: 1,
-                    type: Asn1::integer($this->graceAuthRemaining),
+                    type: Asn1::integer($graceRemaining),
                 )),
             );
         }

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/AllowUserChangeConstraint.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/AllowUserChangeConstraint.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Constraint;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyOutcome;
+
+/**
+ * Denies a self-service change when pwdAllowUserChange is explicitly false.
+ */
+final readonly class AllowUserChangeConstraint implements PasswordChangeConstraint
+{
+    public function check(PasswordChangeAttempt $attempt): ?PasswordPolicyOutcome
+    {
+        if (!$attempt->isSelf || $attempt->policy->change->allowUserChange !== false) {
+            return null;
+        }
+
+        return PasswordPolicyOutcome::deny(
+            PwdPolicyError::PASSWORD_MOD_NOT_ALLOWED,
+            ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+            'Self-service password change is not permitted by policy.',
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/HistoryConstraint.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/HistoryConstraint.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Constraint;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashVerifier;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyOutcome;
+
+/**
+ * Denies a change whose new value matches any retained pwdHistory entry.
+ */
+final readonly class HistoryConstraint implements PasswordChangeConstraint
+{
+    public function __construct(private PasswordHashVerifier $hashVerifier) {}
+
+    /**
+     * Comparison goes through {@see PasswordHashVerifier}; entries stored under a no-longer-supported
+     * scheme silently fail to match and effectively drop out of the history set (draft-behera-10 §5.3.7).
+     */
+    public function check(PasswordChangeAttempt $attempt): ?PasswordPolicyOutcome
+    {
+        $depth = $attempt->policy->quality->inHistory;
+        if ($depth === null || $depth === 0 || $attempt->state->history === []) {
+            return null;
+        }
+
+        foreach ($attempt->state->history as $entry) {
+            if ($this->hashVerifier->verify($attempt->newPassword, $entry->data)) {
+                return PasswordPolicyOutcome::deny(
+                    PwdPolicyError::PASSWORD_IN_HISTORY,
+                    ResultCode::CONSTRAINT_VIOLATION,
+                    'Password matches a recently used password.',
+                );
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/MinAgeConstraint.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/MinAgeConstraint.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Constraint;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\Clock\ClockInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyOutcome;
+
+/**
+ * Denies a change attempted within pwdMinAge seconds of the last password change.
+ */
+final readonly class MinAgeConstraint implements PasswordChangeConstraint
+{
+    public function __construct(private ClockInterface $clock) {}
+
+    public function check(PasswordChangeAttempt $attempt): ?PasswordPolicyOutcome
+    {
+        $minAge = $attempt->policy->change->minAge;
+        $changedAt = $attempt->state->changedAt;
+        if ($minAge === null || $minAge === 0 || $changedAt === null) {
+            return null;
+        }
+
+        $age = $this->clock->now()->getTimestamp() - $changedAt->getTimestamp();
+        if ($age >= $minAge) {
+            return null;
+        }
+
+        return PasswordPolicyOutcome::deny(
+            PwdPolicyError::PASSWORD_TOO_YOUNG,
+            ResultCode::CONSTRAINT_VIOLATION,
+            'Password was changed too recently.',
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/PasswordChangeAttempt.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/PasswordChangeAttempt.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Constraint;
+
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
+use SensitiveParameter;
+
+/**
+ * Snapshot of the inputs to a single password-change evaluation, passed to each {@see PasswordChangeConstraint}.
+ */
+final readonly class PasswordChangeAttempt
+{
+    public function __construct(
+        #[SensitiveParameter]
+        public string $newPassword,
+        #[SensitiveParameter]
+        public ?string $oldPassword,
+        public UserPasswordState $state,
+        public PasswordPolicy $policy,
+        public bool $isSelf,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/PasswordChangeConstraint.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/PasswordChangeConstraint.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Constraint;
+
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyOutcome;
+
+/**
+ * One gate in the password-change pipeline; returns a deny outcome on violation or null when satisfied.
+ */
+interface PasswordChangeConstraint
+{
+    public function check(PasswordChangeAttempt $attempt): ?PasswordPolicyOutcome;
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/PasswordChangeConstraintChain.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/PasswordChangeConstraintChain.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Constraint;
+
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyOutcome;
+
+/**
+ * Ordered pipeline of {@see PasswordChangeConstraint}s; the first violation short-circuits evaluation.
+ */
+final readonly class PasswordChangeConstraintChain
+{
+    /**
+     * @param list<PasswordChangeConstraint> $constraints
+     */
+    public function __construct(private array $constraints) {}
+
+    public function evaluate(PasswordChangeAttempt $attempt): ?PasswordPolicyOutcome
+    {
+        foreach ($this->constraints as $constraint) {
+            $outcome = $constraint->check($attempt);
+            if ($outcome !== null) {
+                return $outcome;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/QualityConstraint.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/QualityConstraint.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Constraint;
+
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyOutcome;
+use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\PasswordQualityCheckerInterface;
+
+/**
+ * Delegates to the configured {@see PasswordQualityCheckerInterface}; maps any returned code into a deny outcome.
+ */
+final readonly class QualityConstraint implements PasswordChangeConstraint
+{
+    public function __construct(private PasswordQualityCheckerInterface $checker) {}
+
+    public function check(PasswordChangeAttempt $attempt): ?PasswordPolicyOutcome
+    {
+        $errorCode = $this->checker->check(
+            $attempt->newPassword,
+            $attempt->policy->quality,
+        );
+        if ($errorCode === null) {
+            return null;
+        }
+
+        return PasswordPolicyOutcome::deny(
+            $errorCode,
+            ResultCode::CONSTRAINT_VIOLATION,
+            'Password does not meet quality requirements.',
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/SafeModifyConstraint.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/SafeModifyConstraint.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Constraint;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyOutcome;
+
+/**
+ * Requires the client to supply the existing password when pwdSafeModify is enabled.
+ */
+final readonly class SafeModifyConstraint implements PasswordChangeConstraint
+{
+    public function check(PasswordChangeAttempt $attempt): ?PasswordPolicyOutcome
+    {
+        if ($attempt->policy->change->safeModify !== true || ($attempt->oldPassword ?? '') !== '') {
+            return null;
+        }
+
+        return PasswordPolicyOutcome::deny(
+            PwdPolicyError::MUST_SUPPLY_OLD_PASSWORD,
+            ResultCode::CONSTRAINT_VIOLATION,
+            'The existing password must be supplied.',
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyEngine.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyEngine.php
@@ -1,0 +1,409 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy;
+
+use DateTimeImmutable;
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Entry\Change;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\Clock\ClockInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeAttempt;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
+use SensitiveParameter;
+
+/**
+ * Core decision / tracking engine for draft-behera-10 password policy.
+ */
+final readonly class PasswordPolicyEngine
+{
+    public function __construct(
+        private ClockInterface $clock,
+        private PasswordChangeConstraintChain $changeConstraints,
+    ) {}
+
+    /**
+     * Lockout check applied before the inner authenticator verifies credentials.
+     */
+    public function evaluatePreBind(
+        UserPasswordState $state,
+        PasswordPolicy $policy,
+    ): PasswordPolicyOutcome {
+        if (!$state->isLocked()) {
+            return PasswordPolicyOutcome::allow();
+        }
+
+        if ($state->permanentlyLocked) {
+            return self::denyLocked();
+        }
+
+        $duration = $policy->lockout->duration;
+        if ($duration === null || $duration === 0) {
+            return self::denyLocked();
+        }
+
+        if ($this->secondsSinceLock($state) < $duration) {
+            return self::denyLocked();
+        }
+
+        return PasswordPolicyOutcome::allow();
+    }
+
+    /**
+     * Record a failed bind: append the current time to pwdFailureTime, and trip the lockout if the retained failure count meets pwdMaxFailure.
+     *
+     * Note: pwdFailureTime accumulates regardless of pwdLockout. Only the lock transition requires pwdLockout=TRUE (draft-behera-10 §5.2.9, §5.3.2).
+     */
+    public function recordBindFailure(
+        UserPasswordState $state,
+        PasswordPolicy $policy,
+    ): RecordedOutcome {
+        $now = $this->clock->now();
+        $retained = $this->trimFailuresToInterval(
+            $state->failureTimes,
+            $policy,
+        );
+        $retained[] = $now;
+
+        $changes = [Change::replace(
+            PasswordPolicyOid::NAME_PWD_FAILURE_TIME,
+            ...self::formatTimes($retained),
+        )];
+
+        $outcome = PasswordPolicyOutcome::allow();
+
+        if ($this->shouldTripLockout($state, $policy, $retained)) {
+            $changes[] = Change::replace(
+                PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME,
+                GeneralizedTime::format($now),
+            );
+            $outcome = self::denyLocked();
+        }
+
+        return new RecordedOutcome(
+            $outcome,
+            OperationalChanges::of(...$changes),
+        );
+    }
+
+    /**
+     * @param list<DateTimeImmutable> $failures
+     * @return list<DateTimeImmutable>
+     */
+    private function trimFailuresToInterval(
+        array $failures,
+        PasswordPolicy $policy,
+    ): array {
+        $interval = $policy->lockout->failureCountInterval;
+        if ($interval === null || $interval === 0) {
+            return $failures;
+        }
+
+        $nowTs = $this->clock->now()->getTimestamp();
+
+        return array_values(array_filter(
+            $failures,
+            static fn(DateTimeImmutable $t): bool => ($nowTs - $t->getTimestamp()) < $interval,
+        ));
+    }
+
+    /**
+     * @param list<DateTimeImmutable> $retained
+     */
+    private function shouldTripLockout(
+        UserPasswordState $state,
+        PasswordPolicy $policy,
+        array $retained,
+    ): bool {
+        return match (true) {
+            $policy->lockout->enabled !== true,
+            $policy->lockout->maxFailure === null,
+            $policy->lockout->maxFailure === 0,
+            $state->isLocked() => false,
+            default => count($retained) >= $policy->lockout->maxFailure,
+        };
+    }
+
+    /**
+     * May deny if the password is expired and no grace remains; otherwise clears failures / lockout and surfaces any
+     * warning (expiration, grace, reset).
+     */
+    public function recordBindSuccess(
+        UserPasswordState $state,
+        PasswordPolicy $policy,
+    ): RecordedOutcome {
+        $now = $this->clock->now();
+        $secondsRemaining = $this->secondsUntilExpiration(
+            $state,
+            $policy,
+        );
+        $isExpired = $secondsRemaining !== null && $secondsRemaining <= 0;
+
+        if ($isExpired && $this->graceRemaining($state, $policy) === 0) {
+            return new RecordedOutcome(
+                PasswordPolicyOutcome::deny(
+                    PwdPolicyError::PASSWORD_EXPIRED,
+                    ResultCode::INVALID_CREDENTIALS,
+                    'Password has expired.',
+                ),
+                OperationalChanges::none(),
+            );
+        }
+
+        $changes = $this->buildSuccessChanges(
+            $state,
+            $now,
+            $isExpired,
+        );
+        $outcome = $this->composeSuccessOutcome(
+            $state,
+            $policy,
+            $secondsRemaining,
+            $isExpired,
+        );
+
+        return new RecordedOutcome(
+            $outcome,
+            OperationalChanges::of(...$changes),
+        );
+    }
+
+    /**
+     * Seconds remaining until pwdChangedTime + pwdMaxAge; null when expiration isn't configured or pwdChangedTime is
+     * missing.
+     *
+     * Note: negative means already expired.
+     */
+    private function secondsUntilExpiration(
+        UserPasswordState $state,
+        PasswordPolicy $policy,
+    ): ?int {
+        $maxAge = $policy->expiration->maxAge;
+        if ($maxAge === null || $maxAge === 0 || $state->changedAt === null) {
+            return null;
+        }
+
+        $age = $this->clock->now()->getTimestamp()
+            - $state->changedAt->getTimestamp();
+
+        return $maxAge - $age;
+    }
+
+    /**
+     * Number of grace logins still available. 0 means none left (or no grace configured).
+     */
+    private function graceRemaining(
+        UserPasswordState $state,
+        PasswordPolicy $policy,
+    ): int {
+        $limit = $policy->expiration->graceAuthnLimit;
+        if ($limit === null || $limit === 0) {
+            return 0;
+        }
+
+        return max(
+            0,
+            $limit - count($state->graceUseTimes),
+        );
+    }
+
+    /**
+     * @return list<Change>
+     */
+    private function buildSuccessChanges(
+        UserPasswordState $state,
+        DateTimeImmutable $now,
+        bool $isExpired,
+    ): array {
+        $changes = [];
+
+        if ($state->failureTimes !== []) {
+            $changes[] = Change::reset(PasswordPolicyOid::NAME_PWD_FAILURE_TIME);
+        }
+        if ($state->accountLockedAt !== null && !$state->permanentlyLocked) {
+            $changes[] = Change::reset(PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME);
+        }
+        if ($isExpired) {
+            $graceTimes = [...$state->graceUseTimes, $now];
+            $changes[] = Change::replace(
+                PasswordPolicyOid::NAME_PWD_GRACE_USE_TIME,
+                ...self::formatTimes($graceTimes),
+            );
+        }
+
+        return $changes;
+    }
+
+    private function composeSuccessOutcome(
+        UserPasswordState $state,
+        PasswordPolicy $policy,
+        ?int $secondsRemaining,
+        bool $isExpired,
+    ): PasswordPolicyOutcome {
+        $errorCode = $state->mustChange ? PwdPolicyError::CHANGE_AFTER_RESET : null;
+        $graceWarning = $isExpired
+            ? $this->graceRemaining($state, $policy) - 1
+            : null;
+        $expirationWarning = $isExpired
+            ? null
+            : $this->expirationWarningSeconds($secondsRemaining, $policy);
+
+        return new PasswordPolicyOutcome(
+            denied: false,
+            errorCode: $errorCode,
+            timeBeforeExpiration: $expirationWarning,
+            graceRemaining: $graceWarning,
+        );
+    }
+
+    private function expirationWarningSeconds(
+        ?int $secondsRemaining,
+        PasswordPolicy $policy,
+    ): ?int {
+        $window = $policy->expiration->expireWarning;
+        if ($secondsRemaining === null || $window === null || $window === 0) {
+            return null;
+        }
+        if ($secondsRemaining > $window) {
+            return null;
+        }
+
+        return $secondsRemaining;
+    }
+
+    /**
+     * Evaluate a password change against the configured constraint chain.
+     */
+    public function evaluatePasswordChange(
+        #[SensitiveParameter]
+        string $newPassword,
+        #[SensitiveParameter]
+        ?string $oldPassword,
+        UserPasswordState $state,
+        PasswordPolicy $policy,
+        bool $isSelf,
+    ): PasswordPolicyOutcome {
+        $attempt = new PasswordChangeAttempt(
+            newPassword: $newPassword,
+            oldPassword: $oldPassword,
+            state: $state,
+            policy: $policy,
+            isSelf: $isSelf,
+        );
+
+        return $this->changeConstraints->evaluate($attempt)
+            ?? PasswordPolicyOutcome::allow();
+    }
+
+    /**
+     * Stamp pwdChangedTime, rotate pwdHistory, clear pwdReset / pwdFailureTime / pwdAccountLockedTime / pwdGraceUseTime.
+     */
+    public function recordPasswordChange(
+        string $hashedNew,
+        UserPasswordState $state,
+        PasswordPolicy $policy,
+    ): OperationalChanges {
+        $now = $this->clock->now();
+        $changes = [Change::replace(
+            PasswordPolicyOid::NAME_PWD_CHANGED_TIME,
+            GeneralizedTime::format($now),
+        )];
+
+        $historyChange = $this->buildHistoryChange(
+            $hashedNew,
+            $state,
+            $policy,
+            $now,
+        );
+        if ($historyChange !== null) {
+            $changes[] = $historyChange;
+        }
+        if ($state->mustChange) {
+            $changes[] = Change::reset(PasswordPolicyOid::NAME_PWD_RESET);
+        }
+        if ($state->failureTimes !== []) {
+            $changes[] = Change::reset(PasswordPolicyOid::NAME_PWD_FAILURE_TIME);
+        }
+        if ($state->isLocked()) {
+            $changes[] = Change::reset(PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME);
+        }
+        if ($state->graceUseTimes !== []) {
+            $changes[] = Change::reset(PasswordPolicyOid::NAME_PWD_GRACE_USE_TIME);
+        }
+
+        return OperationalChanges::of(...$changes);
+    }
+
+    private function buildHistoryChange(
+        string $hashedNew,
+        UserPasswordState $state,
+        PasswordPolicy $policy,
+        DateTimeImmutable $now,
+    ): ?Change {
+        $depth = $policy->quality->inHistory;
+        if ($depth === null || $depth === 0) {
+            return null;
+        }
+
+        $newest = HistoryEntry::forStoredPassword(
+            $now,
+            $hashedNew,
+        );
+        $retained = array_slice(
+            [$newest, ...$state->history],
+            0,
+            $depth,
+        );
+
+        return Change::replace(
+            PasswordPolicyOid::NAME_PWD_HISTORY,
+            ...array_map(
+                static fn(HistoryEntry $entry): string => $entry->encode(),
+                $retained,
+            ),
+        );
+    }
+
+    private function secondsSinceLock(UserPasswordState $state): int
+    {
+        if ($state->accountLockedAt === null) {
+            return 0;
+        }
+
+        return $this->clock->now()->getTimestamp()
+            - $state->accountLockedAt->getTimestamp();
+    }
+
+    /**
+     * @param list<DateTimeImmutable> $instants
+     * @return list<string>
+     */
+    private static function formatTimes(array $instants): array
+    {
+        return array_values(array_map(
+            static fn(DateTimeImmutable $t): string => GeneralizedTime::format($t),
+            $instants,
+        ));
+    }
+
+    private static function denyLocked(): PasswordPolicyOutcome
+    {
+        return PasswordPolicyOutcome::deny(
+            PwdPolicyError::ACCOUNT_LOCKED,
+            ResultCode::INVALID_CREDENTIALS,
+            'Account is locked.',
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/RecordedOutcome.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/RecordedOutcome.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy;
+
+/**
+ * Result of an engine "record" method: the bookkeeping deltas plus the outcome to surface.
+ */
+final readonly class RecordedOutcome
+{
+    public function __construct(
+        public PasswordPolicyOutcome $outcome,
+        public OperationalChanges $changes,
+    ) {}
+}

--- a/tests/support/Server/PasswordPolicy/RecordingPasswordChangeConstraint.php
+++ b/tests/support/Server/PasswordPolicy/RecordingPasswordChangeConstraint.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Support\FreeDSx\Ldap\Server\PasswordPolicy;
+
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeAttempt;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyOutcome;
+
+/**
+ * Test double that records each invocation and returns a configurable outcome.
+ */
+final class RecordingPasswordChangeConstraint implements PasswordChangeConstraint
+{
+    /**
+     * @var list<PasswordChangeAttempt>
+     */
+    public array $invocations = [];
+
+    public function __construct(private readonly ?PasswordPolicyOutcome $outcome = null) {}
+
+    public function check(PasswordChangeAttempt $attempt): ?PasswordPolicyOutcome
+    {
+        $this->invocations[] = $attempt;
+
+        return $this->outcome;
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/Constraint/AllowUserChangeConstraintTest.php
+++ b/tests/unit/Server/PasswordPolicy/Constraint/AllowUserChangeConstraintTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy\Constraint;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\AllowUserChangeConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeAttempt;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordChangeRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
+use PHPUnit\Framework\TestCase;
+
+final class AllowUserChangeConstraintTest extends TestCase
+{
+    private AllowUserChangeConstraint $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new AllowUserChangeConstraint();
+    }
+
+    public function test_admin_bypasses_the_check(): void
+    {
+        $outcome = $this->subject->check(
+            $this->attempt(
+                isSelf: false,
+                allowUserChange: false,
+            ),
+        );
+
+        self::assertNull($outcome);
+    }
+
+    public function test_self_with_unset_rule_passes(): void
+    {
+        $outcome = $this->subject->check(
+            $this->attempt(
+                isSelf: true,
+                allowUserChange: null,
+            ),
+        );
+
+        self::assertNull($outcome);
+    }
+
+    public function test_self_with_explicit_true_passes(): void
+    {
+        $outcome = $this->subject->check(
+            $this->attempt(
+                isSelf: true,
+                allowUserChange: true,
+            ),
+        );
+
+        self::assertNull($outcome);
+    }
+
+    public function test_self_with_explicit_false_denies(): void
+    {
+        $outcome = $this->subject->check(
+            $this->attempt(
+                isSelf: true,
+                allowUserChange: false,
+            ),
+        );
+
+        self::assertNotNull($outcome);
+        self::assertTrue($outcome->denied);
+        self::assertSame(
+            PwdPolicyError::PASSWORD_MOD_NOT_ALLOWED,
+            $outcome->errorCode,
+        );
+    }
+
+    private function attempt(
+        bool $isSelf,
+        ?bool $allowUserChange,
+    ): PasswordChangeAttempt {
+        return new PasswordChangeAttempt(
+            newPassword: 'irrelevant',
+            oldPassword: null,
+            state: new UserPasswordState(),
+            policy: new PasswordPolicy(
+                change: new PasswordChangeRules(allowUserChange: $allowUserChange),
+            ),
+            isSelf: $isSelf,
+        );
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/Constraint/HistoryConstraintTest.php
+++ b/tests/unit/Server/PasswordPolicy/Constraint/HistoryConstraintTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy\Constraint;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashVerifier;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\HistoryConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeAttempt;
+use FreeDSx\Ldap\Server\PasswordPolicy\HistoryEntry;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
+use PHPUnit\Framework\TestCase;
+
+final class HistoryConstraintTest extends TestCase
+{
+    private HistoryConstraint $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new HistoryConstraint(new PasswordHashVerifier());
+    }
+
+    public function test_zero_depth_skips(): void
+    {
+        self::assertNull(
+            $this->subject->check(
+                $this->attempt(
+                    inHistory: 0,
+                    historyPlaintexts: ['secret'],
+                ),
+            ),
+        );
+    }
+
+    public function test_null_depth_skips(): void
+    {
+        self::assertNull(
+            $this->subject->check(
+                $this->attempt(
+                    inHistory: null,
+                    historyPlaintexts: ['secret'],
+                ),
+            ),
+        );
+    }
+
+    public function test_empty_history_skips(): void
+    {
+        self::assertNull(
+            $this->subject->check(
+                $this->attempt(
+                    inHistory: 5,
+                    historyPlaintexts: [],
+                ),
+            ),
+        );
+    }
+
+    public function test_new_password_not_in_history_passes(): void
+    {
+        self::assertNull(
+            $this->subject->check(
+                $this->attempt(
+                    inHistory: 5,
+                    historyPlaintexts: ['old1', 'old2'],
+                    newPassword: 'completely-different',
+                ),
+            ),
+        );
+    }
+
+    public function test_new_password_matching_first_entry_denies(): void
+    {
+        $outcome = $this->subject->check(
+            $this->attempt(
+                inHistory: 5,
+                historyPlaintexts: ['target', 'other'],
+                newPassword: 'target',
+            ),
+        );
+
+        self::assertNotNull($outcome);
+        self::assertTrue($outcome->denied);
+        self::assertSame(
+            PwdPolicyError::PASSWORD_IN_HISTORY,
+            $outcome->errorCode,
+        );
+    }
+
+    public function test_new_password_matching_later_entry_denies(): void
+    {
+        $outcome = $this->subject->check(
+            $this->attempt(
+                inHistory: 5,
+                historyPlaintexts: ['other', 'target'],
+                newPassword: 'target',
+            ),
+        );
+
+        self::assertNotNull($outcome);
+        self::assertTrue($outcome->denied);
+    }
+
+    /**
+     * @param int<0, max>|null $inHistory
+     * @param list<string> $historyPlaintexts
+     */
+    private function attempt(
+        ?int $inHistory,
+        array $historyPlaintexts,
+        string $newPassword = 'newpw',
+    ): PasswordChangeAttempt {
+        $history = array_values(array_map(
+            fn(string $plain): HistoryEntry => HistoryEntry::forStoredPassword(
+                new DateTimeImmutable(
+                    '2026-05-15T00:00:00Z',
+                    new DateTimeZone('UTC'),
+                ),
+                '{BCRYPT}' . password_hash($plain, PASSWORD_BCRYPT),
+            ),
+            $historyPlaintexts,
+        ));
+
+        return new PasswordChangeAttempt(
+            newPassword: $newPassword,
+            oldPassword: null,
+            state: new UserPasswordState(history: $history),
+            policy: new PasswordPolicy(
+                quality: new PasswordQualityRules(inHistory: $inHistory),
+            ),
+            isSelf: true,
+        );
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/Constraint/MinAgeConstraintTest.php
+++ b/tests/unit/Server/PasswordPolicy/Constraint/MinAgeConstraintTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy\Constraint;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\MinAgeConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeAttempt;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordChangeRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
+
+final class MinAgeConstraintTest extends TestCase
+{
+    private const NOW = '2026-05-20T12:00:00Z';
+
+    private FrozenClock $clock;
+    private MinAgeConstraint $subject;
+
+    protected function setUp(): void
+    {
+        $this->clock = FrozenClock::fromString(self::NOW);
+        $this->subject = new MinAgeConstraint($this->clock);
+    }
+
+    public function test_unset_min_age_skips(): void
+    {
+        self::assertNull(
+            $this->subject->check(
+                $this->attempt(
+                    minAge: null,
+                    changedAt: $this->utc('2026-05-20T11:59:00Z'),
+                ),
+            ),
+        );
+    }
+
+    public function test_zero_min_age_skips(): void
+    {
+        self::assertNull(
+            $this->subject->check(
+                $this->attempt(
+                    minAge: 0,
+                    changedAt: $this->utc('2026-05-20T11:59:00Z'),
+                ),
+            ),
+        );
+    }
+
+    public function test_missing_changed_at_skips(): void
+    {
+        self::assertNull(
+            $this->subject->check(
+                $this->attempt(
+                    minAge: 3600,
+                    changedAt: null,
+                ),
+            ),
+        );
+    }
+
+    public function test_age_within_min_age_denies(): void
+    {
+        $outcome = $this->subject->check(
+            $this->attempt(
+                minAge: 3600,
+                changedAt: $this->utc('2026-05-20T11:30:00Z'),
+            ),
+        );
+
+        self::assertNotNull($outcome);
+        self::assertTrue($outcome->denied);
+        self::assertSame(
+            PwdPolicyError::PASSWORD_TOO_YOUNG,
+            $outcome->errorCode,
+        );
+    }
+
+    public function test_age_exactly_at_boundary_passes(): void
+    {
+        self::assertNull(
+            $this->subject->check(
+                $this->attempt(
+                    minAge: 3600,
+                    changedAt: $this->utc('2026-05-20T11:00:00Z'),
+                ),
+            ),
+        );
+    }
+
+    public function test_age_past_boundary_passes(): void
+    {
+        self::assertNull(
+            $this->subject->check(
+                $this->attempt(
+                    minAge: 3600,
+                    changedAt: $this->utc('2026-05-20T10:00:00Z'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @param int<0, max>|null $minAge
+     */
+    private function attempt(
+        ?int $minAge,
+        ?DateTimeImmutable $changedAt,
+    ): PasswordChangeAttempt {
+        return new PasswordChangeAttempt(
+            newPassword: 'newpw',
+            oldPassword: null,
+            state: new UserPasswordState(changedAt: $changedAt),
+            policy: new PasswordPolicy(
+                change: new PasswordChangeRules(minAge: $minAge),
+            ),
+            isSelf: true,
+        );
+    }
+
+    private function utc(string $iso): DateTimeImmutable
+    {
+        return new DateTimeImmutable(
+            $iso,
+            new DateTimeZone('UTC'),
+        );
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/Constraint/PasswordChangeConstraintChainTest.php
+++ b/tests/unit/Server/PasswordPolicy/Constraint/PasswordChangeConstraintChainTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy\Constraint;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeAttempt;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyOutcome;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Server\PasswordPolicy\RecordingPasswordChangeConstraint;
+
+final class PasswordChangeConstraintChainTest extends TestCase
+{
+    public function test_empty_chain_returns_null(): void
+    {
+        $chain = new PasswordChangeConstraintChain([]);
+
+        self::assertNull($chain->evaluate($this->attempt()));
+    }
+
+    public function test_all_passing_constraints_return_null(): void
+    {
+        $passing = $this->stubConstraint(null);
+
+        $chain = new PasswordChangeConstraintChain([
+            $passing,
+            $passing,
+            $passing,
+        ]);
+
+        self::assertNull($chain->evaluate($this->attempt()));
+    }
+
+    public function test_first_denying_constraint_short_circuits(): void
+    {
+        $firstDeny = $this->stubConstraint(
+            PasswordPolicyOutcome::deny(
+                PwdPolicyError::PASSWORD_TOO_SHORT,
+                ResultCode::CONSTRAINT_VIOLATION,
+                'first',
+            ),
+        );
+        $secondDeny = $this->stubConstraint(
+            PasswordPolicyOutcome::deny(
+                PwdPolicyError::PASSWORD_IN_HISTORY,
+                ResultCode::CONSTRAINT_VIOLATION,
+                'second',
+            ),
+        );
+
+        $chain = new PasswordChangeConstraintChain([
+            $firstDeny,
+            $secondDeny,
+        ]);
+
+        $outcome = $chain->evaluate($this->attempt());
+
+        self::assertNotNull($outcome);
+        self::assertSame(
+            PwdPolicyError::PASSWORD_TOO_SHORT,
+            $outcome->errorCode,
+        );
+    }
+
+    public function test_passing_chain_visits_every_constraint(): void
+    {
+        $first = new RecordingPasswordChangeConstraint();
+        $second = new RecordingPasswordChangeConstraint();
+        $third = new RecordingPasswordChangeConstraint();
+
+        $chain = new PasswordChangeConstraintChain([
+            $first,
+            $second,
+            $third,
+        ]);
+        $chain->evaluate($this->attempt());
+
+        self::assertCount(
+            1,
+            $first->invocations,
+        );
+        self::assertCount(
+            1,
+            $second->invocations,
+        );
+        self::assertCount(
+            1,
+            $third->invocations,
+        );
+    }
+
+    private function attempt(): PasswordChangeAttempt
+    {
+        return new PasswordChangeAttempt(
+            newPassword: 'newpw',
+            oldPassword: null,
+            state: new UserPasswordState(),
+            policy: new PasswordPolicy(),
+            isSelf: true,
+        );
+    }
+
+    private function stubConstraint(?PasswordPolicyOutcome $outcome): PasswordChangeConstraint
+    {
+        $stub = $this->createMock(PasswordChangeConstraint::class);
+        $stub
+            ->method('check')
+            ->willReturn($outcome);
+
+        return $stub;
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/Constraint/QualityConstraintTest.php
+++ b/tests/unit/Server/PasswordPolicy/Constraint/QualityConstraintTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy\Constraint;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeAttempt;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\QualityConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\PasswordQualityCheckerInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
+use PHPUnit\Framework\TestCase;
+
+final class QualityConstraintTest extends TestCase
+{
+    public function test_checker_returning_null_allows(): void
+    {
+        $checker = $this->createMock(PasswordQualityCheckerInterface::class);
+        $checker
+            ->method('check')
+            ->willReturn(null);
+
+        $constraint = new QualityConstraint($checker);
+
+        self::assertNull($constraint->check($this->attempt()));
+    }
+
+    public function test_checker_returning_code_denies_with_same_code(): void
+    {
+        $checker = $this->createMock(PasswordQualityCheckerInterface::class);
+        $checker
+            ->method('check')
+            ->willReturn(PwdPolicyError::PASSWORD_TOO_SHORT);
+
+        $constraint = new QualityConstraint($checker);
+
+        $outcome = $constraint->check($this->attempt());
+
+        self::assertNotNull($outcome);
+        self::assertTrue($outcome->denied);
+        self::assertSame(
+            PwdPolicyError::PASSWORD_TOO_SHORT,
+            $outcome->errorCode,
+        );
+    }
+
+    public function test_quality_code_propagates(): void
+    {
+        $checker = $this->createMock(PasswordQualityCheckerInterface::class);
+        $checker
+            ->method('check')
+            ->willReturn(PwdPolicyError::INSUFFICIENT_PASSWORD_QUALITY);
+
+        $constraint = new QualityConstraint($checker);
+
+        $outcome = $constraint->check($this->attempt());
+
+        self::assertNotNull($outcome);
+        self::assertSame(
+            PwdPolicyError::INSUFFICIENT_PASSWORD_QUALITY,
+            $outcome->errorCode,
+        );
+    }
+
+    private function attempt(): PasswordChangeAttempt
+    {
+        return new PasswordChangeAttempt(
+            newPassword: 'newpw',
+            oldPassword: null,
+            state: new UserPasswordState(),
+            policy: new PasswordPolicy(quality: new PasswordQualityRules()),
+            isSelf: true,
+        );
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/Constraint/SafeModifyConstraintTest.php
+++ b/tests/unit/Server/PasswordPolicy/Constraint/SafeModifyConstraintTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy\Constraint;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeAttempt;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\SafeModifyConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordChangeRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
+use PHPUnit\Framework\TestCase;
+
+final class SafeModifyConstraintTest extends TestCase
+{
+    private SafeModifyConstraint $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new SafeModifyConstraint();
+    }
+
+    public function test_unset_safe_modify_skips(): void
+    {
+        self::assertNull(
+            $this->subject->check(
+                $this->attempt(
+                    safeModify: null,
+                    oldPassword: null,
+                ),
+            ),
+        );
+    }
+
+    public function test_disabled_safe_modify_skips(): void
+    {
+        self::assertNull(
+            $this->subject->check(
+                $this->attempt(
+                    safeModify: false,
+                    oldPassword: null,
+                ),
+            ),
+        );
+    }
+
+    public function test_enabled_with_old_password_passes(): void
+    {
+        self::assertNull(
+            $this->subject->check(
+                $this->attempt(
+                    safeModify: true,
+                    oldPassword: 'oldpw',
+                ),
+            ),
+        );
+    }
+
+    public function test_enabled_without_old_password_denies(): void
+    {
+        $outcome = $this->subject->check(
+            $this->attempt(
+                safeModify: true,
+                oldPassword: null,
+            ),
+        );
+
+        self::assertNotNull($outcome);
+        self::assertTrue($outcome->denied);
+        self::assertSame(
+            PwdPolicyError::MUST_SUPPLY_OLD_PASSWORD,
+            $outcome->errorCode,
+        );
+    }
+
+    public function test_enabled_with_empty_string_denies(): void
+    {
+        $outcome = $this->subject->check(
+            $this->attempt(
+                safeModify: true,
+                oldPassword: '',
+            ),
+        );
+
+        self::assertNotNull($outcome);
+        self::assertTrue($outcome->denied);
+    }
+
+    private function attempt(
+        ?bool $safeModify,
+        ?string $oldPassword,
+    ): PasswordChangeAttempt {
+        return new PasswordChangeAttempt(
+            newPassword: 'newpw',
+            oldPassword: $oldPassword,
+            state: new UserPasswordState(),
+            policy: new PasswordPolicy(
+                change: new PasswordChangeRules(safeModify: $safeModify),
+            ),
+            isSelf: true,
+        );
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/PasswordPolicyEngineTest.php
+++ b/tests/unit/Server/PasswordPolicy/PasswordPolicyEngineTest.php
@@ -1,0 +1,696 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Entry\Change;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
+use FreeDSx\Ldap\Server\PasswordPolicy\HistoryEntry;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyOutcome;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordExpirationRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
+use Tests\Support\FreeDSx\Ldap\Server\PasswordPolicy\RecordingPasswordChangeConstraint;
+
+final class PasswordPolicyEngineTest extends TestCase
+{
+    private const NOW = '2026-05-20T12:00:00Z';
+
+    private FrozenClock $clock;
+    private PasswordPolicyEngine $subject;
+
+    protected function setUp(): void
+    {
+        $this->clock = FrozenClock::fromString(self::NOW);
+        $this->subject = new PasswordPolicyEngine(
+            clock: $this->clock,
+            changeConstraints: new PasswordChangeConstraintChain([]),
+        );
+    }
+
+    public function test_evaluatePreBind_unlocked_account_allows(): void
+    {
+        $outcome = $this->subject->evaluatePreBind(
+            new UserPasswordState(),
+            new PasswordPolicy(),
+        );
+
+        self::assertFalse($outcome->denied);
+    }
+
+    public function test_evaluatePreBind_permanently_locked_denies(): void
+    {
+        $outcome = $this->subject->evaluatePreBind(
+            new UserPasswordState(permanentlyLocked: true),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    duration: 3600,
+                ),
+            ),
+        );
+
+        self::assertTrue($outcome->denied);
+        self::assertSame(
+            PwdPolicyError::ACCOUNT_LOCKED,
+            $outcome->errorCode,
+        );
+        self::assertSame(
+            ResultCode::INVALID_CREDENTIALS,
+            $outcome->ldapResultCode,
+        );
+    }
+
+    public function test_evaluatePreBind_locked_without_duration_denies(): void
+    {
+        $outcome = $this->subject->evaluatePreBind(
+            new UserPasswordState(accountLockedAt: $this->minutesAgo(5)),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(enabled: true),
+            ),
+        );
+
+        self::assertTrue($outcome->denied);
+        self::assertSame(
+            PwdPolicyError::ACCOUNT_LOCKED,
+            $outcome->errorCode,
+        );
+    }
+
+    public function test_evaluatePreBind_locked_within_duration_denies(): void
+    {
+        $outcome = $this->subject->evaluatePreBind(
+            new UserPasswordState(accountLockedAt: $this->minutesAgo(5)),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    duration: 3600,
+                ),
+            ),
+        );
+
+        self::assertTrue($outcome->denied);
+    }
+
+    public function test_evaluatePreBind_locked_past_duration_allows(): void
+    {
+        $outcome = $this->subject->evaluatePreBind(
+            new UserPasswordState(accountLockedAt: $this->minutesAgo(120)),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    duration: 3600,
+                ),
+            ),
+        );
+
+        self::assertFalse($outcome->denied);
+    }
+
+    public function test_recordBindFailure_appends_failure_time(): void
+    {
+        $result = $this->subject->recordBindFailure(
+            new UserPasswordState(),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    maxFailure: 3,
+                ),
+            ),
+        );
+
+        self::assertFalse($result->outcome->denied);
+        $change = $this->findChange(
+            $result->changes->changes,
+            PasswordPolicyOid::NAME_PWD_FAILURE_TIME,
+        );
+        self::assertSame(
+            [GeneralizedTime::format($this->clock->now())],
+            $change->getAttribute()->getValues(),
+        );
+    }
+
+    public function test_recordBindFailure_trims_failures_outside_interval(): void
+    {
+        $stale = $this->minutesAgo(120);
+        $recent = $this->minutesAgo(2);
+
+        $result = $this->subject->recordBindFailure(
+            new UserPasswordState(failureTimes: [
+                $stale,
+                $recent,
+            ]),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    maxFailure: 5,
+                    failureCountInterval: 3600,
+                ),
+            ),
+        );
+
+        $change = $this->findChange(
+            $result->changes->changes,
+            PasswordPolicyOid::NAME_PWD_FAILURE_TIME,
+        );
+        self::assertSame(
+            [
+                GeneralizedTime::format($recent),
+                GeneralizedTime::format($this->clock->now()),
+            ],
+            $change->getAttribute()->getValues(),
+        );
+    }
+
+    public function test_recordBindFailure_at_threshold_trips_lockout(): void
+    {
+        $result = $this->subject->recordBindFailure(
+            new UserPasswordState(failureTimes: [
+                $this->minutesAgo(3),
+                $this->minutesAgo(2),
+            ]),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    maxFailure: 3,
+                ),
+            ),
+        );
+
+        self::assertTrue($result->outcome->denied);
+        self::assertSame(
+            PwdPolicyError::ACCOUNT_LOCKED,
+            $result->outcome->errorCode,
+        );
+        $lockChange = $this->findChange(
+            $result->changes->changes,
+            PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME,
+        );
+        self::assertSame(
+            [GeneralizedTime::format($this->clock->now())],
+            $lockChange->getAttribute()->getValues(),
+        );
+    }
+
+    public function test_recordBindFailure_below_threshold_does_not_lock(): void
+    {
+        $result = $this->subject->recordBindFailure(
+            new UserPasswordState(failureTimes: [$this->minutesAgo(2)]),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    maxFailure: 3,
+                ),
+            ),
+        );
+
+        self::assertFalse($result->outcome->denied);
+        self::assertNull($this->findChangeOrNull(
+            $result->changes->changes,
+            PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME,
+        ));
+    }
+
+    public function test_recordBindFailure_lockout_disabled_never_trips(): void
+    {
+        $result = $this->subject->recordBindFailure(
+            new UserPasswordState(failureTimes: [
+                $this->minutesAgo(3),
+                $this->minutesAgo(2),
+            ]),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: false,
+                    maxFailure: 3,
+                ),
+            ),
+        );
+
+        self::assertFalse($result->outcome->denied);
+        self::assertNull($this->findChangeOrNull(
+            $result->changes->changes,
+            PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME,
+        ));
+    }
+
+    public function test_recordBindFailure_already_locked_does_not_re_lock(): void
+    {
+        $result = $this->subject->recordBindFailure(
+            new UserPasswordState(
+                accountLockedAt: $this->minutesAgo(5),
+                failureTimes: [
+                    $this->minutesAgo(3),
+                    $this->minutesAgo(2),
+                ],
+            ),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    maxFailure: 3,
+                ),
+            ),
+        );
+
+        self::assertFalse($result->outcome->denied);
+        self::assertNull($this->findChangeOrNull(
+            $result->changes->changes,
+            PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME,
+        ));
+    }
+
+    public function test_recordBindSuccess_no_state_emits_no_changes(): void
+    {
+        $result = $this->subject->recordBindSuccess(
+            new UserPasswordState(),
+            new PasswordPolicy(),
+        );
+
+        self::assertFalse($result->outcome->denied);
+        self::assertTrue($result->changes->isEmpty());
+    }
+
+    public function test_recordBindSuccess_clears_prior_failures_and_lock(): void
+    {
+        $result = $this->subject->recordBindSuccess(
+            new UserPasswordState(
+                accountLockedAt: $this->minutesAgo(120),
+                failureTimes: [$this->minutesAgo(5)],
+            ),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    duration: 3600,
+                ),
+            ),
+        );
+
+        self::assertTrue($this->findChange(
+            $result->changes->changes,
+            PasswordPolicyOid::NAME_PWD_FAILURE_TIME,
+        )->isReset());
+        self::assertTrue($this->findChange(
+            $result->changes->changes,
+            PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME,
+        )->isReset());
+    }
+
+    public function test_recordBindSuccess_does_not_clear_permanent_lock(): void
+    {
+        $result = $this->subject->recordBindSuccess(
+            new UserPasswordState(permanentlyLocked: true),
+            new PasswordPolicy(),
+        );
+
+        self::assertNull($this->findChangeOrNull(
+            $result->changes->changes,
+            PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME,
+        ));
+    }
+
+    public function test_recordBindSuccess_expired_with_no_grace_denies(): void
+    {
+        $result = $this->subject->recordBindSuccess(
+            new UserPasswordState(changedAt: $this->minutesAgo(120)),
+            new PasswordPolicy(
+                expiration: new PasswordExpirationRules(maxAge: 3600),
+            ),
+        );
+
+        self::assertTrue($result->outcome->denied);
+        self::assertSame(
+            PwdPolicyError::PASSWORD_EXPIRED,
+            $result->outcome->errorCode,
+        );
+        self::assertTrue($result->changes->isEmpty());
+    }
+
+    public function test_recordBindSuccess_expired_within_grace_returns_remaining(): void
+    {
+        $result = $this->subject->recordBindSuccess(
+            new UserPasswordState(changedAt: $this->minutesAgo(120)),
+            new PasswordPolicy(
+                expiration: new PasswordExpirationRules(
+                    maxAge: 3600,
+                    graceAuthnLimit: 3,
+                ),
+            ),
+        );
+
+        self::assertFalse($result->outcome->denied);
+        self::assertSame(
+            2,
+            $result->outcome->graceRemaining,
+        );
+        $graceChange = $this->findChange(
+            $result->changes->changes,
+            PasswordPolicyOid::NAME_PWD_GRACE_USE_TIME,
+        );
+        self::assertSame(
+            [GeneralizedTime::format($this->clock->now())],
+            $graceChange->getAttribute()->getValues(),
+        );
+    }
+
+    public function test_recordBindSuccess_within_warning_returns_seconds_remaining(): void
+    {
+        $result = $this->subject->recordBindSuccess(
+            new UserPasswordState(changedAt: $this->minutesAgo(50)),
+            new PasswordPolicy(
+                expiration: new PasswordExpirationRules(
+                    maxAge: 3600,
+                    expireWarning: 1200,
+                ),
+            ),
+        );
+
+        self::assertFalse($result->outcome->denied);
+        self::assertSame(
+            600,
+            $result->outcome->timeBeforeExpiration,
+        );
+    }
+
+    public function test_recordBindSuccess_outside_warning_window_returns_null(): void
+    {
+        $result = $this->subject->recordBindSuccess(
+            new UserPasswordState(changedAt: $this->minutesAgo(10)),
+            new PasswordPolicy(
+                expiration: new PasswordExpirationRules(
+                    maxAge: 3600,
+                    expireWarning: 600,
+                ),
+            ),
+        );
+
+        self::assertNull($result->outcome->timeBeforeExpiration);
+    }
+
+    public function test_recordBindSuccess_must_change_propagates_error_code(): void
+    {
+        $result = $this->subject->recordBindSuccess(
+            new UserPasswordState(mustChange: true),
+            new PasswordPolicy(),
+        );
+
+        self::assertFalse($result->outcome->denied);
+        self::assertSame(
+            PwdPolicyError::CHANGE_AFTER_RESET,
+            $result->outcome->errorCode,
+        );
+    }
+
+    public function test_evaluatePasswordChange_delegates_to_constraint_chain(): void
+    {
+        $deny = PasswordPolicyOutcome::deny(
+            PwdPolicyError::PASSWORD_TOO_SHORT,
+            ResultCode::CONSTRAINT_VIOLATION,
+            'denied',
+        );
+        $engine = $this->engineWith($this->stubConstraint($deny));
+
+        $outcome = $engine->evaluatePasswordChange(
+            newPassword: 'newpw',
+            oldPassword: null,
+            state: new UserPasswordState(),
+            policy: new PasswordPolicy(),
+            isSelf: true,
+        );
+
+        self::assertSame(
+            $deny,
+            $outcome,
+        );
+    }
+
+    public function test_evaluatePasswordChange_chain_null_returns_allow(): void
+    {
+        $outcome = $this
+            ->engineWith($this->stubConstraint(null))
+            ->evaluatePasswordChange(
+                newPassword: 'newpw',
+                oldPassword: null,
+                state: new UserPasswordState(),
+                policy: new PasswordPolicy(),
+                isSelf: true,
+            );
+
+        self::assertFalse($outcome->denied);
+    }
+
+    public function test_evaluatePasswordChange_passes_attempt_through(): void
+    {
+        $state = new UserPasswordState();
+        $policy = new PasswordPolicy();
+        $constraint = new RecordingPasswordChangeConstraint();
+
+        $this->engineWith($constraint)->evaluatePasswordChange(
+            newPassword: 'newpw',
+            oldPassword: 'oldpw',
+            state: $state,
+            policy: $policy,
+            isSelf: false,
+        );
+
+        self::assertCount(
+            1,
+            $constraint->invocations,
+        );
+        $attempt = $constraint->invocations[0];
+        self::assertSame(
+            'newpw',
+            $attempt->newPassword,
+        );
+        self::assertSame(
+            'oldpw',
+            $attempt->oldPassword,
+        );
+        self::assertSame(
+            $state,
+            $attempt->state,
+        );
+        self::assertSame(
+            $policy,
+            $attempt->policy,
+        );
+        self::assertFalse($attempt->isSelf);
+    }
+
+    public function test_recordPasswordChange_stamps_changed_time(): void
+    {
+        $changes = $this->subject->recordPasswordChange(
+            '{BCRYPT}hashed',
+            new UserPasswordState(),
+            new PasswordPolicy(),
+        );
+
+        $change = $this->findChange(
+            $changes->changes,
+            PasswordPolicyOid::NAME_PWD_CHANGED_TIME,
+        );
+        self::assertSame(
+            [GeneralizedTime::format($this->clock->now())],
+            $change->getAttribute()->getValues(),
+        );
+    }
+
+    public function test_recordPasswordChange_zero_history_emits_no_history_change(): void
+    {
+        $changes = $this->subject->recordPasswordChange(
+            '{BCRYPT}hashed',
+            new UserPasswordState(),
+            new PasswordPolicy(
+                quality: new PasswordQualityRules(inHistory: 0),
+            ),
+        );
+
+        self::assertNull($this->findChangeOrNull(
+            $changes->changes,
+            PasswordPolicyOid::NAME_PWD_HISTORY,
+        ));
+    }
+
+    public function test_recordPasswordChange_prepends_and_trims_history(): void
+    {
+        $oldest = $this->historyEntry(
+            $this->minutesAgo(180),
+            '{BCRYPT}old1',
+        );
+        $newer = $this->historyEntry(
+            $this->minutesAgo(60),
+            '{BCRYPT}old2',
+        );
+
+        $changes = $this->subject->recordPasswordChange(
+            '{BCRYPT}brand-new',
+            new UserPasswordState(history: [
+                $newer,
+                $oldest,
+            ]),
+            new PasswordPolicy(
+                quality: new PasswordQualityRules(inHistory: 2),
+            ),
+        );
+
+        $historyChange = $this->findChange(
+            $changes->changes,
+            PasswordPolicyOid::NAME_PWD_HISTORY,
+        );
+        $values = $historyChange->getAttribute()->getValues();
+        self::assertCount(
+            2,
+            $values,
+        );
+        self::assertStringContainsString(
+            '{BCRYPT}brand-new',
+            $values[0],
+        );
+        self::assertStringContainsString(
+            '{BCRYPT}old2',
+            $values[1],
+        );
+    }
+
+    public function test_recordPasswordChange_clears_must_change_failure_and_lock(): void
+    {
+        $changes = $this->subject->recordPasswordChange(
+            '{BCRYPT}hashed',
+            new UserPasswordState(
+                accountLockedAt: $this->minutesAgo(5),
+                failureTimes: [$this->minutesAgo(2)],
+                graceUseTimes: [$this->minutesAgo(1)],
+                mustChange: true,
+            ),
+            new PasswordPolicy(),
+        );
+
+        self::assertTrue($this->findChange(
+            $changes->changes,
+            PasswordPolicyOid::NAME_PWD_RESET,
+        )->isReset());
+        self::assertTrue($this->findChange(
+            $changes->changes,
+            PasswordPolicyOid::NAME_PWD_FAILURE_TIME,
+        )->isReset());
+        self::assertTrue($this->findChange(
+            $changes->changes,
+            PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME,
+        )->isReset());
+        self::assertTrue($this->findChange(
+            $changes->changes,
+            PasswordPolicyOid::NAME_PWD_GRACE_USE_TIME,
+        )->isReset());
+    }
+
+    public function test_recordPasswordChange_clean_state_emits_only_changed_time(): void
+    {
+        $changes = $this->subject->recordPasswordChange(
+            '{BCRYPT}hashed',
+            new UserPasswordState(),
+            new PasswordPolicy(
+                quality: new PasswordQualityRules(inHistory: 0),
+            ),
+        );
+
+        self::assertCount(
+            1,
+            $changes->changes,
+        );
+        self::assertSame(
+            PasswordPolicyOid::NAME_PWD_CHANGED_TIME,
+            $changes->changes[0]->getAttribute()->getName(),
+        );
+    }
+
+    private function engineWith(PasswordChangeConstraint $constraint): PasswordPolicyEngine
+    {
+        return new PasswordPolicyEngine(
+            clock: $this->clock,
+            changeConstraints: new PasswordChangeConstraintChain([$constraint]),
+        );
+    }
+
+    private function minutesAgo(int $minutes): DateTimeImmutable
+    {
+        return $this->clock
+            ->now()
+            ->sub(new DateInterval(sprintf('PT%dM', $minutes)));
+    }
+
+    /**
+     * @param list<Change> $changes
+     */
+    private function findChange(
+        array $changes,
+        string $name,
+    ): Change {
+        $found = $this->findChangeOrNull(
+            $changes,
+            $name,
+        );
+        self::assertNotNull(
+            $found,
+            sprintf('Expected change for "%s" in operational changes.', $name),
+        );
+
+        return $found;
+    }
+
+    /**
+     * @param list<Change> $changes
+     */
+    private function findChangeOrNull(
+        array $changes,
+        string $name,
+    ): ?Change {
+        foreach ($changes as $change) {
+            if (strcasecmp($change->getAttribute()->getName(), $name) === 0) {
+                return $change;
+            }
+        }
+
+        return null;
+    }
+
+    private function historyEntry(
+        DateTimeImmutable $when,
+        string $stored,
+    ): HistoryEntry {
+        return HistoryEntry::forStoredPassword(
+            $when->setTimezone(new DateTimeZone('UTC')),
+            $stored,
+        );
+    }
+
+    private function stubConstraint(?PasswordPolicyOutcome $outcome): PasswordChangeConstraint
+    {
+        $stub = $this->createMock(PasswordChangeConstraint::class);
+        $stub
+            ->method('check')
+            ->willReturn($outcome);
+
+        return $stub;
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/RecordedOutcomeTest.php
+++ b/tests/unit/Server/PasswordPolicy/RecordedOutcomeTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy;
+
+use FreeDSx\Ldap\Server\PasswordPolicy\OperationalChanges;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyOutcome;
+use FreeDSx\Ldap\Server\PasswordPolicy\RecordedOutcome;
+use PHPUnit\Framework\TestCase;
+
+final class RecordedOutcomeTest extends TestCase
+{
+    public function test_carries_both_outcome_and_changes(): void
+    {
+        $outcome = PasswordPolicyOutcome::allow();
+        $changes = OperationalChanges::none();
+
+        $recorded = new RecordedOutcome(
+            $outcome,
+            $changes,
+        );
+
+        self::assertSame(
+            $outcome,
+            $recorded->outcome,
+        );
+        self::assertSame(
+            $changes,
+            $recorded->changes,
+        );
+    }
+}


### PR DESCRIPTION
This adds the core password policy engine, working with some of the other code put in place in previous PRs. This wires it in the container, but does not yet enforce it anywhere. This just adds the logic + tests. Future PRs will actually enforce it within binds / password changes / etc.