### PR TITLE
[1.0.0] Add a max request size bytes for decoded ASN1 PDUs.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
   ],
   "require": {
     "php": ">=8.2",
-    "freedsx/asn1": "dev-main#46900759ae89b9e709356a86c1d84056c2e7ff67",
-    "freedsx/socket": "dev-main#cb6f5b4",
+    "freedsx/asn1": "dev-main#b57a38f",
+    "freedsx/socket": "dev-main#5738857",
     "freedsx/sasl": "dev-main#85e1ef9",
     "psr/log": "^3"
   },

--- a/src/FreeDSx/Ldap/Exception/RequestSizeExceededException.php
+++ b/src/FreeDSx/Ldap/Exception/RequestSizeExceededException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Exception;
+
+/**
+ * Thrown when an incoming request PDU exceeds the configured maximum size.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class RequestSizeExceededException extends ProtocolException {}

--- a/src/FreeDSx/Ldap/Protocol/LdapEncoder.php
+++ b/src/FreeDSx/Ldap/Protocol/LdapEncoder.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol;
 
 use FreeDSx\Asn1\Encoder\BerEncoder;
+use FreeDSx\Asn1\Encoder\EncoderOptions;
 use FreeDSx\Asn1\Type\AbstractType;
 
 /**
@@ -31,9 +32,9 @@ class LdapEncoder extends BerEncoder
     /**
      * {@inheritdoc}
      */
-    public function __construct()
+    public function __construct(EncoderOptions $options = new EncoderOptions())
     {
-        parent::__construct();
+        parent::__construct($options);
         $this->setTagMap(AbstractType::TAG_CLASS_APPLICATION, [
             0 => AbstractType::TAG_TYPE_SEQUENCE,
             1 => AbstractType::TAG_TYPE_SEQUENCE,

--- a/src/FreeDSx/Ldap/Protocol/LdapQueue.php
+++ b/src/FreeDSx/Ldap/Protocol/LdapQueue.php
@@ -14,14 +14,18 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol;
 
 use FreeDSx\Asn1\Encoder\EncoderInterface;
+use FreeDSx\Asn1\Encoder\EncoderOptions;
 use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Asn1\Exception\PduLengthException;
 use FreeDSx\Ldap\Exception\ProtocolException;
+use FreeDSx\Ldap\Exception\RequestSizeExceededException;
 use FreeDSx\Ldap\Exception\UnsolicitedNotificationException;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Protocol\Queue\MessageWrapperInterface;
 use FreeDSx\Socket\Exception\ConnectionException;
 use FreeDSx\Socket\Queue\Asn1MessageQueue;
 use FreeDSx\Socket\Queue\Buffer;
+use FreeDSx\Socket\Queue\Message;
 use FreeDSx\Socket\Socket;
 
 use function strlen;
@@ -43,10 +47,11 @@ class LdapQueue extends Asn1MessageQueue
     public function __construct(
         Socket $socket,
         ?EncoderInterface $encoder = null,
+        int $maxReceiveSize = 0,
     ) {
         parent::__construct(
             $socket,
-            $encoder ?? new LdapEncoder(),
+            $encoder ?? new LdapEncoder(new EncoderOptions(maxLength: $maxReceiveSize)),
         );
     }
 
@@ -112,6 +117,23 @@ class LdapQueue extends Asn1MessageQueue
         }
 
         return $this->messageWrapper->unwrap($bytes);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws RequestSizeExceededException
+     */
+    protected function decode(string $bytes): Message
+    {
+        try {
+            return parent::decode($bytes);
+        } catch (PduLengthException $e) {
+            throw new RequestSizeExceededException(
+                $e->getMessage(),
+                previous: $e,
+            );
+        }
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -106,9 +106,10 @@ class ServerProtocolHandler
         } catch (ConnectionException) {
             # Connection closure is recorded by the runner's lifecycle logging; no audit event for normal client disconnects.
         } catch (EncoderException|ProtocolException) {
-            # Per RFC 4511, 4.1.1 if the PDU cannot be parsed or is otherwise malformed a disconnect should be sent with
-            # a result code of protocol error. The NoticeOfDisconnectSent event records the malformed-PDU reason.
-            $this->sendNoticeOfDisconnect('The message encoding is malformed.');
+            # Per RFC 4511 §4.1.1, a PDU that cannot be processed — malformed, or rejected for exceeding the configured
+            # size cap (RequestSizeExceededException) — warrants a disconnect with a protocol error. The
+            # NoticeOfDisconnectSent event records the specific reason.
+            $this->sendNoticeOfDisconnect('The message could not be processed.');
         } catch (Throwable $e) {
             if ($this->queue->isConnected()) {
                 $this->sendNoticeOfDisconnect(cause: $e);

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -73,7 +73,10 @@ class ServerProtocolFactory
         Socket $socket,
         ConnectionContext $context = new ConnectionContext(),
     ): ServerProtocolHandler {
-        $serverQueue = new ServerQueue($socket);
+        $serverQueue = new ServerQueue(
+            $socket,
+            maxReceiveSize: $this->options->getMaxRequestSize(),
+        );
         $eventLogger = new EventLogger(
             $this->options->getLogger(),
             $this->options->getEventLogPolicy(),

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -98,6 +98,11 @@ final class ServerOptions
 
     private int $idleTimeout = 600;
 
+    /**
+     * The largest incoming request PDU accepted, in bytes (5 MiB); 0 disables the limit.
+     */
+    private int $maxRequestSize = 5_242_880;
+
     private bool $requireAuthentication = true;
 
     private bool $allowAnonymous = false;
@@ -237,6 +242,18 @@ final class ServerOptions
     public function setIdleTimeout(int $idleTimeout): self
     {
         $this->idleTimeout = $idleTimeout;
+
+        return $this;
+    }
+
+    public function getMaxRequestSize(): int
+    {
+        return $this->maxRequestSize;
+    }
+
+    public function setMaxRequestSize(int $maxRequestSize): self
+    {
+        $this->maxRequestSize = $maxRequestSize;
 
         return $this;
     }

--- a/tests/unit/Protocol/Queue/ServerQueueTest.php
+++ b/tests/unit/Protocol/Queue/ServerQueueTest.php
@@ -24,6 +24,7 @@ use FreeDSx\Ldap\Operation\Response\DeleteResponse;
 use FreeDSx\Ldap\Protocol\LdapEncoder;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Exception\RequestSizeExceededException;
 use FreeDSx\Ldap\Protocol\Queue\MessageWrapperInterface;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Socket\Queue\Buffer;
@@ -254,6 +255,36 @@ final class ServerQueueTest extends TestCase
         self::assertInstanceOf(
             DeleteRequest::class,
             $result->getRequest(),
+        );
+    }
+
+    public function test_it_should_reject_a_request_whose_declared_length_exceeds_the_max_receive_size(): void
+    {
+        $socket = $this->createMock(Socket::class);
+        $socket->method('read')->willReturn(hex2bin('3084000000c8'));
+
+        $queue = new ServerQueue($socket, maxReceiveSize: 100);
+
+        $this->expectException(RequestSizeExceededException::class);
+
+        $queue->getMessage();
+    }
+
+    public function test_it_should_decode_a_request_within_the_max_receive_size(): void
+    {
+        $encoder = new LdapEncoder();
+        $bytes = $encoder->encode(
+            (new LdapMessageRequest(5, new DeleteRequest('dc=foo,dc=bar')))->toAsn1(),
+        );
+
+        $socket = $this->createMock(Socket::class);
+        $socket->method('read')->willReturn($bytes);
+
+        $queue = new ServerQueue($socket, maxReceiveSize: 5_242_880);
+
+        self::assertSame(
+            5,
+            $queue->getMessage()->getMessageId(),
         );
     }
 

--- a/tests/unit/Protocol/ServerProtocolHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandlerTest.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
 use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\ProtocolException;
+use FreeDSx\Ldap\Exception\RequestSizeExceededException;
 use FreeDSx\Ldap\Exception\ResponseAlreadySentException;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\AnonBindRequest;
@@ -228,7 +229,26 @@ final class ServerProtocolHandlerTest extends TestCase
             ->method('sendMessage')
             ->with($this->equalTo(
                 new LdapMessageResponse(0, new ExtendedResponse(
-                    new LdapResult(ResultCode::PROTOCOL_ERROR, '', 'The message encoding is malformed.'),
+                    new LdapResult(ResultCode::PROTOCOL_ERROR, '', 'The message could not be processed.'),
+                    ExtendedResponse::OID_NOTICE_OF_DISCONNECTION,
+                )),
+            ));
+
+        $this->subject->handle();
+    }
+
+    public function test_it_should_send_a_notice_of_disconnect_when_a_request_exceeds_the_max_size(): void
+    {
+        $this->mockQueue
+            ->method('getMessage')
+            ->willThrowException(new RequestSizeExceededException('too big'));
+
+        $this->mockQueue
+            ->expects($this->once())
+            ->method('sendMessage')
+            ->with($this->equalTo(
+                new LdapMessageResponse(0, new ExtendedResponse(
+                    new LdapResult(ResultCode::PROTOCOL_ERROR, '', 'The message could not be processed.'),
                     ExtendedResponse::OID_NOTICE_OF_DISCONNECTION,
                 )),
             ));
@@ -260,7 +280,7 @@ final class ServerProtocolHandlerTest extends TestCase
             ->method('sendMessage')
             ->with($this->equalTo(
                 new LdapMessageResponse(0, new ExtendedResponse(
-                    new LdapResult(ResultCode::PROTOCOL_ERROR, '', 'The message encoding is malformed.'),
+                    new LdapResult(ResultCode::PROTOCOL_ERROR, '', 'The message could not be processed.'),
                     ExtendedResponse::OID_NOTICE_OF_DISCONNECTION,
                 )),
             ));


### PR DESCRIPTION
Add this as a defensive measure to prevent malicious clients from sending requests that could overwhelm the server. Max of 5mb, which seems reasonable. It's configurable if someone wants to increase it.