### PR TITLE
[1.0.0] Add Operation Audit Logging Middleware

### DIFF
--- a/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
@@ -135,7 +135,6 @@ final readonly class ProtocolHandlerProvider implements ProtocolHandlerProviderI
                 ? $this->handlerFactory->makeWriteDispatcher($policyWriteHandler)
                 : $this->writeDispatcher,
             accessControl: $this->options->getAccessControl(),
-            eventRecorder: new ServerProtocolHandler\DispatchEventRecorder($this->eventLogger),
             passwordPolicyContext: $this->passwordPolicyContext,
         );
     }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAbandonHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAbandonHandler.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -26,5 +28,7 @@ final class ServerAbandonHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): void {}
+    ): OperationResult {
+        return OperationOutcomeResult::succeeded();
+    }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerCancelHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerCancelHandler.php
@@ -20,6 +20,8 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -38,10 +40,12 @@ readonly class ServerCancelHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): void {
+    ): OperationResult {
         $this->queue->sendMessage(new LdapMessageResponse(
             $message->getMessageId(),
             new ExtendedResponse(new LdapResult(ResultCode::NO_SUCH_OPERATION)),
         ));
+
+        return OperationOutcomeResult::failed();
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -27,7 +27,9 @@ use FreeDSx\Ldap\Server\Backend\Write\SchemaViolations;
 use FreeDSx\Ldap\Server\Backend\Write\WriteCommandFactory;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
-use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Operation\CompareOperationResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+use FreeDSx\Ldap\Server\Operation\WriteOperationResult;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
@@ -45,7 +47,6 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
         private LdapBackendInterface $backend,
         private WriteOperationDispatcher $writeDispatcher,
         private AccessControlInterface $accessControl,
-        private DispatchEventRecorder $eventRecorder = new DispatchEventRecorder(new EventLogger(null)),
         private WriteCommandFactory $commandFactory = new WriteCommandFactory(),
         private ResponseFactory $responseFactory = new ResponseFactory(),
         private ?PasswordPolicyContext $passwordPolicyContext = null,
@@ -59,7 +60,7 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): void {
+    ): OperationResult {
         $this->passwordPolicyContext?->clear();
         $schemaViolations = new SchemaViolations();
 
@@ -74,13 +75,11 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
                         ? ResultCode::COMPARE_TRUE
                         : ResultCode::COMPARE_FALSE,
                 ));
-                $this->eventRecorder->recordCompareCompleted(
+
+                return CompareOperationResult::completed(
                     $message,
                     $match,
-                    $token,
                 );
-
-                return;
             }
 
             $this->writeDispatcher->dispatch(
@@ -91,11 +90,6 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
                     schemaViolations: $schemaViolations,
                 ),
             );
-            $this->eventRecorder->recordSchemaViolations(
-                $schemaViolations,
-                $message,
-                $token,
-            );
 
             $successControl = $this->passwordPolicyControl();
             $this->queue->sendMessage($this->responseFactory->getStandardResponse(
@@ -105,9 +99,10 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
                 null,
                 ...($successControl === null ? [] : [$successControl]),
             ));
-            $this->eventRecorder->recordWriteSuccess(
+
+            return WriteOperationResult::success(
                 $message,
-                $token,
+                $schemaViolations,
             );
         } catch (OperationException $e) {
             $errorControl = $this->passwordPolicyControl();
@@ -123,15 +118,11 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
                 ),
                 ...($errorControl === null ? [] : [$errorControl]),
             ));
-            $this->eventRecorder->recordSchemaViolations(
-                $schemaViolations,
-                $message,
-                $token,
-            );
-            $this->eventRecorder->recordFailure(
+
+            return WriteOperationResult::failure(
                 $message,
                 $e,
-                $token,
+                $schemaViolations,
             );
         }
     }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -32,6 +32,8 @@ use FreeDSx\Ldap\Server\Paging\PagingRequestComparator;
 use FreeDSx\Ldap\Server\Paging\PagingResponse;
 use FreeDSx\Ldap\Server\RequestHistory;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use Generator;
@@ -66,7 +68,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): void {
+    ): OperationResult {
         $pagingRequest = $this->findOrMakePagingRequest($message);
         $searchRequest = $this->getSearchRequestFromMessage($message);
 
@@ -156,6 +158,10 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
             $this->queue,
             ...$controls,
         );
+
+        return $response !== null
+            ? OperationOutcomeResult::succeeded()
+            : OperationOutcomeResult::failed();
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordModifyHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordModifyHandler.php
@@ -29,6 +29,8 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyResult;
 use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyService;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
@@ -58,7 +60,7 @@ readonly class ServerPasswordModifyHandler implements ServerProtocolHandlerInter
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): void {
+    ): OperationResult {
         $this->passwordPolicyContext?->clear();
         $targetDn = null;
 
@@ -88,7 +90,7 @@ readonly class ServerPasswordModifyHandler implements ServerProtocolHandlerInter
                 $message,
             );
 
-            return;
+            return OperationOutcomeResult::failed();
         }
 
         $this->eventLogger->record(
@@ -99,6 +101,8 @@ readonly class ServerPasswordModifyHandler implements ServerProtocolHandlerInter
             subject: $token,
             message: $message,
         );
+
+        return OperationOutcomeResult::succeeded();
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerProtocolHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerProtocolHandlerInterface.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Socket\Exception\ConnectionException;
 
@@ -27,7 +28,7 @@ use FreeDSx\Socket\Exception\ConnectionException;
 interface ServerProtocolHandlerInterface
 {
     /**
-     * Handle protocol actions specific to the request received.
+     * Handle protocol actions specific to the request received and return its outcome.
      *
      * @throws OperationException
      * @throws ConnectionException
@@ -35,5 +36,5 @@ interface ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): void;
+    ): OperationResult;
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
@@ -24,6 +24,8 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\RequestContext;
 use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -61,7 +63,7 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): void {
+    ): OperationResult {
         $entry = Entry::fromArray('', [
             'namingContexts' => $this->options->getDseNamingContexts(),
             'subschemaSubentry' => [$this->options->getSubschemaEntry()->toString()],
@@ -121,6 +123,8 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
                 new SearchResultDone(ResultCode::SUCCESS),
             ),
         );
+
+        return OperationOutcomeResult::succeeded();
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -28,6 +28,8 @@ use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use Generator;
@@ -61,7 +63,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): void {
+    ): OperationResult {
         $request = $this->getSearchRequestFromMessage($message);
         $state = new SearchResultState();
         $isSuccessful = true;
@@ -132,6 +134,10 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
                 $token,
             );
         }
+
+        return $isSuccessful
+            ? OperationOutcomeResult::succeeded()
+            : OperationOutcomeResult::failed();
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
@@ -24,6 +24,8 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\Exception\ConnectionException;
@@ -57,7 +59,7 @@ class ServerStartTlsHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): void {
+    ): OperationResult {
         # RFC 4511 §4.14.2: return unavailable (not protocolError) when the server cannot negotiate TLS.
         if ($this->options->getSslCert() === null || !self::$hasOpenssl) {
             $this->queue->sendMessage(new LdapMessageResponse($message->getMessageId(), new ExtendedResponse(
@@ -77,7 +79,7 @@ class ServerStartTlsHandler implements ServerProtocolHandlerInterface
                 message: $message,
             );
 
-            return;
+            return OperationOutcomeResult::failed();
         }
         # If we are already encrypted, then consider this an operations error...
         if ($this->queue->isEncrypted()) {
@@ -94,7 +96,7 @@ class ServerStartTlsHandler implements ServerProtocolHandlerInterface
                 message: $message,
             );
 
-            return;
+            return OperationOutcomeResult::failed();
         }
 
         $this->queue->sendMessage(new LdapMessageResponse($message->getMessageId(), new ExtendedResponse(
@@ -106,5 +108,7 @@ class ServerStartTlsHandler implements ServerProtocolHandlerInterface
             ServerEvent::StartTlsSucceeded,
             message: $message,
         );
+
+        return OperationOutcomeResult::succeeded();
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSubschemaHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSubschemaHandler.php
@@ -23,6 +23,8 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Schema\Definition\ObjectClassOid;
 use FreeDSx\Ldap\Schema\Schema;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\ServerOptions;
 
@@ -41,7 +43,7 @@ class ServerSubschemaHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): void {
+    ): OperationResult {
         $schemaDn = $this->options->getSubschemaEntry();
         $rdn = $schemaDn->getRdn();
         $schema = $this->options->getSchema();
@@ -84,6 +86,8 @@ class ServerSubschemaHandler implements ServerProtocolHandlerInterface
                 new SearchResultDone(ResultCode::SUCCESS),
             ),
         );
+
+        return OperationOutcomeResult::succeeded();
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandler.php
@@ -15,6 +15,8 @@ namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -32,7 +34,9 @@ class ServerUnbindHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): void {
+    ): OperationResult {
         $this->queue->close();
+
+        return OperationOutcomeResult::succeeded();
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnsupportedExtendedHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnsupportedExtendedHandler.php
@@ -22,6 +22,8 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -41,7 +43,7 @@ final readonly class ServerUnsupportedExtendedHandler implements ServerProtocolH
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): void {
+    ): OperationResult {
         $request = $message->getRequest();
 
         if (!$request instanceof ExtendedRequest) {
@@ -62,5 +64,7 @@ final readonly class ServerUnsupportedExtendedHandler implements ServerProtocolH
                 $request->getName(),
             ),
         ));
+
+        return OperationOutcomeResult::failed();
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
@@ -21,6 +21,8 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
@@ -40,7 +42,7 @@ class ServerWhoAmIHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): void {
+    ): OperationResult {
         $userId = null;
 
         if ($token instanceof AuthenticatedTokenInterface) {
@@ -58,5 +60,7 @@ class ServerWhoAmIHandler implements ServerProtocolHandlerInterface
             $message->getMessageId(),
             new ExtendedResponse(new LdapResult(ResultCode::SUCCESS), null, $userId),
         ));
+
+        return OperationOutcomeResult::succeeded();
     }
 }

--- a/src/FreeDSx/Ldap/Server/Logging/OperationAuditor.php
+++ b/src/FreeDSx/Ldap/Server/Logging/OperationAuditor.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+namespace FreeDSx\Ldap\Server\Logging;
 
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -24,17 +24,14 @@ use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Server\AccessControl\OperationType;
 use FreeDSx\Ldap\Server\Backend\Write\SchemaViolations;
-use FreeDSx\Ldap\Server\Logging\EventContext;
-use FreeDSx\Ldap\Server\Logging\EventLogger;
-use FreeDSx\Ldap\Server\Logging\ServerEvent;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
- * Builds the per-operation event shape for {@see ServerDispatchHandler} and routes it through {@see EventLogger}.
+ * Builds the per-operation event shape for dispatched operations and routes it through {@see EventLogger}.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final readonly class DispatchEventRecorder
+final readonly class OperationAuditor
 {
     public function __construct(private EventLogger $eventLogger) {}
 

--- a/src/FreeDSx/Ldap/Server/Middleware/CriticalControlMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/CriticalControlMiddleware.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Protocol\Factory\HandlerRouteResolverInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 
 use function in_array;
 use function sprintf;
@@ -43,7 +44,7 @@ final readonly class CriticalControlMiddleware implements MiddlewareInterface
     public function process(
         ServerRequestContext $context,
         MiddlewareHandlerInterface $next,
-    ): void {
+    ): OperationResult {
         $controls = $context->message->controls();
         $routeId = $this->routeResolver->routeIdFor(
             $context->message->getRequest(),
@@ -57,7 +58,7 @@ final readonly class CriticalControlMiddleware implements MiddlewareInterface
             );
         }
 
-        $next->handle($context);
+        return $next->handle($context);
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuditMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuditMiddleware.php
@@ -11,27 +11,38 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Support\FreeDSx\Ldap\Middleware;
+namespace FreeDSx\Ldap\Server\Middleware;
 
+use FreeDSx\Ldap\Server\Logging\OperationAuditor;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\AuditableResult;
 use FreeDSx\Ldap\Server\Operation\OperationResult;
-use Throwable;
 
 /**
- * Throws the given throwable before reaching the next handler.
+ * Audits the operation outcome the handler propagates back up the pipeline.
  *
+ * @internal
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final readonly class ThrowingMiddleware implements MiddlewareInterface
+final readonly class OperationAuditMiddleware implements MiddlewareInterface
 {
-    public function __construct(private Throwable $throwable) {}
+    public function __construct(private OperationAuditor $auditor) {}
 
     public function process(
         ServerRequestContext $context,
         MiddlewareHandlerInterface $next,
     ): OperationResult {
-        throw $this->throwable;
+        $result = $next->handle($context);
+
+        if ($result instanceof AuditableResult) {
+            $result->record(
+                $this->auditor,
+                $context->token,
+            );
+        }
+
+        return $result;
     }
 }

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
@@ -27,13 +27,14 @@ use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Protocol\Factory\HandlerId;
 use FreeDSx\Ldap\Protocol\Factory\HandlerRouteResolverInterface;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\ServerProtocolHandler\DispatchEventRecorder;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\OperationType;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Logging\OperationAuditor;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -49,14 +50,14 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
      */
     private const PRIVILEGED_CONTROLS = [Control::OID_RELAX_RULES];
 
-    private DispatchEventRecorder $writeAuditRecorder;
+    private OperationAuditor $writeAuditRecorder;
 
     public function __construct(
         private HandlerRouteResolverInterface $routeResolver,
         private AccessControlInterface $accessControl,
         private EventLogger $eventLogger = new EventLogger(null),
     ) {
-        $this->writeAuditRecorder = new DispatchEventRecorder($eventLogger);
+        $this->writeAuditRecorder = new OperationAuditor($eventLogger);
     }
 
     /**
@@ -65,7 +66,7 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
     public function process(
         ServerRequestContext $context,
         MiddlewareHandlerInterface $next,
-    ): void {
+    ): OperationResult {
         $routeId = $this->routeResolver->routeIdFor(
             $context->message->getRequest(),
             $context->message->controls(),
@@ -83,7 +84,7 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
             );
         }
 
-        $next->handle($context);
+        return $next->handle($context);
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Middleware/Pipeline/ChainStep.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/Pipeline/ChainStep.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Middleware\Pipeline;
 
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+
 /**
  * Binds a single middleware to the next handler in the chain.
  *
@@ -26,9 +28,9 @@ final readonly class ChainStep implements MiddlewareHandlerInterface
         private MiddlewareHandlerInterface $next,
     ) {}
 
-    public function handle(ServerRequestContext $context): void
+    public function handle(ServerRequestContext $context): OperationResult
     {
-        $this->middleware->process(
+        return $this->middleware->process(
             $context,
             $this->next,
         );

--- a/src/FreeDSx/Ldap/Server/Middleware/Pipeline/HandlerInvoker.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/Pipeline/HandlerInvoker.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Middleware\Pipeline;
 
 use FreeDSx\Ldap\Protocol\Factory\ProtocolHandlerProviderInterface;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 
 /**
  * Terminal handler that resolves and invokes the per-request protocol handler.
@@ -25,13 +26,14 @@ final readonly class HandlerInvoker implements MiddlewareHandlerInterface
 {
     public function __construct(private ProtocolHandlerProviderInterface $protocolHandlerProvider) {}
 
-    public function handle(ServerRequestContext $context): void
+    public function handle(ServerRequestContext $context): OperationResult
     {
         $handler = $this->protocolHandlerProvider->get(
             $context->message->getRequest(),
             $context->message->controls(),
         );
-        $handler->handleRequest(
+
+        return $handler->handleRequest(
             $context->message,
             $context->token,
         );

--- a/src/FreeDSx/Ldap/Server/Middleware/Pipeline/MiddlewareChain.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/Pipeline/MiddlewareChain.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Middleware\Pipeline;
 
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+
 /**
  * Nests an ordered list of middleware around a terminal handler.
  *
@@ -41,8 +43,8 @@ final readonly class MiddlewareChain implements MiddlewareHandlerInterface
         $this->pipeline = $pipeline;
     }
 
-    public function handle(ServerRequestContext $context): void
+    public function handle(ServerRequestContext $context): OperationResult
     {
-        $this->pipeline->handle($context);
+        return $this->pipeline->handle($context);
     }
 }

--- a/src/FreeDSx/Ldap/Server/Middleware/Pipeline/MiddlewareHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/Pipeline/MiddlewareHandlerInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Middleware\Pipeline;
 
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Socket\Exception\ConnectionException;
 
 /**
@@ -28,5 +29,5 @@ interface MiddlewareHandlerInterface
      * @throws OperationException
      * @throws ConnectionException
      */
-    public function handle(ServerRequestContext $context): void;
+    public function handle(ServerRequestContext $context): OperationResult;
 }

--- a/src/FreeDSx/Ldap/Server/Middleware/Pipeline/MiddlewareInterface.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/Pipeline/MiddlewareInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Middleware\Pipeline;
 
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Socket\Exception\ConnectionException;
 
 /**
@@ -33,5 +34,5 @@ interface MiddlewareInterface
     public function process(
         ServerRequestContext $context,
         MiddlewareHandlerInterface $next,
-    ): void;
+    ): OperationResult;
 }

--- a/src/FreeDSx/Ldap/Server/Operation/AuditableResult.php
+++ b/src/FreeDSx/Ldap/Server/Operation/AuditableResult.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Operation;
+
+use FreeDSx\Ldap\Server\Logging\OperationAuditor;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * A result that carries audit-specific detail beyond its coarse outcome.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface AuditableResult extends OperationResult
+{
+    public function record(
+        OperationAuditor $auditor,
+        TokenInterface $token,
+    ): void;
+}

--- a/src/FreeDSx/Ldap/Server/Operation/CompareOperationResult.php
+++ b/src/FreeDSx/Ldap/Server/Operation/CompareOperationResult.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Operation;
+
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Server\Logging\OperationAuditor;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * The outcome of a successful compare, carrying the match result.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class CompareOperationResult implements AuditableResult
+{
+    private function __construct(
+        private LdapMessageRequest $message,
+        private bool $match,
+    ) {}
+
+    public static function completed(
+        LdapMessageRequest $message,
+        bool $match,
+    ): self {
+        return new self(
+            $message,
+            $match,
+        );
+    }
+
+    public function outcome(): OperationOutcome
+    {
+        return OperationOutcome::Succeeded;
+    }
+
+    public function record(
+        OperationAuditor $auditor,
+        TokenInterface $token,
+    ): void {
+        $auditor->recordCompareCompleted(
+            $this->message,
+            $this->match,
+            $token,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Operation/OperationOutcome.php
+++ b/src/FreeDSx/Ldap/Server/Operation/OperationOutcome.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Operation;
+
+/**
+ * The outcome of a handled operation.
+ */
+enum OperationOutcome
+{
+    case Succeeded;
+
+    case Failed;
+}

--- a/src/FreeDSx/Ldap/Server/Operation/OperationOutcomeResult.php
+++ b/src/FreeDSx/Ldap/Server/Operation/OperationOutcomeResult.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Operation;
+
+/**
+ * A result conveying only its outcome, with no further detail to carry.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class OperationOutcomeResult implements OperationResult
+{
+    private function __construct(private OperationOutcome $outcome) {}
+
+    public static function succeeded(): self
+    {
+        return new self(OperationOutcome::Succeeded);
+    }
+
+    public static function failed(): self
+    {
+        return new self(OperationOutcome::Failed);
+    }
+
+    public function outcome(): OperationOutcome
+    {
+        return $this->outcome;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Operation/OperationResult.php
+++ b/src/FreeDSx/Ldap/Server/Operation/OperationResult.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Operation;
+
+/**
+ * The outcome for an operation handler.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface OperationResult
+{
+    public function outcome(): OperationOutcome;
+}

--- a/src/FreeDSx/Ldap/Server/Operation/WriteOperationResult.php
+++ b/src/FreeDSx/Ldap/Server/Operation/WriteOperationResult.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Operation;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Server\Backend\Write\SchemaViolations;
+use FreeDSx\Ldap\Server\Logging\OperationAuditor;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * The outcome of a dispatched write, carrying any schema violations collected during it.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class WriteOperationResult implements AuditableResult
+{
+    private function __construct(
+        private LdapMessageRequest $message,
+        private SchemaViolations $schemaViolations,
+        private ?OperationException $failure = null,
+    ) {}
+
+    public static function success(
+        LdapMessageRequest $message,
+        SchemaViolations $schemaViolations,
+    ): self {
+        return new self(
+            $message,
+            $schemaViolations,
+        );
+    }
+
+    public static function failure(
+        LdapMessageRequest $message,
+        OperationException $exception,
+        SchemaViolations $schemaViolations,
+    ): self {
+        return new self(
+            $message,
+            $schemaViolations,
+            $exception,
+        );
+    }
+
+    public function outcome(): OperationOutcome
+    {
+        return $this->failure === null
+            ? OperationOutcome::Succeeded
+            : OperationOutcome::Failed;
+    }
+
+    public function record(
+        OperationAuditor $auditor,
+        TokenInterface $token,
+    ): void {
+        $auditor->recordSchemaViolations(
+            $this->schemaViolations,
+            $this->message,
+            $token,
+        );
+
+        if ($this->failure !== null) {
+            $auditor->recordFailure(
+                $this->message,
+                $this->failure,
+                $token,
+            );
+
+            return;
+        }
+
+        $auditor->recordWriteSuccess(
+            $this->message,
+            $token,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -41,7 +41,9 @@ use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Logging\OperationAuditor;
 use FreeDSx\Ldap\Server\Middleware\CriticalControlMiddleware;
+use FreeDSx\Ldap\Server\Middleware\OperationAuditMiddleware;
 use FreeDSx\Ldap\Server\Middleware\OperationAuthorizationMiddleware;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\HandlerInvoker;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareChain;
@@ -162,6 +164,7 @@ class ServerProtocolFactory
                         $this->options->getAccessControl(),
                         $eventLogger,
                     ),
+                    new OperationAuditMiddleware(new OperationAuditor($eventLogger)),
                 ],
                 new HandlerInvoker($handlerProvider),
             ),

--- a/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
@@ -33,7 +33,6 @@ use FreeDSx\Ldap\Server\Backend\Write\PasswordPolicyWriteHandler;
 use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerDispatchHandler;
-use FreeDSx\Ldap\Protocol\ServerProtocolHandler\DispatchEventRecorder;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\AllowUserChangeConstraint;
 use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\HistoryConstraint;
@@ -318,7 +317,6 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
                 $this->backend,
             ),
             accessControl: $this->createMock(AccessControlInterface::class),
-            eventRecorder: new DispatchEventRecorder(new EventLogger(null)),
             passwordPolicyContext: $this->context,
         );
     }

--- a/tests/support/Middleware/RecordingMiddleware.php
+++ b/tests/support/Middleware/RecordingMiddleware.php
@@ -16,6 +16,7 @@ namespace Tests\Support\FreeDSx\Ldap\Middleware;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 
 /**
  * Records before/after markers around the next handler for ordering assertions.
@@ -32,9 +33,11 @@ final readonly class RecordingMiddleware implements MiddlewareInterface
     public function process(
         ServerRequestContext $context,
         MiddlewareHandlerInterface $next,
-    ): void {
+    ): OperationResult {
         $this->log->record('before:' . $this->label);
-        $next->handle($context);
+        $result = $next->handle($context);
         $this->log->record('after:' . $this->label);
+
+        return $result;
     }
 }

--- a/tests/support/Middleware/RecordingMiddlewareHandler.php
+++ b/tests/support/Middleware/RecordingMiddlewareHandler.php
@@ -15,6 +15,8 @@ namespace Tests\Support\FreeDSx\Ldap\Middleware;
 
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 
 /**
  * Terminal handler that records its invocation and captures the received context.
@@ -30,9 +32,11 @@ final class RecordingMiddlewareHandler implements MiddlewareHandlerInterface
         private readonly string $label = 'terminal',
     ) {}
 
-    public function handle(ServerRequestContext $context): void
+    public function handle(ServerRequestContext $context): OperationResult
     {
         $this->received = $context;
         $this->log->record($this->label);
+
+        return OperationOutcomeResult::succeeded();
     }
 }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
@@ -35,6 +35,9 @@ use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\Backend\Write\WriteRequestInterface;
+use FreeDSx\Ldap\Server\Operation\CompareOperationResult;
+use FreeDSx\Ldap\Server\Operation\OperationOutcome;
+use FreeDSx\Ldap\Server\Operation\WriteOperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -86,7 +89,13 @@ final class ServerDispatchHandlerTest extends TestCase
             ->method('handle')
             ->with(self::isInstanceOf(WriteRequestInterface::class));
 
-        $this->subject->handleRequest($add, $this->mockToken);
+        $result = $this->subject->handleRequest($add, $this->mockToken);
+
+        self::assertInstanceOf(WriteOperationResult::class, $result);
+        self::assertSame(
+            OperationOutcome::Succeeded,
+            $result->outcome(),
+        );
     }
 
     public function test_it_sends_error_response_for_operation_exceptions_from_the_write_handler(): void
@@ -109,7 +118,13 @@ final class ServerDispatchHandlerTest extends TestCase
             }))
             ->willReturnSelf();
 
-        $this->subject->handleRequest($add, $this->mockToken);
+        $result = $this->subject->handleRequest($add, $this->mockToken);
+
+        self::assertInstanceOf(WriteOperationResult::class, $result);
+        self::assertSame(
+            OperationOutcome::Failed,
+            $result->outcome(),
+        );
     }
 
     public function test_it_delegates_compare_to_the_backend(): void
@@ -130,7 +145,9 @@ final class ServerDispatchHandlerTest extends TestCase
             )
             ->willReturn(true);
 
-        $this->subject->handleRequest($compare, $this->mockToken);
+        $result = $this->subject->handleRequest($compare, $this->mockToken);
+
+        self::assertInstanceOf(CompareOperationResult::class, $result);
     }
 
     public function test_it_sends_error_response_for_operation_exceptions_from_backend_compare(): void

--- a/tests/unit/Server/Logging/OperationAuditorTest.php
+++ b/tests/unit/Server/Logging/OperationAuditorTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+namespace Tests\Unit\FreeDSx\Ldap\Server\Logging;
 
 use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Change;
@@ -27,19 +27,19 @@ use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\ServerProtocolHandler\DispatchEventRecorder;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Server\Backend\Write\SchemaViolationDisposition;
 use FreeDSx\Ldap\Server\Backend\Write\SchemaViolations;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
+use FreeDSx\Ldap\Server\Logging\OperationAuditor;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Tests\Support\FreeDSx\Ldap\Logging\RecordingLogger;
 
-final class DispatchEventRecorderTest extends TestCase
+final class OperationAuditorTest extends TestCase
 {
     private const TARGET_DN = 'cn=Bob,dc=example,dc=com';
 
@@ -49,14 +49,14 @@ final class DispatchEventRecorderTest extends TestCase
 
     private RecordingLogger $recordingLogger;
 
-    private DispatchEventRecorder $subject;
+    private OperationAuditor $subject;
 
     private BindToken $token;
 
     protected function setUp(): void
     {
         $this->recordingLogger = new RecordingLogger();
-        $this->subject = new DispatchEventRecorder(new EventLogger(
+        $this->subject = new OperationAuditor(new EventLogger(
             $this->recordingLogger,
             EventLogPolicy::all(),
         ));

--- a/tests/unit/Server/Middleware/OperationAuditMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationAuditMiddlewareTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Operation\Request\AddRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Server\Backend\Write\SchemaViolations;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
+use FreeDSx\Ldap\Server\Logging\OperationAuditor;
+use FreeDSx\Ldap\Server\Middleware\OperationAuditMiddleware;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+use FreeDSx\Ldap\Server\Operation\WriteOperationResult;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Logging\RecordingLogger;
+
+final class OperationAuditMiddlewareTest extends TestCase
+{
+    private RecordingLogger $logger;
+
+    private OperationAuditMiddleware $subject;
+
+    private ServerRequestContext $context;
+
+    protected function setUp(): void
+    {
+        $this->logger = new RecordingLogger();
+        $this->subject = new OperationAuditMiddleware(new OperationAuditor(new EventLogger(
+            $this->logger,
+            EventLogPolicy::all(),
+        )));
+        $this->context = new ServerRequestContext(
+            new LdapMessageRequest(1, new AddRequest(Entry::create('cn=foo,dc=bar'))),
+            new BindToken(
+                'cn=alice,dc=bar',
+                'secret',
+                new Dn('cn=alice,dc=bar'),
+            ),
+        );
+    }
+
+    public function test_it_records_an_auditable_result(): void
+    {
+        $this->subject->process(
+            $this->context,
+            $this->handlerReturning(WriteOperationResult::success(
+                $this->context->message,
+                new SchemaViolations(),
+            )),
+        );
+
+        self::assertSame(
+            'entry.added',
+            $this->logger->records[0]['message'],
+        );
+    }
+
+    public function test_it_does_not_record_a_non_auditable_result(): void
+    {
+        $this->subject->process(
+            $this->context,
+            $this->handlerReturning(OperationOutcomeResult::succeeded()),
+        );
+
+        self::assertSame(
+            [],
+            $this->logger->records,
+        );
+    }
+
+    public function test_it_returns_the_result_from_the_next_handler_unchanged(): void
+    {
+        $result = OperationOutcomeResult::failed();
+
+        self::assertSame(
+            $result,
+            $this->subject->process(
+                $this->context,
+                $this->handlerReturning($result),
+            ),
+        );
+    }
+
+    private function handlerReturning(OperationResult $result): MiddlewareHandlerInterface
+    {
+        return new class ($result) implements MiddlewareHandlerInterface {
+            public function __construct(private readonly OperationResult $result) {}
+
+            public function handle(ServerRequestContext $context): OperationResult
+            {
+                return $this->result;
+            }
+        };
+    }
+}


### PR DESCRIPTION
This moves the audit logging for operation handlers into a middleware. This is to separate concerns out of the handler and dispatcher and into one spot. The handlers build what should be logged and return the result, but the middleware handles the logging piece in one spot. There will be a follow up to this to replace some other spots. This largely gets the base in place.