### PR TITLE
[1.0.0] Add a "Lenient" mode as an escape hatch for breaking schema changes.

### DIFF
--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -20,6 +20,9 @@ LDAP Server Configuration
     * [ServerOptions:setRootDseHandler](#setrootdsehandler)
     * [ServerOptions:setPasswordAuthenticator](#setpasswordauthenticator)
     * [ServerOptions:setIdentityResolver](#setidentityresolver)
+* [Schema](#schema)
+    * [ServerOptions:setSchemaValidationMode](#setschemavalidationmode)
+    * [ServerOptions:setSchema](#setschema)
 * [RootDSE Options](#rootdse-options)
     * [ServerOptions:setDseNamingContexts](#setdsenamingcontexts)
     * [ServerOptions:setDseAltServer](#setdsealtserver)
@@ -386,6 +389,32 @@ operations is your responsibility and this option has no effect on bind authenti
 Password Modify requests.
 
 **Default**: `null` (`DnBindNameResolver` is tried first; falls back to `AttributeSearchBindNameResolver`)
+
+## Schema
+
+These configure schema validation for `useStorage()` writes. For full documentation, see
+[Schema Validation](Schema.md).
+
+------------------
+#### setSchemaValidationMode
+
+How `add`/`modify` writes are validated:
+
+* `Strict` rejects violations
+* `Lenient` logs them but allows the write
+* `Off` skips validation
+
+See [Validation Mode](Schema.md#validation-mode).
+
+**Default**: `SchemaValidationMode::Strict`
+
+------------------
+#### setSchema
+
+Replaces the active schema used for validation and operational attributes. See
+[Custom Schema](Schema.md#custom-schema).
+
+**Default**: `StandardSchemaProvider::buildCore()`
 
 ## RootDSE Options
 

--- a/docs/Server/Logging.md
+++ b/docs/Server/Logging.md
@@ -51,7 +51,7 @@ $options = (new ServerOptions())->setLogger($logger);
 | `authz.denied.write`        | on      | notice | ACL denies an Add / Modify / Delete / ModifyDn / Compare  |
 | `authz.denied.read`         | on      | notice | ACL denies a Search or Paging request                     |
 | `control.critical.rejected` | on      | notice | Client sent a critical control the server doesn't support |
-| `schema.violation`          | on      | notice | Add/Modify rejected by schema validator                   |
+| `schema.violation`          | on      | notice | Add/Modify violates the schema (rejected, or allowed in Lenient mode) |
 | `session.disconnect_notice` | on      | notice | Server sends an unsolicited Notice of Disconnect          |
 | `entry.added`               | off     | info   | Add succeeds (audit-trail)                                |
 | `entry.modified`            | off     | info   | Modify succeeds (audit-trail)                             |
@@ -77,6 +77,7 @@ Every event carries a structured `context` array with a stable shape:
 | `operation`                                                | write / compare events                                             | One of `add`, `modify`, `delete`, `modify_dn`, `compare`.                                          |
 | `result_code`                                              | failure events                                                     | LDAP result code from the caught `OperationException`.                                             |
 | `reason`                                                   | failure events                                                     | Human-readable diagnostic from the exception.                                                      |
+| `validation_mode`                                          | relaxed schema violations                                          | `lenient` when the write was allowed despite a schema violation.                                   |
 | `mechanism`, `version`                                     | bind events                                                        | SASL mechanism name (or `simple`) and LDAP protocol version.                                       |
 | `match`, `attribute`                                       | compare events                                                     | Match outcome + attribute compared.                                                                |
 | `entries_returned`                                         | search events                                                      | Count of entries delivered to the client.                                                          |

--- a/docs/Server/Schema.md
+++ b/docs/Server/Schema.md
@@ -77,10 +77,15 @@ $entry = Entry::fromArray(
 
 **Default**: `SchemaValidationMode::Strict`
 
-| Mode | Behaviour |
-|------|-----------|
-| `Strict` | Violations are rejected with an LDAP error. |
-| `Off` | All writes pass through without checks. |
+| Mode      | Behaviour                                                     |
+|-----------|---------------------------------------------------------------|
+| `Strict`  | Violations are rejected with an LDAP error.                   |
+| `Lenient` | Violations are logged, but the write is allowed.              |
+| `Off`     | All writes pass through without checks (and without logging). |
+
+`Lenient` logs each relaxed violation as a `schema.violation` event with `validation_mode: lenient` (see
+[Server Logging](Logging.md)). Useful for migrations or editing legacy entries a changed schema would
+otherwise make unmodifiable.
 
 ```php
 use FreeDSx\Ldap\LdapServer;
@@ -89,7 +94,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\ServerOptions;
 
 $server = new LdapServer(
-    (new ServerOptions())->setSchemaValidationMode(SchemaValidationMode::Off)
+    (new ServerOptions())->setSchemaValidationMode(SchemaValidationMode::Lenient)
 );
 $server->useStorage(new InMemoryStorage());
 ```

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/DispatchEventRecorder.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/DispatchEventRecorder.php
@@ -22,7 +22,9 @@ use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Server\Backend\Write\RelaxedSchemaViolations;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
@@ -104,7 +106,76 @@ final readonly class DispatchEventRecorder
             return;
         }
 
-        $request = $message->getRequest();
+        if ($event === ServerEvent::SchemaViolation) {
+            $this->recordSchemaViolation(
+                $exception,
+                $message,
+                $token,
+            );
+
+            return;
+        }
+
+        $this->eventLogger->recordFailure(
+            $event,
+            $exception,
+            $this->writeEventContext($message->getRequest()),
+            subject: $token,
+            message: $message,
+        );
+    }
+
+    /**
+     * Records each schema violation that was allowed under Lenient validation.
+     */
+    public function recordRelaxedSchemaViolations(
+        RelaxedSchemaViolations $violations,
+        LdapMessageRequest $message,
+        TokenInterface $token,
+    ): void {
+        foreach ($violations->all() as $violation) {
+            $this->recordSchemaViolation(
+                $violation,
+                $message,
+                $token,
+                relaxed: true,
+            );
+        }
+    }
+
+    /**
+     * Emits a single SchemaViolation event; $relaxed marks one allowed under Lenient validation.
+     */
+    private function recordSchemaViolation(
+        OperationException $violation,
+        LdapMessageRequest $message,
+        TokenInterface $token,
+        bool $relaxed = false,
+    ): void {
+        $extra = $relaxed
+            ? [EventContext::VALIDATION_MODE => strtolower(SchemaValidationMode::Lenient->name)]
+            : [];
+
+        $this->eventLogger->recordFailure(
+            ServerEvent::SchemaViolation,
+            $violation,
+            $this->writeEventContext(
+                $message->getRequest(),
+                $extra,
+            ),
+            subject: $token,
+            message: $message,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $extra
+     * @return array<string, mixed>
+     */
+    private function writeEventContext(
+        RequestInterface $request,
+        array $extra = [],
+    ): array {
         $context = [EventContext::TARGET => $this->writeTargetFor($request)];
         $operationType = OperationType::fromRequest($request);
 
@@ -112,12 +183,9 @@ final readonly class DispatchEventRecorder
             $context[EventContext::OPERATION] = $operationType->value;
         }
 
-        $this->eventLogger->recordFailure(
-            $event,
-            $exception,
+        return array_merge(
             $context,
-            subject: $token,
-            message: $message,
+            $extra,
         );
     }
 

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -26,6 +26,7 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\OperationType;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Write\RelaxedSchemaViolations;
 use FreeDSx\Ldap\Server\Backend\Write\WriteCommandFactory;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
@@ -99,12 +100,19 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
                 return;
             }
 
+            $relaxedViolations = new RelaxedSchemaViolations();
             $this->writeDispatcher->dispatch(
                 $this->commandFactory->fromRequest($request),
                 new WriteContext(
                     $token,
                     $message->controls(),
+                    relaxedViolations: $relaxedViolations,
                 ),
+            );
+            $this->eventRecorder->recordRelaxedSchemaViolations(
+                $relaxedViolations,
+                $message,
+                $token,
             );
 
             $successControl = $this->passwordPolicyControl();

--- a/src/FreeDSx/Ldap/Schema/SchemaValidationMode.php
+++ b/src/FreeDSx/Ldap/Schema/SchemaValidationMode.php
@@ -15,6 +15,18 @@ namespace FreeDSx\Ldap\Schema;
 
 enum SchemaValidationMode
 {
+    /**
+     * Reject writes that violate the schema.
+     */
     case Strict;
+
+    /**
+     * Log schema violations but allow the write to proceed.
+     */
+    case Lenient;
+
+    /**
+     * Skip schema validation entirely.
+     */
     case Off;
 }

--- a/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
@@ -38,6 +38,11 @@ final class SchemaValidator
         private readonly SchemaValidationMode $mode,
     ) {}
 
+    public function mode(): SchemaValidationMode
+    {
+        return $this->mode;
+    }
+
     /**
      * Validates an entry before it is added to storage.
      *

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -31,6 +31,7 @@ use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\DnTooLongException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\InvalidAttributeException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
+use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\Backend\Write\WritableBackendTrait;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
@@ -197,9 +198,9 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
                 $this->throwEntryAlreadyExists($command->entry->getDn());
             }
 
-            $this->validator?->validateAdd(
-                $command->entry,
-                $context->isSystem(),
+            $this->validateForAdd(
+                $command,
+                $context,
             );
             $this->operationalAttrs->applyForAdd(
                 $command->entry,
@@ -247,10 +248,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             $dn = $command->dn->normalize();
             $entry = $this->findOrFail($storage, $dn);
             $updated = $this->entryHandler->apply($entry, $command);
-            $this->validator?->validateModify(
+            $this->validateForModify(
                 $command,
                 $updated,
-                $context->isSystem(),
+                $context,
             );
             $this->operationalAttrs->applyForModify(
                 $updated,
@@ -258,6 +259,72 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             );
             $storage->store($updated);
         });
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function validateForAdd(
+        AddCommand $command,
+        WriteContext $context,
+    ): void {
+        if ($this->validator === null) {
+            return;
+        }
+
+        try {
+            $this->validator->validateAdd(
+                $command->entry,
+                $context->isSystem(),
+            );
+        } catch (OperationException $e) {
+            $this->relaxOrThrow(
+                $e,
+                $context,
+            );
+        }
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function validateForModify(
+        UpdateCommand $command,
+        Entry $updated,
+        WriteContext $context,
+    ): void {
+        if ($this->validator === null) {
+            return;
+        }
+
+        try {
+            $this->validator->validateModify(
+                $command,
+                $updated,
+                $context->isSystem(),
+            );
+        } catch (OperationException $e) {
+            $this->relaxOrThrow(
+                $e,
+                $context,
+            );
+        }
+    }
+
+    /**
+     * Rejects the violation in Strict mode; records it for logging and allows the write in Lenient mode.
+     *
+     * @throws OperationException
+     */
+    private function relaxOrThrow(
+        OperationException $violation,
+        WriteContext $context,
+    ): void {
+        if ($this->validator?->mode() !== SchemaValidationMode::Lenient) {
+            throw $violation;
+        }
+
+        $context->relaxedViolations()->record($violation);
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Write/RelaxedSchemaViolations.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/RelaxedSchemaViolations.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Write;
+
+use FreeDSx\Ldap\Exception\OperationException;
+
+/**
+ * Request-scoped record of schema violations allowed under Lenient validation.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class RelaxedSchemaViolations
+{
+    /**
+     * @var OperationException[]
+     */
+    private array $violations = [];
+
+    public function record(OperationException $violation): void
+    {
+        $this->violations[] = $violation;
+    }
+
+    /**
+     * @return OperationException[]
+     */
+    public function all(): array
+    {
+        return $this->violations;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Write/WriteContext.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/WriteContext.php
@@ -27,6 +27,7 @@ final readonly class WriteContext
         private TokenInterface $token,
         private ControlBag $controls,
         private bool $isSystem = false,
+        private RelaxedSchemaViolations $relaxedViolations = new RelaxedSchemaViolations(),
     ) {}
 
     /**
@@ -69,5 +70,10 @@ final readonly class WriteContext
     public function getControls(): ControlBag
     {
         return $this->controls;
+    }
+
+    public function relaxedViolations(): RelaxedSchemaViolations
+    {
+        return $this->relaxedViolations;
     }
 }

--- a/src/FreeDSx/Ldap/Server/Logging/EventContext.php
+++ b/src/FreeDSx/Ldap/Server/Logging/EventContext.php
@@ -40,6 +40,7 @@ final class EventContext
     public const OPERATION = 'operation';
     public const RESULT_CODE = 'result_code';
     public const REASON = 'reason';
+    public const VALIDATION_MODE = 'validation_mode';
     public const REASON_CODE = 'reason_code';
     public const REASON_MESSAGE = 'reason_message';
     public const MECHANISM = 'mechanism';

--- a/tests/integration/Storage/LdapSchemaValidationTest.php
+++ b/tests/integration/Storage/LdapSchemaValidationTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Storage;
+
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\Search\Filters;
+use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+
+/**
+ * End-to-end schema validation behaviour; the shared server runs in Lenient mode.
+ */
+final class LdapSchemaValidationTest extends ServerTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        if (!extension_loaded('pcntl')) {
+            return;
+        }
+
+        static::initSharedServer(
+            'ldap-backend-storage',
+            'tcp',
+            ['--validation-mode=lenient'],
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        static::tearDownSharedServer();
+    }
+
+    public function setUp(): void
+    {
+        $this->setServerMode('ldap-backend-storage');
+
+        parent::setUp();
+    }
+
+    public function test_lenient_mode_allows_add_with_disallowed_attribute(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        // 'mail' is not permitted by the 'person' object class; rejected under Strict.
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=drift-add,dc=foo,dc=bar',
+            [
+                'cn' => 'drift-add',
+                'sn' => 'Drift',
+                'objectClass' => 'person',
+                'mail' => 'drift-add@foo.bar',
+            ],
+        ));
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::equal('cn', 'drift-add'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        self::assertCount(1, $entries);
+        self::assertSame(
+            'drift-add@foo.bar',
+            $entries->first()?->get('mail')?->firstValue(),
+        );
+    }
+
+    public function test_lenient_mode_allows_modify_into_violating_state(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=drift-modify,dc=foo,dc=bar',
+            [
+                'cn' => 'drift-modify',
+                'sn' => 'Drift',
+                'objectClass' => 'person',
+            ],
+        ));
+
+        // Adding 'mail' makes the merged entry violate the 'person' object class; rejected under Strict.
+        $entry = Entry::fromArray('cn=drift-modify,dc=foo,dc=bar');
+        $entry->set('mail', 'drift-modify@foo.bar');
+        $this->ldapClient()->update($entry);
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::equal('cn', 'drift-modify'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        self::assertSame(
+            'drift-modify@foo.bar',
+            $entries->first()?->get('mail')?->firstValue(),
+        );
+    }
+}

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -13,6 +13,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\MysqlStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqliteStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
+use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\ServerOptions;
 use PDO;
 use Symfony\Component\Console\Command\Command;
@@ -64,6 +65,13 @@ final class LdapBackendStorageCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Number of additional seed entries to generate',
                 '0',
+            )
+            ->addOption(
+                'validation-mode',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Schema validation mode (strict, lenient, off)',
+                'strict',
             );
     }
 
@@ -93,6 +101,19 @@ final class LdapBackendStorageCommand extends Command
 
         if ($seedEntries < 0) {
             $io->error("Invalid --seed-entries value: {$seedEntries}. Must be zero or greater.");
+
+            return Command::FAILURE;
+        }
+
+        $validationMode = match ($this->getStringOption($input, 'validation-mode')) {
+            'strict' => SchemaValidationMode::Strict,
+            'lenient' => SchemaValidationMode::Lenient,
+            'off' => SchemaValidationMode::Off,
+            default => null,
+        };
+
+        if ($validationMode === null) {
+            $io->error('Invalid --validation-mode value. Expected one of: strict, lenient, off.');
 
             return Command::FAILURE;
         }
@@ -143,6 +164,7 @@ final class LdapBackendStorageCommand extends Command
                 ->setPort($port)
                 ->setTransport($transport)
                 ->setSocketAcceptTimeout(0.1)
+                ->setSchemaValidationMode($validationMode)
                 ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL)),
         );
 

--- a/tests/unit/Protocol/ServerProtocolHandler/DispatchEventRecorderTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/DispatchEventRecorderTest.php
@@ -29,6 +29,7 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\DispatchEventRecorder;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
+use FreeDSx\Ldap\Server\Backend\Write\RelaxedSchemaViolations;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
@@ -350,6 +351,94 @@ final class DispatchEventRecorderTest extends TestCase
                 'Exists',
                 ResultCode::ENTRY_ALREADY_EXISTS,
             ),
+            $this->token,
+        );
+
+        self::assertSame(
+            [],
+            $this->recordingLogger->records,
+        );
+    }
+
+    public function test_record_relaxed_schema_violations_emits_schema_violation_with_lenient_mode(): void
+    {
+        $violations = new RelaxedSchemaViolations();
+        $violations->record(new OperationException(
+            'Required attribute "sn" is missing.',
+            ResultCode::OBJECT_CLASS_VIOLATION,
+        ));
+
+        $this->subject->recordRelaxedSchemaViolations(
+            $violations,
+            self::wrap(new AddRequest(new Entry(
+                new Dn(self::TARGET_DN),
+                new Attribute('cn', 'Bob'),
+            ))),
+            $this->token,
+        );
+
+        $record = $this->onlyRecord();
+        self::assertSame(
+            'schema.violation',
+            $record['message'],
+        );
+        self::assertSame(
+            'lenient',
+            $record['context'][EventContext::VALIDATION_MODE],
+        );
+        self::assertSame(
+            'add',
+            $record['context'][EventContext::OPERATION],
+        );
+        self::assertSame(
+            ResultCode::OBJECT_CLASS_VIOLATION,
+            $record['context'][EventContext::RESULT_CODE],
+        );
+        self::assertSame(
+            'Required attribute "sn" is missing.',
+            $record['context'][EventContext::REASON],
+        );
+        self::assertSame(
+            [EventContext::DN => self::TARGET_DN],
+            $record['context'][EventContext::TARGET],
+        );
+    }
+
+    public function test_record_relaxed_schema_violations_emits_one_event_per_violation(): void
+    {
+        $violations = new RelaxedSchemaViolations();
+        $violations->record(new OperationException(
+            'first',
+            ResultCode::OBJECT_CLASS_VIOLATION,
+        ));
+        $violations->record(new OperationException(
+            'second',
+            ResultCode::CONSTRAINT_VIOLATION,
+        ));
+
+        $this->subject->recordRelaxedSchemaViolations(
+            $violations,
+            self::wrap(new AddRequest(new Entry(
+                new Dn(self::TARGET_DN),
+                new Attribute('cn', 'Bob'),
+            ))),
+            $this->token,
+        );
+
+        self::assertCount(
+            2,
+            $this->recordingLogger->records,
+        );
+    }
+
+    public function test_record_relaxed_schema_violations_is_silent_when_empty(): void
+    {
+        $this->subject->recordRelaxedSchemaViolations(
+            new RelaxedSchemaViolations(),
+            self::wrap(new AddRequest(new Entry(
+                new Dn(self::TARGET_DN),
+                new Attribute('cn', 'Bob'),
+            ))),
             $this->token,
         );
 

--- a/tests/unit/Schema/Validation/SchemaValidatorTest.php
+++ b/tests/unit/Schema/Validation/SchemaValidatorTest.php
@@ -47,6 +47,21 @@ final class SchemaValidatorTest extends TestCase
         );
     }
 
+    public function test_mode_returns_configured_mode(): void
+    {
+        self::assertSame(
+            SchemaValidationMode::Strict,
+            $this->subject->mode(),
+        );
+        self::assertSame(
+            SchemaValidationMode::Lenient,
+            (new SchemaValidator(
+                StandardSchemaProvider::buildCore(),
+                SchemaValidationMode::Lenient,
+            ))->mode(),
+        );
+    }
+
     public function test_valid_add_passes(): void
     {
         $this->expectNotToPerformAssertions();

--- a/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
@@ -43,6 +43,7 @@ use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\MoveCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
+use FreeDSx\Ldap\Server\Backend\Write\RelaxedSchemaViolations;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Backend\Write\WriteRequestInterface;
 use FreeDSx\Ldap\Server\Token\AnonToken;
@@ -987,6 +988,86 @@ final class WritableStorageBackendTest extends TestCase
                 [Change::replace(new Attribute('createTimestamp', '20240101000000Z'))],
             ),
             $this->context(),
+        );
+    }
+
+    public function test_add_with_lenient_validator_allows_invalid_entry_and_records_violation(): void
+    {
+        $backend = new WritableStorageBackend(
+            storage: new InMemoryStorage([$this->base]),
+            validator: new SchemaValidator(
+                StandardSchemaProvider::buildCore(),
+                SchemaValidationMode::Lenient,
+            ),
+        );
+        $violations = new RelaxedSchemaViolations();
+
+        $backend->add(
+            new AddCommand(new Entry(
+                new Dn('cn=Invalid,dc=example,dc=com'),
+                new Attribute('cn', 'Invalid'),
+            )),
+            new WriteContext(
+                new AnonToken(),
+                new ControlBag(),
+                relaxedViolations: $violations,
+            ),
+        );
+
+        self::assertNotNull(
+            $backend->get(new Dn('cn=Invalid,dc=example,dc=com')),
+        );
+        self::assertCount(
+            1,
+            $violations->all(),
+        );
+        self::assertSame(
+            ResultCode::OBJECT_CLASS_VIOLATION,
+            $violations->all()[0]->getCode(),
+        );
+    }
+
+    public function test_update_with_lenient_validator_allows_invalid_modification_and_records_violation(): void
+    {
+        $valid = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'top', 'person'),
+            new Attribute('cn', 'Alice'),
+            new Attribute('sn', 'Smith'),
+        );
+        $backend = new WritableStorageBackend(
+            storage: new InMemoryStorage([$this->base, $valid]),
+            validator: new SchemaValidator(
+                StandardSchemaProvider::buildCore(),
+                SchemaValidationMode::Lenient,
+            ),
+        );
+        $violations = new RelaxedSchemaViolations();
+
+        $backend->update(
+            new UpdateCommand(
+                new Dn('cn=Alice,dc=example,dc=com'),
+                [Change::replace(new Attribute('createTimestamp', '20240101000000Z'))],
+            ),
+            new WriteContext(
+                new AnonToken(),
+                new ControlBag(),
+                relaxedViolations: $violations,
+            ),
+        );
+
+        $stored = $backend->get(new Dn('cn=Alice,dc=example,dc=com'));
+        self::assertSame(
+            '20240101000000Z',
+            $stored?->get('createTimestamp')?->firstValue(),
+        );
+        self::assertCount(
+            1,
+            $violations->all(),
+        );
+        self::assertSame(
+            ResultCode::CONSTRAINT_VIOLATION,
+            $violations->all()[0]->getCode(),
         );
     }
 


### PR DESCRIPTION
This adds an escape hatch to the LDAP server if someone wants to change the underlying schema for entries but have old data that does not adhere to it. Without this, these entries could be otherwise unmodifiable. This is part 1 of a solution to this. Part 2 involves supporting the same control that OpenLDAP / OpenDJ use to signify that modifying past a schema validation issue is allowed. The control can be ACL controlled to specific DNs, which seems more sane than a global setting. But I'd like to give some flexibility here to provide both.

I honestly didn't realize how other LDAP implementations handled schema changes and existing data. I actually feel like AD handles it the most sane way. But at least giving options on par with OpenLDAP / OpenDJ seems reasonable.