### PR TITLE
[1.0.0] Add OperationAuthorizationMiddleware to consolidate access control checks.

### DIFF
--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -15,17 +15,13 @@ namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Control\Control;
-use FreeDSx\Ldap\Control\ControlBag;
-use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request;
-use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\AccessControl\OperationType;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\SchemaViolations;
 use FreeDSx\Ldap\Server\Backend\Write\WriteCommandFactory;
@@ -43,11 +39,6 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
 readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
 {
     use MatchedDnAccessFilterTrait;
-
-    /**
-     * Controls that require an explicit ControlRule grant before they may be used.
-     */
-    private const PRIVILEGED_CONTROLS = [Control::OID_RELAX_RULES];
 
     public function __construct(
         private ServerQueue $queue,
@@ -74,21 +65,8 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
 
         try {
             $request = $message->getRequest();
-            $this->authorizeRequest(
-                $request,
-                $token,
-            );
-            $this->authorizeWriteAttributes(
-                $request,
-                $token,
-            );
 
             if ($request instanceof Request\CompareRequest) {
-                $this->accessControl->authorizeAttribute(
-                    $token,
-                    $request->getDn(),
-                    $request->getFilter()->getAttribute(),
-                );
                 $match = $this->backend->compare($request->getDn(), $request->getFilter());
                 $this->queue->sendMessage($this->responseFactory->getStandardResponse(
                     $message,
@@ -104,12 +82,6 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
 
                 return;
             }
-
-            $this->authorizeControls(
-                $request,
-                $message->controls(),
-                $token,
-            );
 
             $this->writeDispatcher->dispatch(
                 $this->commandFactory->fromRequest($request),
@@ -170,139 +142,5 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
         $this->passwordPolicyContext?->clear();
 
         return $control;
-    }
-
-    /**
-     * Authorizes any privileged control attached to a write before it is dispatched.
-     *
-     * @throws OperationException
-     */
-    private function authorizeControls(
-        RequestInterface $request,
-        ControlBag $controls,
-        TokenInterface $token,
-    ): void {
-        $dn = $this->dnFor($request);
-
-        if ($dn === null) {
-            return;
-        }
-
-        foreach (self::PRIVILEGED_CONTROLS as $oid) {
-            if (!$controls->has($oid)) {
-                continue;
-            }
-
-            $this->accessControl->authorizeControl(
-                $token,
-                $dn,
-                $oid,
-            );
-        }
-    }
-
-    private function dnFor(RequestInterface $request): ?Dn
-    {
-        return match (true) {
-            $request instanceof Request\AddRequest => $request->getEntry()->getDn(),
-            $request instanceof Request\ModifyRequest,
-            $request instanceof Request\DeleteRequest,
-            $request instanceof Request\ModifyDnRequest,
-            $request instanceof Request\CompareRequest => $request->getDn(),
-            default => null,
-        };
-    }
-
-    /**
-     * @throws OperationException
-     */
-    private function authorizeWriteAttributes(
-        RequestInterface $request,
-        TokenInterface $token,
-    ): void {
-        if ($request instanceof Request\AddRequest) {
-            $dn = $request->getEntry()->getDn();
-            foreach ($request->getEntry()->getAttributes() as $attribute) {
-                $this->accessControl->authorizeAttribute(
-                    $token,
-                    $dn,
-                    $attribute->getName(),
-                );
-            }
-
-            return;
-        }
-
-        if ($request instanceof Request\ModifyRequest) {
-            $dn = $request->getDn();
-            foreach ($request->getChanges() as $change) {
-                $this->accessControl->authorizeAttribute(
-                    $token,
-                    $dn,
-                    $change->getAttribute()->getName(),
-                );
-            }
-        }
-    }
-
-    /**
-     * @throws OperationException
-     */
-    private function authorizeRequest(
-        RequestInterface $request,
-        TokenInterface $token,
-    ): void {
-        if ($request instanceof Request\ModifyDnRequest) {
-            $this->authorizeModifyDn(
-                $request,
-                $token,
-            );
-
-            return;
-        }
-
-        $operationType = OperationType::fromRequest($request);
-
-        if ($operationType === null || $operationType === OperationType::Search) {
-            return;
-        }
-
-        $dn = $this->dnFor($request);
-
-        if ($dn === null) {
-            return;
-        }
-
-        $this->accessControl->authorizeOperation(
-            $operationType,
-            $token,
-            $dn,
-        );
-    }
-
-    /**
-     * @throws OperationException
-     */
-    private function authorizeModifyDn(
-        Request\ModifyDnRequest $request,
-        TokenInterface $token,
-    ): void {
-        $this->accessControl->authorizeOperation(
-            OperationType::ModifyDn,
-            $token,
-            $request->getDn(),
-        );
-
-        $newParentDn = $request->getNewParentDn();
-
-        if ($newParentDn === null) {
-            return;
-        }
-
-        $this->accessControl->authorizeOperation(
-            OperationType::ModifyDn,
-            $token,
-            $newParentDn,
-        );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -26,7 +26,6 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
-use FreeDSx\Ldap\Server\AccessControl\OperationType;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Paging\PagingRequest;
 use FreeDSx\Ldap\Server\Paging\PagingRequestComparator;
@@ -74,12 +73,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         $response = null;
         $controls = [];
         try {
-            $baseDn = $this->assertBaseDnProvided($searchRequest);
-            $this->accessControl->authorizeOperation(
-                OperationType::Search,
-                $token,
-                $baseDn,
-            );
+            $this->assertBaseDnProvided($searchRequest);
             $response = $this->handlePaging(
                 $pagingRequest,
                 $message,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -23,7 +23,6 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\AccessControl\OperationType;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
@@ -68,12 +67,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         $isSuccessful = true;
 
         try {
-            $baseDn = $this->assertBaseDnProvided($request);
-            $this->accessControl->authorizeOperation(
-                OperationType::Search,
-                $token,
-                $baseDn,
-            );
+            $this->assertBaseDnProvided($request);
 
             $backendResult = $this->backend->search(
                 $request,

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\AddRequest;
+use FreeDSx\Ldap\Operation\Request\CompareRequest;
+use FreeDSx\Ldap\Operation\Request\DeleteRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Protocol\Factory\HandlerId;
+use FreeDSx\Ldap\Protocol\Factory\HandlerRouteResolverInterface;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\ServerProtocolHandler\DispatchEventRecorder;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * Authorizes the operation before dispatch and audits denials.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class OperationAuthorizationMiddleware implements MiddlewareInterface
+{
+    /**
+     * Controls that require an explicit ControlRule grant before they may be used on a write.
+     */
+    private const PRIVILEGED_CONTROLS = [Control::OID_RELAX_RULES];
+
+    private DispatchEventRecorder $writeAuditRecorder;
+
+    public function __construct(
+        private HandlerRouteResolverInterface $routeResolver,
+        private AccessControlInterface $accessControl,
+        private EventLogger $eventLogger = new EventLogger(null),
+    ) {
+        $this->writeAuditRecorder = new DispatchEventRecorder($eventLogger);
+    }
+
+    /**
+     * @throws OperationException
+     */
+    public function process(
+        ServerRequestContext $context,
+        MiddlewareHandlerInterface $next,
+    ): void {
+        $routeId = $this->routeResolver->routeIdFor(
+            $context->message->getRequest(),
+            $context->message->controls(),
+        );
+
+        if ($routeId === HandlerId::Search || $routeId === HandlerId::Paging) {
+            $this->authorizeSearch(
+                $context->message,
+                $context->token,
+            );
+        } elseif ($routeId === HandlerId::Dispatch) {
+            $this->authorizeDispatch(
+                $context->message,
+                $context->token,
+            );
+        }
+
+        $next->handle($context);
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function authorizeSearch(
+        LdapMessageRequest $message,
+        TokenInterface $token,
+    ): void {
+        $request = $message->getRequest();
+
+        if (!$request instanceof SearchRequest) {
+            return;
+        }
+
+        $baseDn = $request->getBaseDn();
+
+        if ($baseDn === null) {
+            return;
+        }
+
+        try {
+            $this->accessControl->authorizeOperation(
+                OperationType::Search,
+                $token,
+                $baseDn,
+            );
+        } catch (OperationException $e) {
+            $this->eventLogger->recordSearchFailure(
+                $message,
+                $e,
+                $token,
+            );
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function authorizeDispatch(
+        LdapMessageRequest $message,
+        TokenInterface $token,
+    ): void {
+        $request = $message->getRequest();
+
+        try {
+            $this->authorizeRequest(
+                $request,
+                $token,
+            );
+            $this->authorizeWriteAttributes(
+                $request,
+                $token,
+            );
+
+            if ($request instanceof CompareRequest) {
+                $this->accessControl->authorizeAttribute(
+                    $token,
+                    $request->getDn(),
+                    $request->getFilter()->getAttribute(),
+                );
+
+                return;
+            }
+
+            $this->authorizeControls(
+                $request,
+                $message->controls(),
+                $token,
+            );
+        } catch (OperationException $e) {
+            $this->writeAuditRecorder->recordFailure(
+                $message,
+                $e,
+                $token,
+            );
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function authorizeRequest(
+        RequestInterface $request,
+        TokenInterface $token,
+    ): void {
+        if ($request instanceof ModifyDnRequest) {
+            $this->authorizeModifyDn(
+                $request,
+                $token,
+            );
+
+            return;
+        }
+
+        $operationType = OperationType::fromRequest($request);
+
+        if ($operationType === null || $operationType === OperationType::Search) {
+            return;
+        }
+
+        $dn = $this->dnFor($request);
+
+        if ($dn === null) {
+            return;
+        }
+
+        $this->accessControl->authorizeOperation(
+            $operationType,
+            $token,
+            $dn,
+        );
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function authorizeModifyDn(
+        ModifyDnRequest $request,
+        TokenInterface $token,
+    ): void {
+        $this->accessControl->authorizeOperation(
+            OperationType::ModifyDn,
+            $token,
+            $request->getDn(),
+        );
+
+        $newParentDn = $request->getNewParentDn();
+
+        if ($newParentDn === null) {
+            return;
+        }
+
+        $this->accessControl->authorizeOperation(
+            OperationType::ModifyDn,
+            $token,
+            $newParentDn,
+        );
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function authorizeWriteAttributes(
+        RequestInterface $request,
+        TokenInterface $token,
+    ): void {
+        if ($request instanceof AddRequest) {
+            $dn = $request->getEntry()->getDn();
+            foreach ($request->getEntry()->getAttributes() as $attribute) {
+                $this->accessControl->authorizeAttribute(
+                    $token,
+                    $dn,
+                    $attribute->getName(),
+                );
+            }
+
+            return;
+        }
+
+        if ($request instanceof ModifyRequest) {
+            $dn = $request->getDn();
+            foreach ($request->getChanges() as $change) {
+                $this->accessControl->authorizeAttribute(
+                    $token,
+                    $dn,
+                    $change->getAttribute()->getName(),
+                );
+            }
+        }
+    }
+
+    /**
+     * Authorizes any privileged control attached to a write before it is dispatched.
+     *
+     * @throws OperationException
+     */
+    private function authorizeControls(
+        RequestInterface $request,
+        ControlBag $controls,
+        TokenInterface $token,
+    ): void {
+        $dn = $this->dnFor($request);
+
+        if ($dn === null) {
+            return;
+        }
+
+        foreach (self::PRIVILEGED_CONTROLS as $oid) {
+            if (!$controls->has($oid)) {
+                continue;
+            }
+
+            $this->accessControl->authorizeControl(
+                $token,
+                $dn,
+                $oid,
+            );
+        }
+    }
+
+    private function dnFor(RequestInterface $request): ?Dn
+    {
+        return match (true) {
+            $request instanceof AddRequest => $request->getEntry()->getDn(),
+            $request instanceof ModifyRequest,
+            $request instanceof DeleteRequest,
+            $request instanceof ModifyDnRequest,
+            $request instanceof CompareRequest => $request->getDn(),
+            default => null,
+        };
+    }
+}

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -37,6 +37,7 @@ use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Middleware\CriticalControlMiddleware;
+use FreeDSx\Ldap\Server\Middleware\OperationAuthorizationMiddleware;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\HandlerInvoker;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareChain;
 use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyBindGuard;
@@ -142,6 +143,11 @@ class ServerProtocolFactory
             requestPipeline: new MiddlewareChain(
                 [
                     new CriticalControlMiddleware($protocolHandlerFactory),
+                    new OperationAuthorizationMiddleware(
+                        $protocolHandlerFactory,
+                        $this->options->getAccessControl(),
+                        $eventLogger,
+                    ),
                 ],
                 new HandlerInvoker($protocolHandlerFactory),
             ),

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Control\Control;
-use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\Response\DeleteResponse;
@@ -23,9 +22,6 @@ use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Operation\Request\CompareRequest;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
-use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
-use FreeDSx\Ldap\Operation\Request\ModifyRequest;
-use FreeDSx\Ldap\Server\AccessControl\OperationType;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
@@ -137,42 +133,6 @@ final class ServerDispatchHandlerTest extends TestCase
         $this->subject->handleRequest($compare, $this->mockToken);
     }
 
-    public function test_it_sends_error_response_when_authorizeAttribute_denies_compare(): void
-    {
-        $compare = new LdapMessageRequest(
-            1,
-            new CompareRequest(
-                'cn=foo,dc=bar',
-                Filters::equal(
-                    'userpassword',
-                    'secret',
-                ),
-            ),
-        );
-
-        $this->mockAccessControl
-            ->method('authorizeAttribute')
-            ->willThrowException(new OperationException(
-                'Access denied.',
-                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
-            ));
-
-        $this->mockBackend
-            ->expects(self::never())
-            ->method('compare');
-
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->with(self::callback(function (LdapMessageResponse $msg): bool {
-                return $msg->getResponse() instanceof LdapResult
-                    && $msg->getResponse()->getResultCode() === ResultCode::INSUFFICIENT_ACCESS_RIGHTS;
-            }))
-            ->willReturnSelf();
-
-        $this->subject->handleRequest($compare, $this->mockToken);
-    }
-
     public function test_it_sends_error_response_for_operation_exceptions_from_backend_compare(): void
     {
         $compare = new LdapMessageRequest(1, new CompareRequest('cn=foo,dc=bar', Filters::equal('foo', 'bar')));
@@ -241,174 +201,6 @@ final class ServerDispatchHandlerTest extends TestCase
             ->with(self::isInstanceOf(WriteRequestInterface::class));
 
         $this->subject->handleRequest($delete, $this->mockToken);
-    }
-
-    public function test_it_authorizes_modify_dn_against_source_dn_only_when_no_new_superior(): void
-    {
-        $request = new LdapMessageRequest(
-            1,
-            new ModifyDnRequest(
-                'cn=foo,dc=bar',
-                'cn=baz',
-                true,
-            ),
-        );
-
-        $this->mockAccessControl
-            ->expects(self::once())
-            ->method('authorizeOperation')
-            ->with(
-                OperationType::ModifyDn,
-                $this->mockToken,
-                self::isInstanceOf(Dn::class),
-            );
-
-        $this->subject->handleRequest(
-            $request,
-            $this->mockToken,
-        );
-    }
-
-    public function test_it_authorizes_modify_dn_against_both_source_and_new_superior(): void
-    {
-        $request = new LdapMessageRequest(
-            1,
-            new ModifyDnRequest(
-                'cn=foo,dc=bar',
-                'cn=baz',
-                true,
-                'ou=other,dc=bar',
-            ),
-        );
-
-        $this->mockAccessControl
-            ->expects(self::exactly(2))
-            ->method('authorizeOperation')
-            ->with(
-                OperationType::ModifyDn,
-                $this->mockToken,
-                self::isInstanceOf(Dn::class),
-            );
-
-        $this->subject->handleRequest(
-            $request,
-            $this->mockToken,
-        );
-    }
-
-    public function test_it_sends_error_response_when_authorizeAttribute_denies_add(): void
-    {
-        $add = new LdapMessageRequest(
-            1,
-            new AddRequest(
-                Entry::create(
-                    'cn=foo,dc=bar',
-                    ['userpassword' => 'secret'],
-                ),
-            ),
-        );
-
-        $this->mockAccessControl
-            ->method('authorizeAttribute')
-            ->willThrowException(new OperationException(
-                'Access denied.',
-                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
-            ));
-
-        $this->mockWriteHandler
-            ->expects(self::never())
-            ->method('handle');
-
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->with(self::callback(function (LdapMessageResponse $msg): bool {
-                return $msg->getResponse() instanceof LdapResult
-                    && $msg->getResponse()->getResultCode() === ResultCode::INSUFFICIENT_ACCESS_RIGHTS;
-            }))
-            ->willReturnSelf();
-
-        $this->subject->handleRequest(
-            $add,
-            $this->mockToken,
-        );
-    }
-
-    public function test_it_sends_error_response_when_authorizeAttribute_denies_modify(): void
-    {
-        $modify = new LdapMessageRequest(
-            1,
-            new ModifyRequest(
-                'cn=foo,dc=bar',
-                Change::replace(
-                    'userpassword',
-                    'newSecret',
-                ),
-            ),
-        );
-
-        $this->mockAccessControl
-            ->method('authorizeAttribute')
-            ->willThrowException(new OperationException(
-                'Access denied.',
-                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
-            ));
-
-        $this->mockWriteHandler
-            ->expects(self::never())
-            ->method('handle');
-
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->with(self::callback(function (LdapMessageResponse $msg): bool {
-                return $msg->getResponse() instanceof LdapResult
-                    && $msg->getResponse()->getResultCode() === ResultCode::INSUFFICIENT_ACCESS_RIGHTS;
-            }))
-            ->willReturnSelf();
-
-        $this->subject->handleRequest(
-            $modify,
-            $this->mockToken,
-        );
-    }
-
-    public function test_it_sends_error_response_when_access_control_denies_new_superior(): void
-    {
-        $request = new LdapMessageRequest(
-            1,
-            new ModifyDnRequest(
-                'cn=foo,dc=bar',
-                'cn=baz',
-                true,
-                'ou=restricted,dc=bar',
-            ),
-        );
-
-        $this->mockAccessControl
-            ->method('authorizeOperation')
-            ->willReturnCallback(function (OperationType $type, TokenInterface $token, Dn $dn): void {
-                if ($dn->toString() === 'ou=restricted,dc=bar') {
-                    throw new OperationException(
-                        'Access denied.',
-                        ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
-                    );
-                }
-            });
-
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->with(self::callback(function (LdapMessageResponse $msg): bool {
-                return $msg->getResponse() instanceof LdapResult
-                    && $msg->getResponse()->getResultCode() === ResultCode::INSUFFICIENT_ACCESS_RIGHTS;
-            }))
-            ->willReturnSelf();
-
-        $this->subject->handleRequest(
-            $request,
-            $this->mockToken,
-        );
     }
 
     public function test_matched_dn_from_exception_is_used_in_write_response(): void

--- a/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
@@ -1,0 +1,298 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\AddRequest;
+use FreeDSx\Ldap\Operation\Request\CompareRequest;
+use FreeDSx\Ldap\Operation\Request\DeleteRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Factory\HandlerId;
+use FreeDSx\Ldap\Protocol\Factory\HandlerRouteResolverInterface;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
+use FreeDSx\Ldap\Server\Middleware\OperationAuthorizationMiddleware;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Logging\RecordingLogger;
+use Tests\Support\FreeDSx\Ldap\Middleware\CallLog;
+use Tests\Support\FreeDSx\Ldap\Middleware\RecordingMiddlewareHandler;
+
+final class OperationAuthorizationMiddlewareTest extends TestCase
+{
+    private HandlerRouteResolverInterface&MockObject $resolver;
+
+    private AccessControlInterface&MockObject $accessControl;
+
+    private RecordingLogger $logger;
+
+    private TokenInterface&MockObject $token;
+
+    private OperationAuthorizationMiddleware $subject;
+
+    private RecordingMiddlewareHandler $next;
+
+    protected function setUp(): void
+    {
+        $this->resolver = $this->createMock(HandlerRouteResolverInterface::class);
+        $this->accessControl = $this->createMock(AccessControlInterface::class);
+        $this->logger = new RecordingLogger();
+        $this->token = $this->createMock(TokenInterface::class);
+        $this->subject = new OperationAuthorizationMiddleware(
+            $this->resolver,
+            $this->accessControl,
+            new EventLogger(
+                $this->logger,
+                EventLogPolicy::default(),
+            ),
+        );
+        $this->next = new RecordingMiddlewareHandler(new CallLog());
+    }
+
+    public function test_search_route_authorizes_the_search_operation_then_continues(): void
+    {
+        $this->routeResolvesTo(HandlerId::Search);
+        $this->accessControl
+            ->expects(self::once())
+            ->method('authorizeOperation')
+            ->with(
+                OperationType::Search,
+                $this->token,
+                self::isInstanceOf(Dn::class),
+            );
+
+        $this->subject->process(
+            $this->contextFor((new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar')),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    public function test_search_route_denial_audits_a_read_denial_and_blocks_dispatch(): void
+    {
+        $this->routeResolvesTo(HandlerId::Paging);
+        $this->accessControl
+            ->method('authorizeOperation')
+            ->willThrowException($this->denied());
+
+        try {
+            $this->subject->process(
+                $this->contextFor((new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar')),
+                $this->next,
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+                $e->getCode(),
+            );
+        }
+
+        self::assertNull(
+            $this->next->received,
+            'Dispatch must be blocked on denial.',
+        );
+        self::assertTrue($this->wasLogged('authz.denied.read'));
+    }
+
+    public function test_dispatch_route_authorizes_modify_dn_against_source_only(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $this->accessControl
+            ->expects(self::once())
+            ->method('authorizeOperation')
+            ->with(
+                OperationType::ModifyDn,
+                $this->token,
+                self::isInstanceOf(Dn::class),
+            );
+
+        $this->subject->process(
+            $this->contextFor(new ModifyDnRequest('cn=foo,dc=bar', 'cn=baz', true)),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    public function test_dispatch_route_authorizes_modify_dn_against_source_and_new_superior(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $this->accessControl
+            ->expects(self::exactly(2))
+            ->method('authorizeOperation')
+            ->with(
+                OperationType::ModifyDn,
+                $this->token,
+                self::isInstanceOf(Dn::class),
+            );
+
+        $this->subject->process(
+            $this->contextFor(new ModifyDnRequest('cn=foo,dc=bar', 'cn=baz', true, 'ou=other,dc=bar')),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    public function test_dispatch_route_add_attribute_denial_audits_a_write_denial_and_blocks_dispatch(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $this->accessControl
+            ->method('authorizeAttribute')
+            ->willThrowException($this->denied());
+
+        $message = $this->contextFor(new AddRequest(Entry::create(
+            'cn=foo,dc=bar',
+            ['userpassword' => 'secret'],
+        )));
+
+        try {
+            $this->subject->process($message, $this->next);
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+                $e->getCode(),
+            );
+        }
+
+        self::assertNull($this->next->received);
+        self::assertTrue($this->wasLogged('authz.denied.write'));
+    }
+
+    public function test_dispatch_route_compare_attribute_denial_blocks_dispatch(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $this->accessControl
+            ->method('authorizeAttribute')
+            ->willThrowException($this->denied());
+
+        $message = $this->contextFor(new CompareRequest(
+            'cn=foo,dc=bar',
+            Filters::equal('userpassword', 'secret'),
+        ));
+
+        try {
+            $this->subject->process($message, $this->next);
+            self::fail('Expected an OperationException.');
+        } catch (OperationException) {
+        }
+
+        self::assertNull($this->next->received);
+    }
+
+    public function test_dispatch_route_authorizes_a_privileged_control_against_the_target(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $this->accessControl
+            ->expects(self::once())
+            ->method('authorizeControl')
+            ->with(
+                $this->token,
+                self::isInstanceOf(Dn::class),
+                Control::OID_RELAX_RULES,
+            );
+
+        $message = new LdapMessageRequest(
+            1,
+            new DeleteRequest('cn=foo,dc=bar'),
+            new Control(Control::OID_RELAX_RULES, criticality: true),
+        );
+
+        $this->subject->process(
+            new ServerRequestContext($message, $this->token),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    #[DataProvider('unauthorizedRoutes')]
+    public function test_routes_without_operation_authorization_are_not_gated(HandlerId $routeId): void
+    {
+        $this->routeResolvesTo($routeId);
+        $this->accessControl
+            ->expects(self::never())
+            ->method('authorizeOperation');
+
+        $this->subject->process(
+            $this->contextFor((new SearchRequest(Filters::present('cn')))->base('')),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    /**
+     * @return iterable<string, array{HandlerId}>
+     */
+    public static function unauthorizedRoutes(): iterable
+    {
+        yield 'root dse' => [HandlerId::RootDse];
+        yield 'subschema' => [HandlerId::Subschema];
+        yield 'whoami' => [HandlerId::WhoAmI];
+        yield 'start tls' => [HandlerId::StartTls];
+        yield 'cancel' => [HandlerId::Cancel];
+        yield 'unbind' => [HandlerId::Unbind];
+    }
+
+    private function routeResolvesTo(HandlerId $id): void
+    {
+        $this->resolver
+            ->method('routeIdFor')
+            ->willReturn($id);
+    }
+
+    private function contextFor(RequestInterface $request): ServerRequestContext
+    {
+        return new ServerRequestContext(
+            new LdapMessageRequest(1, $request),
+            $this->token,
+        );
+    }
+
+    private function denied(): OperationException
+    {
+        return new OperationException(
+            'Access denied.',
+            ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+        );
+    }
+
+    private function wasLogged(string $event): bool
+    {
+        foreach ($this->logger->records as $record) {
+            if ($record['message'] === $event) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
This is part 2 of the middleware chain implementation for the server request handling. This consolidates the various ACL checks to move it from the request dispatch handler(s) and into here. There will be other things implemented in middleware at some point, but need to decide what is a good fit.