### PR TITLE
[1.0.0] Move remaining audit logging into middleware.

### DIFF
--- a/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
@@ -86,7 +86,6 @@ final readonly class ProtocolHandlerProvider implements ProtocolHandlerProviderI
                 ),
                 passwordPolicyContext: $this->passwordPolicyContext,
             ),
-            eventLogger: $this->eventLogger,
             passwordPolicyContext: $this->passwordPolicyContext,
         );
     }

--- a/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
@@ -117,7 +117,6 @@ final readonly class ProtocolHandlerProvider implements ProtocolHandlerProviderI
             accessControl: $this->options->getAccessControl(),
             schema: $this->options->getSchema(),
             limits: $this->options->makeSearchLimits(),
-            eventLogger: $this->eventLogger,
         );
     }
 
@@ -158,7 +157,6 @@ final readonly class ProtocolHandlerProvider implements ProtocolHandlerProviderI
             requestHistory: $this->requestHistory,
             schema: $this->options->getSchema(),
             limits: $this->options->makeSearchLimits(),
-            eventLogger: $this->eventLogger,
         );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -25,15 +25,14 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Paging\PagingRequest;
 use FreeDSx\Ldap\Server\Paging\PagingRequestComparator;
 use FreeDSx\Ldap\Server\Paging\PagingResponse;
 use FreeDSx\Ldap\Server\RequestHistory;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
-use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
 use FreeDSx\Ldap\Server\Operation\OperationResult;
+use FreeDSx\Ldap\Server\Operation\SearchOperationResult;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use Generator;
@@ -58,7 +57,6 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         private readonly Schema $schema,
         private readonly PagingRequestComparator $requestComparator = new PagingRequestComparator(),
         private readonly SearchLimits $limits = new SearchLimits(),
-        private readonly EventLogger $eventLogger = new EventLogger(null),
     ) {}
 
     /**
@@ -74,6 +72,8 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
 
         $response = null;
         $controls = [];
+        $entriesReturned = 0;
+        $failure = null;
         try {
             $this->assertBaseDnProvided($searchRequest);
             $response = $this->handlePaging(
@@ -99,7 +99,9 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
                         : $pagingRequest->getNextCookie(),
                 );
             }
+            $entriesReturned = $response->getEntries()->count();
         } catch (OperationException $e) {
+            $failure = $e;
             $matchedDn = $this->filterMatchedDn(
                 $e->getMatchedDn(),
                 $token,
@@ -114,19 +116,6 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
                 $e->getMessage(),
             );
             $controls[] = new PagingControl(0, '');
-            $this->eventLogger->recordSearchFailure(
-                $message,
-                $e,
-                $token,
-            );
-        }
-
-        if ($response !== null) {
-            $this->eventLogger->recordSearchSuccess(
-                $message,
-                $response->getEntries()->count(),
-                $token,
-            );
         }
 
         $sortControl = $this->sortingControl($message);
@@ -159,9 +148,15 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
             ...$controls,
         );
 
-        return $response !== null
-            ? OperationOutcomeResult::succeeded()
-            : OperationOutcomeResult::failed();
+        return $failure !== null
+            ? SearchOperationResult::failure(
+                $message,
+                $failure,
+            )
+            : SearchOperationResult::success(
+                $message,
+                $entriesReturned,
+            );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordModifyHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordModifyHandler.php
@@ -15,7 +15,6 @@ namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Control\Control;
-use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
@@ -26,11 +25,8 @@ use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
-use FreeDSx\Ldap\Server\Logging\EventContext;
-use FreeDSx\Ldap\Server\Logging\EventLogger;
-use FreeDSx\Ldap\Server\Logging\ServerEvent;
-use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
 use FreeDSx\Ldap\Server\Operation\OperationResult;
+use FreeDSx\Ldap\Server\Operation\PasswordModifyOperationResult;
 use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyResult;
 use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyService;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
@@ -47,7 +43,6 @@ readonly class ServerPasswordModifyHandler implements ServerProtocolHandlerInter
     public function __construct(
         private ServerQueue $queue,
         private PasswordModifyService $service,
-        private EventLogger $eventLogger = new EventLogger(null),
         private ResponseFactory $responseFactory = new ResponseFactory(),
         private ?PasswordPolicyContext $passwordPolicyContext = null,
     ) {}
@@ -83,26 +78,18 @@ readonly class ServerPasswordModifyHandler implements ServerProtocolHandlerInter
                 null,
                 ...($control === null ? [] : [$control]),
             ));
-            $this->recordFailure(
-                $e,
-                $token,
-                $targetDn,
-                $message,
-            );
 
-            return OperationOutcomeResult::failed();
+            return PasswordModifyOperationResult::failure(
+                $message,
+                $e,
+                $targetDn,
+            );
         }
 
-        $this->eventLogger->record(
-            ServerEvent::PasswordModifySuccess,
-            [
-                EventContext::TARGET => [EventContext::DN => $targetDn->toString()],
-            ],
-            subject: $token,
-            message: $message,
+        return PasswordModifyOperationResult::success(
+            $message,
+            $targetDn,
         );
-
-        return OperationOutcomeResult::succeeded();
     }
 
     /**
@@ -150,36 +137,5 @@ readonly class ServerPasswordModifyHandler implements ServerProtocolHandlerInter
         $this->passwordPolicyContext?->clear();
 
         return $control;
-    }
-
-    private function recordFailure(
-        OperationException $exception,
-        TokenInterface $token,
-        ?Dn $targetDn,
-        LdapMessageRequest $message,
-    ): void {
-        $event = ServerEvent::fromOperationException(
-            $exception,
-            ServerEvent::AuthorizationDeniedWrite,
-            ServerEvent::PasswordModifyFailed,
-        );
-
-        if ($event === null) {
-            return;
-        }
-
-        $context = [];
-
-        if ($targetDn !== null) {
-            $context[EventContext::TARGET] = [EventContext::DN => $targetDn->toString()];
-        }
-
-        $this->eventLogger->recordFailure(
-            $event,
-            $exception,
-            $context,
-            subject: $token,
-            message: $message,
-        );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -27,9 +27,8 @@ use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
-use FreeDSx\Ldap\Server\Logging\EventLogger;
-use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
 use FreeDSx\Ldap\Server\Operation\OperationResult;
+use FreeDSx\Ldap\Server\Operation\SearchOperationResult;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use Generator;
@@ -54,7 +53,6 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         private readonly AccessControlInterface $accessControl,
         private readonly Schema $schema,
         private readonly SearchLimits $limits = new SearchLimits(),
-        private readonly EventLogger $eventLogger = new EventLogger(null),
     ) {}
 
     /**
@@ -66,7 +64,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
     ): OperationResult {
         $request = $this->getSearchRequestFromMessage($message);
         $state = new SearchResultState();
-        $isSuccessful = true;
+        $failure = null;
 
         try {
             $this->assertBaseDnProvided($request);
@@ -94,7 +92,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
                 $state,
             );
         } catch (OperationException $e) {
-            $isSuccessful = false;
+            $failure = $e;
             $matchedDn = $this->filterMatchedDn(
                 $e->getMatchedDn(),
                 $token,
@@ -107,11 +105,6 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
                     ? $matchedDn->toString()
                     : '',
                 $e->getMessage(),
-            );
-            $this->eventLogger->recordSearchFailure(
-                $message,
-                $e,
-                $token,
             );
         }
 
@@ -127,17 +120,15 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
             ...$responseControls,
         );
 
-        if ($isSuccessful) {
-            $this->eventLogger->recordSearchSuccess(
+        return $failure !== null
+            ? SearchOperationResult::failure(
+                $message,
+                $failure,
+            )
+            : SearchOperationResult::success(
                 $message,
                 $state->entriesReturned,
-                $token,
             );
-        }
-
-        return $isSuccessful
-            ? OperationOutcomeResult::succeeded()
-            : OperationOutcomeResult::failed();
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/AccessControl/OperationTargetDn.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/OperationTargetDn.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Operation\Request\AddRequest;
+use FreeDSx\Ldap\Operation\Request\CompareRequest;
+use FreeDSx\Ldap\Operation\Request\DeleteRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+
+/**
+ * Resolves the primary target DN an operation request acts on.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class OperationTargetDn
+{
+    public static function of(RequestInterface $request): ?Dn
+    {
+        return match (true) {
+            $request instanceof AddRequest => $request->getEntry()->getDn(),
+            $request instanceof ModifyRequest,
+            $request instanceof DeleteRequest,
+            $request instanceof ModifyDnRequest,
+            $request instanceof CompareRequest => $request->getDn(),
+            default => null,
+        };
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Logging/EventLogger.php
+++ b/src/FreeDSx/Ldap/Server/Logging/EventLogger.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Logging;
 
 use FreeDSx\Ldap\Exception\OperationException;
-use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -148,68 +147,6 @@ final readonly class EventLogger
             $subject,
             $message,
         );
-    }
-
-    public function recordSearchSuccess(
-        LdapMessageRequest $message,
-        int $entriesReturned,
-        TokenInterface $token,
-    ): void {
-        $request = $message->getRequest();
-
-        if (!$request instanceof SearchRequest) {
-            return;
-        }
-
-        $this->record(
-            ServerEvent::SearchAuthorized,
-            [
-                EventContext::ENTRIES_RETURNED => $entriesReturned,
-                EventContext::TARGET => self::searchTarget($request),
-            ],
-            subject: $token,
-            message: $message,
-        );
-    }
-
-    public function recordSearchFailure(
-        LdapMessageRequest $message,
-        OperationException $exception,
-        TokenInterface $token,
-    ): void {
-        $event = ServerEvent::fromOperationException(
-            $exception,
-            ServerEvent::AuthorizationDeniedRead,
-        );
-
-        if ($event === null) {
-            return;
-        }
-
-        $request = $message->getRequest();
-
-        if (!$request instanceof SearchRequest) {
-            return;
-        }
-
-        $this->recordFailure(
-            $event,
-            $exception,
-            [EventContext::TARGET => self::searchTarget($request)],
-            subject: $token,
-            message: $message,
-        );
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private static function searchTarget(SearchRequest $request): array
-    {
-        return [
-            EventContext::BASE_DN => (string) $request->getBaseDn(),
-            EventContext::SCOPE => $request->getScope(),
-        ];
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Logging/OperationAuditor.php
+++ b/src/FreeDSx/Ldap/Server/Logging/OperationAuditor.php
@@ -21,6 +21,7 @@ use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Server\AccessControl\OperationType;
 use FreeDSx\Ldap\Server\Backend\Write\SchemaViolations;
@@ -83,6 +84,57 @@ final readonly class OperationAuditor
                     EventContext::ATTRIBUTE => $request->getFilter()->getAttribute(),
                 ],
             ],
+            subject: $token,
+            message: $message,
+        );
+    }
+
+    public function recordSearchSuccess(
+        LdapMessageRequest $message,
+        int $entriesReturned,
+        TokenInterface $token,
+    ): void {
+        $request = $message->getRequest();
+
+        if (!$request instanceof SearchRequest) {
+            return;
+        }
+
+        $this->eventLogger->record(
+            ServerEvent::SearchAuthorized,
+            [
+                EventContext::ENTRIES_RETURNED => $entriesReturned,
+                EventContext::TARGET => $this->searchTarget($request),
+            ],
+            subject: $token,
+            message: $message,
+        );
+    }
+
+    public function recordSearchFailure(
+        LdapMessageRequest $message,
+        OperationException $exception,
+        TokenInterface $token,
+    ): void {
+        $event = ServerEvent::fromOperationException(
+            $exception,
+            ServerEvent::AuthorizationDeniedRead,
+        );
+
+        if ($event === null) {
+            return;
+        }
+
+        $request = $message->getRequest();
+
+        if (!$request instanceof SearchRequest) {
+            return;
+        }
+
+        $this->eventLogger->recordFailure(
+            $event,
+            $exception,
+            [EventContext::TARGET => $this->searchTarget($request)],
             subject: $token,
             message: $message,
         );
@@ -152,6 +204,17 @@ final readonly class OperationAuditor
             $context,
             $extra,
         );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function searchTarget(SearchRequest $request): array
+    {
+        return [
+            EventContext::BASE_DN => (string) $request->getBaseDn(),
+            EventContext::SCOPE => $request->getScope(),
+        ];
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Logging/OperationAuditor.php
+++ b/src/FreeDSx/Ldap/Server/Logging/OperationAuditor.php
@@ -15,20 +15,18 @@ namespace FreeDSx\Ldap\Server\Logging;
 
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\OperationException;
-use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Operation\Request\CompareRequest;
-use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
-use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Server\AccessControl\OperationTargetDn;
 use FreeDSx\Ldap\Server\AccessControl\OperationType;
 use FreeDSx\Ldap\Server\Backend\Write\SchemaViolations;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
- * Builds the per-operation event shape for dispatched operations and routes it through {@see EventLogger}.
+ * Builds the per-operation audit event shape and routes it through {@see EventLogger}.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -272,7 +270,7 @@ final readonly class OperationAuditor
             return $this->modifyDnTarget($request);
         }
 
-        return [EventContext::DN => $this->dnFor($request)?->toString() ?? ''];
+        return [EventContext::DN => OperationTargetDn::of($request)?->toString() ?? ''];
     }
 
     /**
@@ -291,17 +289,5 @@ final readonly class OperationAuditor
         }
 
         return $target;
-    }
-
-    private function dnFor(RequestInterface $request): ?Dn
-    {
-        return match (true) {
-            $request instanceof AddRequest => $request->getEntry()->getDn(),
-            $request instanceof ModifyRequest,
-            $request instanceof DeleteRequest,
-            $request instanceof ModifyDnRequest,
-            $request instanceof CompareRequest => $request->getDn(),
-            default => null,
-        };
     }
 }

--- a/src/FreeDSx/Ldap/Server/Logging/OperationAuditor.php
+++ b/src/FreeDSx/Ldap/Server/Logging/OperationAuditor.php
@@ -140,6 +140,52 @@ final readonly class OperationAuditor
         );
     }
 
+    public function recordPasswordModifySuccess(
+        LdapMessageRequest $message,
+        Dn $targetDn,
+        TokenInterface $token,
+    ): void {
+        $this->eventLogger->record(
+            ServerEvent::PasswordModifySuccess,
+            [
+                EventContext::TARGET => [EventContext::DN => $targetDn->toString()],
+            ],
+            subject: $token,
+            message: $message,
+        );
+    }
+
+    public function recordPasswordModifyFailure(
+        LdapMessageRequest $message,
+        OperationException $exception,
+        ?Dn $targetDn,
+        TokenInterface $token,
+    ): void {
+        $event = ServerEvent::fromOperationException(
+            $exception,
+            ServerEvent::AuthorizationDeniedWrite,
+            ServerEvent::PasswordModifyFailed,
+        );
+
+        if ($event === null) {
+            return;
+        }
+
+        $context = [];
+
+        if ($targetDn !== null) {
+            $context[EventContext::TARGET] = [EventContext::DN => $targetDn->toString()];
+        }
+
+        $this->eventLogger->recordFailure(
+            $event,
+            $exception,
+            $context,
+            subject: $token,
+            message: $message,
+        );
+    }
+
     public function recordFailure(
         LdapMessageRequest $message,
         OperationException $exception,

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
@@ -50,14 +50,14 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
      */
     private const PRIVILEGED_CONTROLS = [Control::OID_RELAX_RULES];
 
-    private OperationAuditor $writeAuditRecorder;
+    private OperationAuditor $auditor;
 
     public function __construct(
         private HandlerRouteResolverInterface $routeResolver,
         private AccessControlInterface $accessControl,
-        private EventLogger $eventLogger = new EventLogger(null),
+        EventLogger $eventLogger = new EventLogger(null),
     ) {
-        $this->writeAuditRecorder = new OperationAuditor($eventLogger);
+        $this->auditor = new OperationAuditor($eventLogger);
     }
 
     /**
@@ -113,7 +113,7 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
                 $baseDn,
             );
         } catch (OperationException $e) {
-            $this->eventLogger->recordSearchFailure(
+            $this->auditor->recordSearchFailure(
                 $message,
                 $e,
                 $token,
@@ -158,7 +158,7 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
                 $token,
             );
         } catch (OperationException $e) {
-            $this->writeAuditRecorder->recordFailure(
+            $this->auditor->recordFailure(
                 $message,
                 $e,
                 $token,

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
@@ -15,11 +15,9 @@ namespace FreeDSx\Ldap\Server\Middleware;
 
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\ControlBag;
-use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Operation\Request\CompareRequest;
-use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
@@ -28,6 +26,7 @@ use FreeDSx\Ldap\Protocol\Factory\HandlerId;
 use FreeDSx\Ldap\Protocol\Factory\HandlerRouteResolverInterface;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\AccessControl\OperationTargetDn;
 use FreeDSx\Ldap\Server\AccessControl\OperationType;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\OperationAuditor;
@@ -190,7 +189,7 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
             return;
         }
 
-        $dn = $this->dnFor($request);
+        $dn = OperationTargetDn::of($request);
 
         if ($dn === null) {
             return;
@@ -271,7 +270,7 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
         ControlBag $controls,
         TokenInterface $token,
     ): void {
-        $dn = $this->dnFor($request);
+        $dn = OperationTargetDn::of($request);
 
         if ($dn === null) {
             return;
@@ -288,17 +287,5 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
                 $oid,
             );
         }
-    }
-
-    private function dnFor(RequestInterface $request): ?Dn
-    {
-        return match (true) {
-            $request instanceof AddRequest => $request->getEntry()->getDn(),
-            $request instanceof ModifyRequest,
-            $request instanceof DeleteRequest,
-            $request instanceof ModifyDnRequest,
-            $request instanceof CompareRequest => $request->getDn(),
-            default => null,
-        };
     }
 }

--- a/src/FreeDSx/Ldap/Server/Operation/PasswordModifyOperationResult.php
+++ b/src/FreeDSx/Ldap/Server/Operation/PasswordModifyOperationResult.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Operation;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Server\Logging\OperationAuditor;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * The outcome of a password modify, carrying the resolved target when known.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class PasswordModifyOperationResult implements AuditableResult
+{
+    private function __construct(
+        private LdapMessageRequest $message,
+        private ?Dn $targetDn = null,
+        private ?OperationException $failure = null,
+    ) {}
+
+    public static function success(
+        LdapMessageRequest $message,
+        Dn $targetDn,
+    ): self {
+        return new self(
+            $message,
+            $targetDn,
+        );
+    }
+
+    public static function failure(
+        LdapMessageRequest $message,
+        OperationException $exception,
+        ?Dn $targetDn = null,
+    ): self {
+        return new self(
+            $message,
+            $targetDn,
+            $exception,
+        );
+    }
+
+    public function outcome(): OperationOutcome
+    {
+        return $this->failure === null
+            ? OperationOutcome::Succeeded
+            : OperationOutcome::Failed;
+    }
+
+    public function record(
+        OperationAuditor $auditor,
+        TokenInterface $token,
+    ): void {
+        if ($this->failure !== null) {
+            $auditor->recordPasswordModifyFailure(
+                $this->message,
+                $this->failure,
+                $this->targetDn,
+                $token,
+            );
+
+            return;
+        }
+
+        if ($this->targetDn !== null) {
+            $auditor->recordPasswordModifySuccess(
+                $this->message,
+                $this->targetDn,
+                $token,
+            );
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Operation/SearchOperationResult.php
+++ b/src/FreeDSx/Ldap/Server/Operation/SearchOperationResult.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Operation;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Server\Logging\OperationAuditor;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * The outcome of a search, carrying the entries returned on success.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class SearchOperationResult implements AuditableResult
+{
+    private function __construct(
+        private LdapMessageRequest $message,
+        private int $entriesReturned = 0,
+        private ?OperationException $failure = null,
+    ) {}
+
+    public static function success(
+        LdapMessageRequest $message,
+        int $entriesReturned,
+    ): self {
+        return new self(
+            $message,
+            $entriesReturned,
+        );
+    }
+
+    public static function failure(
+        LdapMessageRequest $message,
+        OperationException $exception,
+    ): self {
+        return new self(
+            $message,
+            failure: $exception,
+        );
+    }
+
+    public function outcome(): OperationOutcome
+    {
+        return $this->failure === null
+            ? OperationOutcome::Succeeded
+            : OperationOutcome::Failed;
+    }
+
+    public function record(
+        OperationAuditor $auditor,
+        TokenInterface $token,
+    ): void {
+        if ($this->failure !== null) {
+            $auditor->recordSearchFailure(
+                $this->message,
+                $this->failure,
+                $token,
+            );
+
+            return;
+        }
+
+        $auditor->recordSearchSuccess(
+            $this->message,
+            $this->entriesReturned,
+            $token,
+        );
+    }
+}

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
@@ -38,6 +38,8 @@ use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Paging\PagingRequest;
 use FreeDSx\Ldap\Server\RequestHistory;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
+use FreeDSx\Ldap\Server\Operation\OperationOutcome;
+use FreeDSx\Ldap\Server\Operation\SearchOperationResult;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use Generator;
@@ -158,7 +160,7 @@ class ServerPagingHandlerTest extends TestCase
             ->with(self::isInstanceOf(SearchRequest::class))
             ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
 
-        $this->subject->handleRequest(
+        $result = $this->subject->handleRequest(
             $message,
             $this->mockToken,
         );
@@ -172,6 +174,11 @@ class ServerPagingHandlerTest extends TestCase
         );
         // Generator was exhausted with only 2 entries, so paging is complete (cookie='').
         self::assertSame('', $this->donePagingControl()->getCookie());
+        self::assertInstanceOf(SearchOperationResult::class, $result);
+        self::assertSame(
+            OperationOutcome::Succeeded,
+            $result->outcome(),
+        );
     }
 
     public function test_it_should_store_the_generator_and_return_a_cookie_when_more_entries_remain(): void
@@ -309,7 +316,7 @@ class ServerPagingHandlerTest extends TestCase
             ->expects(self::never())
             ->method('search');
 
-        $this->subject->handleRequest(
+        $result = $this->subject->handleRequest(
             $message,
             $this->mockToken,
         );
@@ -319,6 +326,11 @@ class ServerPagingHandlerTest extends TestCase
         self::assertInstanceOf(SearchResultDone::class, $done);
         self::assertSame(ResultCode::OPERATIONS_ERROR, $done->getResultCode());
         self::assertSame('', $this->donePagingControl()->getCookie());
+        self::assertInstanceOf(SearchOperationResult::class, $result);
+        self::assertSame(
+            OperationOutcome::Failed,
+            $result->outcome(),
+        );
     }
 
     public function test_it_throws_an_exception_if_the_paging_cookie_does_not_exist(): void

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordModifyHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordModifyHandlerTest.php
@@ -28,6 +28,8 @@ use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\Operation\OperationOutcome;
+use FreeDSx\Ldap\Server\Operation\PasswordModifyOperationResult;
 use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyService;
 use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyTargetResolver;
 use FreeDSx\Ldap\Server\Token\AnonToken;
@@ -97,12 +99,18 @@ final class ServerPasswordModifyHandlerTest extends TestCase
                 && $r->getResponse()->getGeneratedPassword() === null,
             ));
 
-        $this->subject->handleRequest(
+        $result = $this->subject->handleRequest(
             new LdapMessageRequest(
                 1,
                 new PasswordModifyRequest(null, '12345', 'newpass'),
             ),
             $this->userToken,
+        );
+
+        self::assertInstanceOf(PasswordModifyOperationResult::class, $result);
+        self::assertSame(
+            OperationOutcome::Succeeded,
+            $result->outcome(),
         );
     }
 
@@ -162,12 +170,18 @@ final class ServerPasswordModifyHandlerTest extends TestCase
                 && $r->getResponse()->getResultCode() === ResultCode::INVALID_CREDENTIALS,
             ));
 
-        $this->subject->handleRequest(
+        $result = $this->subject->handleRequest(
             new LdapMessageRequest(
                 1,
                 new PasswordModifyRequest(null, 'wrongpass', 'newpass'),
             ),
             $this->userToken,
+        );
+
+        self::assertInstanceOf(PasswordModifyOperationResult::class, $result);
+        self::assertSame(
+            OperationOutcome::Failed,
+            $result->outcome(),
         );
     }
 }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
@@ -38,6 +38,8 @@ use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
+use FreeDSx\Ldap\Server\Operation\OperationOutcome;
+use FreeDSx\Ldap\Server\Operation\SearchOperationResult;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use Generator;
@@ -138,7 +140,7 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('evaluate')
             ->willReturn(true);
 
-        $this->subject->handleRequest(
+        $result = $this->subject->handleRequest(
             $search,
             $this->mockToken,
         );
@@ -151,6 +153,11 @@ final class ServerSearchHandlerTest extends TestCase
                 new SearchResultDone(0, 'dc=foo,dc=bar'),
             ),
         ]);
+        self::assertInstanceOf(SearchOperationResult::class, $result);
+        self::assertSame(
+            OperationOutcome::Succeeded,
+            $result->outcome(),
+        );
     }
 
     public function test_entry_stripped_by_acl_is_excluded_when_it_no_longer_matches_filter(): void
@@ -214,7 +221,7 @@ final class ServerSearchHandlerTest extends TestCase
                 ),
             );
 
-        $this->subject->handleRequest(
+        $result = $this->subject->handleRequest(
             $search,
             $this->mockToken,
         );
@@ -229,6 +236,11 @@ final class ServerSearchHandlerTest extends TestCase
                 ),
             ),
         ]);
+        self::assertInstanceOf(SearchOperationResult::class, $result);
+        self::assertSame(
+            OperationOutcome::Failed,
+            $result->outcome(),
+        );
     }
 
     public function test_it_should_return_size_limit_exceeded_with_partial_results_when_limit_is_hit(): void

--- a/tests/unit/Server/AccessControl/OperationTargetDnTest.php
+++ b/tests/unit/Server/AccessControl/OperationTargetDnTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl;
+
+use FreeDSx\Ldap\Entry\Change;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Operation\Request\AddRequest;
+use FreeDSx\Ldap\Operation\Request\CompareRequest;
+use FreeDSx\Ldap\Operation\Request\DeleteRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\AccessControl\OperationTargetDn;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class OperationTargetDnTest extends TestCase
+{
+    #[DataProvider('provideRequests')]
+    public function test_it_resolves_the_target_dn(
+        RequestInterface $request,
+        ?string $expected,
+    ): void {
+        self::assertSame(
+            $expected,
+            OperationTargetDn::of($request)?->toString(),
+        );
+    }
+
+    /**
+     * @return array<string, array{RequestInterface, ?string}>
+     */
+    public static function provideRequests(): array
+    {
+        return [
+            'add uses the entry dn' => [
+                new AddRequest(Entry::create('cn=add,dc=foo,dc=bar')),
+                'cn=add,dc=foo,dc=bar',
+            ],
+            'modify uses the request dn' => [
+                new ModifyRequest('cn=mod,dc=foo,dc=bar', Change::replace('cn', 'x')),
+                'cn=mod,dc=foo,dc=bar',
+            ],
+            'delete uses the request dn' => [
+                new DeleteRequest('cn=del,dc=foo,dc=bar'),
+                'cn=del,dc=foo,dc=bar',
+            ],
+            'modify dn uses the source dn' => [
+                new ModifyDnRequest('cn=ren,dc=foo,dc=bar', 'cn=new', true),
+                'cn=ren,dc=foo,dc=bar',
+            ],
+            'compare uses the request dn' => [
+                new CompareRequest('cn=cmp,dc=foo,dc=bar', Filters::equal('cn', 'x')),
+                'cn=cmp,dc=foo,dc=bar',
+            ],
+            'search has no single target' => [
+                (new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar'),
+                null,
+            ],
+        ];
+    }
+}

--- a/tests/unit/Server/Logging/OperationAuditorTest.php
+++ b/tests/unit/Server/Logging/OperationAuditorTest.php
@@ -25,9 +25,11 @@ use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
+use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\Backend\Write\SchemaViolationDisposition;
 use FreeDSx\Ldap\Server\Backend\Write\SchemaViolations;
 use FreeDSx\Ldap\Server\Logging\EventContext;
@@ -207,6 +209,58 @@ final class OperationAuditorTest extends TestCase
                 EventContext::ATTRIBUTE => 'cn',
             ],
             $record['context'][EventContext::TARGET],
+        );
+    }
+
+    public function test_record_search_success_carries_entries_and_target(): void
+    {
+        $request = (new SearchRequest(Filters::present('cn')))->base('dc=example,dc=com');
+
+        $this->subject->recordSearchSuccess(
+            self::wrap($request),
+            42,
+            $this->token,
+        );
+
+        $record = $this->onlyRecord();
+        self::assertSame(
+            'search.authorized',
+            $record['message'],
+        );
+        self::assertSame(
+            42,
+            $record['context'][EventContext::ENTRIES_RETURNED],
+        );
+        self::assertSame(
+            [
+                EventContext::BASE_DN => 'dc=example,dc=com',
+                EventContext::SCOPE => $request->getScope(),
+            ],
+            $record['context'][EventContext::TARGET],
+        );
+    }
+
+    public function test_record_search_failure_discriminates_a_read_denial(): void
+    {
+        $request = (new SearchRequest(Filters::present('cn')))->base('dc=example,dc=com');
+
+        $this->subject->recordSearchFailure(
+            self::wrap($request),
+            new OperationException(
+                'Denied',
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+            ),
+            $this->token,
+        );
+
+        $record = $this->onlyRecord();
+        self::assertSame(
+            'authz.denied.read',
+            $record['message'],
+        );
+        self::assertSame(
+            ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+            $record['context'][EventContext::RESULT_CODE],
         );
     }
 

--- a/tests/unit/Server/Logging/OperationAuditorTest.php
+++ b/tests/unit/Server/Logging/OperationAuditorTest.php
@@ -24,6 +24,7 @@ use FreeDSx\Ldap\Operation\Request\CompareRequest;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyRequest;
+use FreeDSx\Ldap\Operation\Request\PasswordModifyRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
@@ -261,6 +262,66 @@ final class OperationAuditorTest extends TestCase
         self::assertSame(
             ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
             $record['context'][EventContext::RESULT_CODE],
+        );
+    }
+
+    public function test_record_password_modify_success_carries_target(): void
+    {
+        $this->subject->recordPasswordModifySuccess(
+            self::wrap(new PasswordModifyRequest(self::TARGET_DN)),
+            new Dn(self::TARGET_DN),
+            $this->token,
+        );
+
+        $record = $this->onlyRecord();
+        self::assertSame(
+            'password_modify.success',
+            $record['message'],
+        );
+        self::assertSame(
+            [EventContext::DN => self::TARGET_DN],
+            $record['context'][EventContext::TARGET],
+        );
+    }
+
+    public function test_record_password_modify_failure_falls_back_to_password_modify_failed(): void
+    {
+        $this->subject->recordPasswordModifyFailure(
+            self::wrap(new PasswordModifyRequest(self::TARGET_DN)),
+            new OperationException(
+                'Boom',
+                ResultCode::OPERATIONS_ERROR,
+            ),
+            new Dn(self::TARGET_DN),
+            $this->token,
+        );
+
+        $record = $this->onlyRecord();
+        self::assertSame(
+            'password_modify.failed',
+            $record['message'],
+        );
+        self::assertSame(
+            [EventContext::DN => self::TARGET_DN],
+            $record['context'][EventContext::TARGET],
+        );
+    }
+
+    public function test_record_password_modify_failure_omits_target_when_unresolved(): void
+    {
+        $this->subject->recordPasswordModifyFailure(
+            self::wrap(new PasswordModifyRequest()),
+            new OperationException(
+                'Boom',
+                ResultCode::OPERATIONS_ERROR,
+            ),
+            null,
+            $this->token,
+        );
+
+        self::assertArrayNotHasKey(
+            EventContext::TARGET,
+            $this->onlyRecord()['context'],
         );
     }
 


### PR DESCRIPTION
This moves search / password modify into the new audit logging middleware structure and removes it from their handlers.