### PR TITLE
[1.0.0] Implement the password policy in the simple bind path.

### DIFF
--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\Queue\ClientQueueInstantiator;
 use FreeDSx\Ldap\Protocol\RootDseLoader;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
+use FreeDSx\Ldap\Server\Clock\ClockInterface;
 use FreeDSx\Ldap\Server\Clock\SystemClock;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\AllowUserChangeConstraint;
@@ -166,6 +167,10 @@ class Container
             factory: $this->makeServerAuthorizer(...),
         );
         $this->registerFactory(
+            className: ClockInterface::class,
+            factory: static fn(): ClockInterface => new SystemClock(),
+        );
+        $this->registerFactory(
             className: PasswordPolicyEngine::class,
             factory: $this->makePasswordPolicyEngine(...),
         );
@@ -174,7 +179,7 @@ class Container
     private function makePasswordPolicyEngine(): PasswordPolicyEngine
     {
         $options = $this->get(ServerOptions::class);
-        $clock = new SystemClock();
+        $clock = $this->get(ClockInterface::class);
 
         $chain = new PasswordChangeConstraintChain([
             new AllowUserChangeConstraint(),
@@ -244,6 +249,7 @@ class Container
             handlerFactory: $this->get(HandlerFactoryInterface::class),
             options: $this->get(ServerOptions::class),
             serverAuthorization: $this->get(ServerAuthorization::class),
+            passwordPolicyEngine: $this->get(PasswordPolicyEngine::class),
         );
     }
 

--- a/src/FreeDSx/Ldap/Protocol/Bind/SimpleBind.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/SimpleBind.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\Bind;
 
+use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Operation\Request\BindRequest;
 use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
@@ -24,6 +26,7 @@ use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -40,6 +43,7 @@ class SimpleBind implements BindInterface
         private readonly PasswordAuthenticatableInterface $authenticator,
         private readonly EventLogger $eventLogger = new EventLogger(null),
         private readonly ResponseFactory $responseFactory = new ResponseFactory(),
+        private readonly ?PasswordPolicyContext $passwordPolicyContext = null,
     ) {}
 
     /**
@@ -75,7 +79,14 @@ class SimpleBind implements BindInterface
             throw $e;
         }
 
-        $this->queue->sendMessage($this->responseFactory->getStandardResponse($message));
+        $control = $this->passwordPolicyControl();
+        $this->queue->sendMessage($this->responseFactory->getStandardResponse(
+            $message,
+            ResultCode::SUCCESS,
+            '',
+            null,
+            ...($control === null ? [] : [$control]),
+        ));
         $this->eventLogger->record(
             ServerEvent::BindSuccess,
             [
@@ -95,6 +106,14 @@ class SimpleBind implements BindInterface
             $request->getUsername(),
             $request->getPassword(),
         );
+    }
+
+    private function passwordPolicyControl(): ?Control
+    {
+        $control = $this->passwordPolicyContext?->buildResponseControl();
+        $this->passwordPolicyContext?->clear();
+
+        return $control;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/LdapMessage.php
+++ b/src/FreeDSx/Ldap/Protocol/LdapMessage.php
@@ -158,17 +158,7 @@ abstract class LdapMessage implements ProtocolElementInterface, PduInterface
                         if (!($control instanceof SequenceType && $control->getChild(0) !== null && $control->getChild(0) instanceof OctetStringType)) {
                             throw new ProtocolException('The control either is not a sequence or has no OID value attached.');
                         }
-                        $controls[] = match ($control->getChild(0)->getValue()) {
-                            Control\Control::OID_PAGING => Control\PagingControl::fromAsn1($control),
-                            Control\Control::OID_SORTING => Control\Sorting\SortingControl::fromAsn1($control),
-                            Control\Control::OID_SORTING_RESPONSE => Control\Sorting\SortingResponseControl::fromAsn1($control),
-                            Control\Control::OID_VLV_RESPONSE => Control\Vlv\VlvResponseControl::fromAsn1($control),
-                            Control\Control::OID_DIR_SYNC => Control\Ad\DirSyncResponseControl::fromAsn1($control),
-                            Control\Control::OID_SYNC_STATE => Control\Sync\SyncStateControl::fromAsn1($control),
-                            Control\Control::OID_SYNC_REQUEST => Control\Sync\SyncRequestControl::fromAsn1($control),
-                            Control\Control::OID_SYNC_DONE => Control\Sync\SyncDoneControl::fromAsn1($control),
-                            default => Control\Control::fromAsn1($control),
-                        };
+                        $controls[] = static::controlFromAsn1($control);
                     }
                 }
             }
@@ -217,6 +207,24 @@ abstract class LdapMessage implements ProtocolElementInterface, PduInterface
             $operation,
             ...$controls,
         );
+    }
+
+    /**
+     * Subclasses override to honor direction-specific OIDs, e.g. controls whose request and response forms differ.
+     */
+    protected static function controlFromAsn1(SequenceType $control): Control\Control
+    {
+        return match ($control->getChild(0)?->getValue()) {
+            Control\Control::OID_PAGING => Control\PagingControl::fromAsn1($control),
+            Control\Control::OID_SORTING => Control\Sorting\SortingControl::fromAsn1($control),
+            Control\Control::OID_SORTING_RESPONSE => Control\Sorting\SortingResponseControl::fromAsn1($control),
+            Control\Control::OID_VLV_RESPONSE => Control\Vlv\VlvResponseControl::fromAsn1($control),
+            Control\Control::OID_DIR_SYNC => Control\Ad\DirSyncResponseControl::fromAsn1($control),
+            Control\Control::OID_SYNC_STATE => Control\Sync\SyncStateControl::fromAsn1($control),
+            Control\Control::OID_SYNC_REQUEST => Control\Sync\SyncRequestControl::fromAsn1($control),
+            Control\Control::OID_SYNC_DONE => Control\Sync\SyncDoneControl::fromAsn1($control),
+            default => Control\Control::fromAsn1($control),
+        };
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/LdapMessageResponse.php
+++ b/src/FreeDSx/Ldap/Protocol/LdapMessageResponse.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol;
 
 use FreeDSx\Asn1\Type\AbstractType;
+use FreeDSx\Asn1\Type\SequenceType;
 use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Response\ResponseInterface;
 
@@ -48,5 +50,13 @@ class LdapMessageResponse extends LdapMessage
     protected function getOperationAsn1(): AbstractType
     {
         return $this->response->toAsn1();
+    }
+
+    protected static function controlFromAsn1(SequenceType $control): Control
+    {
+        return match ($control->getChild(0)?->getValue()) {
+            Control::OID_PWD_POLICY => PwdPolicyResponseControl::fromAsn1($control),
+            default => parent::controlFromAsn1($control),
+        };
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol;
 
 use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Exception\RuntimeException;
@@ -25,6 +26,7 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Socket\Exception\ConnectionException;
 use Throwable;
@@ -50,6 +52,7 @@ class ServerProtocolHandler
         private readonly Authenticator $authenticator,
         private readonly EventLogger $eventLogger = new EventLogger(null),
         private readonly ResponseFactory $responseFactory = new ResponseFactory(),
+        private readonly ?PasswordPolicyContext $passwordPolicyContext = null,
     ) {}
 
     /**
@@ -72,10 +75,13 @@ class ServerProtocolHandler
         } catch (OperationException $e) {
             # OperationExceptions may be thrown by any handler and will be sent back to the client as the response
             # specific error code and message associated with the exception.
+            $control = $this->passwordPolicyControlFor($message);
             $this->queue->sendMessage($this->responseFactory->getStandardResponse(
                 $message,
                 $e->getCode(),
                 $e->getMessage(),
+                null,
+                ...($control === null ? [] : [$control]),
             ));
 
             # Handlers without their own catch (StartTLS, WhoAmI, RootDse, etc.) only reach the audit log via this catch.
@@ -209,6 +215,28 @@ class ServerProtocolHandler
         }
 
         return $this->authenticator->bind($message);
+    }
+
+    /**
+     * Password-policy response control for a failed bind; null for non-bind failures or when no policy is in play.
+     */
+    private function passwordPolicyControlFor(?LdapMessageRequest $message): ?Control
+    {
+        if (!$this->shouldAttachPolicyControl($message)) {
+            return null;
+        }
+
+        $control = $this->passwordPolicyContext?->buildResponseControl();
+        $this->passwordPolicyContext?->clear();
+
+        return $control;
+    }
+
+    private function shouldAttachPolicyControl(?LdapMessageRequest $message): bool
+    {
+        return $this->passwordPolicyContext !== null
+            && $message !== null
+            && $this->authorizer->isAuthenticationRequest($message->getRequest());
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordPolicyAwareAuthenticator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordPolicyAwareAuthenticator.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Auth;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordBindAttempt;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyBindGuard;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
+use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use SensitiveParameter;
+
+/**
+ * Decorates an authenticator to enforce draft-behera password policy on the simple-bind path.
+ */
+final readonly class PasswordPolicyAwareAuthenticator implements PasswordAuthenticatableInterface
+{
+    public function __construct(
+        private PasswordAuthenticatableInterface $decoratedAuthenticator,
+        private BindNameResolverInterface $nameResolver,
+        private LdapBackendInterface $backend,
+        private PasswordPolicyResolver $policyResolver,
+        private PasswordPolicyBindGuard $guard,
+    ) {}
+
+    public function authenticate(
+        string $name,
+        #[SensitiveParameter]
+        string $password,
+    ): AuthenticatedTokenInterface {
+        $entry = $this->nameResolver->resolve(
+            $name,
+            $this->backend,
+        );
+        if ($entry === null) {
+            return $this->decoratedAuthenticator->authenticate(
+                $name,
+                $password,
+            );
+        }
+
+        $policy = $this->policyResolver->resolveFor($entry);
+        if ($policy === null) {
+            return $this->decoratedAuthenticator->authenticate(
+                $name,
+                $password,
+            );
+        }
+
+        $attempt = new PasswordBindAttempt(
+            name: $name,
+            dn: $entry->getDn(),
+            state: UserPasswordState::fromEntry($entry),
+            policy: $policy,
+        );
+        $this->guard->preBind($attempt);
+
+        try {
+            $token = $this->decoratedAuthenticator->authenticate(
+                $name,
+                $password,
+            );
+        } catch (OperationException $cause) {
+            if ($cause->getCode() === ResultCode::INVALID_CREDENTIALS) {
+                $this->guard->recordFailure($attempt);
+            }
+
+            throw $cause;
+        }
+
+        $this->guard->recordSuccess($attempt);
+
+        return $token;
+    }
+
+    public function getSaslIdentity(
+        string $username,
+        MechanismName $mechanism,
+    ): ?SaslIdentity {
+        return $this->decoratedAuthenticator->getSaslIdentity(
+            $username,
+            $mechanism,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Write/SystemChangeWriter.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/SystemChangeWriter.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Write;
+
+use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
+use FreeDSx\Ldap\Server\PasswordPolicy\OperationalChanges;
+use FreeDSx\Ldap\Server\Token\SystemToken;
+
+/**
+ * Applies server-generated writes, bypassing schema NO-USER-MODIFICATION and ACL checks.
+ */
+final readonly class SystemChangeWriter
+{
+    public function __construct(private WriteOperationDispatcher $writeDispatcher) {}
+
+    /**
+     * @throws OperationException
+     */
+    public function write(
+        Dn $dn,
+        OperationalChanges $changes,
+    ): void {
+        if ($changes->isEmpty()) {
+            return;
+        }
+
+        $this->writeDispatcher->dispatch(
+            new UpdateCommand(
+                $dn,
+                $changes->changes,
+            ),
+            WriteContext::system(
+                new SystemToken(),
+                new ControlBag(),
+            ),
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordBindAttempt.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordBindAttempt.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy;
+
+use FreeDSx\Ldap\Entry\Dn;
+
+/**
+ * Inputs for a single bind being evaluated against the password policy.
+ */
+final readonly class PasswordBindAttempt
+{
+    public function __construct(
+        public string $name,
+        public Dn $dn,
+        public UserPasswordState $state,
+        public PasswordPolicy $policy,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyBindGuard.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyBindGuard.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
+use FreeDSx\Ldap\Server\Logging\EventContext;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Logging\ServerEvent;
+
+/**
+ * Applies the engine's bind-time decisions.
+ */
+final readonly class PasswordPolicyBindGuard
+{
+    public function __construct(
+        private PasswordPolicyEngine $engine,
+        private SystemChangeWriter $writer,
+        private PasswordPolicyContext $context,
+        private EventLogger $eventLogger,
+    ) {}
+
+    /**
+     * @throws OperationException when the account is locked and may not yet attempt a bind.
+     */
+    public function preBind(PasswordBindAttempt $attempt): void
+    {
+        $outcome = $this->engine->evaluatePreBind(
+            $attempt->state,
+            $attempt->policy,
+        );
+        if (!$outcome->denied) {
+            return;
+        }
+
+        $this->context->setOutcome($outcome);
+        $this->eventLogger->record(
+            ServerEvent::PasswordPolicyAccountLocked,
+            $this->subjectFor($attempt),
+        );
+
+        throw new OperationException(
+            $outcome->diagnostic,
+            $outcome->ldapResultCode,
+        );
+    }
+
+    /**
+     * Surfaces a lockout outcome but never throws (the caller re-throws the credential error).
+     */
+    public function recordFailure(PasswordBindAttempt $attempt): void
+    {
+        $recorded = $this->engine->recordBindFailure(
+            $attempt->state,
+            $attempt->policy,
+        );
+        $this->writer->write(
+            $attempt->dn,
+            $recorded->changes,
+        );
+
+        if (!$recorded->outcome->denied) {
+            return;
+        }
+
+        $this->context->setOutcome($recorded->outcome);
+        $this->eventLogger->record(
+            ServerEvent::PasswordPolicyAccountLocked,
+            $this->subjectFor($attempt),
+        );
+    }
+
+    /**
+     * @throws OperationException when the password is expired with no grace logins remaining.
+     */
+    public function recordSuccess(PasswordBindAttempt $attempt): void
+    {
+        $recorded = $this->engine->recordBindSuccess(
+            $attempt->state,
+            $attempt->policy,
+        );
+        $outcome = $recorded->outcome;
+
+        if ($outcome->denied) {
+            $this->context->setOutcome($outcome);
+            $this->eventLogger->record(
+                ServerEvent::PasswordPolicyExpired,
+                $this->subjectFor($attempt),
+            );
+
+            throw new OperationException(
+                $outcome->diagnostic,
+                $outcome->ldapResultCode,
+            );
+        }
+
+        $this->writer->write(
+            $attempt->dn,
+            $recorded->changes,
+        );
+        $this->context->setOutcome($outcome);
+        $this->emitSuccessEvents(
+            $attempt,
+            $outcome,
+        );
+    }
+
+    private function emitSuccessEvents(
+        PasswordBindAttempt $attempt,
+        PasswordPolicyOutcome $outcome,
+    ): void {
+        $subject = $this->subjectFor($attempt);
+
+        if ($attempt->state->isLocked() && !$attempt->state->permanentlyLocked) {
+            $this->eventLogger->record(
+                ServerEvent::PasswordPolicyAccountUnlocked,
+                $subject,
+            );
+        }
+        if ($outcome->graceRemaining !== null) {
+            $this->eventLogger->record(
+                ServerEvent::PasswordPolicyGraceLogin,
+                $subject,
+            );
+        }
+        if ($outcome->errorCode === PwdPolicyError::CHANGE_AFTER_RESET) {
+            $this->eventLogger->record(
+                ServerEvent::PasswordPolicyMustChange,
+                $subject,
+            );
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function subjectFor(PasswordBindAttempt $attempt): array
+    {
+        return [
+            EventContext::USERNAME => $attempt->name,
+            EventContext::DN => $attempt->dn->toString(),
+        ];
+    }
+}

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -27,8 +27,16 @@ use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordPolicyAwareAuthenticator;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyBindGuard;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\Socket;
 
@@ -38,6 +46,7 @@ class ServerProtocolFactory
         private readonly HandlerFactoryInterface $handlerFactory,
         private readonly ServerOptions $options,
         private readonly ServerAuthorization $serverAuthorization,
+        private readonly PasswordPolicyEngine $passwordPolicyEngine,
     ) {}
 
     public function make(
@@ -54,11 +63,23 @@ class ServerProtocolFactory
         $backend = $this->handlerFactory->makeBackend();
         $passwordAuthenticator = $this->handlerFactory->makePasswordAuthenticator();
 
+        $policyContext = null;
+        if ($this->options->isPasswordPolicyEnabled()) {
+            $policyContext = new PasswordPolicyContext();
+            $passwordAuthenticator = $this->decoratePasswordAuthenticator(
+                $passwordAuthenticator,
+                $backend,
+                $policyContext,
+                $eventLogger,
+            );
+        }
+
         $authenticators = [
             new SimpleBind(
                 queue: $serverQueue,
                 authenticator: $passwordAuthenticator,
                 eventLogger: $eventLogger,
+                passwordPolicyContext: $policyContext,
             ),
             new AnonymousBind(
                 $serverQueue,
@@ -97,6 +118,31 @@ class ServerProtocolFactory
             authorizer: $this->serverAuthorization,
             authenticator: new Authenticator($authenticators),
             eventLogger: $eventLogger,
+            passwordPolicyContext: $policyContext,
+        );
+    }
+
+    private function decoratePasswordAuthenticator(
+        PasswordAuthenticatableInterface $inner,
+        LdapBackendInterface $backend,
+        PasswordPolicyContext $policyContext,
+        EventLogger $eventLogger,
+    ): PasswordPolicyAwareAuthenticator {
+        return new PasswordPolicyAwareAuthenticator(
+            $inner,
+            $this->handlerFactory->makeIdentityResolverChain(),
+            $backend,
+            new PasswordPolicyResolver(
+                $backend,
+                $this->options->getDefaultPasswordPolicyDn(),
+                $this->options->getPasswordPolicy(),
+            ),
+            new PasswordPolicyBindGuard(
+                $this->passwordPolicyEngine,
+                new SystemChangeWriter($this->handlerFactory->makeWriteDispatcher()),
+                $policyContext,
+                $eventLogger,
+            ),
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/Token/SystemToken.php
+++ b/src/FreeDSx/Ldap/Server/Token/SystemToken.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Token;
+
+use FreeDSx\Ldap\Server\Utility\Uuid;
+
+/**
+ * Token for server-internal writes, recorded as cn=system rather than any bound user.
+ */
+final readonly class SystemToken implements TokenInterface
+{
+    public const IDENTITY = 'cn=system';
+
+    private string $id;
+
+    public function __construct(private int $version = 3)
+    {
+        $this->id = Uuid::v4();
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getUsername(): string
+    {
+        return self::IDENTITY;
+    }
+
+    public function getPassword(): ?string
+    {
+        return null;
+    }
+
+    public function getVersion(): int
+    {
+        return $this->version;
+    }
+}

--- a/tests/bin/ldap-password-policy.php
+++ b/tests/bin/ldap-password-policy.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Console\Application;
+use Tests\Support\FreeDSx\Ldap\LdapPasswordPolicyCommand;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$command = new LdapPasswordPolicyCommand();
+$app = new Application('LDAP password policy test server');
+$app->add($command);
+$app->setDefaultCommand(
+    (string) $command->getName(),
+    true,
+);
+$app->run();

--- a/tests/integration/LdapPasswordPolicyServerTest.php
+++ b/tests/integration/LdapPasswordPolicyServerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap;
+
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
+
+final class LdapPasswordPolicyServerTest extends ServerTestCase
+{
+    public function setUp(): void
+    {
+        $this->setServerMode('ldap-password-policy');
+
+        parent::setUp();
+
+        $this->createServerProcess('tcp');
+    }
+
+    public function testBindUnderResetCarriesThePasswordPolicyControl(): void
+    {
+        $response = $this->ldapClient()->bind(
+            'cn=reset-user,dc=foo,dc=bar',
+            '12345',
+        );
+
+        $control = $response->controls()->getByClass(PwdPolicyResponseControl::class);
+
+        $this->assertInstanceOf(
+            PwdPolicyResponseControl::class,
+            $control,
+            'A bind under pwdReset should carry the typed password policy response control.',
+        );
+        $this->assertSame(
+            PwdPolicyError::CHANGE_AFTER_RESET,
+            $control->getError(),
+        );
+    }
+
+    public function testBindWithoutPolicyStateCarriesNoControl(): void
+    {
+        $response = $this->ldapClient()->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+
+        $this->assertFalse(
+            $response->controls()->has(Control::OID_PWD_POLICY),
+            'A clean bind should not carry a password policy response control.',
+        );
+    }
+}

--- a/tests/integration/PasswordPolicyBindEnforcementTest.php
+++ b/tests/integration/PasswordPolicyBindEnforcementTest.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap;
+
+use DateInterval;
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\DnBindNameResolver;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticator;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordPolicyAwareAuthenticator;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
+use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
+use FreeDSx\Ldap\Server\Logging\ServerEvent;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyBindGuard;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordExpirationRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
+use Tests\Support\FreeDSx\Ldap\Logging\RecordingLogger;
+
+/**
+ * In-process integration of the real bind-enforcement stack against a writable backend.
+ */
+final class PasswordPolicyBindEnforcementTest extends TestCase
+{
+    private const NOW = '2026-05-20T12:00:00Z';
+    private const USER_DN = 'cn=user,dc=foo,dc=bar';
+    private const PASSWORD = '12345';
+
+    private FrozenClock $clock;
+    private WritableStorageBackend $backend;
+    private PasswordPolicyContext $context;
+    private RecordingLogger $logger;
+
+    protected function setUp(): void
+    {
+        $this->clock = FrozenClock::fromString(self::NOW);
+        $this->context = new PasswordPolicyContext();
+        $this->logger = new RecordingLogger();
+    }
+
+    public function test_repeated_failures_lock_the_account(): void
+    {
+        $authenticator = $this->authenticatorFor(
+            $this->user(),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    maxFailure: 2,
+                ),
+            ),
+        );
+
+        $this->attemptBind(
+            $authenticator,
+            'wrong',
+        );
+        $this->attemptBind(
+            $authenticator,
+            'wrong',
+        );
+
+        self::assertNotNull(
+            $this->storedValue(PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME),
+            'Account should be locked after reaching pwdMaxFailure.',
+        );
+
+        try {
+            $authenticator->authenticate(
+                self::USER_DN,
+                self::PASSWORD,
+            );
+            self::fail('A locked account must reject even a correct password.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INVALID_CREDENTIALS,
+                $e->getCode(),
+            );
+        }
+
+        self::assertSame(
+            PwdPolicyError::ACCOUNT_LOCKED,
+            $this->context->getOutcome()?->errorCode,
+        );
+        $this->assertEventRecorded(ServerEvent::PasswordPolicyAccountLocked);
+    }
+
+    public function test_elapsed_lockout_unlocks_on_success(): void
+    {
+        $authenticator = $this->authenticatorFor(
+            $this->user([
+                PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME => $this->minutesAgo(120),
+            ]),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    duration: 3600,
+                ),
+            ),
+        );
+
+        $authenticator->authenticate(
+            self::USER_DN,
+            self::PASSWORD,
+        );
+
+        self::assertNull(
+            $this->storedValue(PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME),
+            'A successful bind past the lockout duration should clear the lock.',
+        );
+        $this->assertEventRecorded(ServerEvent::PasswordPolicyAccountUnlocked);
+    }
+
+    public function test_bind_within_expiry_warning_returns_seconds_remaining(): void
+    {
+        $authenticator = $this->authenticatorFor(
+            $this->user([
+                PasswordPolicyOid::NAME_PWD_CHANGED_TIME => $this->minutesAgo(50),
+            ]),
+            new PasswordPolicy(
+                expiration: new PasswordExpirationRules(
+                    maxAge: 3600,
+                    expireWarning: 1200,
+                ),
+            ),
+        );
+
+        $authenticator->authenticate(
+            self::USER_DN,
+            self::PASSWORD,
+        );
+
+        self::assertSame(
+            600,
+            $this->context->getOutcome()?->timeBeforeExpiration,
+        );
+    }
+
+    public function test_expired_password_within_grace_warns_and_records_use(): void
+    {
+        $authenticator = $this->authenticatorFor(
+            $this->user([
+                PasswordPolicyOid::NAME_PWD_CHANGED_TIME => $this->minutesAgo(120),
+            ]),
+            new PasswordPolicy(
+                expiration: new PasswordExpirationRules(
+                    maxAge: 3600,
+                    graceAuthnLimit: 3,
+                ),
+            ),
+        );
+
+        $authenticator->authenticate(
+            self::USER_DN,
+            self::PASSWORD,
+        );
+
+        self::assertSame(
+            2,
+            $this->context->getOutcome()?->graceRemaining,
+        );
+        self::assertNotNull($this->storedValue(PasswordPolicyOid::NAME_PWD_GRACE_USE_TIME));
+        $this->assertEventRecorded(ServerEvent::PasswordPolicyGraceLogin);
+    }
+
+    public function test_expired_password_beyond_grace_is_denied(): void
+    {
+        $exhausted = [
+            $this->minutesAgo(30),
+            $this->minutesAgo(20),
+            $this->minutesAgo(10),
+        ];
+        $authenticator = $this->authenticatorFor(
+            $this->user([
+                PasswordPolicyOid::NAME_PWD_CHANGED_TIME => $this->minutesAgo(120),
+                PasswordPolicyOid::NAME_PWD_GRACE_USE_TIME => $exhausted,
+            ]),
+            new PasswordPolicy(
+                expiration: new PasswordExpirationRules(
+                    maxAge: 3600,
+                    graceAuthnLimit: 3,
+                ),
+            ),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        try {
+            $authenticator->authenticate(
+                self::USER_DN,
+                self::PASSWORD,
+            );
+        } finally {
+            self::assertSame(
+                PwdPolicyError::PASSWORD_EXPIRED,
+                $this->context->getOutcome()?->errorCode,
+            );
+        }
+    }
+
+    public function test_pwd_reset_surfaces_change_after_reset(): void
+    {
+        $authenticator = $this->authenticatorFor(
+            $this->user([
+                PasswordPolicyOid::NAME_PWD_RESET => 'TRUE',
+            ]),
+            new PasswordPolicy(),
+        );
+
+        $authenticator->authenticate(
+            self::USER_DN,
+            self::PASSWORD,
+        );
+
+        self::assertSame(
+            PwdPolicyError::CHANGE_AFTER_RESET,
+            $this->context->getOutcome()?->errorCode,
+        );
+        $this->assertEventRecorded(ServerEvent::PasswordPolicyMustChange);
+    }
+
+    /**
+     * @param array<string, string|list<string>> $extra
+     */
+    private function user(array $extra = []): Entry
+    {
+        return Entry::fromArray(
+            self::USER_DN,
+            [
+                'objectClass' => ['inetOrgPerson'],
+                'cn' => ['user'],
+                'sn' => ['User'],
+                'userPassword' => [self::PASSWORD],
+            ] + $extra,
+        );
+    }
+
+    private function authenticatorFor(
+        Entry $user,
+        PasswordPolicy $policy,
+    ): PasswordPolicyAwareAuthenticator {
+        $this->backend = new WritableStorageBackend(new InMemoryStorage([
+            Entry::fromArray(
+                'dc=foo,dc=bar',
+                [
+                    'objectClass' => ['domain'],
+                    'dc' => ['foo'],
+                ],
+            ),
+            $user,
+        ]));
+
+        $nameResolver = new DnBindNameResolver();
+        $engine = new PasswordPolicyEngine(
+            clock: $this->clock,
+            changeConstraints: new PasswordChangeConstraintChain([]),
+        );
+        $guard = new PasswordPolicyBindGuard(
+            $engine,
+            new SystemChangeWriter(new WriteOperationDispatcher($this->backend)),
+            $this->context,
+            new EventLogger(
+                $this->logger,
+                EventLogPolicy::all(),
+            ),
+        );
+
+        return new PasswordPolicyAwareAuthenticator(
+            new PasswordAuthenticator(
+                $nameResolver,
+                $this->backend,
+            ),
+            $nameResolver,
+            $this->backend,
+            new PasswordPolicyResolver(
+                $this->backend,
+                null,
+                $policy,
+            ),
+            $guard,
+        );
+    }
+
+    private function attemptBind(
+        PasswordPolicyAwareAuthenticator $authenticator,
+        string $password,
+    ): void {
+        try {
+            $authenticator->authenticate(
+                self::USER_DN,
+                $password,
+            );
+        } catch (OperationException) {
+            // Expected for the failure-path scenarios under test.
+        }
+    }
+
+    private function minutesAgo(int $minutes): string
+    {
+        return GeneralizedTime::format(
+            $this->clock
+                ->now()
+                ->sub(new DateInterval(sprintf('PT%dM', $minutes))),
+        );
+    }
+
+    private function storedValue(string $attribute): ?string
+    {
+        return $this->backend
+            ->get(new Dn(self::USER_DN))
+            ?->get($attribute)
+            ?->firstValue();
+    }
+
+    private function assertEventRecorded(ServerEvent $event): void
+    {
+        $events = [];
+        foreach ($this->logger->records as $record) {
+            $recorded = $record['context']['event'] ?? null;
+            if (is_string($recorded)) {
+                $events[] = $recorded;
+            }
+        }
+
+        self::assertContains(
+            $event->value,
+            $events,
+        );
+    }
+}

--- a/tests/support/Backend/RecordingWriteHandler.php
+++ b/tests/support/Backend/RecordingWriteHandler.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Support\FreeDSx\Ldap\Backend;
+
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
+use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
+use FreeDSx\Ldap\Server\Backend\Write\WriteRequestInterface;
+
+/**
+ * Write handler that accepts every command and records each dispatch for inspection.
+ */
+final class RecordingWriteHandler implements WriteHandlerInterface
+{
+    /**
+     * @var list<array{request: WriteRequestInterface, context: WriteContext}>
+     */
+    public array $dispatched = [];
+
+    public function supports(WriteRequestInterface $request): bool
+    {
+        return true;
+    }
+
+    public function handle(
+        WriteRequestInterface $request,
+        WriteContext $context,
+    ): void {
+        $this->dispatched[] = [
+            'request' => $request,
+            'context' => $context,
+        ];
+    }
+}

--- a/tests/support/LdapPasswordPolicyCommand.php
+++ b/tests/support/LdapPasswordPolicyCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\FreeDSx\Ldap;
+
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\ServerOptions;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class LdapPasswordPolicyCommand extends Command
+{
+    use ConsoleOptionsTrait;
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('ldap-password-policy')
+            ->setDescription('Run the test LDAP server with server-side password policy enabled')
+            ->addOption(
+                'transport',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Transport type (tcp, unix)',
+                'tcp',
+            )
+            ->addOption(
+                'port',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Port to listen on',
+                '10389',
+            );
+    }
+
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output,
+    ): int {
+        $transport = $this->getStringOption($input, 'transport');
+        $port = (int) $this->getStringOption($input, 'port');
+        $passwordHash = '{SHA}' . base64_encode(sha1('12345', true));
+
+        $entries = [
+            new Entry(
+                new Dn('dc=foo,dc=bar'),
+                new Attribute('dc', 'foo'),
+                new Attribute('objectClass', 'domain'),
+            ),
+            new Entry(
+                new Dn('cn=user,dc=foo,dc=bar'),
+                new Attribute('cn', 'user'),
+                new Attribute('sn', 'User'),
+                new Attribute('objectClass', 'inetOrgPerson'),
+                new Attribute('userPassword', $passwordHash),
+            ),
+            new Entry(
+                new Dn('cn=reset-user,dc=foo,dc=bar'),
+                new Attribute('cn', 'reset-user'),
+                new Attribute('sn', 'Reset'),
+                new Attribute('objectClass', 'inetOrgPerson'),
+                new Attribute('userPassword', $passwordHash),
+                new Attribute(PasswordPolicyOid::NAME_PWD_RESET, 'TRUE'),
+            ),
+        ];
+
+        $server = new LdapServer(
+            (new ServerOptions())
+                ->setPort($port)
+                ->setTransport($transport)
+                ->setSocketAcceptTimeout(0.1)
+                ->setPasswordPolicy(new PasswordPolicy())
+                ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL)),
+        );
+        $server->useStorage(new InMemoryStorage($entries));
+        $server->run();
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/unit/Protocol/LdapMessageRequestTest.php
+++ b/tests/unit/Protocol/LdapMessageRequestTest.php
@@ -14,8 +14,11 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Protocol;
 
 use FreeDSx\Asn1\Asn1;
+use FreeDSx\Asn1\Type\IncompleteType;
 use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
+use FreeDSx\Ldap\Protocol\LdapEncoder;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use PHPUnit\Framework\TestCase;
 
@@ -63,5 +66,19 @@ final class LdapMessageRequestTest extends TestCase
             ),
             $this->subject->toAsn1(),
         );
+    }
+
+    public function test_it_leaves_the_shared_pwd_policy_oid_generic_on_the_request_path(): void
+    {
+        $encoder = new LdapEncoder();
+
+        $message = LdapMessageRequest::fromAsn1(Asn1::sequence(
+            Asn1::integer(2),
+            Asn1::application(10, Asn1::octetString('dc=foo,dc=bar')),
+            Asn1::context(0, (new IncompleteType($encoder->encode((new Control(Control::OID_PWD_POLICY))->toAsn1())))->setIsConstructed(true)),
+        ));
+
+        self::assertTrue($message->controls()->has(Control::OID_PWD_POLICY));
+        self::assertNull($message->controls()->getByClass(PwdPolicyResponseControl::class));
     }
 }

--- a/tests/unit/Protocol/LdapMessageResponseTest.php
+++ b/tests/unit/Protocol/LdapMessageResponseTest.php
@@ -16,6 +16,8 @@ namespace Tests\Unit\FreeDSx\Ldap\Protocol;
 use FreeDSx\Asn1\Asn1;
 use FreeDSx\Asn1\Type\IncompleteType;
 use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
 use FreeDSx\Ldap\Operation\Response\DeleteResponse;
 use FreeDSx\Ldap\Operation\Response\SearchResponse;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
@@ -90,5 +92,32 @@ class LdapMessageResponseTest extends TestCase
             $this->subject->getResponse(),
         );
         self::assertTrue($this->subject->controls()->has('foo'));
+    }
+
+    public function test_it_decodes_the_pwd_policy_control_as_its_typed_class(): void
+    {
+        $encoder = new LdapEncoder();
+        $control = new PwdPolicyResponseControl(error: PwdPolicyError::CHANGE_AFTER_RESET);
+
+        $message = LdapMessageResponse::fromAsn1(Asn1::sequence(
+            Asn1::integer(4),
+            Asn1::application(11, Asn1::sequence(
+                Asn1::enumerated(0),
+                Asn1::octetString('dc=foo,dc=bar'),
+                Asn1::octetString(''),
+            )),
+            Asn1::context(0, (new IncompleteType($encoder->encode($control->toAsn1())))->setIsConstructed(true)),
+        ));
+
+        $decoded = $message->controls()->getByClass(PwdPolicyResponseControl::class);
+
+        self::assertInstanceOf(
+            PwdPolicyResponseControl::class,
+            $decoded,
+        );
+        self::assertSame(
+            PwdPolicyError::CHANGE_AFTER_RESET,
+            $decoded->getError(),
+        );
     }
 }

--- a/tests/unit/Server/Backend/Auth/PasswordPolicyAwareAuthenticatorTest.php
+++ b/tests/unit/Server/Backend/Auth/PasswordPolicyAwareAuthenticatorTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Auth;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordPolicyAwareAuthenticator;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
+use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyBindGuard;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Backend\RecordingWriteHandler;
+use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
+
+final class PasswordPolicyAwareAuthenticatorTest extends TestCase
+{
+    private const DN = 'cn=foo,dc=example,dc=com';
+
+    private PasswordAuthenticatableInterface&MockObject $inner;
+    private BindNameResolverInterface&MockObject $nameResolver;
+    private RecordingWriteHandler $writeHandler;
+    private PasswordPolicyContext $context;
+
+    protected function setUp(): void
+    {
+        $this->inner = $this->createMock(PasswordAuthenticatableInterface::class);
+        $this->nameResolver = $this->createMock(BindNameResolverInterface::class);
+        $this->writeHandler = new RecordingWriteHandler();
+        $this->context = new PasswordPolicyContext();
+    }
+
+    public function test_delegates_when_no_entry_is_found(): void
+    {
+        $this->nameResolver
+            ->method('resolve')
+            ->willReturn(null);
+        $token = $this->expectInnerReturnsToken();
+
+        $result = $this->authenticator(new PasswordPolicy())->authenticate(
+            'foo',
+            'secret',
+        );
+
+        self::assertSame(
+            $token,
+            $result,
+        );
+        self::assertNull($this->context->getOutcome());
+    }
+
+    public function test_delegates_when_no_policy_applies(): void
+    {
+        $this->nameResolver
+            ->method('resolve')
+            ->willReturn($this->entry());
+        $token = $this->expectInnerReturnsToken();
+
+        $result = $this->authenticator(null)->authenticate(
+            'foo',
+            'secret',
+        );
+
+        self::assertSame(
+            $token,
+            $result,
+        );
+        self::assertNull($this->context->getOutcome());
+    }
+
+    public function test_locked_account_is_denied_before_inner_runs(): void
+    {
+        $this->nameResolver
+            ->method('resolve')
+            ->willReturn($this->entry([
+                PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME => PasswordPolicyOid::PERMANENT_LOCK_SENTINEL,
+            ]));
+        $this->inner
+            ->expects(self::never())
+            ->method('authenticate');
+
+        $this->expectException(OperationException::class);
+
+        $this->authenticator(new PasswordPolicy())->authenticate(
+            'foo',
+            'secret',
+        );
+    }
+
+    public function test_successful_bind_records_outcome(): void
+    {
+        $this->nameResolver
+            ->method('resolve')
+            ->willReturn($this->entry());
+        $token = $this->expectInnerReturnsToken();
+
+        $result = $this->authenticator(new PasswordPolicy())->authenticate(
+            'foo',
+            'secret',
+        );
+
+        self::assertSame(
+            $token,
+            $result,
+        );
+        self::assertFalse($this->context->getOutcome()?->denied);
+    }
+
+    public function test_invalid_credentials_records_a_failure(): void
+    {
+        $this->nameResolver
+            ->method('resolve')
+            ->willReturn($this->entry());
+        $this->inner
+            ->method('authenticate')
+            ->willThrowException(new OperationException(
+                'Invalid credentials.',
+                ResultCode::INVALID_CREDENTIALS,
+            ));
+
+        try {
+            $this->authenticator($this->lockoutPolicy())->authenticate(
+                'foo',
+                'secret',
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INVALID_CREDENTIALS,
+                $e->getCode(),
+            );
+        }
+
+        self::assertCount(
+            1,
+            $this->writeHandler->dispatched,
+        );
+    }
+
+    public function test_non_credential_failure_is_not_recorded(): void
+    {
+        $this->nameResolver
+            ->method('resolve')
+            ->willReturn($this->entry());
+        $this->inner
+            ->method('authenticate')
+            ->willThrowException(new OperationException(
+                'Server is busy.',
+                ResultCode::BUSY,
+            ));
+
+        try {
+            $this->authenticator($this->lockoutPolicy())->authenticate(
+                'foo',
+                'secret',
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::BUSY,
+                $e->getCode(),
+            );
+        }
+
+        self::assertSame(
+            [],
+            $this->writeHandler->dispatched,
+        );
+    }
+
+    private function authenticator(?PasswordPolicy $policy): PasswordPolicyAwareAuthenticator
+    {
+        $backend = $this->createMock(LdapBackendInterface::class);
+        $engine = new PasswordPolicyEngine(
+            clock: FrozenClock::fromString('2026-05-20T12:00:00Z'),
+            changeConstraints: new PasswordChangeConstraintChain([]),
+        );
+        $guard = new PasswordPolicyBindGuard(
+            $engine,
+            new SystemChangeWriter(new WriteOperationDispatcher($this->writeHandler)),
+            $this->context,
+            new EventLogger(null),
+        );
+
+        return new PasswordPolicyAwareAuthenticator(
+            $this->inner,
+            $this->nameResolver,
+            $backend,
+            new PasswordPolicyResolver(
+                $backend,
+                null,
+                $policy,
+            ),
+            $guard,
+        );
+    }
+
+    private function expectInnerReturnsToken(): BindToken
+    {
+        $token = BindToken::fromDn(
+            self::DN,
+            'secret',
+        );
+        $this->inner
+            ->method('authenticate')
+            ->willReturn($token);
+
+        return $token;
+    }
+
+    /**
+     * @param array<string, string> $attributes
+     */
+    private function entry(array $attributes = []): Entry
+    {
+        return Entry::fromArray(
+            new Dn(self::DN),
+            $attributes,
+        );
+    }
+
+    private function lockoutPolicy(): PasswordPolicy
+    {
+        return new PasswordPolicy(
+            lockout: new PasswordLockoutRules(
+                enabled: true,
+                maxFailure: 3,
+            ),
+        );
+    }
+}

--- a/tests/unit/Server/Backend/Write/SystemChangeWriterTest.php
+++ b/tests/unit/Server/Backend/Write/SystemChangeWriterTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Write;
+
+use FreeDSx\Ldap\Entry\Change;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
+use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
+use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\PasswordPolicy\OperationalChanges;
+use FreeDSx\Ldap\Server\Token\SystemToken;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Backend\RecordingWriteHandler;
+
+final class SystemChangeWriterTest extends TestCase
+{
+    private RecordingWriteHandler $handler;
+    private SystemChangeWriter $subject;
+
+    protected function setUp(): void
+    {
+        $this->handler = new RecordingWriteHandler();
+        $this->subject = new SystemChangeWriter(new WriteOperationDispatcher($this->handler));
+    }
+
+    public function test_empty_changes_dispatch_nothing(): void
+    {
+        $this->subject->write(
+            new Dn('cn=foo,dc=example,dc=com'),
+            OperationalChanges::none(),
+        );
+
+        self::assertSame(
+            [],
+            $this->handler->dispatched,
+        );
+    }
+
+    public function test_dispatches_update_command_for_the_dn(): void
+    {
+        $dn = new Dn('cn=foo,dc=example,dc=com');
+        $change = Change::replace(
+            'pwdFailureTime',
+            '20260520120000Z',
+        );
+
+        $this->subject->write(
+            $dn,
+            OperationalChanges::of($change),
+        );
+
+        self::assertCount(
+            1,
+            $this->handler->dispatched,
+        );
+        $request = $this->handler->dispatched[0]['request'];
+        self::assertInstanceOf(
+            UpdateCommand::class,
+            $request,
+        );
+        self::assertSame(
+            $dn,
+            $request->dn,
+        );
+        self::assertSame(
+            [$change],
+            $request->changes,
+        );
+    }
+
+    public function test_dispatch_uses_a_system_flagged_context(): void
+    {
+        $this->subject->write(
+            new Dn('cn=foo,dc=example,dc=com'),
+            OperationalChanges::of(Change::reset('pwdFailureTime')),
+        );
+
+        $context = $this->handler->dispatched[0]['context'];
+
+        self::assertTrue($context->isSystem());
+        self::assertSame(
+            SystemToken::IDENTITY,
+            $context->getBoundDn(),
+        );
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/PasswordPolicyBindGuardTest.php
+++ b/tests/unit/Server/PasswordPolicy/PasswordPolicyBindGuardTest.php
@@ -1,0 +1,307 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy;
+
+use DateInterval;
+use DateTimeImmutable;
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
+use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
+use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
+use FreeDSx\Ldap\Server\Logging\ServerEvent;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordBindAttempt;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyBindGuard;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordExpirationRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Backend\RecordingWriteHandler;
+use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
+use Tests\Support\FreeDSx\Ldap\Logging\RecordingLogger;
+
+final class PasswordPolicyBindGuardTest extends TestCase
+{
+    private const NOW = '2026-05-20T12:00:00Z';
+    private const DN = 'cn=foo,dc=example,dc=com';
+
+    private FrozenClock $clock;
+    private RecordingWriteHandler $writeHandler;
+    private RecordingLogger $logger;
+    private PasswordPolicyContext $context;
+    private PasswordPolicyBindGuard $subject;
+
+    protected function setUp(): void
+    {
+        $this->clock = FrozenClock::fromString(self::NOW);
+        $this->writeHandler = new RecordingWriteHandler();
+        $this->logger = new RecordingLogger();
+        $this->context = new PasswordPolicyContext();
+
+        $engine = new PasswordPolicyEngine(
+            clock: $this->clock,
+            changeConstraints: new PasswordChangeConstraintChain([]),
+        );
+        $this->subject = new PasswordPolicyBindGuard(
+            $engine,
+            new SystemChangeWriter(new WriteOperationDispatcher($this->writeHandler)),
+            $this->context,
+            new EventLogger(
+                $this->logger,
+                EventLogPolicy::all(),
+            ),
+        );
+    }
+
+    public function test_preBind_allows_an_unlocked_account(): void
+    {
+        $this->subject->preBind($this->attempt(new UserPasswordState()));
+
+        self::assertNull($this->context->getOutcome());
+        self::assertSame(
+            [],
+            $this->writeHandler->dispatched,
+        );
+    }
+
+    public function test_preBind_denies_a_locked_account(): void
+    {
+        try {
+            $this->subject->preBind($this->attempt(new UserPasswordState(permanentlyLocked: true)));
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INVALID_CREDENTIALS,
+                $e->getCode(),
+            );
+        }
+
+        self::assertSame(
+            PwdPolicyError::ACCOUNT_LOCKED,
+            $this->context->getOutcome()?->errorCode,
+        );
+        $this->assertEventRecorded(ServerEvent::PasswordPolicyAccountLocked);
+    }
+
+    public function test_recordFailure_below_threshold_writes_without_locking(): void
+    {
+        $this->subject->recordFailure($this->attempt(
+            new UserPasswordState(),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    maxFailure: 3,
+                ),
+            ),
+        ));
+
+        self::assertNull($this->context->getOutcome());
+        $this->assertWroteAttribute(PasswordPolicyOid::NAME_PWD_FAILURE_TIME);
+        $this->assertNoEventRecorded(ServerEvent::PasswordPolicyAccountLocked);
+    }
+
+    public function test_recordFailure_trips_lockout_at_threshold(): void
+    {
+        $this->subject->recordFailure($this->attempt(
+            new UserPasswordState(failureTimes: [
+                $this->minutesAgo(3),
+                $this->minutesAgo(2),
+            ]),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    maxFailure: 3,
+                ),
+            ),
+        ));
+
+        self::assertSame(
+            PwdPolicyError::ACCOUNT_LOCKED,
+            $this->context->getOutcome()?->errorCode,
+        );
+        $this->assertWroteAttribute(PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME);
+        $this->assertEventRecorded(ServerEvent::PasswordPolicyAccountLocked);
+    }
+
+    public function test_recordSuccess_clean_state_stashes_allow_without_writes(): void
+    {
+        $this->subject->recordSuccess($this->attempt(new UserPasswordState()));
+
+        self::assertFalse($this->context->getOutcome()?->denied);
+        self::assertSame(
+            [],
+            $this->writeHandler->dispatched,
+        );
+    }
+
+    public function test_recordSuccess_expired_without_grace_denies(): void
+    {
+        try {
+            $this->subject->recordSuccess($this->attempt(
+                new UserPasswordState(changedAt: $this->minutesAgo(120)),
+                new PasswordPolicy(
+                    expiration: new PasswordExpirationRules(maxAge: 3600),
+                ),
+            ));
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INVALID_CREDENTIALS,
+                $e->getCode(),
+            );
+        }
+
+        self::assertSame(
+            PwdPolicyError::PASSWORD_EXPIRED,
+            $this->context->getOutcome()?->errorCode,
+        );
+        self::assertSame(
+            [],
+            $this->writeHandler->dispatched,
+        );
+        $this->assertEventRecorded(ServerEvent::PasswordPolicyExpired);
+    }
+
+    public function test_recordSuccess_expired_within_grace_warns_and_records(): void
+    {
+        $this->subject->recordSuccess($this->attempt(
+            new UserPasswordState(changedAt: $this->minutesAgo(120)),
+            new PasswordPolicy(
+                expiration: new PasswordExpirationRules(
+                    maxAge: 3600,
+                    graceAuthnLimit: 3,
+                ),
+            ),
+        ));
+
+        self::assertSame(
+            2,
+            $this->context->getOutcome()?->graceRemaining,
+        );
+        $this->assertWroteAttribute(PasswordPolicyOid::NAME_PWD_GRACE_USE_TIME);
+        $this->assertEventRecorded(ServerEvent::PasswordPolicyGraceLogin);
+    }
+
+    public function test_recordSuccess_unlocks_a_previously_locked_account(): void
+    {
+        $this->subject->recordSuccess($this->attempt(
+            new UserPasswordState(accountLockedAt: $this->minutesAgo(120)),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    duration: 3600,
+                ),
+            ),
+        ));
+
+        $this->assertWroteAttribute(PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME);
+        $this->assertEventRecorded(ServerEvent::PasswordPolicyAccountUnlocked);
+    }
+
+    public function test_recordSuccess_surfaces_must_change(): void
+    {
+        $this->subject->recordSuccess($this->attempt(new UserPasswordState(mustChange: true)));
+
+        self::assertSame(
+            PwdPolicyError::CHANGE_AFTER_RESET,
+            $this->context->getOutcome()?->errorCode,
+        );
+        $this->assertEventRecorded(ServerEvent::PasswordPolicyMustChange);
+    }
+
+    private function attempt(
+        UserPasswordState $state,
+        PasswordPolicy $policy = new PasswordPolicy(),
+    ): PasswordBindAttempt {
+        return new PasswordBindAttempt(
+            name: 'foo',
+            dn: new Dn(self::DN),
+            state: $state,
+            policy: $policy,
+        );
+    }
+
+    private function minutesAgo(int $minutes): DateTimeImmutable
+    {
+        return $this->clock
+            ->now()
+            ->sub(new DateInterval(sprintf('PT%dM', $minutes)));
+    }
+
+    private function assertWroteAttribute(string $name): void
+    {
+        self::assertTrue(
+            $this->wroteAttribute($name),
+            sprintf('Expected a system write touching "%s".', $name),
+        );
+    }
+
+    private function wroteAttribute(string $name): bool
+    {
+        foreach ($this->writeHandler->dispatched as $dispatch) {
+            $request = $dispatch['request'];
+            if (!$request instanceof UpdateCommand) {
+                continue;
+            }
+            foreach ($request->changes as $change) {
+                if (strcasecmp($change->getAttribute()->getName(), $name) === 0) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function assertEventRecorded(ServerEvent $event): void
+    {
+        self::assertContains(
+            $event->value,
+            $this->recordedEvents(),
+        );
+    }
+
+    private function assertNoEventRecorded(ServerEvent $event): void
+    {
+        self::assertNotContains(
+            $event->value,
+            $this->recordedEvents(),
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function recordedEvents(): array
+    {
+        $events = [];
+        foreach ($this->logger->records as $record) {
+            $event = $record['context']['event'] ?? null;
+            if (is_string($event)) {
+                $events[] = $event;
+            }
+        }
+
+        return $events;
+    }
+}

--- a/tests/unit/Server/ServerProtocolFactoryTest.php
+++ b/tests/unit/Server/ServerProtocolFactoryTest.php
@@ -14,9 +14,16 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Server;
 
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
+use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\Clock\SystemClock;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
 use FreeDSx\Ldap\Server\ServerProtocolFactory;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluator;
 use FreeDSx\Ldap\ServerOptions;
@@ -49,6 +56,15 @@ final class ServerProtocolFactoryTest extends TestCase
             $this->mockHandlerFactory,
             new ServerOptions(),
             $this->mockServerAuthorization,
+            $this->passwordPolicyEngine(),
+        );
+    }
+
+    private function passwordPolicyEngine(): PasswordPolicyEngine
+    {
+        return new PasswordPolicyEngine(
+            new SystemClock(),
+            new PasswordChangeConstraintChain([]),
         );
     }
 
@@ -74,6 +90,33 @@ final class ServerProtocolFactoryTest extends TestCase
             $this->mockHandlerFactory,
             (new ServerOptions())->setSaslMechanisms(ServerOptions::SASL_PLAIN),
             $this->mockServerAuthorization,
+            $this->passwordPolicyEngine(),
+        );
+
+        $subject->make($mockSocket);
+    }
+
+    public function test_it_wraps_the_authenticator_when_password_policy_is_enabled(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $mockSocket = $this->createMock(Socket::class);
+
+        $this->mockHandlerFactory
+            ->method('makePasswordAuthenticator')
+            ->willReturn($this->createMock(PasswordAuthenticatableInterface::class));
+        $this->mockHandlerFactory
+            ->method('makeIdentityResolverChain')
+            ->willReturn($this->createMock(BindNameResolverInterface::class));
+        $this->mockHandlerFactory
+            ->method('makeWriteDispatcher')
+            ->willReturn(new WriteOperationDispatcher());
+
+        $subject = new ServerProtocolFactory(
+            $this->mockHandlerFactory,
+            (new ServerOptions())->setPasswordPolicy(new PasswordPolicy()),
+            $this->mockServerAuthorization,
+            $this->passwordPolicyEngine(),
         );
 
         $subject->make($mockSocket);

--- a/tests/unit/Server/Token/SystemTokenTest.php
+++ b/tests/unit/Server/Token/SystemTokenTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Token;
+
+use FreeDSx\Ldap\Server\Token\SystemToken;
+use PHPUnit\Framework\TestCase;
+
+final class SystemTokenTest extends TestCase
+{
+    public function test_it_reports_the_system_identity(): void
+    {
+        $token = new SystemToken();
+
+        self::assertSame(
+            'cn=system',
+            $token->getUsername(),
+        );
+        self::assertSame(
+            SystemToken::IDENTITY,
+            $token->getUsername(),
+        );
+    }
+
+    public function test_it_carries_no_password(): void
+    {
+        self::assertNull((new SystemToken())->getPassword());
+    }
+
+    public function test_it_defaults_to_ldap_v3(): void
+    {
+        self::assertSame(
+            3,
+            (new SystemToken())->getVersion(),
+        );
+    }
+
+    public function test_each_instance_has_a_unique_id(): void
+    {
+        self::assertNotSame(
+            (new SystemToken())->getId(),
+            (new SystemToken())->getId(),
+        );
+    }
+}


### PR DESCRIPTION
With all the prerequisites in place, this now implements the password policy engine in the path for simple binds. This leaves out SASL handling for now. That will be implemented in a follow-up PR. Adding integration tests to fully cover it.