### PR TITLE
[1.0.0] Enforce password policy on SASL, Password Modify, and plain modify operations.

### DIFF
--- a/src/FreeDSx/Ldap/Entry/Attribute.php
+++ b/src/FreeDSx/Ldap/Entry/Attribute.php
@@ -146,6 +146,7 @@ class Attribute implements IteratorAggregate, Countable, Stringable
                 }
             }
         }
+        $this->values = array_values($this->values);
 
         return $this;
     }

--- a/src/FreeDSx/Ldap/Protocol/Bind/SaslBind.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/SaslBind.php
@@ -24,6 +24,7 @@ use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\MessageWrapper\SaslMessageWrapper;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\Backend\Auth\SaslBindPolicyEnforcer;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
@@ -55,6 +56,7 @@ class SaslBind implements BindInterface
         private readonly array $mechanisms = [],
         private readonly ResponseFactory $responseFactory = new ResponseFactory(),
         private readonly EventLogger $eventLogger = new EventLogger(null),
+        private readonly ?SaslBindPolicyEnforcer $policyEnforcer = null,
     ) {}
 
     /**
@@ -176,6 +178,9 @@ class SaslBind implements BindInterface
         $message = $result->getLastMessage();
 
         if (!$context->isAuthenticated()) {
+            $this->policyEnforcer?->recordFailure($result->getUsername());
+            $control = $this->policyEnforcer?->responseControl();
+
             // Send the failure response directly using the current $message, which reflects
             // the latest message consumed from the queue (correct ID for multi-round exchanges).
             // Without this, the outer OperationException handler would use the stale first
@@ -184,6 +189,8 @@ class SaslBind implements BindInterface
                 $message,
                 ResultCode::INVALID_CREDENTIALS,
                 'Invalid credentials.',
+                null,
+                ...($control === null ? [] : [$control]),
             ));
 
             throw new OperationException(
@@ -210,18 +217,33 @@ class SaslBind implements BindInterface
                     ResultCode::INVALID_CREDENTIALS,
                 );
             }
+
+            $this->policyEnforcer?->enforceSuccess(
+                $username,
+                $resolvedDn,
+            );
         } catch (OperationException $e) {
+            $control = $this->policyEnforcer?->responseControl();
             $this->queue->sendMessage($this->responseFactory->getStandardResponse(
                 $message,
                 $e->getCode(),
                 $e->getMessage(),
+                null,
+                ...($control === null ? [] : [$control]),
             ));
 
             throw $e;
         }
 
         // The success response must be sent before activating the security layer.
-        $this->queue->sendMessage($this->responseFactory->getStandardResponse($message));
+        $control = $this->policyEnforcer?->responseControl();
+        $this->queue->sendMessage($this->responseFactory->getStandardResponse(
+            $message,
+            ResultCode::SUCCESS,
+            '',
+            null,
+            ...($control === null ? [] : [$control]),
+        ));
 
         if ($context->hasSecurityLayer()) {
             $mech = $this->sasl->get($mechName);

--- a/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Protocol\Factory;
 
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
@@ -24,6 +25,9 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerProtocolHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHasher;
+use FreeDSx\Ldap\Server\Backend\Write\PasswordPolicyWriteHandler;
+use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
+use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyChangeGuard;
@@ -102,14 +106,40 @@ class ServerProtocolHandlerFactory
         } elseif ($request instanceof UnbindRequest) {
             return new ServerProtocolHandler\ServerUnbindHandler($this->queue);
         } else {
+            $policyWriteHandler = $this->makePasswordPolicyWriteHandler();
+
             return new ServerProtocolHandler\ServerDispatchHandler(
                 queue: $this->queue,
                 backend: $this->handlerFactory->makeBackend(),
-                writeDispatcher: $this->handlerFactory->makeWriteDispatcher(),
+                writeDispatcher: $policyWriteHandler !== null
+                    ? $this->handlerFactory->makeWriteDispatcher($policyWriteHandler)
+                    : $this->handlerFactory->makeWriteDispatcher(),
                 accessControl: $this->options->getAccessControl(),
                 eventRecorder: new ServerProtocolHandler\DispatchEventRecorder($this->eventLogger),
+                passwordPolicyContext: $this->passwordPolicyContext,
             );
         }
+    }
+
+    private function makePasswordPolicyWriteHandler(): ?PasswordPolicyWriteHandler
+    {
+        $guard = $this->makePasswordPolicyChangeGuard();
+        if ($guard === null) {
+            return null;
+        }
+
+        $backend = $this->handlerFactory->makeBackend();
+        if (!$backend instanceof WriteHandlerInterface) {
+            throw new RuntimeException(
+                'A backend implementing WriteHandlerInterface is required to enforce policy on userPassword modifications.',
+            );
+        }
+
+        return new PasswordPolicyWriteHandler(
+            $backend,
+            $guard,
+            new SystemChangeWriter($this->handlerFactory->makeWriteDispatcher()),
+        );
     }
 
     private function makePasswordPolicyChangeGuard(): ?PasswordPolicyChangeGuard

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request;
@@ -29,6 +30,7 @@ use FreeDSx\Ldap\Server\Backend\Write\WriteCommandFactory;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -49,6 +51,7 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
         private DispatchEventRecorder $eventRecorder = new DispatchEventRecorder(new EventLogger(null)),
         private WriteCommandFactory $commandFactory = new WriteCommandFactory(),
         private ResponseFactory $responseFactory = new ResponseFactory(),
+        private ?PasswordPolicyContext $passwordPolicyContext = null,
     ) {}
 
     /**
@@ -60,6 +63,8 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
     ): void {
+        $this->passwordPolicyContext?->clear();
+
         try {
             $this->assertNoCriticalUnsupportedControls($message->controls());
             $request = $message->getRequest();
@@ -102,12 +107,20 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
                 ),
             );
 
-            $this->queue->sendMessage($this->responseFactory->getStandardResponse($message));
+            $successControl = $this->passwordPolicyControl();
+            $this->queue->sendMessage($this->responseFactory->getStandardResponse(
+                $message,
+                ResultCode::SUCCESS,
+                '',
+                null,
+                ...($successControl === null ? [] : [$successControl]),
+            ));
             $this->eventRecorder->recordWriteSuccess(
                 $message,
                 $token,
             );
         } catch (OperationException $e) {
+            $errorControl = $this->passwordPolicyControl();
             $this->queue->sendMessage($this->responseFactory->getStandardResponse(
                 $message,
                 $e->getCode(),
@@ -118,6 +131,7 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
                     $this->backend,
                     $this->accessControl,
                 ),
+                ...($errorControl === null ? [] : [$errorControl]),
             ));
             $this->eventRecorder->recordFailure(
                 $message,
@@ -125,6 +139,14 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
                 $token,
             );
         }
+    }
+
+    private function passwordPolicyControl(): ?Control
+    {
+        $control = $this->passwordPolicyContext?->buildResponseControl();
+        $this->passwordPolicyContext?->clear();
+
+        return $control;
     }
 
     private function dnFor(RequestInterface $request): ?Dn

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/SaslBindPolicyEnforcer.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/SaslBindPolicyEnforcer.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Auth;
+
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\Attempt\PasswordBindAttempt;
+use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyBindGuard;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
+
+/**
+ * Drives the bind guard for the SASL flow, where the identity is only known once the exchange completes.
+ */
+final readonly class SaslBindPolicyEnforcer
+{
+    public function __construct(
+        private BindNameResolverInterface $nameResolver,
+        private LdapBackendInterface $backend,
+        private PasswordPolicyResolver $resolver,
+        private PasswordPolicyBindGuard $guard,
+        private PasswordPolicyContext $context,
+    ) {}
+
+    public function recordFailure(?string $username): void
+    {
+        if ($username === null) {
+            return;
+        }
+
+        $entry = $this->nameResolver->resolve(
+            $username,
+            $this->backend,
+        );
+        $attempt = $entry !== null
+            ? $this->attemptFor($username, $entry)
+            : null;
+        if ($attempt === null) {
+            return;
+        }
+
+        $this->guard->recordFailure($attempt);
+    }
+
+    /**
+     * @throws OperationException when the account is locked or the password is expired without grace.
+     */
+    public function enforceSuccess(
+        string $username,
+        Dn $resolvedDn,
+    ): void {
+        $entry = $this->backend->get($resolvedDn);
+        $attempt = $entry !== null
+            ? $this->attemptFor($username, $entry)
+            : null;
+        if ($attempt === null) {
+            return;
+        }
+
+        $this->guard->preBind($attempt);
+        $this->guard->recordSuccess($attempt);
+    }
+
+    public function responseControl(): ?Control
+    {
+        $control = $this->context->buildResponseControl();
+        $this->context->clear();
+
+        return $control;
+    }
+
+    private function attemptFor(
+        string $username,
+        Entry $entry,
+    ): ?PasswordBindAttempt {
+        $policy = $this->resolver->resolveFor($entry);
+        if ($policy === null) {
+            return null;
+        }
+
+        return new PasswordBindAttempt(
+            name: $username,
+            dn: $entry->getDn(),
+            state: UserPasswordState::fromEntry($entry),
+            policy: $policy,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Write/PasswordPolicyWriteHandler.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/PasswordPolicyWriteHandler.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Write;
+
+use FreeDSx\Ldap\Entry\Change;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
+use FreeDSx\Ldap\Server\PasswordPolicy\Attempt\PasswordModifyAttempt;
+use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
+use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyChangeGuard;
+
+/**
+ * Enforces password policy on a plain ldapmodify of userPassword, delegating the write to a decorated handler.
+ */
+final readonly class PasswordPolicyWriteHandler implements WriteHandlerInterface
+{
+    /**
+     * Change types that set a new password value.
+     */
+    private const SET_TYPES = [
+        Change::TYPE_ADD,
+        Change::TYPE_REPLACE,
+    ];
+
+    public function __construct(
+        private LdapBackendInterface&WriteHandlerInterface $backend,
+        private PasswordPolicyChangeGuard $changeGuard,
+        private SystemChangeWriter $systemChangeWriter,
+    ) {}
+
+    public function supports(WriteRequestInterface $request): bool
+    {
+        return $request instanceof UpdateCommand
+            && $this->userPasswordValues($request, self::SET_TYPES) !== [];
+    }
+
+    /**
+     * @throws OperationException
+     */
+    public function handle(
+        WriteRequestInterface $request,
+        WriteContext $context,
+    ): void {
+        if (!$request instanceof UpdateCommand) {
+            $this->backend->handle(
+                $request,
+                $context,
+            );
+
+            return;
+        }
+
+        $newPasswords = $this->userPasswordValues($request, self::SET_TYPES);
+        $entry = $this->backend->get($request->dn);
+        if ($newPasswords === [] || $entry === null) {
+            $this->backend->handle(
+                $request,
+                $context,
+            );
+
+            return;
+        }
+
+        $oldPassword = $this->userPasswordValues($request, [Change::TYPE_DELETE])[0] ?? null;
+        $isSelf = $this->isSelf(
+            $context,
+            $request->dn,
+        );
+
+        // Every value being set must satisfy policy; otherwise a weak value could ride along behind a valid one.
+        $deltas = OperationalChanges::none();
+        foreach ($newPasswords as $newPassword) {
+            $deltas = $this->changeGuard->enforce(new PasswordModifyAttempt(
+                target: $entry,
+                newPassword: $newPassword,
+                hashedNewPassword: $newPassword,
+                oldPassword: $oldPassword,
+                isSelf: $isSelf,
+            ));
+        }
+
+        $this->backend->handle(
+            $request,
+            $context,
+        );
+        $this->systemChangeWriter->write(
+            $request->dn,
+            $deltas,
+        );
+    }
+
+    /**
+     * @param list<int> $types
+     * @return list<string>
+     */
+    private function userPasswordValues(
+        UpdateCommand $command,
+        array $types,
+    ): array {
+        $values = [];
+        foreach ($command->changes as $change) {
+            if (!$this->isUserPasswordChange($change)) {
+                continue;
+            }
+            if (!in_array($change->getType(), $types, true)) {
+                continue;
+            }
+
+            foreach ($change->getAttribute()->getValues() as $value) {
+                $values[] = $value;
+            }
+        }
+
+        return $values;
+    }
+
+    private function isUserPasswordChange(Change $change): bool
+    {
+        return strcasecmp(
+            $change->getAttribute()->getName(),
+            AttributeTypeOid::NAME_USER_PASSWORD,
+        ) === 0;
+    }
+
+    private function isSelf(
+        WriteContext $context,
+        Dn $targetDn,
+    ): bool {
+        $boundDn = $context->getBoundDn();
+
+        return $boundDn !== null
+            && (new Dn($boundDn))->normalize()->toString() === $targetDn->normalize()->toString();
+    }
+}

--- a/src/FreeDSx/Ldap/Server/HandlerFactoryInterface.php
+++ b/src/FreeDSx/Ldap/Server/HandlerFactoryInterface.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Server;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
@@ -45,11 +46,9 @@ interface HandlerFactoryInterface
     /**
      * Build the write operation dispatcher.
      *
-     * Explicit write handlers (registered via LdapServer::useWriteHandler()) are
-     * added first (higher priority). The backend is appended as a fallback if it
-     * implements WriteHandlerInterface.
+     * Any $prepend handlers run first, then explicit write handlers.
      */
-    public function makeWriteDispatcher(): WriteOperationDispatcher;
+    public function makeWriteDispatcher(WriteHandlerInterface ...$prepend): WriteOperationDispatcher;
 
     /**
      * Return a PasswordAuthenticatableInterface for simple-bind and SASL PLAIN.

--- a/src/FreeDSx/Ldap/Server/RequestHandler/HandlerFactory.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/HandlerFactory.php
@@ -109,7 +109,7 @@ class HandlerFactory implements HandlerFactoryInterface
     /**
      * @inheritDoc
      */
-    public function makeWriteDispatcher(): WriteOperationDispatcher
+    public function makeWriteDispatcher(WriteHandlerInterface ...$prepend): WriteOperationDispatcher
     {
         $handlers = $this->options->getWriteHandlers();
 
@@ -118,6 +118,9 @@ class HandlerFactory implements HandlerFactoryInterface
             $handlers[] = $backend;
         }
 
-        return new WriteOperationDispatcher(...$handlers);
+        return new WriteOperationDispatcher(
+            ...$prepend,
+            ...$handlers,
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -29,6 +29,7 @@ use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordPolicyAwareAuthenticator;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
+use FreeDSx\Ldap\Server\Backend\Auth\SaslBindPolicyEnforcer;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
@@ -103,6 +104,9 @@ class ServerProtocolFactory
                 mechanisms: $saslMechanisms,
                 responseFactory: $responseFactory,
                 eventLogger: $eventLogger,
+                policyEnforcer: $policyContext !== null
+                    ? $this->makeSaslPolicyEnforcer($backend, $policyContext, $eventLogger)
+                    : null,
             );
         }
 
@@ -134,17 +138,43 @@ class ServerProtocolFactory
             $inner,
             $this->handlerFactory->makeIdentityResolverChain(),
             $backend,
-            new PasswordPolicyResolver(
-                $backend,
-                $this->options->getDefaultPasswordPolicyDn(),
-                $this->options->getPasswordPolicy(),
-            ),
-            new PasswordPolicyBindGuard(
-                $this->passwordPolicyEngine,
-                new SystemChangeWriter($this->handlerFactory->makeWriteDispatcher()),
-                $policyContext,
-                $eventLogger,
-            ),
+            $this->makePasswordPolicyResolver($backend),
+            $this->makeBindGuard($policyContext, $eventLogger),
+        );
+    }
+
+    private function makeSaslPolicyEnforcer(
+        LdapBackendInterface $backend,
+        PasswordPolicyContext $policyContext,
+        EventLogger $eventLogger,
+    ): SaslBindPolicyEnforcer {
+        return new SaslBindPolicyEnforcer(
+            $this->handlerFactory->makeIdentityResolverChain(),
+            $backend,
+            $this->makePasswordPolicyResolver($backend),
+            $this->makeBindGuard($policyContext, $eventLogger),
+            $policyContext,
+        );
+    }
+
+    private function makePasswordPolicyResolver(LdapBackendInterface $backend): PasswordPolicyResolver
+    {
+        return new PasswordPolicyResolver(
+            $backend,
+            $this->options->getDefaultPasswordPolicyDn(),
+            $this->options->getPasswordPolicy(),
+        );
+    }
+
+    private function makeBindGuard(
+        PasswordPolicyContext $policyContext,
+        EventLogger $eventLogger,
+    ): PasswordPolicyBindGuard {
+        return new PasswordPolicyBindGuard(
+            $this->passwordPolicyEngine,
+            new SystemChangeWriter($this->handlerFactory->makeWriteDispatcher()),
+            $policyContext,
+            $eventLogger,
         );
     }
 

--- a/tests/integration/Security/LdapPasswordPolicySaslServerTest.php
+++ b/tests/integration/Security/LdapPasswordPolicySaslServerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Security;
+
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\PlainOptions;
+use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+
+final class LdapPasswordPolicySaslServerTest extends ServerTestCase
+{
+    public function setUp(): void
+    {
+        $this->setServerMode('ldap-password-policy');
+
+        parent::setUp();
+
+        $this->createServerProcess('tcp');
+    }
+
+    public function testSaslBindUnderResetCarriesThePasswordPolicyControl(): void
+    {
+        $response = $this->ldapClient()->bindSasl(
+            (new PlainOptions())->setUsername('reset-user')->setPassword('12345'),
+            MechanismName::PLAIN,
+        );
+
+        $control = $response->controls()->getByClass(PwdPolicyResponseControl::class);
+
+        $this->assertInstanceOf(
+            PwdPolicyResponseControl::class,
+            $control,
+            'A SASL bind under pwdReset should carry the password policy response control.',
+        );
+        $this->assertSame(
+            PwdPolicyError::CHANGE_AFTER_RESET,
+            $control->getError(),
+        );
+    }
+
+    public function testCleanSaslBindCarriesNoControl(): void
+    {
+        $response = $this->ldapClient()->bindSasl(
+            (new PlainOptions())->setUsername('user')->setPassword('12345'),
+            MechanismName::PLAIN,
+        );
+
+        $this->assertFalse($response->controls()->has(Control::OID_PWD_POLICY));
+    }
+}

--- a/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Security;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
+use FreeDSx\Ldap\Entry\Change;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Operation\LdapResult;
+use FreeDSx\Ldap\Operation\Request\ModifyRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashVerifier;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\Write\PasswordPolicyWriteHandler;
+use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
+use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerDispatchHandler;
+use FreeDSx\Ldap\Protocol\ServerProtocolHandler\DispatchEventRecorder;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\AllowUserChangeConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\HistoryConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\MinAgeConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\QualityConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\SafeModifyConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyChangeGuard;
+use FreeDSx\Ldap\Server\PasswordPolicy\HistoryEntry;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
+use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\DefaultPasswordQualityChecker;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
+
+/**
+ * In-process integration of a plain ldapmodify of userPassword flowing through the dispatch handler.
+ */
+final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
+{
+    private const NOW = '2026-05-20T12:00:00Z';
+    private const USER_DN = 'cn=user,dc=foo,dc=bar';
+
+    private FrozenClock $clock;
+    private WritableStorageBackend $backend;
+    private PasswordPolicyContext $context;
+    private ?LdapMessageResponse $response = null;
+
+    protected function setUp(): void
+    {
+        $this->clock = FrozenClock::fromString(self::NOW);
+        $this->context = new PasswordPolicyContext();
+    }
+
+    public function test_reused_password_is_rejected_with_history_control(): void
+    {
+        $handler = $this->dispatchHandler(
+            new PasswordPolicy(quality: new PasswordQualityRules(inHistory: 5)),
+            [PasswordPolicyOid::NAME_PWD_HISTORY => $this->historyValue('previous-pass')],
+        );
+
+        $handler->handleRequest(
+            $this->modify('previous-pass'),
+            $this->token(),
+        );
+
+        $response = $this->response?->getResponse();
+        self::assertInstanceOf(
+            LdapResult::class,
+            $response,
+        );
+        self::assertSame(
+            ResultCode::CONSTRAINT_VIOLATION,
+            $response->getResultCode(),
+        );
+
+        $control = $this->response?->controls()->getByClass(PwdPolicyResponseControl::class);
+        self::assertInstanceOf(
+            PwdPolicyResponseControl::class,
+            $control,
+        );
+        self::assertSame(
+            PwdPolicyError::PASSWORD_IN_HISTORY,
+            $control->getError(),
+        );
+    }
+
+    public function test_successful_change_persists_and_records_bookkeeping(): void
+    {
+        $handler = $this->dispatchHandler(
+            new PasswordPolicy(quality: new PasswordQualityRules(inHistory: 3)),
+            [PasswordPolicyOid::NAME_PWD_RESET => 'TRUE'],
+        );
+
+        $handler->handleRequest(
+            $this->modify('a-fresh-password'),
+            $this->token(),
+        );
+
+        $response = $this->response?->getResponse();
+        self::assertInstanceOf(
+            LdapResult::class,
+            $response,
+        );
+        self::assertSame(
+            ResultCode::SUCCESS,
+            $response->getResultCode(),
+        );
+
+        $entry = $this->backend->get(new Dn(self::USER_DN));
+        self::assertNotNull($entry);
+        self::assertTrue(
+            (new PasswordHashVerifier())->verify(
+                'a-fresh-password',
+                (string) $entry->get('userPassword')?->firstValue(),
+            ),
+        );
+        self::assertNotNull($entry->get(PasswordPolicyOid::NAME_PWD_CHANGED_TIME));
+        self::assertNull(
+            $entry->get(PasswordPolicyOid::NAME_PWD_RESET),
+            'A successful change should clear pwdReset.',
+        );
+    }
+
+    /**
+     * @param array<string, string> $userAttrs
+     */
+    private function dispatchHandler(
+        PasswordPolicy $policy,
+        array $userAttrs = [],
+    ): ServerDispatchHandler {
+        $this->backend = new WritableStorageBackend(new InMemoryStorage([
+            Entry::fromArray(
+                'dc=foo,dc=bar',
+                [
+                    'objectClass' => ['domain'],
+                    'dc' => ['foo'],
+                ],
+            ),
+            Entry::fromArray(
+                self::USER_DN,
+                [
+                    'objectClass' => ['inetOrgPerson'],
+                    'cn' => ['user'],
+                    'sn' => ['User'],
+                    'userPassword' => ['original-pass'],
+                ] + $userAttrs,
+            ),
+        ]));
+
+        $guard = new PasswordPolicyChangeGuard(
+            new PasswordPolicyEngine(
+                clock: $this->clock,
+                changeConstraints: new PasswordChangeConstraintChain([
+                    new AllowUserChangeConstraint(),
+                    new SafeModifyConstraint(),
+                    new MinAgeConstraint($this->clock),
+                    new QualityConstraint(new DefaultPasswordQualityChecker()),
+                    new HistoryConstraint(new PasswordHashVerifier()),
+                ]),
+            ),
+            new PasswordPolicyResolver(
+                $this->backend,
+                null,
+                $policy,
+            ),
+            $this->context,
+            new EventLogger(null),
+        );
+        $policyWriteHandler = new PasswordPolicyWriteHandler(
+            $this->backend,
+            $guard,
+            new SystemChangeWriter(new WriteOperationDispatcher($this->backend)),
+        );
+
+        return new ServerDispatchHandler(
+            queue: $this->capturingQueue(),
+            backend: $this->backend,
+            writeDispatcher: new WriteOperationDispatcher(
+                $policyWriteHandler,
+                $this->backend,
+            ),
+            accessControl: $this->createMock(AccessControlInterface::class),
+            eventRecorder: new DispatchEventRecorder(new EventLogger(null)),
+            passwordPolicyContext: $this->context,
+        );
+    }
+
+    private function capturingQueue(): ServerQueue
+    {
+        $queue = $this->createMock(ServerQueue::class);
+        $queue
+            ->method('sendMessage')
+            ->willReturnCallback(function (LdapMessageResponse $response) use ($queue): ServerQueue {
+                $this->response = $response;
+
+                return $queue;
+            });
+
+        return $queue;
+    }
+
+    private function modify(string $newPassword): LdapMessageRequest
+    {
+        return new LdapMessageRequest(
+            1,
+            new ModifyRequest(
+                self::USER_DN,
+                Change::replace('userPassword', $newPassword),
+            ),
+        );
+    }
+
+    private function token(): BindToken
+    {
+        return BindToken::fromDn(
+            self::USER_DN,
+            'original-pass',
+        );
+    }
+
+    private function historyValue(string $plaintext): string
+    {
+        return HistoryEntry::forStoredPassword(
+            $this->clock->now(),
+            '{BCRYPT}' . password_hash($plaintext, PASSWORD_BCRYPT),
+        )->encode();
+    }
+}

--- a/tests/support/LdapPasswordPolicyCommand.php
+++ b/tests/support/LdapPasswordPolicyCommand.php
@@ -48,7 +48,8 @@ final class LdapPasswordPolicyCommand extends Command
     ): int {
         $transport = $this->getStringOption($input, 'transport');
         $port = (int) $this->getStringOption($input, 'port');
-        $passwordHash = '{SHA}' . base64_encode(sha1('12345', true));
+        // Plaintext so both simple bind and SASL PLAIN can verify against the stored value.
+        $password = '12345';
 
         $entries = [
             new Entry(
@@ -59,16 +60,18 @@ final class LdapPasswordPolicyCommand extends Command
             new Entry(
                 new Dn('cn=user,dc=foo,dc=bar'),
                 new Attribute('cn', 'user'),
+                new Attribute('uid', 'user'),
                 new Attribute('sn', 'User'),
                 new Attribute('objectClass', 'inetOrgPerson'),
-                new Attribute('userPassword', $passwordHash),
+                new Attribute('userPassword', $password),
             ),
             new Entry(
                 new Dn('cn=reset-user,dc=foo,dc=bar'),
                 new Attribute('cn', 'reset-user'),
+                new Attribute('uid', 'reset-user'),
                 new Attribute('sn', 'Reset'),
                 new Attribute('objectClass', 'inetOrgPerson'),
-                new Attribute('userPassword', $passwordHash),
+                new Attribute('userPassword', $password),
                 new Attribute(PasswordPolicyOid::NAME_PWD_RESET, 'TRUE'),
             ),
         ];
@@ -79,6 +82,7 @@ final class LdapPasswordPolicyCommand extends Command
                 ->setTransport($transport)
                 ->setSocketAcceptTimeout(0.1)
                 ->setPasswordPolicy(new PasswordPolicy())
+                ->setSaslMechanisms(ServerOptions::SASL_PLAIN)
                 ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL)),
         );
         $server->useStorage(new InMemoryStorage($entries));

--- a/tests/unit/Entry/AttributeTest.php
+++ b/tests/unit/Entry/AttributeTest.php
@@ -146,6 +146,20 @@ class AttributeTest extends TestCase
         );
     }
 
+    public function test_removing_the_first_value_reindexes_the_list(): void
+    {
+        $this->subject->remove('foo');
+
+        self::assertSame(
+            ['bar'],
+            $this->subject->getValues(),
+        );
+        self::assertSame(
+            'bar',
+            $this->subject->firstValue(),
+        );
+    }
+
     public function test_it_should_set_values(): void
     {
         $this->subject->set('foo');

--- a/tests/unit/Protocol/Factory/ServerProtocolHandlerFactoryTest.php
+++ b/tests/unit/Protocol/Factory/ServerProtocolHandlerFactoryTest.php
@@ -16,6 +16,7 @@ namespace Tests\Unit\FreeDSx\Ldap\Protocol\Factory;
 use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Control\PagingControl;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
@@ -32,10 +33,16 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerUnsupportedExtendedHandler
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerWhoAmIHandler;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\DnBindNameResolver;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\Clock\SystemClock;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
 use FreeDSx\Ldap\Server\RequestHistory;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluator;
 use FreeDSx\Ldap\ServerOptions;
@@ -76,6 +83,33 @@ final class ServerProtocolHandlerFactoryTest extends TestCase
             new ServerOptions(),
             new RequestHistory(),
             $this->mockQueue,
+        );
+    }
+
+    public function test_it_throws_when_password_policy_is_enabled_but_the_backend_is_not_writable(): void
+    {
+        $handlerFactory = $this->createMock(HandlerFactoryInterface::class);
+        $handlerFactory
+            ->method('makeBackend')
+            ->willReturn($this->createMock(LdapBackendInterface::class));
+
+        $factory = new ServerProtocolHandlerFactory(
+            $handlerFactory,
+            (new ServerOptions())->setPasswordPolicy(new PasswordPolicy()),
+            new RequestHistory(),
+            $this->mockQueue,
+            passwordPolicyEngine: new PasswordPolicyEngine(
+                new SystemClock(),
+                new PasswordChangeConstraintChain([]),
+            ),
+            passwordPolicyContext: new PasswordPolicyContext(),
+        );
+
+        $this->expectException(RuntimeException::class);
+
+        $factory->get(
+            Operations::delete('cn=foo,dc=bar'),
+            new ControlBag(),
         );
     }
 

--- a/tests/unit/Server/Backend/Auth/SaslBindPolicyEnforcerTest.php
+++ b/tests/unit/Server/Backend/Auth/SaslBindPolicyEnforcerTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Auth;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\DnBindNameResolver;
+use FreeDSx\Ldap\Server\Backend\Auth\SaslBindPolicyEnforcer;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
+use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
+use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyBindGuard;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
+
+final class SaslBindPolicyEnforcerTest extends TestCase
+{
+    private const NOW = '2026-05-20T12:00:00Z';
+    private const USER_DN = 'cn=user,dc=foo,dc=bar';
+
+    private FrozenClock $clock;
+    private WritableStorageBackend $backend;
+    private PasswordPolicyContext $context;
+
+    protected function setUp(): void
+    {
+        $this->clock = FrozenClock::fromString(self::NOW);
+        $this->context = new PasswordPolicyContext();
+    }
+
+    public function test_without_a_policy_it_does_nothing(): void
+    {
+        $enforcer = $this->enforcer(null);
+
+        $enforcer->recordFailure(self::USER_DN);
+        $enforcer->enforceSuccess(
+            self::USER_DN,
+            new Dn(self::USER_DN),
+        );
+
+        self::assertNull($this->context->getOutcome());
+        self::assertNull($enforcer->responseControl());
+    }
+
+    public function test_null_username_failure_is_ignored(): void
+    {
+        $this->enforcer($this->lockoutPolicy())->recordFailure(null);
+
+        self::assertNull($this->context->getOutcome());
+    }
+
+    public function test_failure_is_recorded_through_the_guard(): void
+    {
+        $this->enforcer($this->lockoutPolicy())->recordFailure(self::USER_DN);
+
+        self::assertSame(
+            PwdPolicyError::ACCOUNT_LOCKED,
+            $this->context->getOutcome()?->errorCode,
+        );
+        self::assertNotNull(
+            $this->backend
+                ->get(new Dn(self::USER_DN))
+                ?->get(PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME),
+        );
+    }
+
+    public function test_locked_account_is_denied_on_success(): void
+    {
+        $enforcer = $this->enforcer(
+            $this->lockoutPolicy(),
+            [PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME => PasswordPolicyOid::PERMANENT_LOCK_SENTINEL],
+        );
+
+        try {
+            $enforcer->enforceSuccess(
+                self::USER_DN,
+                new Dn(self::USER_DN),
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INVALID_CREDENTIALS,
+                $e->getCode(),
+            );
+        }
+
+        self::assertSame(
+            PwdPolicyError::ACCOUNT_LOCKED,
+            $this->context->getOutcome()?->errorCode,
+        );
+    }
+
+    public function test_must_change_surfaces_a_response_control(): void
+    {
+        $enforcer = $this->enforcer(
+            new PasswordPolicy(),
+            [PasswordPolicyOid::NAME_PWD_RESET => 'TRUE'],
+        );
+
+        $enforcer->enforceSuccess(
+            self::USER_DN,
+            new Dn(self::USER_DN),
+        );
+
+        $control = $enforcer->responseControl();
+        self::assertInstanceOf(
+            PwdPolicyResponseControl::class,
+            $control,
+        );
+        self::assertSame(
+            PwdPolicyError::CHANGE_AFTER_RESET,
+            $control->getError(),
+        );
+        self::assertNull(
+            $this->context->getOutcome(),
+            'responseControl() should clear the context.',
+        );
+    }
+
+    public function test_clean_success_carries_no_control(): void
+    {
+        $enforcer = $this->enforcer(new PasswordPolicy());
+
+        $enforcer->enforceSuccess(
+            self::USER_DN,
+            new Dn(self::USER_DN),
+        );
+
+        self::assertNull($enforcer->responseControl());
+    }
+
+    /**
+     * @param array<string, string> $userAttrs
+     */
+    private function enforcer(
+        ?PasswordPolicy $policy,
+        array $userAttrs = [],
+    ): SaslBindPolicyEnforcer {
+        $this->backend = new WritableStorageBackend(new InMemoryStorage([
+            Entry::fromArray(
+                'dc=foo,dc=bar',
+                [
+                    'objectClass' => ['domain'],
+                    'dc' => ['foo'],
+                ],
+            ),
+            Entry::fromArray(
+                self::USER_DN,
+                [
+                    'objectClass' => ['inetOrgPerson'],
+                    'cn' => ['user'],
+                    'sn' => ['User'],
+                    'userPassword' => ['12345'],
+                ] + $userAttrs,
+            ),
+        ]));
+
+        $guard = new PasswordPolicyBindGuard(
+            new PasswordPolicyEngine(
+                clock: $this->clock,
+                changeConstraints: new PasswordChangeConstraintChain([]),
+            ),
+            new SystemChangeWriter(new WriteOperationDispatcher($this->backend)),
+            $this->context,
+            new EventLogger(null, EventLogPolicy::all()),
+        );
+
+        return new SaslBindPolicyEnforcer(
+            new DnBindNameResolver(),
+            $this->backend,
+            new PasswordPolicyResolver(
+                $this->backend,
+                null,
+                $policy,
+            ),
+            $guard,
+            $this->context,
+        );
+    }
+
+    private function lockoutPolicy(): PasswordPolicy
+    {
+        return new PasswordPolicy(
+            lockout: new PasswordLockoutRules(
+                enabled: true,
+                maxFailure: 1,
+            ),
+        );
+    }
+}

--- a/tests/unit/Server/Backend/Write/PasswordPolicyWriteHandlerTest.php
+++ b/tests/unit/Server/Backend/Write/PasswordPolicyWriteHandlerTest.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Write;
+
+use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Entry\Change;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashVerifier;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
+use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
+use FreeDSx\Ldap\Server\Backend\Write\PasswordPolicyWriteHandler;
+use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
+use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\AllowUserChangeConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\HistoryConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\MinAgeConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\QualityConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\SafeModifyConstraint;
+use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyChangeGuard;
+use FreeDSx\Ldap\Server\PasswordPolicy\HistoryEntry;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
+use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\DefaultPasswordQualityChecker;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordChangeRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
+
+final class PasswordPolicyWriteHandlerTest extends TestCase
+{
+    private const NOW = '2026-05-20T12:00:00Z';
+    private const USER_DN = 'cn=user,dc=foo,dc=bar';
+
+    private FrozenClock $clock;
+    private WritableStorageBackend $backend;
+    private PasswordPolicyContext $context;
+
+    protected function setUp(): void
+    {
+        $this->clock = FrozenClock::fromString(self::NOW);
+        $this->context = new PasswordPolicyContext();
+    }
+
+    public function test_supports_a_user_password_replace(): void
+    {
+        $handler = $this->handler(new PasswordPolicy());
+
+        self::assertTrue($handler->supports(new UpdateCommand(
+            new Dn(self::USER_DN),
+            [Change::replace('userPassword', 'newpass')],
+        )));
+    }
+
+    public function test_ignores_modifications_that_do_not_touch_user_password(): void
+    {
+        $handler = $this->handler(new PasswordPolicy());
+
+        self::assertFalse($handler->supports(new UpdateCommand(
+            new Dn(self::USER_DN),
+            [Change::replace('description', 'hello')],
+        )));
+    }
+
+    public function test_ignores_non_update_commands(): void
+    {
+        $handler = $this->handler(new PasswordPolicy());
+
+        self::assertFalse($handler->supports(new DeleteCommand(new Dn(self::USER_DN))));
+    }
+
+    public function test_allowed_change_writes_password_and_bookkeeping(): void
+    {
+        $handler = $this->handler(new PasswordPolicy(
+            quality: new PasswordQualityRules(inHistory: 3),
+        ));
+
+        $handler->handle(
+            new UpdateCommand(
+                new Dn(self::USER_DN),
+                [Change::replace('userPassword', 'a-fresh-password')],
+            ),
+            $this->writeContext(),
+        );
+
+        $entry = $this->backend->get(new Dn(self::USER_DN));
+        self::assertNotNull($entry);
+        self::assertSame(
+            'a-fresh-password',
+            $entry->get('userPassword')?->firstValue(),
+        );
+        self::assertNotNull($entry->get(PasswordPolicyOid::NAME_PWD_CHANGED_TIME));
+        self::assertNotNull($entry->get(PasswordPolicyOid::NAME_PWD_HISTORY));
+    }
+
+    public function test_reused_password_is_rejected_and_password_left_unchanged(): void
+    {
+        $handler = $this->handler(
+            new PasswordPolicy(quality: new PasswordQualityRules(inHistory: 5)),
+            [PasswordPolicyOid::NAME_PWD_HISTORY => $this->historyValue('previous-pass')],
+        );
+
+        try {
+            $handler->handle(
+                new UpdateCommand(
+                    new Dn(self::USER_DN),
+                    [Change::replace('userPassword', 'previous-pass')],
+                ),
+                $this->writeContext(),
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::CONSTRAINT_VIOLATION,
+                $e->getCode(),
+            );
+        }
+
+        self::assertSame(
+            PwdPolicyError::PASSWORD_IN_HISTORY,
+            $this->context->getOutcome()?->errorCode,
+        );
+        self::assertSame(
+            'original-pass',
+            $this->backend->get(new Dn(self::USER_DN))?->get('userPassword')?->firstValue(),
+            'A rejected change must not modify the stored password.',
+        );
+    }
+
+    public function test_a_weak_value_tacked_on_after_a_valid_one_is_rejected(): void
+    {
+        $handler = $this->handler(new PasswordPolicy(
+            quality: new PasswordQualityRules(minLength: 8),
+        ));
+
+        try {
+            $handler->handle(
+                new UpdateCommand(
+                    new Dn(self::USER_DN),
+                    [Change::replace('userPassword', 'a-strong-password', 'weak')],
+                ),
+                $this->writeContext(),
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::CONSTRAINT_VIOLATION,
+                $e->getCode(),
+            );
+        }
+
+        self::assertSame(
+            PwdPolicyError::PASSWORD_TOO_SHORT,
+            $this->context->getOutcome()?->errorCode,
+        );
+        self::assertSame(
+            'original-pass',
+            $this->backend->get(new Dn(self::USER_DN))?->get('userPassword')?->firstValue(),
+            'A rejected multi-value set must leave the stored password untouched.',
+        );
+    }
+
+    public function test_safe_modify_is_satisfied_by_delete_old_add_new(): void
+    {
+        $handler = $this->handler(new PasswordPolicy(
+            change: new PasswordChangeRules(safeModify: true),
+        ));
+
+        $handler->handle(
+            new UpdateCommand(
+                new Dn(self::USER_DN),
+                [
+                    Change::delete('userPassword', 'original-pass'),
+                    Change::add('userPassword', 'a-fresh-password'),
+                ],
+            ),
+            $this->writeContext(),
+        );
+
+        self::assertContains(
+            'a-fresh-password',
+            $this->backend->get(new Dn(self::USER_DN))?->get('userPassword')?->getValues() ?? [],
+        );
+    }
+
+    public function test_safe_modify_rejects_a_replace_without_the_old_password(): void
+    {
+        $handler = $this->handler(new PasswordPolicy(
+            change: new PasswordChangeRules(safeModify: true),
+        ));
+
+        try {
+            $handler->handle(
+                new UpdateCommand(
+                    new Dn(self::USER_DN),
+                    [Change::replace('userPassword', 'a-fresh-password')],
+                ),
+                $this->writeContext(),
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::CONSTRAINT_VIOLATION,
+                $e->getCode(),
+            );
+        }
+
+        self::assertSame(
+            PwdPolicyError::MUST_SUPPLY_OLD_PASSWORD,
+            $this->context->getOutcome()?->errorCode,
+        );
+    }
+
+    public function test_without_a_policy_it_writes_without_bookkeeping(): void
+    {
+        $handler = $this->handler(null);
+
+        $handler->handle(
+            new UpdateCommand(
+                new Dn(self::USER_DN),
+                [Change::replace('userPassword', 'a-fresh-password')],
+            ),
+            $this->writeContext(),
+        );
+
+        $entry = $this->backend->get(new Dn(self::USER_DN));
+        self::assertNotNull($entry);
+        self::assertSame(
+            'a-fresh-password',
+            $entry->get('userPassword')?->firstValue(),
+        );
+        self::assertNull($entry->get(PasswordPolicyOid::NAME_PWD_CHANGED_TIME));
+    }
+
+    /**
+     * @param array<string, string> $userAttrs
+     */
+    private function handler(
+        ?PasswordPolicy $policy,
+        array $userAttrs = [],
+    ): PasswordPolicyWriteHandler {
+        $this->backend = new WritableStorageBackend(new InMemoryStorage([
+            Entry::fromArray(
+                'dc=foo,dc=bar',
+                [
+                    'objectClass' => ['domain'],
+                    'dc' => ['foo'],
+                ],
+            ),
+            Entry::fromArray(
+                self::USER_DN,
+                [
+                    'objectClass' => ['inetOrgPerson'],
+                    'cn' => ['user'],
+                    'sn' => ['User'],
+                    'userPassword' => ['original-pass'],
+                ] + $userAttrs,
+            ),
+        ]));
+
+        $guard = new PasswordPolicyChangeGuard(
+            new PasswordPolicyEngine(
+                clock: $this->clock,
+                changeConstraints: new PasswordChangeConstraintChain([
+                    new AllowUserChangeConstraint(),
+                    new SafeModifyConstraint(),
+                    new MinAgeConstraint($this->clock),
+                    new QualityConstraint(new DefaultPasswordQualityChecker()),
+                    new HistoryConstraint(new PasswordHashVerifier()),
+                ]),
+            ),
+            new PasswordPolicyResolver(
+                $this->backend,
+                null,
+                $policy,
+            ),
+            $this->context,
+            new EventLogger(null, EventLogPolicy::all()),
+        );
+
+        return new PasswordPolicyWriteHandler(
+            $this->backend,
+            $guard,
+            new SystemChangeWriter(new WriteOperationDispatcher($this->backend)),
+        );
+    }
+
+    private function writeContext(): WriteContext
+    {
+        return new WriteContext(
+            BindToken::fromDn(
+                self::USER_DN,
+                'original-pass',
+            ),
+            new ControlBag(),
+        );
+    }
+
+    private function historyValue(string $plaintext): string
+    {
+        return HistoryEntry::forStoredPassword(
+            $this->clock->now(),
+            '{BCRYPT}' . password_hash($plaintext, PASSWORD_BCRYPT),
+        )->encode();
+    }
+}


### PR DESCRIPTION
This enforces the password policy in the remaining areas:

* The SASL bind process.
* RFC 3062 password modify requests.
* Plain LDAP modify requests that include the userPassword attribute.

The only real thing left after this is documentation and probably a deeper analysis of the system looking for any potential gotchyas / issues that slipped through.