### PR TITLE
[1.0.0] Fix server side sort order for when values are null / missing.

### DIFF
--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectInterface.php
@@ -124,7 +124,10 @@ interface PdoDialectInterface
     public function maxDnLength(): ?int;
 
     /**
-     * Returns a single ORDER BY term for one sort key; caller provides $direction ("ASC" or "DESC") and appends "?" for the attribute name param.
+     * Returns the ORDER BY term and bound params for one sort key, with NULL/missing values ordered per RFC 2891 §2.2.
      */
-    public function sortKeyClause(string $direction): string;
+    public function sortKeyClause(
+        string $attributeLower,
+        string $direction,
+    ): SortClause;
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
@@ -120,13 +120,24 @@ trait PdoDialectTrait
         return 'INSERT INTO entry_attribute_values (entry_lc_dn, attr_name_lower, value_lower, value_original) VALUES ';
     }
 
-    public function sortKeyClause(string $direction): string
-    {
-        return <<<SQL
+    public function sortKeyClause(
+        string $attributeLower,
+        string $direction,
+    ): SortClause {
+        $expr = <<<SQL
             (SELECT MIN(eav.value_lower)
              FROM entry_attribute_values eav
              WHERE eav.entry_lc_dn = LOWER(dn)
-               AND eav.attr_name_lower = ?) $direction
-        SQL;
+               AND eav.attr_name_lower = ?)
+            SQL;
+
+        // MySQL/MariaDB lack NULLS FIRST/LAST...emulate via an "IS NULL" ordering prefix.
+        return new SortClause(
+            $expr . ' IS NULL ' . $direction . ', ' . $expr . ' ' . $direction,
+            [
+                $attributeLower,
+                $attributeLower,
+            ],
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SortClause.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SortClause.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
+
+/**
+ * ORDER BY term for one sort key plus its bound parameters.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class SortClause
+{
+    /**
+     * @param list<string> $params
+     */
+    public function __construct(
+        public string $sql,
+        public array $params = [],
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SqliteDialect.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SqliteDialect.php
@@ -97,13 +97,23 @@ final class SqliteDialect implements PdoDialectInterface
         return null;
     }
 
-    public function sortKeyClause(string $direction): string
-    {
-        return <<<SQL
-            (SELECT MIN(eav.value_lower)
-             FROM entry_attribute_values eav
-             WHERE eav.entry_lc_dn = LOWER(dn)
-               AND eav.attr_name_lower = ?) $direction NULLS LAST
-        SQL;
+    public function sortKeyClause(
+        string $attributeLower,
+        string $direction,
+    ): SortClause {
+        // RFC 2891 §2.2: NULL is the largest value, so missing entries sort last (ASC) or first (DESC).
+        $nulls = $direction === 'ASC'
+            ? 'NULLS LAST'
+            : 'NULLS FIRST';
+
+        return new SortClause(
+            <<<SQL
+                (SELECT MIN(eav.value_lower)
+                 FROM entry_attribute_values eav
+                 WHERE eav.entry_lc_dn = LOWER(dn)
+                   AND eav.attr_name_lower = ?) $direction $nulls
+            SQL,
+            [$attributeLower],
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilder.php
@@ -142,9 +142,15 @@ final readonly class PdoListQueryBuilder
         $params = [];
 
         foreach ($sortKeys as $sortKey) {
-            $direction = $sortKey->getUseReverseOrder() ? 'DESC' : 'ASC';
-            $clauses[] = $this->dialect->sortKeyClause($direction);
-            $params[] = strtolower($sortKey->getAttribute());
+            $clause = $this->dialect->sortKeyClause(
+                strtolower($sortKey->getAttribute()),
+                $sortKey->getUseReverseOrder() ? 'DESC' : 'ASC',
+            );
+            $clauses[] = $clause->sql;
+            $params = array_merge(
+                $params,
+                $clause->params,
+            );
         }
 
         return $query->appending(

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/SortKeyComparator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/SortKeyComparator.php
@@ -74,15 +74,27 @@ final class SortKeyComparator
         Entry $b,
         SortKey $sortKey,
     ): int {
-        $aValue = $this->minValue(
-            $a,
-            $sortKey->getAttribute(),
-        );
-        $bValue = $this->minValue(
-            $b,
-            $sortKey->getAttribute(),
+        $cmp = $this->rawCompare(
+            $this->minValue(
+                $a,
+                $sortKey->getAttribute(),
+            ),
+            $this->minValue(
+                $b,
+                $sortKey->getAttribute(),
+            ),
         );
 
+        return $sortKey->getUseReverseOrder() ? -$cmp : $cmp;
+    }
+
+    /**
+     * Compares two values treating NULL (a missing attribute) as the largest value, per RFC 2891 §2.2.
+     */
+    private function rawCompare(
+        ?string $aValue,
+        ?string $bValue,
+    ): int {
         if ($aValue === null && $bValue === null) {
             return 0;
         }
@@ -95,12 +107,10 @@ final class SortKeyComparator
             return -1;
         }
 
-        $cmp = strcasecmp(
+        return strcasecmp(
             $aValue,
             $bValue,
         );
-
-        return $sortKey->getUseReverseOrder() ? -$cmp : $cmp;
     }
 
     /**

--- a/tests/integration/Storage/LdapBackendStorageTest.php
+++ b/tests/integration/Storage/LdapBackendStorageTest.php
@@ -116,8 +116,10 @@ class LdapBackendStorageTest extends ServerTestCase
                 ->useSingleLevelScope(),
         );
 
-        // cn=user and ou=people are direct children; cn=alice is not
-        self::assertCount(2, $entries);
+        self::assertCount(
+            3,
+            $entries,
+        );
     }
 
     public function testSearchSubtreeWithFilterReturnsMatchingEntry(): void
@@ -321,8 +323,10 @@ class LdapBackendStorageTest extends ServerTestCase
             }
         }
 
-        // Seed has 4 entries: dc=foo,dc=bar + cn=user + ou=people + cn=alice
-        self::assertCount(4, $allEntries);
+        self::assertCount(
+            5,
+            $allEntries,
+        );
     }
 
     public function testPagingCanBeAbandoned(): void
@@ -489,6 +493,44 @@ class LdapBackendStorageTest extends ServerTestCase
         self::assertSame(
             ['Smith', 'Admin'],
             $sns,
+        );
+    }
+
+    public function testSortControlPlacesMissingAttributeLastWhenAscending(): void
+    {
+        $this->authenticateUser();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::present('cn'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+            new SortingControl(SortKey::ascending('sn')),
+        )->toArray();
+
+        $last = $entries[count($entries) - 1];
+        self::assertNull($last->get('sn'));
+        self::assertSame(
+            'nosn',
+            $last->get('cn')?->getValues()[0],
+        );
+    }
+
+    public function testSortControlPlacesMissingAttributeFirstWhenDescending(): void
+    {
+        $this->authenticateUser();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::present('cn'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+            new SortingControl(SortKey::descending('sn')),
+        )->toArray();
+
+        $first = $entries[0];
+        self::assertNull($first->get('sn'));
+        self::assertSame(
+            'nosn',
+            $first->get('cn')?->getValues()[0],
         );
     }
 }

--- a/tests/integration/Storage/MysqlLdapBackendStorageTest.php
+++ b/tests/integration/Storage/MysqlLdapBackendStorageTest.php
@@ -29,11 +29,20 @@ final class MysqlLdapBackendStorageTest extends LdapBackendStorageTest
 {
     public static function setUpBeforeClass(): void
     {
-        if (!self::isMysqlAvailable()) {
+        if (!extension_loaded('pcntl') || !self::isMysqlAvailable()) {
             return;
         }
 
-        parent::setUpBeforeClass();
+        static::initSharedServer(
+            'ldap-backend-storage',
+            'tcp',
+            ['--storage=mysql'],
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        static::tearDownSharedServer();
     }
 
     public function setUp(): void
@@ -50,11 +59,6 @@ final class MysqlLdapBackendStorageTest extends LdapBackendStorageTest
         $this->stopServer();
 
         parent::tearDown();
-    }
-
-    protected static function storageHandlerArg(): string
-    {
-        return '--storage=mysql';
     }
 
     private static function isMysqlAvailable(): bool

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -158,6 +158,12 @@ final class LdapBackendStorageCommand extends Command
                 new Attribute('mail', 'alice@foo.bar'),
                 new Attribute('uidNumber', '99'),
             ),
+            new Entry(
+                new Dn('cn=nosn,dc=foo,dc=bar'),
+                new Attribute('cn', 'nosn'),
+                new Attribute('objectClass', 'groupOfNames'),
+                new Attribute('member', 'cn=user,dc=foo,dc=bar'),
+            ),
         ];
 
         for ($i = 1; $i <= $seedEntries; $i++) {

--- a/tests/unit/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilderTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilderTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo;
+
+use FreeDSx\Ldap\Control\Sorting\SortKey;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\MysqlDialect;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SqliteDialect;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoListQueryBuilder;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterResult;
+use PHPUnit\Framework\TestCase;
+
+final class PdoListQueryBuilderTest extends TestCase
+{
+    /**
+     * @return array{0: string, 1: list<string>}
+     */
+    private function rootQuery(
+        PdoListQueryBuilder $builder,
+        ?SqlFilterResult $filter,
+        SortKey ...$sortKeys,
+    ): array {
+        $query = $builder->build(
+            '',
+            true,
+            $filter,
+            null,
+            $sortKeys,
+        );
+
+        return [$query->sql, $query->params];
+    }
+
+    public function test_no_sort_keys_appends_no_order_by(): void
+    {
+        [$sql, $params] = $this->rootQuery(
+            new PdoListQueryBuilder(new SqliteDialect()),
+            null,
+        );
+
+        self::assertStringNotContainsString('ORDER BY', $sql);
+        self::assertSame([], $params);
+    }
+
+    public function test_sqlite_ascending_orders_nulls_last_with_one_param(): void
+    {
+        [$sql, $params] = $this->rootQuery(
+            new PdoListQueryBuilder(new SqliteDialect()),
+            null,
+            SortKey::ascending('CN'),
+        );
+
+        self::assertStringContainsString('ORDER BY', $sql);
+        self::assertStringContainsString('ASC NULLS LAST', $sql);
+        self::assertSame(['cn'], $params);
+    }
+
+    public function test_sqlite_descending_orders_nulls_first_with_one_param(): void
+    {
+        [$sql, $params] = $this->rootQuery(
+            new PdoListQueryBuilder(new SqliteDialect()),
+            null,
+            SortKey::descending('cn'),
+        );
+
+        self::assertStringContainsString('DESC NULLS FIRST', $sql);
+        self::assertSame(['cn'], $params);
+    }
+
+    public function test_mysql_ascending_emulates_nulls_last_with_two_params(): void
+    {
+        [$sql, $params] = $this->rootQuery(
+            new PdoListQueryBuilder(new MysqlDialect()),
+            null,
+            SortKey::ascending('cn'),
+        );
+
+        self::assertStringContainsString('IS NULL ASC', $sql);
+        self::assertSame(['cn', 'cn'], $params);
+    }
+
+    public function test_mysql_descending_emulates_nulls_first_with_two_params(): void
+    {
+        [$sql, $params] = $this->rootQuery(
+            new PdoListQueryBuilder(new MysqlDialect()),
+            null,
+            SortKey::descending('cn'),
+        );
+
+        self::assertStringContainsString('IS NULL DESC', $sql);
+        self::assertSame(['cn', 'cn'], $params);
+    }
+
+    public function test_mysql_multi_key_preserves_param_order(): void
+    {
+        [, $params] = $this->rootQuery(
+            new PdoListQueryBuilder(new MysqlDialect()),
+            null,
+            SortKey::ascending('sn'),
+            SortKey::descending('cn'),
+        );
+
+        self::assertSame(
+            ['sn', 'sn', 'cn', 'cn'],
+            $params,
+        );
+    }
+
+    public function test_filter_params_precede_sort_params(): void
+    {
+        [, $params] = $this->rootQuery(
+            new PdoListQueryBuilder(new SqliteDialect()),
+            new SqlFilterResult('eav.value_lower = ?', ['smith']),
+            SortKey::ascending('sn'),
+        );
+
+        self::assertSame(
+            ['smith', 'sn'],
+            $params,
+        );
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Adapter/Support/SortKeyComparatorTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Support/SortKeyComparatorTest.php
@@ -141,21 +141,39 @@ final class SortKeyComparatorTest extends TestCase
         self::assertNull($sorted[1]->get('cn'));
     }
 
-    public function test_entries_missing_attribute_sort_last_for_descending(): void
+    public function test_entries_missing_attribute_sort_first_for_descending(): void
     {
         $alice = $this->entry('cn=Alice,dc=example,dc=com', 'Alice');
         $noAttr = new Entry(new Dn('cn=NoAttr,dc=example,dc=com'));
 
         $sorted = $this->subject->sort(
-            [$noAttr, $alice],
+            [$alice, $noAttr],
             [SortKey::descending('cn')],
         );
 
+        self::assertNull($sorted[0]->get('cn'));
         self::assertSame(
             'Alice',
-            $sorted[0]->get('cn')?->getValues()[0],
+            $sorted[1]->get('cn')?->getValues()[0],
         );
-        self::assertNull($sorted[1]->get('cn'));
+    }
+
+    public function test_present_and_missing_entries_respect_reverse_order(): void
+    {
+        $alice = $this->entry('cn=Alice,dc=example,dc=com', 'Alice');
+        $charlie = $this->entry('cn=Charlie,dc=example,dc=com', 'Charlie');
+        $noAttr = new Entry(new Dn('cn=NoAttr,dc=example,dc=com'));
+
+        $sorted = $this->subject->sort(
+            [$alice, $noAttr, $charlie],
+            [SortKey::descending('cn')],
+        );
+
+        self::assertNull($sorted[0]->get('cn'));
+        self::assertSame(
+            ['', 'Charlie', 'Alice'],
+            $this->cnValues($sorted),
+        );
     }
 
     public function test_sort_cascades_through_multiple_keys(): void


### PR DESCRIPTION
This aligns server-side sort with what the RFC describes for how missing values should be ordered in sorts.