### PR TITLE
[1.0.0] Implement RFC 4518 string preparation for matching comparators.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,9 @@
     "ext-swoole": "For the LDAP server SwooleServerRunner fucntionality. Coroutine-based connection handling.",
     "ext-mbstring": "For the PDO based storage backends.",
     "ext-pdo_sqlite": "For the SQLite storage backend.",
-    "ext-pdo_mysql": "For the MySQL storage backend."
+    "ext-pdo_mysql": "For the MySQL storage backend.",
+    "symfony/polyfill-intl-normalizer": "Deterministic Unicode NFKC normalization (RFC 4518) for string matching when ext-intl is absent.",
+    "symfony/polyfill-mbstring": "Unicode-aware case folding (RFC 4518) for string matching when ext-mbstring is absent."
   },
   "autoload": {
     "psr-4": {"FreeDSx\\Ldap\\": "src/FreeDSx/Ldap"}

--- a/docs/Server/Schema.md
+++ b/docs/Server/Schema.md
@@ -10,6 +10,7 @@ Schema Validation
 * [Custom Schema](#custom-schema)
     * [ServerOptions:setSchema](#setschema)
 * [Operational Attributes](#operational-attributes)
+* [String Matching and Internationalization (RFC 4518)](#string-matching-and-internationalization-rfc-4518)
 
 Calling `LdapServer::useStorage()` automatically enables schema validation using the built-in RFC 4519
 schema in `Strict` mode.
@@ -163,3 +164,37 @@ attributes remain unchanged.
 **`hasSubordinates` (dynamic):** Never stored. Injected into search results when requested via the `+` shorthand
 or by name. Value is `TRUE` if the entry has at least one direct child, `FALSE` otherwise.
 ```
+
+## String Matching and Internationalization (RFC 4518)
+
+String matching rules (`caseIgnoreMatch`, `caseExactMatch`, `caseIgnoreIA5Match`, and their substring/ordering
+variants) apply a pragmatic profile of [RFC 4518](https://www.rfc-editor.org/rfc/rfc4518) string preparation before
+comparing values:
+
+- **Insignificant whitespace is ignored.** Leading/trailing spaces are trimmed and internal runs collapse to a single
+  space, so `cn=John  Smith` matches `cn=John Smith`.
+- **Ignorable code points are removed** — soft hyphen, zero-width spaces/joiners, BOM, and variation selectors.
+- **Unicode space variants are folded** to a normal space (NBSP, ideographic space, en/em spaces, etc.).
+
+### Optional Unicode normalization
+
+Two further steps run only when the supporting capability is available:
+
+| Step | Provided by | Without it |
+|---|---|---|
+| NFKC normalization (compatibility forms, composed/decomposed equivalence) | `ext-intl` **or** `symfony/polyfill-intl-normalizer` | Skipped |
+| Unicode-aware case folding (e.g. `É` ↔ `é`) | `ext-mbstring` **or** `symfony/polyfill-mbstring` | ASCII-only case folding |
+
+ASCII matching is always identical regardless of the above. For byte-identical matching of **non-ASCII** values across
+hosts with differing extensions, install the polyfills (or the extensions) so every host normalizes the same way:
+
+```bash
+composer require symfony/polyfill-intl-normalizer symfony/polyfill-mbstring
+```
+
+### Notes
+
+- `caseExactMatch` preserves case but still ignores insignificant whitespace and applies NFKC — it is no longer a raw
+  byte comparison. `octetStringMatch` (used by binary attributes such as `userPassword`) remains byte-exact.
+- Distinguished name matching is not affected by this profile.
+- The Prohibit and Bidirectional steps of RFC 4518 are not implemented.

--- a/src/FreeDSx/Ldap/Schema/Matching/CaseExactComparator.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/CaseExactComparator.php
@@ -13,17 +13,18 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Schema\Matching;
 
+use FreeDSx\Ldap\Schema\Matching\Prep\StringPrep;
+
 /**
- * Case-sensitive string comparator (caseExactMatch / caseExactSubstringsMatch / caseExactOrderingMatch).
- * Delegates to OctetStringComparator since both perform byte-exact comparison.
+ * Case-sensitive comparator (caseExactMatch / caseExactSubstringsMatch / caseExactOrderingMatch) using RFC 4518 prep without case folding.
  */
 final readonly class CaseExactComparator implements MatchingRuleComparatorInterface
 {
-    private OctetStringComparator $inner;
+    private PreparedStringComparator $inner;
 
     public function __construct()
     {
-        $this->inner = new OctetStringComparator();
+        $this->inner = new PreparedStringComparator(new StringPrep(foldCase: false));
     }
 
     public function equals(

--- a/src/FreeDSx/Ldap/Schema/Matching/CaseIgnoreComparator.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/CaseIgnoreComparator.php
@@ -13,23 +13,35 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Schema\Matching;
 
+use FreeDSx\Ldap\Schema\Matching\Prep\StringPrep;
+
 /**
  * Case-insensitive string comparator (caseIgnoreMatch / caseIgnoreSubstringsMatch / caseIgnoreOrderingMatch).
  */
-final class CaseIgnoreComparator implements MatchingRuleComparatorInterface
+final readonly class CaseIgnoreComparator implements MatchingRuleComparatorInterface
 {
+    private PreparedStringComparator $inner;
+
+    public function __construct()
+    {
+        $this->inner = new PreparedStringComparator(new StringPrep(foldCase: true));
+    }
+
     public function equals(
         string $a,
         string $b,
     ): bool {
-        return strtolower($a) === strtolower($b);
+        return $this->inner->equals(
+            $a,
+            $b,
+        );
     }
 
     public function compare(
         string $a,
         string $b,
     ): int {
-        return strcasecmp(
+        return $this->inner->compare(
             $a,
             $b,
         );
@@ -39,29 +51,9 @@ final class CaseIgnoreComparator implements MatchingRuleComparatorInterface
         string $value,
         SubstringAssertion $assertion,
     ): bool {
-        $lower = strtolower($value);
-
-        if ($assertion->initial !== null && !str_starts_with($lower, strtolower($assertion->initial))) {
-            return false;
-        }
-
-        $pos = $assertion->initial !== null ? strlen($assertion->initial) : 0;
-
-        foreach ($assertion->any as $substr) {
-            $found = stripos($lower, strtolower($substr), $pos);
-            if ($found === false) {
-                return false;
-            }
-            $pos = $found + strlen($substr);
-        }
-
-        if ($assertion->final === null) {
-            return true;
-        }
-
-        $finalLower = strtolower($assertion->final);
-        $finalStart = strlen($lower) - strlen($finalLower);
-
-        return $finalStart >= $pos && str_ends_with($lower, $finalLower);
+        return $this->inner->substringMatches(
+            $value,
+            $assertion,
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Schema/Matching/Prep/StringPrep.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/Prep/StringPrep.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Matching\Prep;
+
+use FreeDSx\Ldap\Schema\Text;
+use Normalizer;
+
+/**
+ * Pragmatic RFC 4518 string preparation shared by the case-ignore and case-exact comparators.
+ */
+final readonly class StringPrep
+{
+    /**
+     * Code points removed by the Map step (RFC 4518 §2.2): soft hyphen, zero-width, variation selectors, NULL.
+     */
+    private const MAP_TO_NOTHING = '/[\x{00AD}\x{034F}\x{200B}\x{200C}\x{200D}\x{2060}\x{FEFF}\x{180B}-\x{180D}\x{FE00}-\x{FE0F}\x{0000}]/u';
+
+    /**
+     * Whitespace variants folded to SPACE by the Map step (RFC 4518 §2.2).
+     */
+    private const MAP_TO_SPACE = '/[\x{0009}-\x{000D}\x{0085}\x{00A0}\x{1680}\x{2000}-\x{200A}\x{2028}\x{2029}\x{202F}\x{205F}\x{3000}]/u';
+
+    private bool $canFoldUnicode;
+
+    private bool $canNormalize;
+
+    public function __construct(
+        public bool $foldCase = true,
+    ) {
+        $this->canFoldUnicode = function_exists('mb_strtolower');
+        $this->canNormalize = class_exists(Normalizer::class);
+    }
+
+    /**
+     * Canonical form for equality, ordering, and the substring value side.
+     */
+    public function prepareForEquality(string $value): string
+    {
+        return $this->prepare(
+            $value,
+            trim: true,
+        );
+    }
+
+    /**
+     * Substring fragment prep: interior spaces collapse but leading/trailing spaces are preserved.
+     */
+    public function prepareFragment(string $fragment): string
+    {
+        return $this->prepare(
+            $fragment,
+            trim: false,
+        );
+    }
+
+    private function prepare(
+        string $value,
+        bool $trim,
+    ): string {
+        if (!Text::isUtf8($value)) {
+            return $this->prepareRawBytes(
+                $value,
+                $trim,
+            );
+        }
+
+        $prepared = $this->normalize($this->caseFold($this->map($value)));
+
+        return $this->squeeze(
+            $prepared,
+            $trim,
+        );
+    }
+
+    private function prepareRawBytes(
+        string $value,
+        bool $trim,
+    ): string {
+        $folded = $this->foldCase
+            ? strtolower($value)
+            : $value;
+
+        return $this->squeeze(
+            $folded,
+            $trim,
+        );
+    }
+
+    private function map(string $value): string
+    {
+        $stripped = preg_replace(
+            self::MAP_TO_NOTHING,
+            '',
+            $value,
+        ) ?? $value;
+
+        return preg_replace(
+            self::MAP_TO_SPACE,
+            ' ',
+            $stripped,
+        ) ?? $stripped;
+    }
+
+    private function caseFold(string $value): string
+    {
+        if (!$this->foldCase) {
+            return $value;
+        }
+
+        if ($this->canFoldUnicode) {
+            return mb_strtolower(
+                $value,
+                'UTF-8',
+            );
+        }
+
+        return strtolower($value);
+    }
+
+    private function normalize(string $value): string
+    {
+        if (!$this->canNormalize) {
+            return $value;
+        }
+
+        $normalized = Normalizer::normalize(
+            $value,
+            Normalizer::FORM_KC,
+        );
+
+        return $normalized !== false
+            ? $normalized
+            : $value;
+    }
+
+    private function squeeze(
+        string $value,
+        bool $trim,
+    ): string {
+        $collapsed = preg_replace(
+            '/ +/',
+            ' ',
+            $value,
+        ) ?? $value;
+
+        if (!$trim) {
+            return $collapsed;
+        }
+
+        return trim(
+            $collapsed,
+            ' ',
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Matching/PreparedStringComparator.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/PreparedStringComparator.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Matching;
+
+use FreeDSx\Ldap\Schema\Matching\Prep\StringPrep;
+
+/**
+ * String comparator that applies an RFC 4518 preparation profile, then matches byte-exact.
+ */
+final readonly class PreparedStringComparator implements MatchingRuleComparatorInterface
+{
+    private OctetStringComparator $matcher;
+
+    public function __construct(
+        private StringPrep $prep,
+    ) {
+        $this->matcher = new OctetStringComparator();
+    }
+
+    public function equals(
+        string $a,
+        string $b,
+    ): bool {
+        return $this->prep->prepareForEquality($a)
+            === $this->prep->prepareForEquality($b);
+    }
+
+    public function compare(
+        string $a,
+        string $b,
+    ): int {
+        return strcmp(
+            $this->prep->prepareForEquality($a),
+            $this->prep->prepareForEquality($b),
+        );
+    }
+
+    public function substringMatches(
+        string $value,
+        SubstringAssertion $assertion,
+    ): bool {
+        return $this->matcher->substringMatches(
+            $this->prep->prepareForEquality($value),
+            $this->prepareAssertion($assertion),
+        );
+    }
+
+    private function prepareAssertion(SubstringAssertion $assertion): SubstringAssertion
+    {
+        return new SubstringAssertion(
+            initial: $assertion->initial !== null
+                ? $this->prep->prepareFragment($assertion->initial)
+                : null,
+            any: array_map(
+                $this->prep->prepareFragment(...),
+                $assertion->any,
+            ),
+            final: $assertion->final !== null
+                ? $this->prep->prepareFragment($assertion->final)
+                : null,
+        );
+    }
+}

--- a/tests/unit/Schema/Matching/CaseExactComparatorTest.php
+++ b/tests/unit/Schema/Matching/CaseExactComparatorTest.php
@@ -80,4 +80,28 @@ final class CaseExactComparatorTest extends TestCase
 
         self::assertFalse($result);
     }
+
+    public function test_equals_collapses_whitespace_but_keeps_case(): void
+    {
+        self::assertTrue($this->subject->equals(
+            'Foo  Bar',
+            'Foo Bar',
+        ));
+        self::assertFalse($this->subject->equals(
+            'Foo  Bar',
+            'foo bar',
+        ));
+    }
+
+    public function test_substring_case_sensitive_with_extra_spaces(): void
+    {
+        self::assertTrue($this->subject->substringMatches(
+            'Foo  Bar',
+            new SubstringAssertion(initial: 'Foo Bar'),
+        ));
+        self::assertFalse($this->subject->substringMatches(
+            'Foo  Bar',
+            new SubstringAssertion(initial: 'foo bar'),
+        ));
+    }
 }

--- a/tests/unit/Schema/Matching/CaseIgnoreComparatorTest.php
+++ b/tests/unit/Schema/Matching/CaseIgnoreComparatorTest.php
@@ -130,4 +130,84 @@ final class CaseIgnoreComparatorTest extends TestCase
 
         self::assertTrue($result);
     }
+
+    public function test_equals_collapses_double_space(): void
+    {
+        $result = $this->subject->equals(
+            'Foo  Bar',
+            'foo bar',
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_trims_whitespace(): void
+    {
+        $result = $this->subject->equals(
+            '  foo  ',
+            'foo',
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_strips_soft_hyphen(): void
+    {
+        $result = $this->subject->equals(
+            "foo\u{00AD}bar",
+            'foobar',
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_equals_folds_unicode_space(): void
+    {
+        $result = $this->subject->equals(
+            "foo\u{00A0}bar",
+            'foo bar',
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_substring_initial_with_extra_spaces_in_value(): void
+    {
+        $result = $this->subject->substringMatches(
+            'Foo   Bar Baz',
+            new SubstringAssertion(initial: 'foo bar'),
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_substring_any_across_collapsed_spaces(): void
+    {
+        $result = $this->subject->substringMatches(
+            'a  b  c',
+            new SubstringAssertion(any: ['b c']),
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_substring_final_with_trailing_space_in_value(): void
+    {
+        $result = $this->subject->substringMatches(
+            'foo bar  ',
+            new SubstringAssertion(final: 'bar'),
+        );
+
+        self::assertTrue($result);
+    }
+
+    public function test_compare_equal_after_space_collapse(): void
+    {
+        $result = $this->subject->compare(
+            'a  b',
+            'a b',
+        );
+
+        self::assertSame(0, $result);
+    }
 }

--- a/tests/unit/Schema/Matching/Prep/StringPrepTest.php
+++ b/tests/unit/Schema/Matching/Prep/StringPrepTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Matching\Prep;
+
+use FreeDSx\Ldap\Schema\Matching\Prep\StringPrep;
+use PHPUnit\Framework\TestCase;
+
+final class StringPrepTest extends TestCase
+{
+    private StringPrep $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new StringPrep();
+    }
+
+    public function test_collapses_double_internal_spaces(): void
+    {
+        self::assertSame(
+            'foo bar',
+            $this->subject->prepareForEquality('foo  bar'),
+        );
+    }
+
+    public function test_trims_leading_and_trailing_spaces(): void
+    {
+        self::assertSame(
+            'foo',
+            $this->subject->prepareForEquality('  foo  '),
+        );
+    }
+
+    public function test_lowercases_ascii_when_folding(): void
+    {
+        self::assertSame(
+            'foobar',
+            $this->subject->prepareForEquality('FooBar'),
+        );
+    }
+
+    public function test_does_not_lowercase_when_fold_disabled(): void
+    {
+        $subject = new StringPrep(foldCase: false);
+
+        self::assertSame(
+            'FooBar',
+            $subject->prepareForEquality('FooBar'),
+        );
+    }
+
+    public function test_strips_soft_hyphen(): void
+    {
+        self::assertSame(
+            'foobar',
+            $this->subject->prepareForEquality("foo\u{00AD}bar"),
+        );
+    }
+
+    public function test_strips_zero_width_space(): void
+    {
+        self::assertSame(
+            'foobar',
+            $this->subject->prepareForEquality("foo\u{200B}bar"),
+        );
+    }
+
+    public function test_folds_nbsp_to_space_then_collapses(): void
+    {
+        self::assertSame(
+            'foo bar',
+            $this->subject->prepareForEquality("foo\u{00A0}\u{00A0}bar"),
+        );
+    }
+
+    public function test_fragment_collapses_interior_but_keeps_bounding_spaces(): void
+    {
+        self::assertSame(
+            ' foo bar ',
+            $this->subject->prepareFragment(' foo  bar '),
+        );
+    }
+
+    public function test_normalizes_compatibility_form_when_available(): void
+    {
+        if (!class_exists(\Normalizer::class)) {
+            self::markTestSkipped('NFKC requires ext-intl or symfony/polyfill-intl-normalizer.');
+        }
+
+        self::assertSame(
+            'a',
+            $this->subject->prepareForEquality("\u{FF21}"),
+        );
+    }
+
+    public function test_folds_non_ascii_case_when_available(): void
+    {
+        if (!function_exists('mb_strtolower')) {
+            self::markTestSkipped('Unicode case folding requires ext-mbstring or symfony/polyfill-mbstring.');
+        }
+
+        self::assertSame(
+            'é',
+            $this->subject->prepareForEquality('É'),
+        );
+    }
+}

--- a/tests/unit/Server/Backend/Storage/FilterEvaluatorTest.php
+++ b/tests/unit/Server/Backend/Storage/FilterEvaluatorTest.php
@@ -905,6 +905,38 @@ final class FilterEvaluatorTest extends TestCase
         );
     }
 
+    public function test_schema_equality_collapses_whitespace_for_cn(): void
+    {
+        $subject = new FilterEvaluator(StandardSchemaProvider::buildCore());
+        $entry = new Entry(
+            new Dn('cn=Foo  Bar,dc=example,dc=com'),
+            new Attribute('cn', 'Foo  Bar'),
+        );
+
+        self::assertTrue(
+            $subject->evaluate($entry, Filters::equal('cn', 'foo bar')),
+        );
+        self::assertTrue(
+            $subject->evaluate($entry, Filters::equal('cn', 'foo   bar')),
+        );
+    }
+
+    public function test_schema_substring_matches_across_collapsed_spaces(): void
+    {
+        $subject = new FilterEvaluator(StandardSchemaProvider::buildCore());
+        $entry = new Entry(
+            new Dn('cn=Foo  Bar Baz,dc=example,dc=com'),
+            new Attribute('cn', 'Foo  Bar Baz'),
+        );
+
+        self::assertTrue(
+            $subject->evaluate(
+                $entry,
+                (new SubstringFilter('cn'))->setStartsWith('foo bar'),
+            ),
+        );
+    }
+
     public function test_schema_matching_rule_filter_resolves_non_hardcoded_oid(): void
     {
         $subject = new FilterEvaluator(StandardSchemaProvider::buildCore());


### PR DESCRIPTION
This closes some issues the current comparators / string matching has with the backend (around whitespace / unicode / etc).