### PR TITLE
[1.0.0] Clean-up password policy related issues post-implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ It supports encryption of the LDAP connection through TLS via the OpenSSL extens
 * [LDAP Server](/docs/Server)
   * [Configuration](/docs/Server/Configuration.md)
   * [General Usage](/docs/Server/General-Usage.md)
+  * [Schema](/docs/Server/Schema.md)
+  * [Logging](/docs/Server/Logging.md)
+  * [Access Control](/docs/Server/Access-Control.md)
+  * [Password Policy](/docs/Server/Password-Policy.md)
 
 # Getting Started
 

--- a/docs/Server/Password-Policy.md
+++ b/docs/Server/Password-Policy.md
@@ -1,0 +1,325 @@
+Password Policy
+================
+
+* [Overview](#overview)
+* [Enabling Password Policy](#enabling-password-policy)
+* [Defining a Policy](#defining-a-policy)
+    * [In Memory](#in-memory)
+    * [In the Directory](#in-the-directory)
+    * [Policy Resolution Order](#policy-resolution-order)
+* [Enforced Behaviours](#enforced-behaviours)
+    * [Quality](#quality)
+    * [History](#history)
+    * [Minimum Age](#minimum-age)
+    * [Safe Modify](#safe-modify)
+    * [Self-Service Changes](#self-service-changes)
+    * [Expiration, Warnings, and Grace Logins](#expiration-warnings-and-grace-logins)
+    * [Account Lockout](#account-lockout)
+    * [Idle Lockout](#idle-lockout)
+    * [Change After Reset](#change-after-reset)
+    * [Validity Window](#validity-window)
+* [Custom Quality Checker](#custom-quality-checker)
+* [Client Side](#client-side)
+* [Operational Attributes](#operational-attributes)
+* [Not Yet Enforced / Limitations](#not-yet-enforced--limitations)
+
+## Overview
+
+The server implements the password policy described in `draft-behera-ldap-password-policy-10`. When enabled it
+enforces policy across four paths:
+
+- **Simple bind** — account lockout, expiration, grace logins, the validity window, and the change-after-reset flag.
+- **SASL bind** — the same bind-time checks, applied once the identity is resolved.
+- **RFC 3062 Password Modify** — quality, history, minimum age, safe-modify, and self-service rules on the new password.
+- **Plain `ldapmodify` of `userPassword`** — the same change-time rules as the Password Modify extended operation.
+
+Policy is **opt-in**: nothing is enforced until a policy source is configured.
+
+## Enabling Password Policy
+
+Configure a policy on `ServerOptions`, either in memory or by pointing at a policy entry in the directory:
+
+```php
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
+
+$options = (new ServerOptions())
+    ->setPasswordPolicy(new PasswordPolicy(
+        quality: new PasswordQualityRules(minLength: 8),
+        lockout: new PasswordLockoutRules(
+            enabled: true,
+            duration: 300,
+            maxFailure: 5,
+        ),
+    ));
+
+$ldap = new LdapServer($options);
+```
+
+Password policy is active when either `setPasswordPolicy()` or `setDefaultPasswordPolicyDn()` has been called
+(`ServerOptions::isPasswordPolicyEnabled()`). When active, the policy schema (the `pwdPolicy` auxiliary class and the
+`pwd*` attribute types) is merged into the server schema automatically.
+
+## Defining a Policy
+
+### In Memory
+
+A `PasswordPolicy` is composed of four rule groups and can be composed directly in code and set in the server options.
+Every field is nullable. A `null` field means "unspecified" and is treated as "no limit".
+
+```php
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordChangeRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordExpirationRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
+
+$policy = new PasswordPolicy(
+    pwdAttribute: 'userPassword',
+    quality: new PasswordQualityRules(
+        minLength: 8,
+        maxLength: 128,
+        inHistory: 5,
+        checkQuality: 1,
+    ),
+    change: new PasswordChangeRules(
+        minAge: 3600,
+        mustChange: true,
+        allowUserChange: true,
+        safeModify: true,
+    ),
+    expiration: new PasswordExpirationRules(
+        maxAge: 7776000,
+        expireWarning: 604800,
+        graceAuthnLimit: 3,
+    ),
+    lockout: new PasswordLockoutRules(
+        enabled: true,
+        duration: 300,
+        maxFailure: 5,
+        failureCountInterval: 900,
+    ),
+);
+```
+
+**Note**: All durations are in seconds.
+
+### In the Directory
+
+A policy can instead live in the DIT as an entry carrying the `pwdPolicy` object class. The only required attribute
+is `pwdAttribute`:
+
+```ldif
+dn: cn=default,ou=policies,dc=example,dc=com
+objectClass: top
+objectClass: device
+objectClass: pwdPolicy
+cn: default
+pwdAttribute: userPassword
+pwdMinLength: 8
+pwdInHistory: 5
+pwdMaxAge: 7776000
+pwdExpireWarning: 604800
+pwdGraceAuthNLimit: 3
+pwdLockout: TRUE
+pwdMaxFailure: 5
+pwdLockoutDuration: 300
+pwdFailureCountInterval: 900
+pwdMustChange: TRUE
+pwdSafeModify: TRUE
+```
+
+Register it as the default:
+
+```php
+use FreeDSx\Ldap\Entry\Dn;
+
+$options->setDefaultPasswordPolicyDn(new Dn('cn=default,ou=policies,dc=example,dc=com'));
+```
+
+Per-user policies are supported by setting `pwdPolicySubentry` on the user entry to the DN of a `pwdPolicy` entry.
+
+### Policy Resolution Order
+
+For a given user the governing policy is resolved as:
+
+1. The `pwdPolicy` entry named by the user's `pwdPolicySubentry` (if present).
+2. The default DN from `setDefaultPasswordPolicyDn()` (if configured).
+3. The in-memory policy from `setPasswordPolicy()` (if configured).
+
+If none apply, then no policy is enforced for the user.
+
+## Enforced Behaviours
+
+When a check denies an operation, the server returns the appropriate LDAP result code and (when applicable) a
+[password policy response control](#client-side) carrying a `PwdPolicyError` code.
+
+### Quality
+
+`pwdMinLength` and `pwdMaxLength` are enforced by the built-in checker (lengths are measured in characters, not bytes).
+`pwdCheckQuality` controls how strictly quality is applied:
+
+- `0`: Quality checking is disabled.
+- `1`: Check the password when it is presented in cleartext. Accept it when it cannot be inspected.
+- `2`: Check the password; **reject** it when it cannot be inspected (for example, a pre-hashed value).
+
+A too-short password returns `passwordTooShort`. Other quality failure returns `insufficientPasswordQuality`. Both
+map to `CONSTRAINT_VIOLATION`.
+
+### History
+
+With `pwdInHistory` set, the server retains that many previous values in `pwdHistory` and rejects a new password that
+matches any retained value with `passwordInHistory` (`CONSTRAINT_VIOLATION`).
+
+### Minimum Age
+
+`pwdMinAge` rejects a change attempted within that many seconds of the last change (`pwdChangedTime`) with
+`passwordTooYoung` (`CONSTRAINT_VIOLATION`).
+
+### Safe Modify
+
+When `pwdSafeModify` is `TRUE`, a change must supply the current password. A missing existing password returns
+`mustSupplyOldPassword` (`CONSTRAINT_VIOLATION`). A supplied-but-incorrect one returns `INVALID_CREDENTIALS`.
+
+### Self-Service Changes
+
+When `pwdAllowUserChange` is `FALSE`, a user changing their own password is denied with `passwordModNotAllowed`
+(`INSUFFICIENT_ACCESS_RIGHTS`). Administrative changes to another entry are unaffected.
+
+### Expiration, Warnings, and Grace Logins
+
+With `pwdMaxAge` set, a password expires that many seconds after `pwdChangedTime`. On bind:
+
+- Within `pwdExpireWarning` of expiry, the response control reports `timeBeforeExpiration`.
+- Once expired, each bind consumes a grace login capped by `pwdGraceAuthNLimit`, and by `pwdGraceExpiry` seconds
+  since expiry if set. The control reports `graceAuthNsRemaining`.
+- With no grace left, the bind fails `INVALID_CREDENTIALS` with `passwordExpired`.
+
+> A password with no `pwdChangedTime` is treated as non-expiring. The server stamps `pwdChangedTime` on every
+> policy-managed change.
+
+### Account Lockout
+
+When `pwdLockout` is `TRUE`, each failed bind is recorded in `pwdFailureTime`. Reaching `pwdMaxFailure` failures locks
+the account by setting `pwdAccountLockedTime`. `pwdFailureCountInterval`, when set, only counts failures within that
+recent window.
+
+`pwdLockoutDuration` controls how long a lock lasts:
+
+- `0` (or unset): the account stays locked until an administrator clears `pwdAccountLockedTime`, or a later successful
+  bind clears it.
+- A positive value: the lock expires after that many seconds. The next bind attempt clears the stale lock. Failures
+  then accumulate again and can re-lock the account.
+
+A locked bind returns `INVALID_CREDENTIALS` with the `accountLocked` error.
+
+### Idle Lockout
+
+When `pwdMaxIdle` is set, an account with no successful bind within that many seconds is locked, returning
+`INVALID_CREDENTIALS` with `accountLocked`. Idleness is measured from `pwdLastSuccess` (stamped on each successful
+bind), falling back to `pwdChangedTime` when no successful bind has been recorded yet.
+
+### Change After Reset
+
+When `pwdMustChange` is `TRUE` and an administrator changes another user's password, the server sets `pwdReset`. At the
+user's next bind the response control reports `changeAfterReset`, and the session is restricted to bind, unbind, and the
+RFC 3062 Password Modify. Any other operation is rejected `UNWILLING_TO_PERFORM` with `changeAfterReset` until the
+password is changed. A successful self-change clears `pwdReset`.
+
+### Validity Window
+
+`pwdStartTime` and `pwdEndTime` on a user entry bound the period the password may be used to authenticate. A bind before
+`pwdStartTime` or after `pwdEndTime` fails with `INVALID_CREDENTIALS` (the latter also reports `passwordExpired`).
+
+## Custom Quality Checker
+
+To enforce composition or strength rules beyond length, implement `PasswordQualityCheckerInterface` and register it.
+The checker receives the cleartext password and the active `PasswordQualityRules`, and returns a `PwdPolicyError` code
+to deny, or `null` to accept:
+
+```php
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\PasswordQualityCheckerInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
+use SensitiveParameter;
+
+final class ContainsDigitChecker implements PasswordQualityCheckerInterface
+{
+    public function check(
+        #[SensitiveParameter]
+        string $plain,
+        PasswordQualityRules $rules,
+    ): ?int {
+        return preg_match('/\d/', $plain) === 1
+            ? null
+            : PwdPolicyError::INSUFFICIENT_PASSWORD_QUALITY;
+    }
+}
+
+$options->setPasswordQualityChecker(new ContainsDigitChecker());
+```
+
+The default checker (`DefaultPasswordQualityChecker`) enforces `pwdMinLength` / `pwdMaxLength` and honours
+`pwdCheckQuality`.
+
+## Client Side
+
+A client requests policy feedback by attaching the password policy request control to a bind, modify, or password
+modify request:
+
+```php
+use FreeDSx\Ldap\Controls;
+
+$response = $ldap->bind('cn=user,dc=example,dc=com', 'secret', Controls::pwdPolicy());
+```
+
+Read the response control to surface warnings and errors:
+
+```php
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
+
+$control = $response->controls()->get(Control::OID_PWD_POLICY);
+
+if ($control instanceof PwdPolicyResponseControl) {
+    $secondsLeft = $control->getTimeBeforeExpiration();
+    $graceLeft = $control->getGraceAttemptsRemaining();
+    $error = $control->getError();
+}
+```
+
+`getError()` returns one of the `PwdPolicyError` constants: `PASSWORD_EXPIRED`, `ACCOUNT_LOCKED`, `CHANGE_AFTER_RESET`,
+`PASSWORD_MOD_NOT_ALLOWED`, `MUST_SUPPLY_OLD_PASSWORD`, `INSUFFICIENT_PASSWORD_QUALITY`, `PASSWORD_TOO_SHORT`,
+`PASSWORD_TOO_YOUNG`, or `PASSWORD_IN_HISTORY`.
+
+## Operational Attributes
+
+The server manages these attributes on user entries; they are written with system privileges and should not be set by
+clients:
+
+| Attribute              | Purpose                                                          |
+|------------------------|------------------------------------------------------------------|
+| `pwdChangedTime`       | Time of the last password change; drives age and expiration.     |
+| `pwdFailureTime`       | Timestamps of recent failed binds.                               |
+| `pwdAccountLockedTime` | Time the account was locked.                                     |
+| `pwdHistory`           | Previous password values retained for `pwdInHistory`.            |
+| `pwdGraceUseTime`      | Timestamps of grace logins used after expiration.                |
+| `pwdLastSuccess`       | Time of the last successful bind.                                |
+| `pwdReset`             | Set when an administrative reset requires a change at next bind. |
+
+`pwdPolicySubentry`, `pwdStartTime`, and `pwdEndTime` are read from the user entry but managed by the operator.
+
+## Not Yet Enforced / Limitations
+
+`pwdMinDelay` / `pwdMaxDelay` and not yet supported. No artificial delay is applied after a failed bind.
+
+Additional notes:
+
+- Policy is assumed to apply to `userPassword`. Custom password attributes are not supported.
+- A plain `ldapmodify` stores the submitted value verbatim. Pre-hashed value cannot be inspected.
+- The password policy response control is returned whenever there is something to report, regardless of whether the
+  client sent the request control.

--- a/src/FreeDSx/Ldap/Protocol/Bind/SaslBind.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/SaslBind.php
@@ -235,6 +235,9 @@ class SaslBind implements BindInterface
             throw $e;
         }
 
+        // Captured before responseControl() clears the policy context.
+        $mustChangePassword = $this->policyEnforcer?->mustChangePassword() ?? false;
+
         // The success response must be sent before activating the security layer.
         $control = $this->policyEnforcer?->responseControl();
         $this->queue->sendMessage($this->responseFactory->getStandardResponse(
@@ -250,9 +253,14 @@ class SaslBind implements BindInterface
             $this->queue->setMessageWrapper(new SaslMessageWrapper($mech->securityLayer(), $context));
         }
 
-        return BindToken::fromSasl(
+        $token = BindToken::fromSasl(
             $username,
             $resolvedDn,
         );
+        if ($mustChangePassword) {
+            $token->markMustChangePassword();
+        }
+
+        return $token;
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -15,9 +15,15 @@ namespace FreeDSx\Ldap\Protocol;
 
 use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Operation\Request\AbandonRequest;
+use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Request\UnbindRequest;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
@@ -27,6 +33,7 @@ use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Socket\Exception\ConnectionException;
 use Throwable;
@@ -157,6 +164,12 @@ class ServerProtocolHandler
 
         # They are authenticated or authentication is not required, so pass the request along...
         if ($this->authorizer->isAuthenticated() || !$this->authorizer->isAuthenticationRequired($request)) {
+            if ($this->requiresPasswordChangeFirst($request)) {
+                $this->rejectUntilPasswordChanged($message);
+
+                return;
+            }
+
             $handler->handleRequest(
                 $message,
                 $this->authorizer->getToken(),
@@ -169,6 +182,42 @@ class ServerProtocolHandler
                 'Authentication required.',
             ));
         }
+    }
+
+    /**
+     * A bound identity flagged with pwdReset may only change its password or end the session (draft-behera-10 §8.1.2).
+     */
+    private function requiresPasswordChangeFirst(RequestInterface $request): bool
+    {
+        $token = $this->authorizer->getToken();
+
+        return $token instanceof AuthenticatedTokenInterface
+            && $token->mustChangePassword()
+            && !$this->isPermittedDuringPasswordChange($request);
+    }
+
+    private function isPermittedDuringPasswordChange(RequestInterface $request): bool
+    {
+        if ($request instanceof UnbindRequest || $request instanceof AbandonRequest) {
+            return true;
+        }
+
+        return $request instanceof ExtendedRequest
+            && $request->getName() === ExtendedRequest::OID_PWD_MODIFY;
+    }
+
+    /**
+     * @throws EncoderException
+     */
+    private function rejectUntilPasswordChanged(LdapMessageRequest $message): void
+    {
+        $this->queue->sendMessage($this->responseFactory->getStandardResponse(
+            $message,
+            ResultCode::UNWILLING_TO_PERFORM,
+            'The password must be changed before any other operation is permitted.',
+            null,
+            new PwdPolicyResponseControl(error: PwdPolicyError::CHANGE_AFTER_RESET),
+        ));
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordModifyHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordModifyHandler.php
@@ -165,6 +165,7 @@ readonly class ServerPasswordModifyHandler implements ServerProtocolHandlerInter
             hashedNewPassword: $hashed,
             oldPassword: $request->getOldPassword(),
             isSelf: $this->isSelf($token, $targetDn),
+            passwordIsCleartext: true,
         )) ?? OperationalChanges::none();
 
         $this->applyPasswordChange(

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordHashVerifier.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordHashVerifier.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Auth;
 
+use FreeDSx\Ldap\Exception\RuntimeException;
 use SensitiveParameter;
 
 /**
@@ -22,19 +23,81 @@ use SensitiveParameter;
  */
 final class PasswordHashVerifier
 {
+    /**
+     * Read-only legacy prefixes recognized in addition to the writable {@see PasswordHashScheme} set.
+     *
+     * @var list<string>
+     */
+    private const LEGACY_READ_PREFIXES = [
+        '{SHA}',
+        '{MD5}',
+        '{SMD5}',
+    ];
+
+    /**
+     * Whether a value begins with a recognized hash scheme, and so is not cleartext we can inspect.
+     */
+    public static function isHashed(string $value): bool
+    {
+        foreach (self::recognizedPrefixes() as $prefix) {
+            if (str_starts_with($value, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function verify(
         #[SensitiveParameter]
         string $plain,
         string $stored,
     ): bool {
-        return match (true) {
-            str_starts_with($stored, '{SHA}') => $this->verifySha($plain, substr($stored, 5)),
-            str_starts_with($stored, '{SSHA}') => $this->verifySsha($plain, substr($stored, 6)),
-            str_starts_with($stored, '{MD5}') => $this->verifyMd5($plain, substr($stored, 5)),
-            str_starts_with($stored, '{SMD5}') => $this->verifySmd5($plain, substr($stored, 6)),
-            str_starts_with($stored, '{BCRYPT}') => password_verify($plain, substr($stored, 8)),
-            str_starts_with($stored, '{ARGON2}') => password_verify($plain, substr($stored, 8)),
-            default => $plain === $stored,
+        foreach (self::recognizedPrefixes() as $prefix) {
+            if (str_starts_with($stored, $prefix)) {
+                return $this->verifyScheme(
+                    $prefix,
+                    $plain,
+                    substr($stored, strlen($prefix)),
+                );
+            }
+        }
+
+        return $plain === $stored;
+    }
+
+    /**
+     * Prefixes the verifier recognizes: every writable scheme plus the legacy read-only ones.
+     *
+     * @return list<string>
+     */
+    private static function recognizedPrefixes(): array
+    {
+        return [
+            ...array_map(
+                static fn(PasswordHashScheme $scheme): string => $scheme->value,
+                PasswordHashScheme::cases(),
+            ),
+            ...self::LEGACY_READ_PREFIXES,
+        ];
+    }
+
+    private function verifyScheme(
+        string $prefix,
+        #[SensitiveParameter]
+        string $plain,
+        string $encoded,
+    ): bool {
+        return match ($prefix) {
+            PasswordHashScheme::Ssha->value => $this->verifySsha($plain, $encoded),
+            PasswordHashScheme::Bcrypt->value, PasswordHashScheme::Argon2->value => password_verify($plain, $encoded),
+            '{SHA}' => $this->verifySha($plain, $encoded),
+            '{MD5}' => $this->verifyMd5($plain, $encoded),
+            '{SMD5}' => $this->verifySmd5($plain, $encoded),
+            default => throw new RuntimeException(sprintf(
+                'No verification is implemented for the recognized hash scheme "%s".',
+                $prefix,
+            )),
         };
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordPolicyAwareAuthenticator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordPolicyAwareAuthenticator.php
@@ -22,6 +22,7 @@ use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyBindGuard;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
 use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
+use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Sasl\Mechanism\MechanismName;
 use SensitiveParameter;
 
@@ -84,6 +85,10 @@ final readonly class PasswordPolicyAwareAuthenticator implements PasswordAuthent
         }
 
         $this->guard->recordSuccess($attempt);
+
+        if ($attempt->state->mustChange && $token instanceof BindToken) {
+            $token->markMustChangePassword();
+        }
 
         return $token;
     }

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/SaslBindPolicyEnforcer.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/SaslBindPolicyEnforcer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Auth;
 
 use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\PwdPolicyError;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -75,6 +76,14 @@ final readonly class SaslBindPolicyEnforcer
 
         $this->guard->preBind($attempt);
         $this->guard->recordSuccess($attempt);
+    }
+
+    /**
+     * Whether the just-enforced bind flagged that the password must be changed; read before {@see responseControl}.
+     */
+    public function mustChangePassword(): bool
+    {
+        return $this->context->getOutcome()?->errorCode === PwdPolicyError::CHANGE_AFTER_RESET;
     }
 
     public function responseControl(): ?Control

--- a/src/FreeDSx/Ldap/Server/Backend/Write/PasswordPolicyWriteHandler.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/PasswordPolicyWriteHandler.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashVerifier;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 use FreeDSx\Ldap\Server\PasswordPolicy\Attempt\PasswordModifyAttempt;
@@ -90,6 +91,7 @@ final readonly class PasswordPolicyWriteHandler implements WriteHandlerInterface
                 hashedNewPassword: $newPassword,
                 oldPassword: $oldPassword,
                 isSelf: $isSelf,
+                passwordIsCleartext: !PasswordHashVerifier::isHashed($newPassword),
             ));
         }
 

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Attempt/PasswordModifyAttempt.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Attempt/PasswordModifyAttempt.php
@@ -29,5 +29,6 @@ final readonly class PasswordModifyAttempt
         #[SensitiveParameter]
         public ?string $oldPassword,
         public bool $isSelf,
+        public bool $passwordIsCleartext = true,
     ) {}
 }

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/PasswordChangeAttempt.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/PasswordChangeAttempt.php
@@ -30,5 +30,6 @@ final readonly class PasswordChangeAttempt
         public UserPasswordState $state,
         public PasswordPolicy $policy,
         public bool $isSelf,
+        public bool $passwordIsCleartext = true,
     ) {}
 }

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/QualityConstraint.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/QualityConstraint.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\PasswordPolicy\Constraint;
 
+use FreeDSx\Ldap\Control\PwdPolicyError;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\PasswordPolicyOutcome;
 use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\PasswordQualityCheckerInterface;
@@ -26,6 +27,10 @@ final readonly class QualityConstraint implements PasswordChangeConstraint
 
     public function check(PasswordChangeAttempt $attempt): ?PasswordPolicyOutcome
     {
+        if (!$attempt->passwordIsCleartext) {
+            return $this->forUninspectablePassword($attempt->policy->quality->checkQuality);
+        }
+
         $errorCode = $this->checker->check(
             $attempt->newPassword,
             $attempt->policy->quality,
@@ -38,6 +43,22 @@ final readonly class QualityConstraint implements PasswordChangeConstraint
             $errorCode,
             ResultCode::CONSTRAINT_VIOLATION,
             'Password does not meet quality requirements.',
+        );
+    }
+
+    /**
+     * pwdCheckQuality = 2 forbids accepting a password whose quality cannot be checked (draft-behera-10 §5.2.5).
+     */
+    private function forUninspectablePassword(?int $checkQuality): ?PasswordPolicyOutcome
+    {
+        if ($checkQuality !== 2) {
+            return null;
+        }
+
+        return PasswordPolicyOutcome::deny(
+            PwdPolicyError::INSUFFICIENT_PASSWORD_QUALITY,
+            ResultCode::CONSTRAINT_VIOLATION,
+            'Password quality cannot be verified for a pre-hashed value.',
         );
     }
 }

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Guard/PasswordPolicyChangeGuard.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Guard/PasswordPolicyChangeGuard.php
@@ -15,11 +15,15 @@ namespace FreeDSx\Ldap\Server\PasswordPolicy\Guard;
 
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\PasswordPolicyException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashVerifier;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
 use FreeDSx\Ldap\Server\PasswordPolicy\Attempt\PasswordModifyAttempt;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
+use FreeDSx\Ldap\Server\PasswordPolicy\Decision\PasswordPolicyOutcome;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
@@ -35,6 +39,7 @@ final readonly class PasswordPolicyChangeGuard
         private PasswordPolicyResolver $resolver,
         private PasswordPolicyContext $context,
         private EventLogger $eventLogger,
+        private PasswordHashVerifier $hashVerifier = new PasswordHashVerifier(),
     ) {}
 
     /**
@@ -54,25 +59,75 @@ final readonly class PasswordPolicyChangeGuard
             $state,
             $policy,
             $attempt->isSelf,
+            $attempt->passwordIsCleartext,
         );
 
         if ($outcome->denied) {
-            $this->context->setOutcome($outcome);
-            $this->eventLogger->record(
-                ServerEvent::PasswordPolicyChangeRejected,
-                [EventContext::TARGET => [EventContext::DN => $attempt->target->getDn()->toString()]],
-            );
-
-            throw new OperationException(
-                $outcome->diagnostic,
-                $outcome->ldapResultCode,
+            $this->reject(
+                $outcome,
+                $attempt,
             );
         }
+
+        $this->assertSafeModifyCredential(
+            $policy,
+            $attempt,
+        );
 
         return $this->engine->recordPasswordChange(
             $attempt->hashedNewPassword,
             $state,
             $policy,
+            $attempt->isSelf,
+        );
+    }
+
+    /**
+     * Verifies the supplied existing password under pwdSafeModify; presence is already enforced by the constraint chain.
+     *
+     * @throws OperationException when an existing password is supplied but does not match the stored value.
+     */
+    private function assertSafeModifyCredential(
+        PasswordPolicy $policy,
+        PasswordModifyAttempt $attempt,
+    ): void {
+        $oldPassword = $attempt->oldPassword;
+        if ($policy->change->safeModify !== true || $oldPassword === null || $oldPassword === '') {
+            return;
+        }
+
+        foreach ($attempt->target->get($policy->pwdAttribute)?->getValues() ?? [] as $stored) {
+            if ($this->hashVerifier->verify($oldPassword, $stored)) {
+                return;
+            }
+        }
+
+        $this->reject(
+            new PasswordPolicyOutcome(
+                denied: true,
+                ldapResultCode: ResultCode::INVALID_CREDENTIALS,
+                diagnostic: 'The supplied existing password is incorrect.',
+            ),
+            $attempt,
+        );
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function reject(
+        PasswordPolicyOutcome $outcome,
+        PasswordModifyAttempt $attempt,
+    ): never {
+        $this->context->setOutcome($outcome);
+        $this->eventLogger->record(
+            ServerEvent::PasswordPolicyChangeRejected,
+            [EventContext::TARGET => [EventContext::DN => $attempt->target->getDn()->toString()]],
+        );
+
+        throw new OperationException(
+            $outcome->diagnostic,
+            $outcome->ldapResultCode,
         );
     }
 }

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyEngine.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyEngine.php
@@ -44,24 +44,95 @@ final readonly class PasswordPolicyEngine
         UserPasswordState $state,
         PasswordPolicy $policy,
     ): PasswordPolicyOutcome {
-        if (!$state->isLocked()) {
-            return PasswordPolicyOutcome::allow();
+        return $this->evaluateValidityWindow($state)
+            ?? $this->evaluateIdleLockout($state, $policy)
+            ?? ($this->isLockoutEffective($state, $policy)
+                ? self::denyLocked()
+                : PasswordPolicyOutcome::allow());
+    }
+
+    /**
+     * Lock an account that has had no successful bind within pwdMaxIdle seconds (draft-behera-10 §5.2.19, §5.3.x).
+     */
+    private function evaluateIdleLockout(
+        UserPasswordState $state,
+        PasswordPolicy $policy,
+    ): ?PasswordPolicyOutcome {
+        $maxIdle = $policy->expiration->maxIdle;
+        $since = $state->lastSuccess ?? $state->changedAt;
+        if ($maxIdle === null || $maxIdle === 0 || $since === null) {
+            return null;
         }
 
+        $idleSeconds = $this->clock->now()->getTimestamp() - $since->getTimestamp();
+        if ($idleSeconds <= $maxIdle) {
+            return null;
+        }
+
+        return PasswordPolicyOutcome::deny(
+            PwdPolicyError::ACCOUNT_LOCKED,
+            ResultCode::INVALID_CREDENTIALS,
+            'Account is locked due to inactivity.',
+        );
+    }
+
+    /**
+     * Reject a bind outside the pwdStartTime / pwdEndTime validity window (draft-behera-10 §5.3.8-5.3.9).
+     */
+    private function evaluateValidityWindow(UserPasswordState $state): ?PasswordPolicyOutcome
+    {
+        $now = $this->clock->now();
+
+        if ($state->startTime !== null && $now < $state->startTime) {
+            return new PasswordPolicyOutcome(
+                denied: true,
+                ldapResultCode: ResultCode::INVALID_CREDENTIALS,
+                diagnostic: 'Password is not yet valid.',
+            );
+        }
+        if ($state->endTime !== null && $now > $state->endTime) {
+            return PasswordPolicyOutcome::deny(
+                PwdPolicyError::PASSWORD_EXPIRED,
+                ResultCode::INVALID_CREDENTIALS,
+                'Password is no longer valid.',
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether the account is currently locked: permanently, or within an unexpired pwdLockoutDuration window.
+     */
+    private function isLockoutEffective(
+        UserPasswordState $state,
+        PasswordPolicy $policy,
+    ): bool {
         if ($state->permanentlyLocked) {
-            return self::denyLocked();
+            return true;
+        }
+        if ($state->accountLockedAt === null) {
+            return false;
         }
 
         $duration = $policy->lockout->duration;
         if ($duration === null || $duration === 0) {
-            return self::denyLocked();
+            return true;
         }
 
-        if ($this->secondsSinceLock($state) < $duration) {
-            return self::denyLocked();
-        }
+        return $this->secondsSinceLock($state) < $duration;
+    }
 
-        return PasswordPolicyOutcome::allow();
+    /**
+     * A timed lock whose pwdLockoutDuration has elapsed (such a lock must be cleared so failure counting restarts).
+     */
+    private function hasExpiredLock(
+        UserPasswordState $state,
+        PasswordPolicy $policy,
+    ): bool {
+        return $state->accountLockedAt !== null
+            && !$state->permanentlyLocked
+            && !$this->isLockoutEffective($state, $policy);
     }
 
     /**
@@ -74,8 +145,11 @@ final readonly class PasswordPolicyEngine
         PasswordPolicy $policy,
     ): RecordedOutcome {
         $now = $this->clock->now();
+        $expired = $this->hasExpiredLock($state, $policy);
+        $priorFailures = $expired ? [] : $state->failureTimes;
+
         $retained = $this->trimFailuresToInterval(
-            $state->failureTimes,
+            $priorFailures,
             $policy,
         );
         $retained[] = $now;
@@ -93,6 +167,8 @@ final readonly class PasswordPolicyEngine
                 GeneralizedTime::format($now),
             );
             $outcome = self::denyLocked();
+        } elseif ($expired) {
+            $changes[] = Change::reset(PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME);
         }
 
         return new RecordedOutcome(
@@ -134,7 +210,7 @@ final readonly class PasswordPolicyEngine
             $policy->lockout->enabled !== true,
             $policy->lockout->maxFailure === null,
             $policy->lockout->maxFailure === 0,
-            $state->isLocked() => false,
+            $this->isLockoutEffective($state, $policy) => false,
             default => count($retained) >= $policy->lockout->maxFailure,
         };
     }
@@ -154,7 +230,7 @@ final readonly class PasswordPolicyEngine
         );
         $isExpired = $secondsRemaining !== null && $secondsRemaining <= 0;
 
-        if ($isExpired && $this->graceRemaining($state, $policy) === 0) {
+        if ($isExpired && !$this->graceAvailable($state, $policy, $secondsRemaining)) {
             return new RecordedOutcome(
                 PasswordPolicyOutcome::deny(
                     PwdPolicyError::PASSWORD_EXPIRED,
@@ -223,6 +299,28 @@ final readonly class PasswordPolicyEngine
     }
 
     /**
+     * Whether an expired password may still authenticate via a grace login: by count, and within pwdGraceExpiry if set.
+     */
+    private function graceAvailable(
+        UserPasswordState $state,
+        PasswordPolicy $policy,
+        ?int $secondsRemaining,
+    ): bool {
+        if ($this->graceRemaining($state, $policy) === 0) {
+            return false;
+        }
+
+        $window = $policy->expiration->graceExpiry;
+        if ($window === null || $window === 0) {
+            return true;
+        }
+
+        $secondsSinceExpiry = $secondsRemaining === null ? 0 : -$secondsRemaining;
+
+        return $secondsSinceExpiry <= $window;
+    }
+
+    /**
      * @return list<Change>
      */
     private function buildSuccessChanges(
@@ -230,7 +328,10 @@ final readonly class PasswordPolicyEngine
         DateTimeImmutable $now,
         bool $isExpired,
     ): array {
-        $changes = [];
+        $changes = [Change::replace(
+            PasswordPolicyOid::NAME_PWD_LAST_SUCCESS,
+            GeneralizedTime::format($now),
+        )];
 
         if ($state->failureTimes !== []) {
             $changes[] = Change::reset(PasswordPolicyOid::NAME_PWD_FAILURE_TIME);
@@ -297,6 +398,7 @@ final readonly class PasswordPolicyEngine
         UserPasswordState $state,
         PasswordPolicy $policy,
         bool $isSelf,
+        bool $passwordIsCleartext = true,
     ): PasswordPolicyOutcome {
         $attempt = new PasswordChangeAttempt(
             newPassword: $newPassword,
@@ -304,6 +406,7 @@ final readonly class PasswordPolicyEngine
             state: $state,
             policy: $policy,
             isSelf: $isSelf,
+            passwordIsCleartext: $passwordIsCleartext,
         );
 
         return $this->changeConstraints->evaluate($attempt)
@@ -311,12 +414,14 @@ final readonly class PasswordPolicyEngine
     }
 
     /**
-     * Stamp pwdChangedTime, rotate pwdHistory, clear pwdReset / pwdFailureTime / pwdAccountLockedTime / pwdGraceUseTime.
+     * Stamp pwdChangedTime, rotate pwdHistory, set/clear pwdReset, and clear pwdFailureTime / pwdAccountLockedTime /
+     * pwdGraceUseTime.
      */
     public function recordPasswordChange(
         string $hashedNew,
         UserPasswordState $state,
         PasswordPolicy $policy,
+        bool $isSelf = true,
     ): OperationalChanges {
         $now = $this->clock->now();
         $changes = [Change::replace(
@@ -333,8 +438,14 @@ final readonly class PasswordPolicyEngine
         if ($historyChange !== null) {
             $changes[] = $historyChange;
         }
-        if ($state->mustChange) {
-            $changes[] = Change::reset(PasswordPolicyOid::NAME_PWD_RESET);
+
+        $resetChange = $this->buildResetChange(
+            $state,
+            $policy,
+            $isSelf,
+        );
+        if ($resetChange !== null) {
+            $changes[] = $resetChange;
         }
         if ($state->failureTimes !== []) {
             $changes[] = Change::reset(PasswordPolicyOid::NAME_PWD_FAILURE_TIME);
@@ -347,6 +458,27 @@ final readonly class PasswordPolicyEngine
         }
 
         return OperationalChanges::of(...$changes);
+    }
+
+    /**
+     * An administrative reset under pwdMustChange sets pwdReset; otherwise a prior pwdReset is satisfied and cleared.
+     */
+    private function buildResetChange(
+        UserPasswordState $state,
+        PasswordPolicy $policy,
+        bool $isSelf,
+    ): ?Change {
+        if (!$isSelf && $policy->change->mustChange === true) {
+            return Change::replace(
+                PasswordPolicyOid::NAME_PWD_RESET,
+                'TRUE',
+            );
+        }
+        if ($state->mustChange) {
+            return Change::reset(PasswordPolicyOid::NAME_PWD_RESET);
+        }
+
+        return null;
     }
 
     private function buildHistoryChange(

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/QualityCheck/DefaultPasswordQualityChecker.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/QualityCheck/DefaultPasswordQualityChecker.php
@@ -28,6 +28,10 @@ final class DefaultPasswordQualityChecker implements PasswordQualityCheckerInter
         string $plain,
         PasswordQualityRules $rules,
     ): ?int {
+        if ($rules->checkQuality === 0) {
+            return null;
+        }
+
         $length = mb_strlen($plain);
 
         if ($rules->minLength !== null && $length < $rules->minLength) {

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/UserPasswordState.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/UserPasswordState.php
@@ -41,6 +41,9 @@ final readonly class UserPasswordState
         public array $graceUseTimes = [],
         public bool $mustChange = false,
         public ?Dn $policySubentry = null,
+        public ?DateTimeImmutable $startTime = null,
+        public ?DateTimeImmutable $endTime = null,
+        public ?DateTimeImmutable $lastSuccess = null,
     ) {}
 
     /**
@@ -71,6 +74,18 @@ final readonly class UserPasswordState
             policySubentry: self::readDn(
                 $entry,
                 PasswordPolicyOid::NAME_PWD_POLICY_SUBENTRY,
+            ),
+            startTime: self::readGeneralizedTime(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_START_TIME,
+            ),
+            endTime: self::readGeneralizedTime(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_END_TIME,
+            ),
+            lastSuccess: self::readGeneralizedTime(
+                $entry,
+                PasswordPolicyOid::NAME_PWD_LAST_SUCCESS,
             ),
         );
     }

--- a/src/FreeDSx/Ldap/Server/Token/AuthenticatedTokenInterface.php
+++ b/src/FreeDSx/Ldap/Server/Token/AuthenticatedTokenInterface.php
@@ -23,4 +23,9 @@ use FreeDSx\Ldap\Entry\Dn;
 interface AuthenticatedTokenInterface extends TokenInterface
 {
     public function getResolvedDn(): Dn;
+
+    /**
+     * Whether the bound identity must change its password before any other operation is permitted (pwdReset).
+     */
+    public function mustChangePassword(): bool;
 }

--- a/src/FreeDSx/Ldap/Server/Token/BindToken.php
+++ b/src/FreeDSx/Ldap/Server/Token/BindToken.php
@@ -34,6 +34,8 @@ class BindToken implements AuthenticatedTokenInterface
 
     private int $version;
 
+    private bool $mustChangePassword = false;
+
     public function __construct(
         string $username,
         #[SensitiveParameter]
@@ -96,6 +98,19 @@ class BindToken implements AuthenticatedTokenInterface
     public function getResolvedDn(): Dn
     {
         return $this->resolvedDn;
+    }
+
+    /**
+     * Flags that the bound identity must change its password before any other operation is permitted.
+     */
+    public function markMustChangePassword(): void
+    {
+        $this->mustChangePassword = true;
+    }
+
+    public function mustChangePassword(): bool
+    {
+        return $this->mustChangePassword;
     }
 
     public function getVersion(): int

--- a/tests/integration/Security/PasswordPolicyBindEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyBindEnforcementTest.php
@@ -110,6 +110,46 @@ final class PasswordPolicyBindEnforcementTest extends TestCase
         $this->assertEventRecorded(ServerEvent::PasswordPolicyAccountLocked);
     }
 
+    public function test_lockout_retriggers_after_duration_elapses(): void
+    {
+        $authenticator = $this->authenticatorFor(
+            $this->user([
+                PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME => $this->minutesAgo(120),
+                PasswordPolicyOid::NAME_PWD_FAILURE_TIME => [
+                    $this->minutesAgo(121),
+                    $this->minutesAgo(120),
+                ],
+            ]),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    duration: 3600,
+                    maxFailure: 2,
+                ),
+            ),
+        );
+
+        // The duration has elapsed, so a failed bind is attempted and the stale lock is cleared rather than persisting.
+        $this->attemptBind(
+            $authenticator,
+            'wrong',
+        );
+        self::assertNull(
+            $this->storedValue(PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME),
+            'An elapsed lock must be cleared on the next failed bind, not left stale.',
+        );
+
+        // Fresh failures must be able to lock the account again.
+        $this->attemptBind(
+            $authenticator,
+            'wrong',
+        );
+        self::assertNotNull(
+            $this->storedValue(PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME),
+            'Reaching pwdMaxFailure again after an elapsed lock must re-lock the account.',
+        );
+    }
+
     public function test_elapsed_lockout_unlocks_on_success(): void
     {
         $authenticator = $this->authenticatorFor(
@@ -224,6 +264,154 @@ final class PasswordPolicyBindEnforcementTest extends TestCase
         }
     }
 
+    public function test_grace_login_within_grace_expiry_window_is_allowed(): void
+    {
+        $authenticator = $this->authenticatorFor(
+            $this->user([
+                // Expired ten minutes ago (maxAge 60m), still inside the 30m grace-expiry window.
+                PasswordPolicyOid::NAME_PWD_CHANGED_TIME => $this->minutesAgo(70),
+            ]),
+            new PasswordPolicy(
+                expiration: new PasswordExpirationRules(
+                    maxAge: 3600,
+                    graceAuthnLimit: 3,
+                    graceExpiry: 1800,
+                ),
+            ),
+        );
+
+        $authenticator->authenticate(
+            self::USER_DN,
+            self::PASSWORD,
+        );
+
+        self::assertSame(
+            2,
+            $this->context->getOutcome()?->graceRemaining,
+        );
+        self::assertNotNull($this->storedValue(PasswordPolicyOid::NAME_PWD_GRACE_USE_TIME));
+    }
+
+    public function test_grace_login_past_grace_expiry_window_is_denied(): void
+    {
+        $authenticator = $this->authenticatorFor(
+            $this->user([
+                // Expired sixty minutes ago, beyond the 30m grace-expiry window, despite grace remaining by count.
+                PasswordPolicyOid::NAME_PWD_CHANGED_TIME => $this->minutesAgo(120),
+            ]),
+            new PasswordPolicy(
+                expiration: new PasswordExpirationRules(
+                    maxAge: 3600,
+                    graceAuthnLimit: 3,
+                    graceExpiry: 1800,
+                ),
+            ),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        try {
+            $authenticator->authenticate(
+                self::USER_DN,
+                self::PASSWORD,
+            );
+        } finally {
+            self::assertSame(
+                PwdPolicyError::PASSWORD_EXPIRED,
+                $this->context->getOutcome()?->errorCode,
+            );
+        }
+    }
+
+    public function test_idle_account_beyond_pwd_max_idle_is_locked(): void
+    {
+        $authenticator = $this->authenticatorFor(
+            $this->user([
+                PasswordPolicyOid::NAME_PWD_LAST_SUCCESS => $this->minutesAgo(120),
+            ]),
+            new PasswordPolicy(
+                expiration: new PasswordExpirationRules(maxIdle: 3600),
+            ),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        try {
+            $authenticator->authenticate(
+                self::USER_DN,
+                self::PASSWORD,
+            );
+        } finally {
+            self::assertSame(
+                PwdPolicyError::ACCOUNT_LOCKED,
+                $this->context->getOutcome()?->errorCode,
+            );
+        }
+    }
+
+    public function test_successful_bind_records_last_success(): void
+    {
+        $authenticator = $this->authenticatorFor(
+            $this->user(),
+            new PasswordPolicy(),
+        );
+
+        $authenticator->authenticate(
+            self::USER_DN,
+            self::PASSWORD,
+        );
+
+        self::assertSame(
+            GeneralizedTime::format($this->clock->now()),
+            $this->storedValue(PasswordPolicyOid::NAME_PWD_LAST_SUCCESS),
+        );
+    }
+
+    public function test_bind_rejected_before_password_start_time(): void
+    {
+        $authenticator = $this->authenticatorFor(
+            $this->user([
+                PasswordPolicyOid::NAME_PWD_START_TIME => $this->minutesFromNow(10),
+            ]),
+            new PasswordPolicy(),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        $authenticator->authenticate(
+            self::USER_DN,
+            self::PASSWORD,
+        );
+    }
+
+    public function test_bind_rejected_after_password_end_time(): void
+    {
+        $authenticator = $this->authenticatorFor(
+            $this->user([
+                PasswordPolicyOid::NAME_PWD_END_TIME => $this->minutesAgo(10),
+            ]),
+            new PasswordPolicy(),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        try {
+            $authenticator->authenticate(
+                self::USER_DN,
+                self::PASSWORD,
+            );
+        } finally {
+            self::assertSame(
+                PwdPolicyError::PASSWORD_EXPIRED,
+                $this->context->getOutcome()?->errorCode,
+            );
+        }
+    }
+
     public function test_pwd_reset_surfaces_change_after_reset(): void
     {
         $authenticator = $this->authenticatorFor(
@@ -243,6 +431,38 @@ final class PasswordPolicyBindEnforcementTest extends TestCase
             $this->context->getOutcome()?->errorCode,
         );
         $this->assertEventRecorded(ServerEvent::PasswordPolicyMustChange);
+    }
+
+    public function test_pwd_reset_marks_token_for_required_change(): void
+    {
+        $authenticator = $this->authenticatorFor(
+            $this->user([
+                PasswordPolicyOid::NAME_PWD_RESET => 'TRUE',
+            ]),
+            new PasswordPolicy(),
+        );
+
+        $token = $authenticator->authenticate(
+            self::USER_DN,
+            self::PASSWORD,
+        );
+
+        self::assertTrue($token->mustChangePassword());
+    }
+
+    public function test_normal_bind_does_not_mark_token_for_required_change(): void
+    {
+        $authenticator = $this->authenticatorFor(
+            $this->user(),
+            new PasswordPolicy(),
+        );
+
+        $token = $authenticator->authenticate(
+            self::USER_DN,
+            self::PASSWORD,
+        );
+
+        self::assertFalse($token->mustChangePassword());
     }
 
     /**
@@ -327,6 +547,15 @@ final class PasswordPolicyBindEnforcementTest extends TestCase
             $this->clock
                 ->now()
                 ->sub(new DateInterval(sprintf('PT%dM', $minutes))),
+        );
+    }
+
+    private function minutesFromNow(int $minutes): string
+    {
+        return GeneralizedTime::format(
+            $this->clock
+                ->now()
+                ->add(new DateInterval(sprintf('PT%dM', $minutes))),
         );
     }
 

--- a/tests/integration/Security/PasswordPolicyChangeEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyChangeEnforcementTest.php
@@ -171,6 +171,56 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
         );
     }
 
+    public function test_admin_reset_sets_pwd_reset_when_policy_requires_change(): void
+    {
+        $handler = $this->handlerFor(
+            new PasswordPolicy(change: new PasswordChangeRules(mustChange: true)),
+        );
+
+        $handler->handleRequest(
+            $this->request(
+                null,
+                'admin-set-password',
+                self::USER_DN,
+            ),
+            $this->adminToken(),
+        );
+
+        self::assertInstanceOf(
+            PasswordModifyResponse::class,
+            $this->response?->getResponse(),
+        );
+
+        $entry = $this->backend->get(new Dn(self::USER_DN));
+        self::assertSame(
+            'TRUE',
+            $entry?->get(PasswordPolicyOid::NAME_PWD_RESET)?->firstValue(),
+            'An administrative reset under pwdMustChange must force a password change.',
+        );
+    }
+
+    public function test_self_change_clears_pwd_reset_even_under_must_change_policy(): void
+    {
+        $handler = $this->handlerFor(
+            new PasswordPolicy(change: new PasswordChangeRules(mustChange: true)),
+            [PasswordPolicyOid::NAME_PWD_RESET => 'TRUE'],
+        );
+
+        $handler->handleRequest(
+            $this->request(
+                self::OLD_PASSWORD,
+                'a-fresh-password',
+            ),
+            $this->selfToken(),
+        );
+
+        $entry = $this->backend->get(new Dn(self::USER_DN));
+        self::assertNull(
+            $entry?->get(PasswordPolicyOid::NAME_PWD_RESET),
+            'A self-change satisfies the reset requirement and must clear pwdReset.',
+        );
+    }
+
     /**
      * @param array<string, string> $extra
      */
@@ -248,11 +298,12 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
     private function request(
         ?string $oldPassword,
         string $newPassword,
+        ?string $userIdentity = null,
     ): LdapMessageRequest {
         return new LdapMessageRequest(
             1,
             new PasswordModifyRequest(
-                null,
+                $userIdentity,
                 $oldPassword,
                 $newPassword,
             ),
@@ -264,6 +315,14 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
         return BindToken::fromDn(
             self::USER_DN,
             self::OLD_PASSWORD,
+        );
+    }
+
+    private function adminToken(): BindToken
+    {
+        return BindToken::fromDn(
+            'cn=admin,dc=foo,dc=bar',
+            'admin-pass',
         );
     }
 

--- a/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
@@ -48,6 +48,7 @@ use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
 use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\DefaultPasswordQualityChecker;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordChangeRules;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use PHPUnit\Framework\TestCase;
@@ -142,6 +143,92 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
         );
     }
 
+    public function test_prehashed_value_rejected_when_check_quality_is_strict(): void
+    {
+        $handler = $this->dispatchHandler(
+            new PasswordPolicy(quality: new PasswordQualityRules(
+                minLength: 8,
+                checkQuality: 2,
+            )),
+        );
+
+        $handler->handleRequest(
+            $this->modify('{SSHA}' . base64_encode('cannot-introspect-this')),
+            $this->token(),
+        );
+
+        $response = $this->response?->getResponse();
+        self::assertInstanceOf(
+            LdapResult::class,
+            $response,
+        );
+        self::assertSame(
+            ResultCode::CONSTRAINT_VIOLATION,
+            $response->getResultCode(),
+        );
+
+        $control = $this->response?->controls()->getByClass(PwdPolicyResponseControl::class);
+        self::assertInstanceOf(
+            PwdPolicyResponseControl::class,
+            $control,
+        );
+        self::assertSame(
+            PwdPolicyError::INSUFFICIENT_PASSWORD_QUALITY,
+            $control->getError(),
+        );
+    }
+
+    public function test_safe_modify_with_wrong_old_password_is_rejected(): void
+    {
+        $handler = $this->dispatchHandler(
+            new PasswordPolicy(change: new PasswordChangeRules(safeModify: true)),
+        );
+
+        $handler->handleRequest(
+            $this->modifyWithOld('wrong-old', 'a-fresh-password'),
+            $this->token(),
+        );
+
+        $response = $this->response?->getResponse();
+        self::assertInstanceOf(
+            LdapResult::class,
+            $response,
+        );
+        self::assertSame(
+            ResultCode::INVALID_CREDENTIALS,
+            $response->getResultCode(),
+        );
+
+        $entry = $this->backend->get(new Dn(self::USER_DN));
+        self::assertSame(
+            'original-pass',
+            $entry?->get('userPassword')?->firstValue(),
+            'A rejected safe-modify must not alter the stored password.',
+        );
+    }
+
+    public function test_safe_modify_with_correct_old_password_succeeds(): void
+    {
+        $handler = $this->dispatchHandler(
+            new PasswordPolicy(change: new PasswordChangeRules(safeModify: true)),
+        );
+
+        $handler->handleRequest(
+            $this->modifyWithOld('original-pass', 'a-fresh-password'),
+            $this->token(),
+        );
+
+        $response = $this->response?->getResponse();
+        self::assertInstanceOf(
+            LdapResult::class,
+            $response,
+        );
+        self::assertSame(
+            ResultCode::SUCCESS,
+            $response->getResultCode(),
+        );
+    }
+
     /**
      * @param array<string, string> $userAttrs
      */
@@ -227,6 +314,20 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
             new ModifyRequest(
                 self::USER_DN,
                 Change::replace('userPassword', $newPassword),
+            ),
+        );
+    }
+
+    private function modifyWithOld(
+        string $oldPassword,
+        string $newPassword,
+    ): LdapMessageRequest {
+        return new LdapMessageRequest(
+            1,
+            new ModifyRequest(
+                self::USER_DN,
+                Change::delete('userPassword', $oldPassword),
+                Change::add('userPassword', $newPassword),
             ),
         );
     }

--- a/tests/unit/Protocol/ServerProtocolHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandlerTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Protocol;
 
 use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Operation\LdapResult;
@@ -483,6 +485,117 @@ final class ServerProtocolHandlerTest extends TestCase
             ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
             $record['context']['result_code'],
         );
+    }
+
+    public function test_a_must_change_token_blocks_other_operations(): void
+    {
+        $token = BindToken::fromDn(
+            'cn=user,dc=foo,dc=bar',
+            'secret',
+        );
+        $token->markMustChangePassword();
+
+        $this->mockProtocolHandler
+            ->expects(self::never())
+            ->method('handleRequest');
+
+        $captured = $this->runWithToken(
+            $token,
+            [
+                new LdapMessageRequest(1, new SimpleBindRequest('cn=user,dc=foo,dc=bar', 'secret')),
+                new LdapMessageRequest(2, new ModifyRequest('cn=user,dc=foo,dc=bar')),
+            ],
+        );
+
+        self::assertCount(
+            1,
+            $captured,
+        );
+        $response = $captured[0]->getResponse();
+        self::assertInstanceOf(
+            LdapResult::class,
+            $response,
+        );
+        self::assertSame(
+            ResultCode::UNWILLING_TO_PERFORM,
+            $response->getResultCode(),
+        );
+
+        $control = $captured[0]->controls()->getByClass(PwdPolicyResponseControl::class);
+        self::assertInstanceOf(
+            PwdPolicyResponseControl::class,
+            $control,
+        );
+        self::assertSame(
+            PwdPolicyError::CHANGE_AFTER_RESET,
+            $control->getError(),
+        );
+    }
+
+    public function test_a_must_change_token_allows_the_password_modify_operation(): void
+    {
+        $token = BindToken::fromDn(
+            'cn=user,dc=foo,dc=bar',
+            'secret',
+        );
+        $token->markMustChangePassword();
+
+        $this->mockProtocolHandler
+            ->expects(self::once())
+            ->method('handleRequest');
+
+        $this->runWithToken(
+            $token,
+            [
+                new LdapMessageRequest(1, new SimpleBindRequest('cn=user,dc=foo,dc=bar', 'secret')),
+                new LdapMessageRequest(2, new ExtendedRequest(ExtendedRequest::OID_PWD_MODIFY)),
+            ],
+        );
+    }
+
+    /**
+     * @param list<LdapMessageRequest> $messages
+     * @return list<LdapMessageResponse>
+     */
+    private function runWithToken(
+        BindToken $token,
+        array $messages,
+    ): array {
+        $captured = [];
+        $queue = $this->createMock(ServerQueue::class);
+        $queue
+            ->method('isConnected')
+            ->willReturn(true);
+        $queue
+            ->method('getMessage')
+            ->willReturnCallback(static function () use (&$messages): LdapMessageRequest {
+                if ($messages === []) {
+                    throw new ConnectionException();
+                }
+
+                return array_shift($messages);
+            });
+        $queue
+            ->method('sendMessage')
+            ->willReturnCallback(function (LdapMessageResponse $response) use (&$captured, $queue): ServerQueue {
+                $captured[] = $response;
+
+                return $queue;
+            });
+
+        $this->mockAuthenticator
+            ->method('bind')
+            ->willReturn($token);
+
+        $subject = new ServerProtocolHandler(
+            $queue,
+            $this->mockProtocolHandlerFactory,
+            new ServerAuthorization(new ServerOptions()),
+            $this->mockAuthenticator,
+        );
+        $subject->handle();
+
+        return $captured;
     }
 
     private function makeSubjectWithEventLogger(EventLogger $eventLogger): ServerProtocolHandler

--- a/tests/unit/Server/PasswordPolicy/Constraint/QualityConstraintTest.php
+++ b/tests/unit/Server/PasswordPolicy/Constraint/QualityConstraintTest.php
@@ -73,14 +73,79 @@ final class QualityConstraintTest extends TestCase
         );
     }
 
-    private function attempt(): PasswordChangeAttempt
+    public function test_prehashed_value_is_not_passed_to_the_checker(): void
     {
+        $checker = $this->createMock(PasswordQualityCheckerInterface::class);
+        $checker
+            ->expects(self::never())
+            ->method('check');
+
+        $constraint = new QualityConstraint($checker);
+
+        self::assertNull($constraint->check($this->attempt(
+            checkQuality: 1,
+            passwordIsCleartext: false,
+        )));
+    }
+
+    public function test_prehashed_value_denied_when_check_quality_is_strict(): void
+    {
+        $checker = $this->createMock(PasswordQualityCheckerInterface::class);
+        $checker
+            ->expects(self::never())
+            ->method('check');
+
+        $constraint = new QualityConstraint($checker);
+
+        $outcome = $constraint->check($this->attempt(
+            checkQuality: 2,
+            passwordIsCleartext: false,
+        ));
+
+        self::assertNotNull($outcome);
+        self::assertTrue($outcome->denied);
+        self::assertSame(
+            PwdPolicyError::INSUFFICIENT_PASSWORD_QUALITY,
+            $outcome->errorCode,
+        );
+    }
+
+    public function test_cleartext_value_is_still_checked(): void
+    {
+        $checker = $this->createMock(PasswordQualityCheckerInterface::class);
+        $checker
+            ->expects(self::once())
+            ->method('check')
+            ->willReturn(PwdPolicyError::PASSWORD_TOO_SHORT);
+
+        $constraint = new QualityConstraint($checker);
+
+        $outcome = $constraint->check($this->attempt(
+            checkQuality: 2,
+            passwordIsCleartext: true,
+        ));
+
+        self::assertNotNull($outcome);
+        self::assertSame(
+            PwdPolicyError::PASSWORD_TOO_SHORT,
+            $outcome->errorCode,
+        );
+    }
+
+    /**
+     * @param int<0, max>|null $checkQuality
+     */
+    private function attempt(
+        ?int $checkQuality = null,
+        bool $passwordIsCleartext = true,
+    ): PasswordChangeAttempt {
         return new PasswordChangeAttempt(
             newPassword: 'newpw',
             oldPassword: null,
             state: new UserPasswordState(),
-            policy: new PasswordPolicy(quality: new PasswordQualityRules()),
+            policy: new PasswordPolicy(quality: new PasswordQualityRules(checkQuality: $checkQuality)),
             isSelf: true,
+            passwordIsCleartext: $passwordIsCleartext,
         );
     }
 }

--- a/tests/unit/Server/PasswordPolicy/Guard/PasswordPolicyBindGuardTest.php
+++ b/tests/unit/Server/PasswordPolicy/Guard/PasswordPolicyBindGuardTest.php
@@ -143,15 +143,12 @@ final class PasswordPolicyBindGuardTest extends TestCase
         $this->assertEventRecorded(ServerEvent::PasswordPolicyAccountLocked);
     }
 
-    public function test_recordSuccess_clean_state_stashes_allow_without_writes(): void
+    public function test_recordSuccess_clean_state_stamps_last_success(): void
     {
         $this->subject->recordSuccess($this->attempt(new UserPasswordState()));
 
         self::assertFalse($this->context->getOutcome()?->denied);
-        self::assertSame(
-            [],
-            $this->writeHandler->dispatched,
-        );
+        $this->assertWroteAttribute(PasswordPolicyOid::NAME_PWD_LAST_SUCCESS);
     }
 
     public function test_recordSuccess_expired_without_grace_denies(): void

--- a/tests/unit/Server/PasswordPolicy/PasswordPolicyEngineTest.php
+++ b/tests/unit/Server/PasswordPolicy/PasswordPolicyEngineTest.php
@@ -281,7 +281,7 @@ final class PasswordPolicyEngineTest extends TestCase
         ));
     }
 
-    public function test_recordBindSuccess_no_state_emits_no_changes(): void
+    public function test_recordBindSuccess_stamps_last_success(): void
     {
         $result = $this->subject->recordBindSuccess(
             new UserPasswordState(),
@@ -289,7 +289,13 @@ final class PasswordPolicyEngineTest extends TestCase
         );
 
         self::assertFalse($result->outcome->denied);
-        self::assertTrue($result->changes->isEmpty());
+        self::assertSame(
+            GeneralizedTime::format($this->clock->now()),
+            $this->findChange(
+                $result->changes->changes,
+                PasswordPolicyOid::NAME_PWD_LAST_SUCCESS,
+            )->getAttribute()->firstValue(),
+        );
     }
 
     public function test_recordBindSuccess_clears_prior_failures_and_lock(): void

--- a/tests/unit/Server/PasswordPolicy/QualityCheck/DefaultPasswordQualityCheckerTest.php
+++ b/tests/unit/Server/PasswordPolicy/QualityCheck/DefaultPasswordQualityCheckerTest.php
@@ -102,6 +102,34 @@ final class DefaultPasswordQualityCheckerTest extends TestCase
         );
     }
 
+    public function test_check_quality_zero_disables_all_checks(): void
+    {
+        self::assertNull(
+            $this->subject->check(
+                'short',
+                new PasswordQualityRules(
+                    minLength: 8,
+                    checkQuality: 0,
+                ),
+            ),
+            'pwdCheckQuality=0 must disable length enforcement entirely.',
+        );
+    }
+
+    public function test_check_quality_enabled_still_enforces_length(): void
+    {
+        self::assertSame(
+            PwdPolicyError::PASSWORD_TOO_SHORT,
+            $this->subject->check(
+                'short',
+                new PasswordQualityRules(
+                    minLength: 8,
+                    checkQuality: 1,
+                ),
+            ),
+        );
+    }
+
     public function test_check_uses_multibyte_length_not_byte_length(): void
     {
         // 4 multi-byte chars; 12 bytes in UTF-8.


### PR DESCRIPTION
Server side password policy support was implemented but not yet documented. I figured it needed more care before actually wrapping it up. This is a set of fixes post implementation to address several issues. Still need to address some more gaps and also add documentation.