### PR TITLE
[1.0.0] Validate invalid attribute syntax based on the schema.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,11 @@
   "prefer-stable": true,
   "suggest": {
     "ext-openssl": "For SSL/TLS support and some SASL mechanisms.",
-    "ext-pcntl": "For LDAP server functionality.",
-    "ext-swoole": "For the SwooleServerRunner, enabling coroutine-based connection handling with shared in-memory storage."
+    "ext-pcntl": "For the LDAP server PcntlServerRunner functionality. Process forking based connection handling.",
+    "ext-swoole": "For the LDAP server SwooleServerRunner fucntionality. Coroutine-based connection handling.",
+    "ext-mbstring": "For the PDO based storage backends.",
+    "ext-pdo_sqlite": "For the SQLite storage backend.",
+    "ext-pdo_mysql": "For the MySQL storage backend."
   },
   "autoload": {
     "psr-4": {"FreeDSx\\Ldap\\": "src/FreeDSx/Ldap"}

--- a/src/FreeDSx/Ldap/Schema/Text.php
+++ b/src/FreeDSx/Ldap/Schema/Text.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema;
+
+/**
+ * Helpers for the character-encoding checks LDAP syntaxes rely on (without needing the full ext-mb extension).
+ */
+final class Text
+{
+    private function __construct() {}
+
+    /**
+     * Whether the value contains only ASCII (IA5) bytes.
+     */
+    public static function isAscii(string $value): bool
+    {
+        return preg_match('/[^\x00-\x7F]/', $value) === 0;
+    }
+
+    /**
+     * Whether the value is well-formed UTF-8.
+     */
+    public static function isUtf8(string $value): bool
+    {
+        return preg_match('//u', $value) === 1;
+    }
+
+    /**
+     * Counts UTF-8 code points; continuation bytes (0x80-0xBF) are not counted.
+     */
+    public static function lengthOf(string $value): int
+    {
+        return (int) preg_match_all('/[^\x80-\xBF]/', $value);
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
@@ -147,19 +147,92 @@ final class SchemaValidator
         Entry $entry,
         array $objectClasses,
     ): void {
-        foreach ($objectClasses as $oc) {
-            if ($oc->type === ObjectClassType::StructuralClass) {
-                return;
-            }
+        $structural = array_values(array_filter(
+            $objectClasses,
+            fn(ObjectClass $oc) => $oc->type === ObjectClassType::StructuralClass,
+        ));
+
+        if ($structural === []) {
+            $this->fail(
+                sprintf(
+                    'Entry "%s" must have at least one structural object class.',
+                    $entry->getDn()->toString(),
+                ),
+                ResultCode::OBJECT_CLASS_VIOLATION,
+            );
+        }
+
+        if ($this->hasSingleStructuralChain($structural)) {
+            return;
         }
 
         $this->fail(
             sprintf(
-                'Entry "%s" must have at least one structural object class.',
+                'Entry "%s" must not combine unrelated structural object classes.',
                 $entry->getDn()->toString(),
             ),
             ResultCode::OBJECT_CLASS_VIOLATION,
         );
+    }
+
+    /**
+     * Whether one structural class is the head of a single chain covering all the others.
+     *
+     * @param list<ObjectClass> $structural
+     */
+    private function hasSingleStructuralChain(array $structural): bool
+    {
+        foreach ($structural as $candidate) {
+            if ($this->coversAllStructural($candidate, $structural)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<ObjectClass> $structural
+     */
+    private function coversAllStructural(
+        ObjectClass $head,
+        array $structural,
+    ): bool {
+        $closure = $this->superclassClosure($head);
+
+        foreach ($structural as $oc) {
+            if (!isset($closure[$oc->oid])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array<string, true> OIDs of the class and its transitive superclasses
+     */
+    private function superclassClosure(ObjectClass $oc): array
+    {
+        $closure = [];
+        $queue = [$oc];
+
+        while ($queue !== []) {
+            $current = array_shift($queue);
+            if (isset($closure[$current->oid])) {
+                continue;
+            }
+
+            $closure[$current->oid] = true;
+            foreach ($current->superClassOids as $superOid) {
+                $super = $this->schema->getObjectClass($superOid);
+                if ($super !== null) {
+                    $queue[] = $super;
+                }
+            }
+        }
+
+        return $closure;
     }
 
     /**
@@ -204,8 +277,6 @@ final class SchemaValidator
                     sprintf('Undefined attribute type: "%s".', $attr->getName()),
                     ResultCode::UNDEFINED_ATTRIBUTE_TYPE,
                 );
-
-                continue;
             }
 
             if ($attrType->usage !== AttributeUsage::UserApplications) {
@@ -377,7 +448,7 @@ final class SchemaValidator
     private function fail(
         string $message,
         int $code,
-    ): void {
+    ): never {
         throw new OperationException(
             $message,
             $code,

--- a/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
@@ -13,15 +13,19 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Schema\Validation;
 
+use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Definition\AttributeType;
 use FreeDSx\Ldap\Schema\Definition\AttributeUsage;
 use FreeDSx\Ldap\Schema\Definition\ObjectClass;
 use FreeDSx\Ldap\Schema\Definition\ObjectClassType;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
+use FreeDSx\Ldap\Schema\Validation\Syntax\SyntaxValidatorInterface;
+use FreeDSx\Ldap\Schema\Validation\Syntax\SyntaxValidatorRegistry;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 
 /**
@@ -33,10 +37,15 @@ final class SchemaValidator
 {
     private const EXTENSIBLE_OBJECT = 'extensibleObject';
 
+    private readonly SyntaxValidatorRegistry $syntaxValidators;
+
     public function __construct(
         private readonly Schema $schema,
         private readonly SchemaValidationMode $mode,
-    ) {}
+        ?SyntaxValidatorRegistry $syntaxValidators = null,
+    ) {
+        $this->syntaxValidators = $syntaxValidators ?? SyntaxValidatorRegistry::default();
+    }
 
     public function mode(): SchemaValidationMode
     {
@@ -89,6 +98,8 @@ final class SchemaValidator
      */
     private function validateStructure(Entry $entry): void
     {
+        $this->checkAttributeSyntaxes($entry);
+
         if ($this->hasExtensibleObject($entry)) {
             $this->checkSingleValuedAttributes($entry);
 
@@ -236,6 +247,76 @@ final class SchemaValidator
                 ResultCode::CONSTRAINT_VIOLATION,
             );
         }
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function checkAttributeSyntaxes(Entry $entry): void
+    {
+        foreach ($entry->getAttributes() as $attr) {
+            $attrType = $this->schema->getAttributeType($attr->getName());
+            if ($attrType === null) {
+                continue;
+            }
+
+            $syntaxOid = $this->resolveSyntaxOid($attrType);
+            $validator = $syntaxOid === null
+                ? null
+                : $this->syntaxValidators->get($syntaxOid);
+            if ($validator === null) {
+                continue;
+            }
+
+            $this->checkValuesConform(
+                $attr,
+                $validator,
+            );
+        }
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function checkValuesConform(
+        Attribute $attr,
+        SyntaxValidatorInterface $validator,
+    ): void {
+        foreach ($attr->getValues() as $value) {
+            if ($validator->isValid($value)) {
+                continue;
+            }
+
+            $this->fail(
+                sprintf(
+                    'A value for attribute "%s" does not conform to its syntax.',
+                    $attr->getName(),
+                ),
+                ResultCode::INVALID_ATTRIBUTE_SYNTAX,
+            );
+        }
+    }
+
+    /**
+     * Resolves the effective syntax OID, walking the SUP chain when not set directly.
+     */
+    private function resolveSyntaxOid(AttributeType $type): ?string
+    {
+        $visited = [];
+        $current = $type;
+
+        while ($current !== null && !isset($visited[$current->oid])) {
+            if ($current->syntaxOid !== null) {
+                return $current->syntaxOid;
+            }
+
+            $visited[$current->oid] = true;
+            $current = $current->superTypeOid !== null
+                ? $this->schema->getAttributeType($current->superTypeOid)
+                : null;
+        }
+
+        return null;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/BitStringSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/BitStringSyntaxValidator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Validation\Syntax;
+
+/**
+ * Validates the Bit String syntax (RFC 4517 §3.3.2): binary digits quoted and suffixed with B.
+ *
+ * e.g. "'0101'B"
+ */
+final class BitStringSyntaxValidator implements SyntaxValidatorInterface
+{
+    private const PATTERN = "/^'[01]*'[Bb]$/";
+
+    public function isValid(string $value): bool
+    {
+        return preg_match(self::PATTERN, $value) === 1;
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/BooleanSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/BooleanSyntaxValidator.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Validation\Syntax;
+
+/**
+ * Validates the Boolean syntax (RFC 4517 §3.3.3): only the exact literals TRUE and FALSE.
+ *
+ * e.g. "TRUE"
+ */
+final class BooleanSyntaxValidator implements SyntaxValidatorInterface
+{
+    private const BOOLEAN_TRUE = 'TRUE';
+
+    private const BOOLEAN_FALSE = 'FALSE';
+
+    public function isValid(string $value): bool
+    {
+        return $value === self::BOOLEAN_TRUE
+            || $value === self::BOOLEAN_FALSE;
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/DistinguishedNameSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/DistinguishedNameSyntaxValidator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Validation\Syntax;
+
+use FreeDSx\Ldap\Entry\Dn;
+
+/**
+ * Validates the Distinguished Name syntax (RFC 4517 §3.3.9) by parsing the value as a DN.
+ *
+ * e.g. "cn=Alice,dc=example,dc=com"
+ */
+final class DistinguishedNameSyntaxValidator implements SyntaxValidatorInterface
+{
+    public function isValid(string $value): bool
+    {
+        return Dn::isValid($value);
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/GeneralizedTimeSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/GeneralizedTimeSyntaxValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Validation\Syntax;
+
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
+
+/**
+ * Validates the Generalized Time syntax (RFC 4517 §3.3.13) by delegating to the canonical parser.
+ *
+ * e.g. "20240101123000Z"
+ */
+final class GeneralizedTimeSyntaxValidator implements SyntaxValidatorInterface
+{
+    public function isValid(string $value): bool
+    {
+        try {
+            GeneralizedTime::parse($value);
+
+            return true;
+        } catch (InvalidArgumentException) {
+            return false;
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/Ia5StringSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/Ia5StringSyntaxValidator.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Schema\Validation\Syntax;
 
+use FreeDSx\Ldap\Schema\Text;
+
 /**
  * Validates the IA5 String syntax (RFC 4517 §3.3.15): characters from the ASCII (IA5) range only.
  *
@@ -22,9 +24,6 @@ final class Ia5StringSyntaxValidator implements SyntaxValidatorInterface
 {
     public function isValid(string $value): bool
     {
-        return mb_check_encoding(
-            $value,
-            'ASCII',
-        );
+        return Text::isAscii($value);
     }
 }

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/Ia5StringSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/Ia5StringSyntaxValidator.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Validation\Syntax;
+
+/**
+ * Validates the IA5 String syntax (RFC 4517 §3.3.15): characters from the ASCII (IA5) range only.
+ *
+ * e.g. "user@example.com"
+ */
+final class Ia5StringSyntaxValidator implements SyntaxValidatorInterface
+{
+    public function isValid(string $value): bool
+    {
+        return mb_check_encoding(
+            $value,
+            'ASCII',
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/IntegerSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/IntegerSyntaxValidator.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Validation\Syntax;
+
+/**
+ * Validates the Integer syntax (RFC 4517 §3.3.16): an optional minus sign with no leading zeros.
+ *
+ * e.g. "-42"
+ */
+final class IntegerSyntaxValidator implements SyntaxValidatorInterface
+{
+    public function isValid(string $value): bool
+    {
+        if ($value === '0') {
+            return true;
+        }
+
+        $digits = str_starts_with($value, '-')
+            ? substr($value, 1)
+            : $value;
+
+        return $digits !== ''
+            && $digits[0] !== '0'
+            && ctype_digit($digits);
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/NumericStringSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/NumericStringSyntaxValidator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Validation\Syntax;
+
+/**
+ * Validates the Numeric String syntax (RFC 4517 §3.3.23): one or more digits and spaces.
+ *
+ * e.g. "15 079 672 281"
+ */
+final class NumericStringSyntaxValidator implements SyntaxValidatorInterface
+{
+    private const PATTERN = '/^[0-9 ]+$/';
+
+    public function isValid(string $value): bool
+    {
+        return preg_match(self::PATTERN, $value) === 1;
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/OidSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/OidSyntaxValidator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Validation\Syntax;
+
+/**
+ * Validates the OID syntax (RFC 4517 §3.3.26): a numeric OID or a descriptor (keystring).
+ *
+ * e.g. "1.3.6.1.4.1.1466.115.121.1.15"
+ */
+final class OidSyntaxValidator implements SyntaxValidatorInterface
+{
+    private const PATTERN = '/^([0-9]+(\.[0-9]+)*|[A-Za-z][A-Za-z0-9-]*)$/';
+
+    public function isValid(string $value): bool
+    {
+        return preg_match(self::PATTERN, $value) === 1;
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/PrintableStringSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/PrintableStringSyntaxValidator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Validation\Syntax;
+
+/**
+ * Validates the Printable String syntax (RFC 4517 §3.3.27): one or more printable characters.
+ *
+ * e.g. "Example Co., Ltd."
+ */
+final class PrintableStringSyntaxValidator implements SyntaxValidatorInterface
+{
+    private const PATTERN = '/^[A-Za-z0-9\'()+,\-.\/:? =]+$/';
+
+    public function isValid(string $value): bool
+    {
+        return preg_match(self::PATTERN, $value) === 1;
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/SyntaxValidatorInterface.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/SyntaxValidatorInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Validation\Syntax;
+
+/**
+ * Validates that a single attribute value conforms to an LDAP syntax (RFC 4517).
+ */
+interface SyntaxValidatorInterface
+{
+    /**
+     * Whether the given attribute value conforms to this LDAP syntax.
+     */
+    public function isValid(string $value): bool;
+}

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/SyntaxValidatorRegistry.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/SyntaxValidatorRegistry.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Validation\Syntax;
+
+use FreeDSx\Ldap\Schema\Definition\SyntaxOid;
+
+/**
+ * Maps a syntax OID to the validator that enforces it, if any.
+ */
+final class SyntaxValidatorRegistry
+{
+    /**
+     * @param array<string, SyntaxValidatorInterface> $validators keyed by syntax OID
+     */
+    public function __construct(private readonly array $validators) {}
+
+    /**
+     * Builds a registry covering the syntaxes with crisp RFC 4517 rules.
+     */
+    public static function default(): self
+    {
+        return new self([
+            SyntaxOid::OID_INTEGER => new IntegerSyntaxValidator(),
+            SyntaxOid::OID_BOOLEAN => new BooleanSyntaxValidator(),
+            SyntaxOid::OID_GENERALIZED_TIME => new GeneralizedTimeSyntaxValidator(),
+            SyntaxOid::OID_DISTINGUISHED_NAME => new DistinguishedNameSyntaxValidator(),
+            SyntaxOid::OID_OID => new OidSyntaxValidator(),
+            SyntaxOid::OID_NUMERIC_STRING => new NumericStringSyntaxValidator(),
+            SyntaxOid::OID_PRINTABLE_STRING => new PrintableStringSyntaxValidator(),
+            SyntaxOid::OID_IA5_STRING => new Ia5StringSyntaxValidator(),
+            SyntaxOid::OID_BIT_STRING => new BitStringSyntaxValidator(),
+        ]);
+    }
+
+    /**
+     * Returns the validator for a syntax OID, or null when the syntax is unconstrained.
+     */
+    public function get(string $syntaxOid): ?SyntaxValidatorInterface
+    {
+        return $this->validators[$syntaxOid] ?? null;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/MysqlStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/MysqlStorage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter;
 
+use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\MysqlDialect;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactoryInterface;
@@ -76,6 +77,12 @@ final class MysqlStorage implements PdoStorageFactoryInterface
 
     protected function openConnection(PdoDialectInterface $dialect): PDO
     {
+        if (!extension_loaded('pdo_mysql')) {
+            throw new RuntimeException(
+                'The "pdo_mysql" extension is required for the MySQL storage backend.',
+            );
+        }
+
         $pdo = new PDO(
             $this->dsn,
             $this->username,

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -16,6 +16,8 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter;
 use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Schema\Text;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConnectionProviderInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoListQueryBuilder;
@@ -57,6 +59,12 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
         private readonly FilterTranslatorInterface $translator,
         private readonly PdoDialectInterface $dialect,
     ) {
+        if (!extension_loaded('mbstring')) {
+            throw new RuntimeException(
+                'The PDO storage backend requires the "mbstring" extension.',
+            );
+        }
+
         $this->queryBuilder = new PdoListQueryBuilder($dialect);
     }
 
@@ -249,7 +257,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface
 
     private function buildSidecarValueLower(string $value): string
     {
-        if (!mb_check_encoding($value, 'UTF-8')) {
+        if (!Text::isUtf8($value)) {
             return '';
         }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter;
 
+use FreeDSx\Ldap\Schema\Text;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\InvalidAttributeException;
 use FreeDSx\Ldap\Search\Filter\AndFilter;
 use FreeDSx\Ldap\Search\Filter\ApproximateFilter;
@@ -179,9 +180,9 @@ trait SqlFilterTranslatorTrait
 
     private function isExactEquality(string $value): bool
     {
-        return SqlFilterUtility::isAscii($value)
-            && mb_check_encoding($value, 'UTF-8')
-            && mb_strlen($value, 'UTF-8') <= SqlFilterUtility::MAX_INDEXED_VALUE_CHARS;
+        return Text::isAscii($value)
+            && Text::isUtf8($value)
+            && Text::lengthOf($value) <= SqlFilterUtility::MAX_INDEXED_VALUE_CHARS;
     }
 
     /**
@@ -189,10 +190,10 @@ trait SqlFilterTranslatorTrait
      */
     private function isExactOrdered(string $value): bool
     {
-        return SqlFilterUtility::isAscii($value)
+        return Text::isAscii($value)
             && !ctype_digit($value)
-            && mb_check_encoding($value, 'UTF-8')
-            && mb_strlen($value, 'UTF-8') <= SqlFilterUtility::MAX_INDEXED_VALUE_CHARS;
+            && Text::isUtf8($value)
+            && Text::lengthOf($value) <= SqlFilterUtility::MAX_INDEXED_VALUE_CHARS;
     }
 
     /**
@@ -211,9 +212,9 @@ trait SqlFilterTranslatorTrait
             return false;
         }
 
-        return SqlFilterUtility::isAscii($startsWith)
-            && mb_check_encoding($startsWith, 'UTF-8')
-            && mb_strlen($startsWith, 'UTF-8') <= SqlFilterUtility::MAX_INDEXED_VALUE_CHARS;
+        return Text::isAscii($startsWith)
+            && Text::isUtf8($startsWith)
+            && Text::lengthOf($startsWith) <= SqlFilterUtility::MAX_INDEXED_VALUE_CHARS;
     }
 
     /**
@@ -221,7 +222,7 @@ trait SqlFilterTranslatorTrait
      */
     private function prepareMatchValue(string $value): string
     {
-        if (!mb_check_encoding($value, 'UTF-8')) {
+        if (!Text::isUtf8($value)) {
             return '';
         }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterUtility.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterUtility.php
@@ -36,15 +36,4 @@ final class SqlFilterUtility
             $value,
         );
     }
-
-    /**
-     * True when $value is 7-bit ASCII.
-     */
-    public static function isAscii(string $value): bool
-    {
-        return preg_match(
-            '/[\x80-\xff]/',
-            $value,
-        ) !== 1;
-    }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqliteStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqliteStorage.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter;
 
 use Closure;
+use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SqliteDialect;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactoryInterface;
@@ -77,6 +78,12 @@ final class SqliteStorage implements PdoStorageFactoryInterface
 
     protected function openConnection(PdoDialectInterface $dialect): PDO
     {
+        if (!extension_loaded('pdo_sqlite')) {
+            throw new RuntimeException(
+                'The "pdo_sqlite" extension is required for the SQLite storage backend.',
+            );
+        }
+
         $pdo = new PDO(
             self::DB_CONNECTION_PREFIX . $this->dbPath,
             null,

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -321,7 +321,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         OperationException $violation,
         WriteContext $context,
     ): void {
-        $disposition = $this->dispositionFor($context);
+        $disposition = $this->dispositionFor(
+            $violation,
+            $context,
+        );
         $context->schemaViolations()->record(
             $violation,
             $disposition,
@@ -332,8 +335,14 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         }
     }
 
-    private function dispositionFor(WriteContext $context): SchemaViolationDisposition
-    {
+    private function dispositionFor(
+        OperationException $violation,
+        WriteContext $context,
+    ): SchemaViolationDisposition {
+        if ($violation->getCode() === ResultCode::INVALID_ATTRIBUTE_SYNTAX) {
+            return SchemaViolationDisposition::Rejected;
+        }
+
         if ($context->getControls()->has(Control::OID_RELAX_RULES)) {
             return SchemaViolationDisposition::RelaxedByControl;
         }

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/QualityCheck/DefaultPasswordQualityChecker.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/QualityCheck/DefaultPasswordQualityChecker.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck;
 
 use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Schema\Text;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
 use SensitiveParameter;
 
@@ -32,7 +33,7 @@ final class DefaultPasswordQualityChecker implements PasswordQualityCheckerInter
             return null;
         }
 
-        $length = mb_strlen($plain);
+        $length = Text::lengthOf($plain);
 
         if ($rules->minLength !== null && $length < $rules->minLength) {
             return PwdPolicyError::PASSWORD_TOO_SHORT;

--- a/tests/integration/Schema/LdapRelaxControlTest.php
+++ b/tests/integration/Schema/LdapRelaxControlTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Integration\FreeDSx\Ldap\Storage;
+namespace Tests\Integration\FreeDSx\Ldap\Schema;
 
 use FreeDSx\Ldap\Controls;
 use FreeDSx\Ldap\Entry\Entry;
@@ -102,5 +102,26 @@ final class LdapRelaxControlTest extends ServerTestCase
                 'mail' => 'relax-rejected@foo.bar',
             ],
         ));
+    }
+
+    public function test_relax_control_does_not_bypass_invalid_attribute_syntax(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
+
+        $this->ldapClient()->create(
+            Entry::fromArray(
+                'cn=relax-bad-syntax,dc=foo,dc=bar',
+                [
+                    'cn' => 'relax-bad-syntax',
+                    'sn' => 'Drift',
+                    'objectClass' => 'person',
+                    'seeAlso' => 'not a dn',
+                ],
+            ),
+            Controls::relaxRules(),
+        );
     }
 }

--- a/tests/integration/Schema/LdapSchemaConstraintTest.php
+++ b/tests/integration/Schema/LdapSchemaConstraintTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Schema;
+
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+
+/**
+ * End-to-end rejection of malformed values and conflicting structural classes under Strict validation.
+ */
+final class LdapSchemaConstraintTest extends ServerTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        if (!extension_loaded('pcntl')) {
+            return;
+        }
+
+        static::initSharedServer(
+            'ldap-backend-storage',
+            'tcp',
+            ['--validation-mode=strict'],
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        static::tearDownSharedServer();
+    }
+
+    public function setUp(): void
+    {
+        $this->setServerMode('ldap-backend-storage');
+
+        parent::setUp();
+    }
+
+    public function test_add_with_invalid_attribute_syntax_is_rejected(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=bad-syntax,dc=foo,dc=bar',
+            [
+                'cn' => 'bad-syntax',
+                'sn' => 'Smith',
+                'objectClass' => 'person',
+                'seeAlso' => 'not a dn',
+            ],
+        ));
+    }
+
+    public function test_add_with_two_unrelated_structural_classes_is_rejected(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=two-structural,dc=foo,dc=bar',
+            [
+                'cn' => 'two-structural',
+                'sn' => 'Smith',
+                'ou' => 'People',
+                'objectClass' => ['person', 'organizationalUnit'],
+            ],
+        ));
+    }
+}

--- a/tests/integration/Schema/LdapSchemaValidationTest.php
+++ b/tests/integration/Schema/LdapSchemaValidationTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Integration\FreeDSx\Ldap\Storage;
+namespace Tests\Integration\FreeDSx\Ldap\Schema;
 
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operations;

--- a/tests/unit/Schema/TextTest.php
+++ b/tests/unit/Schema/TextTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema;
+
+use FreeDSx\Ldap\Schema\Text;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class TextTest extends TestCase
+{
+    #[DataProvider('asciiProvider')]
+    public function test_is_ascii(
+        string $value,
+        bool $expected,
+    ): void {
+        self::assertSame(
+            $expected,
+            Text::isAscii($value),
+        );
+    }
+
+    #[DataProvider('utf8Provider')]
+    public function test_is_utf8(
+        string $value,
+        bool $expected,
+    ): void {
+        self::assertSame(
+            $expected,
+            Text::isUtf8($value),
+        );
+    }
+
+    #[DataProvider('lengthProvider')]
+    public function test_length_of(
+        string $value,
+        int $expected,
+    ): void {
+        self::assertSame(
+            $expected,
+            Text::lengthOf($value),
+        );
+    }
+
+    /**
+     * @return array<string, array{string, bool}>
+     */
+    public static function asciiProvider(): array
+    {
+        return [
+            'plain ascii' => ['user@example.com', true],
+            'empty' => ['', true],
+            'control characters' => ["tab\tnewline\n", true],
+            'accented letter' => ['café', false],
+            'emoji' => ['😀', false],
+            'high byte' => ["\xFF", false],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, bool}>
+     */
+    public static function utf8Provider(): array
+    {
+        return [
+            'plain ascii' => ['plain', true],
+            'empty' => ['', true],
+            'multibyte' => ['café', true],
+            'emoji' => ['😀', true],
+            'high byte' => ["\xFF", false],
+            'invalid two byte sequence' => ["\xC3\x28", false],
+            'lone continuation byte' => ["\x80", false],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string, int}>
+     */
+    public static function lengthProvider(): array
+    {
+        return [
+            'ascii' => ['hello', 5],
+            'empty' => ['', 0],
+            'accented counts as one code point' => ['café', 4],
+            'emoji counts as one code point' => ['😀', 1],
+            'mixed' => ['a😀b', 3],
+        ];
+    }
+}

--- a/tests/unit/Schema/Validation/SchemaValidatorTest.php
+++ b/tests/unit/Schema/Validation/SchemaValidatorTest.php
@@ -19,6 +19,11 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Definition\AttributeType;
+use FreeDSx\Ldap\Schema\Definition\ObjectClass;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassType;
+use FreeDSx\Ldap\Schema\Definition\SyntaxOid;
+use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Schema\StandardSchemaProvider;
 use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
@@ -44,6 +49,48 @@ final class SchemaValidatorTest extends TestCase
             new Attribute('objectClass', 'top', 'person'),
             new Attribute('cn', 'Alice'),
             new Attribute('sn', 'Smith'),
+        );
+    }
+
+    private function syntaxValidator(): SchemaValidator
+    {
+        $schema = (new Schema())
+            ->addAttributeType(new AttributeType(
+                '1.5',
+                ['objectClass'],
+                syntaxOid: SyntaxOid::OID_OID,
+            ))
+            ->addAttributeType(new AttributeType(
+                '1.10',
+                ['widgetCount'],
+                syntaxOid: SyntaxOid::OID_INTEGER,
+            ))
+            ->addAttributeType(new AttributeType(
+                '1.11',
+                ['widgetOwner'],
+                syntaxOid: SyntaxOid::OID_DISTINGUISHED_NAME,
+            ))
+            ->addAttributeType(new AttributeType(
+                '1.12',
+                ['widgetSeenAt'],
+                syntaxOid: SyntaxOid::OID_GENERALIZED_TIME,
+            ))
+            ->addAttributeType(new AttributeType(
+                '1.13',
+                ['widgetActive'],
+                syntaxOid: SyntaxOid::OID_BOOLEAN,
+            ))
+            ->addObjectClass(new ObjectClass(
+                '2.10',
+                ['widget'],
+                ObjectClassType::StructuralClass,
+                must: ['objectClass'],
+                may: ['widgetCount', 'widgetOwner', 'widgetSeenAt', 'widgetActive'],
+            ));
+
+        return new SchemaValidator(
+            $schema,
+            SchemaValidationMode::Strict,
         );
     }
 
@@ -286,6 +333,101 @@ final class SchemaValidatorTest extends TestCase
         $this->subject->validateModify(
             $command,
             $result,
+            isSystem: true,
+        );
+    }
+
+    public function test_add_invalid_integer_value_throws_invalid_attribute_syntax(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Widget,dc=example,dc=com'),
+            new Attribute('objectClass', 'widget'),
+            new Attribute('widgetCount', 'not-a-number'),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
+
+        $this->syntaxValidator()->validateAdd($entry);
+    }
+
+    public function test_add_invalid_distinguished_name_value_throws_invalid_attribute_syntax(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Widget,dc=example,dc=com'),
+            new Attribute('objectClass', 'widget'),
+            new Attribute('widgetOwner', 'not a dn'),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
+
+        $this->syntaxValidator()->validateAdd($entry);
+    }
+
+    public function test_add_with_conforming_values_passes(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Widget,dc=example,dc=com'),
+            new Attribute('objectClass', 'widget'),
+            new Attribute('widgetCount', '42'),
+            new Attribute('widgetOwner', 'cn=Owner,dc=example,dc=com'),
+            new Attribute('widgetSeenAt', '20240101000000Z'),
+            new Attribute('widgetActive', 'TRUE'),
+        );
+
+        $this->expectNotToPerformAssertions();
+        $this->syntaxValidator()->validateAdd($entry);
+    }
+
+    public function test_modify_invalid_generalized_time_throws_invalid_attribute_syntax(): void
+    {
+        $command = new UpdateCommand(
+            new Dn('cn=Widget,dc=example,dc=com'),
+            [Change::replace(new Attribute('widgetSeenAt', 'not-a-time'))],
+        );
+        $result = new Entry(
+            new Dn('cn=Widget,dc=example,dc=com'),
+            new Attribute('objectClass', 'widget'),
+            new Attribute('widgetSeenAt', 'not-a-time'),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
+
+        $this->syntaxValidator()->validateModify(
+            $command,
+            $result,
+        );
+    }
+
+    public function test_extensible_object_still_validates_value_syntax(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Widget,dc=example,dc=com'),
+            new Attribute('objectClass', 'extensibleObject'),
+            new Attribute('widgetCount', 'not-a-number'),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
+
+        $this->syntaxValidator()->validateAdd($entry);
+    }
+
+    public function test_system_add_still_validates_value_syntax(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Widget,dc=example,dc=com'),
+            new Attribute('objectClass', 'widget'),
+            new Attribute('widgetCount', 'not-a-number'),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
+
+        $this->syntaxValidator()->validateAdd(
+            $entry,
             isSystem: true,
         );
     }

--- a/tests/unit/Schema/Validation/SchemaValidatorTest.php
+++ b/tests/unit/Schema/Validation/SchemaValidatorTest.php
@@ -431,4 +431,66 @@ final class SchemaValidatorTest extends TestCase
             isSystem: true,
         );
     }
+
+    private function structuralChainValidator(): SchemaValidator
+    {
+        $schema = (new Schema())
+            ->addAttributeType(new AttributeType(
+                '1.5',
+                ['objectClass'],
+            ))
+            ->addObjectClass(new ObjectClass(
+                '2.0',
+                ['top'],
+                ObjectClassType::AbstractClass,
+                must: ['objectClass'],
+            ))
+            ->addObjectClass(new ObjectClass(
+                '2.1',
+                ['alpha'],
+                ObjectClassType::StructuralClass,
+                superClassOids: ['2.0'],
+            ))
+            ->addObjectClass(new ObjectClass(
+                '2.2',
+                ['alphaChild'],
+                ObjectClassType::StructuralClass,
+                superClassOids: ['2.1'],
+            ))
+            ->addObjectClass(new ObjectClass(
+                '2.3',
+                ['beta'],
+                ObjectClassType::StructuralClass,
+                superClassOids: ['2.0'],
+            ));
+
+        return new SchemaValidator(
+            $schema,
+            SchemaValidationMode::Strict,
+        );
+    }
+
+    public function test_add_structural_chain_passes(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Thing,dc=example,dc=com'),
+            new Attribute('objectClass', 'top', 'alpha', 'alphaChild'),
+        );
+
+        $this->expectNotToPerformAssertions();
+        $this->structuralChainValidator()->validateAdd($entry);
+    }
+
+    public function test_add_two_unrelated_structural_classes_throws_object_class_violation(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Thing,dc=example,dc=com'),
+            new Attribute('objectClass', 'top', 'alpha', 'beta'),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
+
+        $this->structuralChainValidator()->validateAdd($entry);
+    }
 }

--- a/tests/unit/Schema/Validation/Syntax/BitStringSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/BitStringSyntaxValidatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Validation\Syntax;
+
+use FreeDSx\Ldap\Schema\Validation\Syntax\BitStringSyntaxValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class BitStringSyntaxValidatorTest extends TestCase
+{
+    private BitStringSyntaxValidator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new BitStringSyntaxValidator();
+    }
+
+    #[DataProvider('validValuesProvider')]
+    public function test_it_accepts_quoted_binary_digits(string $value): void
+    {
+        self::assertTrue($this->subject->isValid($value));
+    }
+
+    #[DataProvider('invalidValuesProvider')]
+    public function test_it_rejects_malformed_bit_strings(string $value): void
+    {
+        self::assertFalse($this->subject->isValid($value));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function validValuesProvider(): array
+    {
+        return [
+            'uppercase suffix' => ["'0101'B"],
+            'lowercase suffix' => ["'0101'b"],
+            'single bit' => ["'1'B"],
+            'empty bit string' => ["''B"],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidValuesProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'missing quotes' => ['0101'],
+            'missing suffix' => ["'0101'"],
+            'non binary digit' => ["'012'B"],
+            'wrong suffix letter' => ["'0101'X"],
+        ];
+    }
+}

--- a/tests/unit/Schema/Validation/Syntax/BooleanSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/BooleanSyntaxValidatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Validation\Syntax;
+
+use FreeDSx\Ldap\Schema\Validation\Syntax\BooleanSyntaxValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class BooleanSyntaxValidatorTest extends TestCase
+{
+    private BooleanSyntaxValidator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new BooleanSyntaxValidator();
+    }
+
+    #[DataProvider('validValuesProvider')]
+    public function test_it_accepts_the_exact_boolean_literals(string $value): void
+    {
+        self::assertTrue($this->subject->isValid($value));
+    }
+
+    #[DataProvider('invalidValuesProvider')]
+    public function test_it_rejects_anything_else(string $value): void
+    {
+        self::assertFalse($this->subject->isValid($value));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function validValuesProvider(): array
+    {
+        return [
+            'true' => ['TRUE'],
+            'false' => ['FALSE'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidValuesProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'lowercase true' => ['true'],
+            'mixed case false' => ['False'],
+            'yes' => ['yes'],
+            'numeric one' => ['1'],
+            'numeric zero' => ['0'],
+            'trailing space' => ['TRUE '],
+        ];
+    }
+}

--- a/tests/unit/Schema/Validation/Syntax/DistinguishedNameSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/DistinguishedNameSyntaxValidatorTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Validation\Syntax;
+
+use FreeDSx\Ldap\Schema\Validation\Syntax\DistinguishedNameSyntaxValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DistinguishedNameSyntaxValidatorTest extends TestCase
+{
+    private DistinguishedNameSyntaxValidator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new DistinguishedNameSyntaxValidator();
+    }
+
+    #[DataProvider('validValuesProvider')]
+    public function test_it_accepts_valid_distinguished_names(string $value): void
+    {
+        self::assertTrue($this->subject->isValid($value));
+    }
+
+    #[DataProvider('invalidValuesProvider')]
+    public function test_it_rejects_invalid_distinguished_names(string $value): void
+    {
+        self::assertFalse($this->subject->isValid($value));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function validValuesProvider(): array
+    {
+        return [
+            'multi rdn' => ['cn=Alice,dc=example,dc=com'],
+            'single rdn' => ['dc=example'],
+            'multivalued rdn' => ['cn=Alice+sn=Smith,dc=example'],
+            'empty is the root dse dn' => [''],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidValuesProvider(): array
+    {
+        return [
+            'free text' => ['not a dn'],
+            'no assertion' => ['foo'],
+            'trailing rdn without value' => ['cn=Alice,com'],
+        ];
+    }
+}

--- a/tests/unit/Schema/Validation/Syntax/GeneralizedTimeSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/GeneralizedTimeSyntaxValidatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Validation\Syntax;
+
+use FreeDSx\Ldap\Schema\Validation\Syntax\GeneralizedTimeSyntaxValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class GeneralizedTimeSyntaxValidatorTest extends TestCase
+{
+    private GeneralizedTimeSyntaxValidator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new GeneralizedTimeSyntaxValidator();
+    }
+
+    #[DataProvider('validValuesProvider')]
+    public function test_it_accepts_valid_generalized_time(string $value): void
+    {
+        self::assertTrue($this->subject->isValid($value));
+    }
+
+    #[DataProvider('invalidValuesProvider')]
+    public function test_it_rejects_invalid_generalized_time(string $value): void
+    {
+        self::assertFalse($this->subject->isValid($value));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function validValuesProvider(): array
+    {
+        return [
+            'utc' => ['20240101123000Z'],
+            'numeric offset' => ['20240101123000+0500'],
+            'hour precision' => ['2024010112Z'],
+            'fractional seconds' => ['20240101123000.5Z'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidValuesProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'year only' => ['2024'],
+            'not a time' => ['notatime'],
+            'missing zone' => ['20240101123000'],
+            'invalid month' => ['20241301010000Z'],
+        ];
+    }
+}

--- a/tests/unit/Schema/Validation/Syntax/Ia5StringSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/Ia5StringSyntaxValidatorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Validation\Syntax;
+
+use FreeDSx\Ldap\Schema\Validation\Syntax\Ia5StringSyntaxValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class Ia5StringSyntaxValidatorTest extends TestCase
+{
+    private Ia5StringSyntaxValidator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Ia5StringSyntaxValidator();
+    }
+
+    #[DataProvider('validValuesProvider')]
+    public function test_it_accepts_ascii_only_values(string $value): void
+    {
+        self::assertTrue($this->subject->isValid($value));
+    }
+
+    #[DataProvider('invalidValuesProvider')]
+    public function test_it_rejects_non_ascii_values(string $value): void
+    {
+        self::assertFalse($this->subject->isValid($value));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function validValuesProvider(): array
+    {
+        return [
+            'email' => ['user@example.com'],
+            'ascii punctuation' => ['plain ascii !@#$%^&*()'],
+            'empty is permitted' => [''],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidValuesProvider(): array
+    {
+        return [
+            'accented letter' => ['café'],
+            'diaeresis' => ['naïve'],
+            'emoji' => ['hello 😀'],
+        ];
+    }
+}

--- a/tests/unit/Schema/Validation/Syntax/IntegerSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/IntegerSyntaxValidatorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Validation\Syntax;
+
+use FreeDSx\Ldap\Schema\Validation\Syntax\IntegerSyntaxValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class IntegerSyntaxValidatorTest extends TestCase
+{
+    private IntegerSyntaxValidator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new IntegerSyntaxValidator();
+    }
+
+    #[DataProvider('validValuesProvider')]
+    public function test_it_accepts_valid_integers(string $value): void
+    {
+        self::assertTrue($this->subject->isValid($value));
+    }
+
+    #[DataProvider('invalidValuesProvider')]
+    public function test_it_rejects_invalid_integers(string $value): void
+    {
+        self::assertFalse($this->subject->isValid($value));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function validValuesProvider(): array
+    {
+        return [
+            'zero' => ['0'],
+            'positive' => ['42'],
+            'negative' => ['-42'],
+            'arbitrary precision' => ['123456789012345678901234567890'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidValuesProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'alpha' => ['abc'],
+            'leading zero' => ['007'],
+            'negative zero' => ['-0'],
+            'decimal' => ['1.5'],
+            'plus sign' => ['+5'],
+            'space between sign and digits' => ['- 5'],
+            'leading space' => [' 5'],
+            'trailing space' => ['5 '],
+            'trailing text' => ['12abc'],
+        ];
+    }
+}

--- a/tests/unit/Schema/Validation/Syntax/NumericStringSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/NumericStringSyntaxValidatorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Validation\Syntax;
+
+use FreeDSx\Ldap\Schema\Validation\Syntax\NumericStringSyntaxValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class NumericStringSyntaxValidatorTest extends TestCase
+{
+    private NumericStringSyntaxValidator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new NumericStringSyntaxValidator();
+    }
+
+    #[DataProvider('validValuesProvider')]
+    public function test_it_accepts_digits_and_spaces(string $value): void
+    {
+        self::assertTrue($this->subject->isValid($value));
+    }
+
+    #[DataProvider('invalidValuesProvider')]
+    public function test_it_rejects_non_numeric_characters(string $value): void
+    {
+        self::assertFalse($this->subject->isValid($value));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function validValuesProvider(): array
+    {
+        return [
+            'digits' => ['12345'],
+            'grouped with spaces' => ['15 079 672 281'],
+            'single zero' => ['0'],
+            'spaces only are permitted by the abnf' => ['   '],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidValuesProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'embedded letter' => ['12a45'],
+            'hyphen' => ['12-34'],
+            'decimal point' => ['12.34'],
+        ];
+    }
+}

--- a/tests/unit/Schema/Validation/Syntax/OidSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/OidSyntaxValidatorTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Validation\Syntax;
+
+use FreeDSx\Ldap\Schema\Validation\Syntax\OidSyntaxValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class OidSyntaxValidatorTest extends TestCase
+{
+    private OidSyntaxValidator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new OidSyntaxValidator();
+    }
+
+    #[DataProvider('validValuesProvider')]
+    public function test_it_accepts_numeric_oids_and_descriptors(string $value): void
+    {
+        self::assertTrue($this->subject->isValid($value));
+    }
+
+    #[DataProvider('invalidValuesProvider')]
+    public function test_it_rejects_malformed_oids(string $value): void
+    {
+        self::assertFalse($this->subject->isValid($value));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function validValuesProvider(): array
+    {
+        return [
+            'numeric oid' => ['1.3.6.1.4.1.1466.115.121.1.15'],
+            'short numeric oid' => ['2.5.4.3'],
+            'descriptor' => ['cn'],
+            'descriptor with digits and hyphen' => ['x-my-attr2'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidValuesProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'leading dot' => ['.1.2'],
+            'double dot' => ['1..2'],
+            'trailing dot' => ['1.2.'],
+            'descriptor starting with digit' => ['1cn'],
+            'descriptor with underscore' => ['cn_x'],
+            'with space' => ['1.2 3'],
+        ];
+    }
+}

--- a/tests/unit/Schema/Validation/Syntax/PrintableStringSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/PrintableStringSyntaxValidatorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Validation\Syntax;
+
+use FreeDSx\Ldap\Schema\Validation\Syntax\PrintableStringSyntaxValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PrintableStringSyntaxValidatorTest extends TestCase
+{
+    private PrintableStringSyntaxValidator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new PrintableStringSyntaxValidator();
+    }
+
+    #[DataProvider('validValuesProvider')]
+    public function test_it_accepts_printable_characters(string $value): void
+    {
+        self::assertTrue($this->subject->isValid($value));
+    }
+
+    #[DataProvider('invalidValuesProvider')]
+    public function test_it_rejects_non_printable_characters(string $value): void
+    {
+        self::assertFalse($this->subject->isValid($value));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function validValuesProvider(): array
+    {
+        return [
+            'words' => ['Hello World'],
+            'punctuation subset' => ['Example Co., Ltd.'],
+            'apostrophe and digits' => ["abc'123"],
+            'operators' => ['a+b=c'],
+            'parentheses and question mark' => ['(who?)'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidValuesProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'hash' => ['hash#'],
+            'at sign' => ['user@host'],
+            'asterisk' => ['a*b'],
+            'non ascii letter' => ['unicodé'],
+        ];
+    }
+}

--- a/tests/unit/Schema/Validation/Syntax/SyntaxValidatorRegistryTest.php
+++ b/tests/unit/Schema/Validation/Syntax/SyntaxValidatorRegistryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Validation\Syntax;
+
+use FreeDSx\Ldap\Schema\Definition\SyntaxOid;
+use FreeDSx\Ldap\Schema\Validation\Syntax\BooleanSyntaxValidator;
+use FreeDSx\Ldap\Schema\Validation\Syntax\IntegerSyntaxValidator;
+use FreeDSx\Ldap\Schema\Validation\Syntax\SyntaxValidatorInterface;
+use FreeDSx\Ldap\Schema\Validation\Syntax\SyntaxValidatorRegistry;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class SyntaxValidatorRegistryTest extends TestCase
+{
+    #[DataProvider('constrainedSyntaxProvider')]
+    public function test_default_provides_a_validator_for_constrained_syntaxes(string $syntaxOid): void
+    {
+        self::assertInstanceOf(
+            SyntaxValidatorInterface::class,
+            SyntaxValidatorRegistry::default()->get($syntaxOid),
+        );
+    }
+
+    public function test_default_returns_null_for_a_permissive_syntax(): void
+    {
+        self::assertNull(SyntaxValidatorRegistry::default()->get(SyntaxOid::OID_OCTET_STRING));
+    }
+
+    public function test_default_returns_null_for_an_unknown_syntax(): void
+    {
+        self::assertNull(SyntaxValidatorRegistry::default()->get('1.2.3.4.5.6.7.8.9'));
+    }
+
+    public function test_it_uses_the_validators_it_is_constructed_with(): void
+    {
+        $integer = new IntegerSyntaxValidator();
+        $registry = new SyntaxValidatorRegistry([SyntaxOid::OID_INTEGER => $integer]);
+
+        self::assertSame(
+            $integer,
+            $registry->get(SyntaxOid::OID_INTEGER),
+        );
+        self::assertNull($registry->get(SyntaxOid::OID_BOOLEAN));
+    }
+
+    public function test_default_maps_each_syntax_to_its_matching_validator(): void
+    {
+        self::assertInstanceOf(
+            BooleanSyntaxValidator::class,
+            SyntaxValidatorRegistry::default()->get(SyntaxOid::OID_BOOLEAN),
+        );
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function constrainedSyntaxProvider(): array
+    {
+        return [
+            'integer' => [SyntaxOid::OID_INTEGER],
+            'boolean' => [SyntaxOid::OID_BOOLEAN],
+            'generalized time' => [SyntaxOid::OID_GENERALIZED_TIME],
+            'distinguished name' => [SyntaxOid::OID_DISTINGUISHED_NAME],
+            'oid' => [SyntaxOid::OID_OID],
+            'numeric string' => [SyntaxOid::OID_NUMERIC_STRING],
+            'printable string' => [SyntaxOid::OID_PRINTABLE_STRING],
+            'ia5 string' => [SyntaxOid::OID_IA5_STRING],
+            'bit string' => [SyntaxOid::OID_BIT_STRING],
+        ];
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
@@ -1113,6 +1113,94 @@ final class WritableStorageBackendTest extends TestCase
         );
     }
 
+    public function test_relax_control_does_not_relax_invalid_attribute_syntax(): void
+    {
+        $backend = new WritableStorageBackend(
+            storage: new InMemoryStorage([$this->base]),
+            validator: new SchemaValidator(
+                StandardSchemaProvider::buildCore(),
+                SchemaValidationMode::Strict,
+            ),
+        );
+        $violations = new SchemaViolations();
+
+        $code = null;
+        try {
+            $backend->add(
+                new AddCommand(new Entry(
+                    new Dn('cn=Alice,dc=example,dc=com'),
+                    new Attribute('objectClass', 'top', 'person'),
+                    new Attribute('cn', 'Alice'),
+                    new Attribute('sn', 'Smith'),
+                    new Attribute('seeAlso', 'not a dn'),
+                )),
+                new WriteContext(
+                    new AnonToken(),
+                    new ControlBag(Controls::relaxRules()),
+                    schemaViolations: $violations,
+                ),
+            );
+        } catch (OperationException $e) {
+            $code = $e->getCode();
+        }
+
+        self::assertSame(
+            ResultCode::INVALID_ATTRIBUTE_SYNTAX,
+            $code,
+        );
+        self::assertNull(
+            $backend->get(new Dn('cn=Alice,dc=example,dc=com')),
+        );
+        self::assertSame(
+            SchemaViolationDisposition::Rejected,
+            $violations->all()[0]->disposition,
+        );
+    }
+
+    public function test_lenient_validator_does_not_relax_invalid_attribute_syntax(): void
+    {
+        $backend = new WritableStorageBackend(
+            storage: new InMemoryStorage([$this->base]),
+            validator: new SchemaValidator(
+                StandardSchemaProvider::buildCore(),
+                SchemaValidationMode::Lenient,
+            ),
+        );
+        $violations = new SchemaViolations();
+
+        $code = null;
+        try {
+            $backend->add(
+                new AddCommand(new Entry(
+                    new Dn('cn=Alice,dc=example,dc=com'),
+                    new Attribute('objectClass', 'top', 'person'),
+                    new Attribute('cn', 'Alice'),
+                    new Attribute('sn', 'Smith'),
+                    new Attribute('seeAlso', 'not a dn'),
+                )),
+                new WriteContext(
+                    new AnonToken(),
+                    new ControlBag(),
+                    schemaViolations: $violations,
+                ),
+            );
+        } catch (OperationException $e) {
+            $code = $e->getCode();
+        }
+
+        self::assertSame(
+            ResultCode::INVALID_ATTRIBUTE_SYNTAX,
+            $code,
+        );
+        self::assertNull(
+            $backend->get(new Dn('cn=Alice,dc=example,dc=com')),
+        );
+        self::assertSame(
+            SchemaViolationDisposition::Rejected,
+            $violations->all()[0]->disposition,
+        );
+    }
+
     public function test_system_update_bypasses_no_user_modification_check(): void
     {
         $valid = new Entry(


### PR DESCRIPTION
A few things going on here:

* Adds actual value validation on add / modify based on the defined schema.
* Validates entries have a single structural class chain.
* Makes `ext-mb` a suggested requirement. Enforces it for PDO based backends.
