### PR TITLE
[1.0.0] Add interceptor logic for the queue. Move password policy response attachment to it.

### DIFF
--- a/src/FreeDSx/Ldap/Protocol/Bind/SaslBind.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/SaslBind.php
@@ -180,7 +180,6 @@ class SaslBind implements BindInterface
 
         if (!$context->isAuthenticated()) {
             $this->policyEnforcer?->recordFailure($result->getUsername());
-            $control = $this->policyEnforcer?->responseControl();
 
             // Send the failure response directly using the current $message, which reflects
             // the latest message consumed from the queue (correct ID for multi-round exchanges).
@@ -190,8 +189,6 @@ class SaslBind implements BindInterface
                 $message,
                 ResultCode::INVALID_CREDENTIALS,
                 'Invalid credentials.',
-                null,
-                ...($control === null ? [] : [$control]),
             ));
 
             // The response was sent here, so signal the dispatcher not to send a second one.
@@ -225,30 +222,20 @@ class SaslBind implements BindInterface
                 $resolvedDn,
             );
         } catch (OperationException $e) {
-            $control = $this->policyEnforcer?->responseControl();
             $this->queue->sendMessage($this->responseFactory->getStandardResponse(
                 $message,
                 $e->getCode(),
                 $e->getMessage(),
-                null,
-                ...($control === null ? [] : [$control]),
             ));
 
             throw $e;
         }
 
-        // Captured before responseControl() clears the policy context.
+        // Captured before the queue interceptor clears the policy context on send.
         $mustChangePassword = $this->policyEnforcer?->mustChangePassword() ?? false;
 
         // The success response must be sent before activating the security layer.
-        $control = $this->policyEnforcer?->responseControl();
-        $this->queue->sendMessage($this->responseFactory->getStandardResponse(
-            $message,
-            ResultCode::SUCCESS,
-            '',
-            null,
-            ...($control === null ? [] : [$control]),
-        ));
+        $this->queue->sendMessage($this->responseFactory->getStandardResponse($message));
 
         if ($context->hasSecurityLayer()) {
             $mech = $this->sasl->get($mechName);

--- a/src/FreeDSx/Ldap/Protocol/Bind/SimpleBind.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/SimpleBind.php
@@ -13,12 +13,10 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\Bind;
 
-use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Operation\Request\BindRequest;
 use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
-use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
@@ -26,7 +24,6 @@ use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
-use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -43,7 +40,6 @@ class SimpleBind implements BindInterface
         private readonly PasswordAuthenticatableInterface $authenticator,
         private readonly EventLogger $eventLogger = new EventLogger(null),
         private readonly ResponseFactory $responseFactory = new ResponseFactory(),
-        private readonly ?PasswordPolicyContext $passwordPolicyContext = null,
     ) {}
 
     /**
@@ -79,14 +75,7 @@ class SimpleBind implements BindInterface
             throw $e;
         }
 
-        $control = $this->passwordPolicyControl();
-        $this->queue->sendMessage($this->responseFactory->getStandardResponse(
-            $message,
-            ResultCode::SUCCESS,
-            '',
-            null,
-            ...($control === null ? [] : [$control]),
-        ));
+        $this->queue->sendMessage($this->responseFactory->getStandardResponse($message));
         $this->eventLogger->record(
             ServerEvent::BindSuccess,
             [
@@ -106,14 +95,6 @@ class SimpleBind implements BindInterface
             $request->getUsername(),
             $request->getPassword(),
         );
-    }
-
-    private function passwordPolicyControl(): ?Control
-    {
-        $control = $this->passwordPolicyContext?->buildResponseControl();
-        $this->passwordPolicyContext?->clear();
-
-        return $control;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
@@ -86,7 +86,6 @@ final readonly class ProtocolHandlerProvider implements ProtocolHandlerProviderI
                 ),
                 passwordPolicyContext: $this->passwordPolicyContext,
             ),
-            passwordPolicyContext: $this->passwordPolicyContext,
         );
     }
 
@@ -135,7 +134,6 @@ final readonly class ProtocolHandlerProvider implements ProtocolHandlerProviderI
             accessControl: $this->options->getAccessControl(),
             filterEvaluator: $this->options->getFilterEvaluator(),
             schema: $this->options->getSchema(),
-            passwordPolicyContext: $this->passwordPolicyContext,
         );
     }
 

--- a/src/FreeDSx/Ldap/Protocol/Queue/Response/PasswordPolicyResponseInterceptor.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/Response/PasswordPolicyResponseInterceptor.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Queue\Response;
+
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+
+/**
+ * Attaches the password-policy response control to the next outgoing response when the context holds one.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class PasswordPolicyResponseInterceptor implements ResponseInterceptor
+{
+    public function __construct(private PasswordPolicyContext $context) {}
+
+    public function intercept(LdapMessageResponse $response): LdapMessageResponse
+    {
+        $control = $this->context->buildResponseControl();
+
+        if ($control === null) {
+            return $response;
+        }
+
+        $response->controls()->add($control);
+        $this->context->clear();
+
+        return $response;
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Queue/Response/ResponseInterceptor.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/Response/ResponseInterceptor.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Queue\Response;
+
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+
+/**
+ * Observes or transforms an outgoing response before it is encoded and sent.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface ResponseInterceptor
+{
+    /**
+     * Return the response to send.
+     */
+    public function intercept(LdapMessageResponse $response): LdapMessageResponse;
+}

--- a/src/FreeDSx/Ldap/Protocol/Queue/ServerQueue.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/ServerQueue.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\Queue;
 
+use FreeDSx\Asn1\Encoder\EncoderInterface;
 use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Asn1\Exception\PartialPduException;
 use FreeDSx\Asn1\Type\AbstractType;
@@ -25,8 +26,11 @@ use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\LdapQueue;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseInterceptor;
 use FreeDSx\Socket\Exception\ConnectionException;
 use FreeDSx\Socket\Queue\Message;
+use FreeDSx\Socket\Socket;
+use Generator;
 
 /**
  * The LDAP Queue class for sending and receiving messages for servers.
@@ -39,6 +43,28 @@ class ServerQueue extends LdapQueue
      * @var LdapMessageRequest[]
      */
     private array $pendingMessages = [];
+
+    /**
+     * @var ResponseInterceptor[]
+     */
+    private readonly array $interceptors;
+
+    /**
+     * @param ResponseInterceptor[] $interceptors applied to every outgoing response, in order.
+     */
+    public function __construct(
+        Socket $socket,
+        ?EncoderInterface $encoder = null,
+        int $maxReceiveSize = 0,
+        array $interceptors = [],
+    ) {
+        parent::__construct(
+            $socket,
+            $encoder,
+            $maxReceiveSize,
+        );
+        $this->interceptors = $interceptors;
+    }
 
     /**
      * @throws ProtocolException
@@ -91,7 +117,10 @@ class ServerQueue extends LdapQueue
      */
     public function sendMessage(LdapMessageResponse ...$response): self
     {
-        $this->sendLdapMessage($response);
+        $this->sendLdapMessage(array_map(
+            $this->applyInterceptors(...),
+            $response,
+        ));
 
         return $this;
     }
@@ -104,9 +133,31 @@ class ServerQueue extends LdapQueue
      */
     public function sendMessages(iterable $responses): self
     {
-        $this->sendLdapMessage($responses);
+        $this->sendLdapMessage($this->interceptLazily($responses));
 
         return $this;
+    }
+
+    /**
+     * Apply each interceptor to a response one message at a time, preserving lazy streaming.
+     *
+     * @param iterable<LdapMessageResponse> $responses
+     * @return Generator<LdapMessageResponse>
+     */
+    private function interceptLazily(iterable $responses): Generator
+    {
+        foreach ($responses as $response) {
+            yield $this->applyInterceptors($response);
+        }
+    }
+
+    private function applyInterceptors(LdapMessageResponse $response): LdapMessageResponse
+    {
+        foreach ($this->interceptors as $interceptor) {
+            $response = $interceptor->intercept($response);
+        }
+
+        return $response;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol;
 
 use FreeDSx\Asn1\Exception\EncoderException;
-use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\PwdPolicyError;
 use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -32,7 +31,6 @@ use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
-use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Socket\Exception\ConnectionException;
 use Throwable;
@@ -59,7 +57,6 @@ class ServerProtocolHandler
         private readonly DispatchAuthorizer $dispatchAuthorizer,
         private readonly EventLogger $eventLogger = new EventLogger(null),
         private readonly ResponseFactory $responseFactory = new ResponseFactory(),
-        private readonly ?PasswordPolicyContext $passwordPolicyContext = null,
         private readonly ConnectionContext $connectionContext = new ConnectionContext(),
     ) {}
 
@@ -90,13 +87,10 @@ class ServerProtocolHandler
         } catch (OperationException $e) {
             # OperationExceptions may be thrown by any handler and will be sent back to the client as the response
             # specific error code and message associated with the exception.
-            $control = $this->passwordPolicyControlFor($message);
             $this->queue->sendMessage($this->responseFactory->getStandardResponse(
                 $message,
                 $e->getCode(),
                 $e->getMessage(),
-                null,
-                ...($control === null ? [] : [$control]),
             ));
 
             $this->logCriticalControlRejection(
@@ -242,28 +236,6 @@ class ServerProtocolHandler
         }
 
         return $this->authenticator->bind($message);
-    }
-
-    /**
-     * Password-policy response control for a failed bind; null for non-bind failures or when no policy is in play.
-     */
-    private function passwordPolicyControlFor(?LdapMessageRequest $message): ?Control
-    {
-        if (!$this->shouldAttachPolicyControl($message)) {
-            return null;
-        }
-
-        $control = $this->passwordPolicyContext?->buildResponseControl();
-        $this->passwordPolicyContext?->clear();
-
-        return $control;
-    }
-
-    private function shouldAttachPolicyControl(?LdapMessageRequest $message): bool
-    {
-        return $this->passwordPolicyContext !== null
-            && $message !== null
-            && $this->authorizer->isAuthenticationRequest($message->getRequest());
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -38,7 +38,6 @@ use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\Operation\CompareOperationResult;
 use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Operation\WriteOperationResult;
-use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -63,7 +62,6 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
         Schema $schema,
         private WriteCommandFactory $commandFactory = new WriteCommandFactory(),
         private ResponseFactory $responseFactory = new ResponseFactory(),
-        private ?PasswordPolicyContext $passwordPolicyContext = null,
     ) {
         $this->assertionEvaluator = new AssertionEvaluator(
             $filterEvaluator,
@@ -84,7 +82,6 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
     ): OperationResult {
-        $this->passwordPolicyContext?->clear();
         $schemaViolations = new SchemaViolations();
         $request = $message->getRequest();
         $controls = $message->controls();
@@ -256,7 +253,6 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
         TokenInterface $token,
         SchemaViolations $schemaViolations,
     ): OperationResult {
-        $errorControl = $this->passwordPolicyControl();
         $this->queue->sendMessage($this->responseFactory->getStandardResponse(
             $message,
             $e->getCode(),
@@ -267,7 +263,6 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
                 $this->backend,
                 $this->accessControl,
             ),
-            ...($errorControl === null ? [] : [$errorControl]),
         ));
 
         return WriteOperationResult::failure(
@@ -285,17 +280,8 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
         ?Control $postRead,
     ): array {
         return array_values(array_filter([
-            $this->passwordPolicyControl(),
             $preRead,
             $postRead,
         ]));
-    }
-
-    private function passwordPolicyControl(): ?Control
-    {
-        $control = $this->passwordPolicyContext?->buildResponseControl();
-        $this->passwordPolicyContext?->clear();
-
-        return $control;
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordModifyHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordModifyHandler.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Asn1\Exception\EncoderException;
-use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
@@ -29,7 +28,6 @@ use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Operation\PasswordModifyOperationResult;
 use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyResult;
 use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyService;
-use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
@@ -44,7 +42,6 @@ readonly class ServerPasswordModifyHandler implements ServerProtocolHandlerInter
         private ServerQueue $queue,
         private PasswordModifyService $service,
         private ResponseFactory $responseFactory = new ResponseFactory(),
-        private ?PasswordPolicyContext $passwordPolicyContext = null,
     ) {}
 
     /**
@@ -56,7 +53,6 @@ readonly class ServerPasswordModifyHandler implements ServerProtocolHandlerInter
         LdapMessageRequest $message,
         TokenInterface $token,
     ): OperationResult {
-        $this->passwordPolicyContext?->clear();
         $targetDn = null;
 
         try {
@@ -70,13 +66,10 @@ readonly class ServerPasswordModifyHandler implements ServerProtocolHandlerInter
                 $result,
             );
         } catch (OperationException $e) {
-            $control = $this->passwordPolicyControl();
             $this->queue->sendMessage($this->responseFactory->getStandardResponse(
                 $message,
                 $e->getCode(),
                 $e->getMessage(),
-                null,
-                ...($control === null ? [] : [$control]),
             ));
 
             return PasswordModifyOperationResult::failure(
@@ -120,22 +113,12 @@ readonly class ServerPasswordModifyHandler implements ServerProtocolHandlerInter
         LdapMessageRequest $message,
         PasswordModifyResult $result,
     ): void {
-        $control = $this->passwordPolicyControl();
         $this->queue->sendMessage(new LdapMessageResponse(
             $message->getMessageId(),
             new PasswordModifyResponse(
                 new LdapResult(ResultCode::SUCCESS),
                 $result->generatedPassword,
             ),
-            ...($control === null ? [] : [$control]),
         ));
-    }
-
-    private function passwordPolicyControl(): ?Control
-    {
-        $control = $this->passwordPolicyContext?->buildResponseControl();
-        $this->passwordPolicyContext?->clear();
-
-        return $control;
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/SaslBindPolicyEnforcer.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/SaslBindPolicyEnforcer.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Auth;
 
-use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\PwdPolicyError;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
@@ -79,19 +78,11 @@ final readonly class SaslBindPolicyEnforcer
     }
 
     /**
-     * Whether the just-enforced bind flagged that the password must be changed; read before {@see responseControl}.
+     * Whether the just-enforced bind flagged that the password must be changed.
      */
     public function mustChangePassword(): bool
     {
         return $this->context->getOutcome()?->errorCode === PwdPolicyError::CHANGE_AFTER_RESET;
-    }
-
-    public function responseControl(): ?Control
-    {
-        $control = $this->context->buildResponseControl();
-        $this->context->clear();
-
-        return $control;
     }
 
     private function attemptFor(

--- a/src/FreeDSx/Ldap/Server/ServerConnectionScaffoldingTrait.php
+++ b/src/FreeDSx/Ldap/Server/ServerConnectionScaffoldingTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server;
 
 use FreeDSx\Ldap\Protocol\Bind\AnonymousBind;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseInterceptor;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
@@ -29,11 +30,17 @@ trait ServerConnectionScaffoldingTrait
 {
     abstract protected function serverOptions(): ServerOptions;
 
-    private function makeServerQueue(Socket $socket): ServerQueue
-    {
+    /**
+     * @param ResponseInterceptor[] $interceptors applied to every outgoing response, in order.
+     */
+    private function makeServerQueue(
+        Socket $socket,
+        array $interceptors = [],
+    ): ServerQueue {
         return new ServerQueue(
             $socket,
             maxReceiveSize: $this->serverOptions()->getMaxRequestSize(),
+            interceptors: $interceptors,
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -46,6 +46,7 @@ use FreeDSx\Ldap\Server\Middleware\OperationAuthorizationMiddleware;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\HandlerInvoker;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareChain;
 use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyBindGuard;
+use FreeDSx\Ldap\Protocol\Queue\Response\PasswordPolicyResponseInterceptor;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
@@ -78,15 +79,16 @@ class ServerProtocolFactory implements ServerProtocolFactoryInterface
         Socket $socket,
         ConnectionContext $context = new ConnectionContext(),
     ): ServerProtocolHandler {
-        $serverQueue = $this->makeServerQueue($socket);
         $eventLogger = $this->makeEventLogger($context);
 
         $backend = $this->handlerFactory->makeBackend();
         $passwordAuthenticator = $this->handlerFactory->makePasswordAuthenticator();
 
         $policyContext = null;
+        $interceptors = [];
         if ($this->options->isPasswordPolicyEnabled()) {
             $policyContext = new PasswordPolicyContext();
+            $interceptors[] = new PasswordPolicyResponseInterceptor($policyContext);
             $passwordAuthenticator = $this->decoratePasswordAuthenticator(
                 $passwordAuthenticator,
                 $backend,
@@ -95,12 +97,16 @@ class ServerProtocolFactory implements ServerProtocolFactoryInterface
             );
         }
 
+        $serverQueue = $this->makeServerQueue(
+            $socket,
+            $interceptors,
+        );
+
         $authenticators = [
             new SimpleBind(
                 queue: $serverQueue,
                 authenticator: $passwordAuthenticator,
                 eventLogger: $eventLogger,
-                passwordPolicyContext: $policyContext,
             ),
             $this->makeAnonymousBind(
                 $serverQueue,
@@ -174,7 +180,6 @@ class ServerProtocolFactory implements ServerProtocolFactoryInterface
             authenticator: new Authenticator($authenticators),
             dispatchAuthorizer: $dispatchAuthorizer,
             eventLogger: $eventLogger,
-            passwordPolicyContext: $policyContext,
             connectionContext: $context,
         );
     }

--- a/tests/integration/Security/PasswordPolicyChangeEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyChangeEnforcementTest.php
@@ -24,6 +24,7 @@ use FreeDSx\Ldap\Operation\Response\PasswordModifyResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\Response\PasswordPolicyResponseInterceptor;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
@@ -298,7 +299,6 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
                 ),
                 passwordPolicyContext: $this->context,
             ),
-            passwordPolicyContext: $this->context,
         );
     }
 
@@ -318,11 +318,12 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
 
     private function capturingQueue(): ServerQueue
     {
+        $interceptor = new PasswordPolicyResponseInterceptor($this->context);
         $queue = $this->createMock(ServerQueue::class);
         $queue
             ->method('sendMessage')
-            ->willReturnCallback(function (LdapMessageResponse $response) use ($queue): ServerQueue {
-                $this->response = $response;
+            ->willReturnCallback(function (LdapMessageResponse $response) use ($queue, $interceptor): ServerQueue {
+                $this->response = $interceptor->intercept($response);
 
                 return $queue;
             });

--- a/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\Response\PasswordPolicyResponseInterceptor;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
@@ -321,17 +322,17 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
             accessControl: $this->createMock(AccessControlInterface::class),
             filterEvaluator: new FilterEvaluator(),
             schema: new Schema(),
-            passwordPolicyContext: $this->context,
         );
     }
 
     private function capturingQueue(): ServerQueue
     {
+        $interceptor = new PasswordPolicyResponseInterceptor($this->context);
         $queue = $this->createMock(ServerQueue::class);
         $queue
             ->method('sendMessage')
-            ->willReturnCallback(function (LdapMessageResponse $response) use ($queue): ServerQueue {
-                $this->response = $response;
+            ->willReturnCallback(function (LdapMessageResponse $response) use ($queue, $interceptor): ServerQueue {
+                $this->response = $interceptor->intercept($response);
 
                 return $queue;
             });

--- a/tests/support/Protocol/Queue/Response/RecordingInterceptor.php
+++ b/tests/support/Protocol/Queue/Response/RecordingInterceptor.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Support\FreeDSx\Ldap\Protocol\Queue\Response;
+
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseInterceptor;
+use Tests\Support\FreeDSx\Ldap\Middleware\CallLog;
+
+/**
+ * Records its marker for ordering assertions and attaches a marker control so transformation is observable.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class RecordingInterceptor implements ResponseInterceptor
+{
+    public function __construct(
+        private CallLog $log,
+        private string $marker,
+    ) {}
+
+    public function intercept(LdapMessageResponse $response): LdapMessageResponse
+    {
+        $this->log->record($this->marker);
+        $response->controls()->add(new Control($this->marker));
+
+        return $response;
+    }
+}

--- a/tests/unit/Protocol/Queue/Response/PasswordPolicyResponseInterceptorTest.php
+++ b/tests/unit/Protocol/Queue/Response/PasswordPolicyResponseInterceptorTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Protocol\Queue\Response;
+
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
+use FreeDSx\Ldap\Operation\Response\BindResponse;
+use FreeDSx\Ldap\Operation\LdapResult;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\Response\PasswordPolicyResponseInterceptor;
+use FreeDSx\Ldap\Server\PasswordPolicy\Decision\PasswordPolicyOutcome;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+use PHPUnit\Framework\TestCase;
+
+final class PasswordPolicyResponseInterceptorTest extends TestCase
+{
+    private PasswordPolicyContext $context;
+
+    private PasswordPolicyResponseInterceptor $subject;
+
+    protected function setUp(): void
+    {
+        $this->context = new PasswordPolicyContext();
+        $this->subject = new PasswordPolicyResponseInterceptor($this->context);
+    }
+
+    public function test_it_attaches_the_control_and_clears_when_the_context_has_a_payload(): void
+    {
+        $this->context->setOutcome(PasswordPolicyOutcome::allowWithGraceWarning(3));
+
+        $response = $this->subject->intercept($this->bindResponse());
+
+        $control = $response->controls()->get(Control::OID_PWD_POLICY);
+        self::assertInstanceOf(
+            PwdPolicyResponseControl::class,
+            $control,
+        );
+        self::assertSame(
+            3,
+            $control->getGraceAttemptsRemaining(),
+        );
+        self::assertNull(
+            $this->context->getOutcome(),
+            'The context should be cleared after the control is attached.',
+        );
+    }
+
+    public function test_it_does_not_leak_the_control_onto_a_later_message(): void
+    {
+        $this->context->setOutcome(PasswordPolicyOutcome::allowWithGraceWarning(3));
+
+        $first = $this->subject->intercept($this->bindResponse());
+        $second = $this->subject->intercept($this->bindResponse());
+
+        self::assertTrue($first->controls()->has(Control::OID_PWD_POLICY));
+        self::assertFalse(
+            $second->controls()->has(Control::OID_PWD_POLICY),
+            'Clearing on attach prevents the control leaking onto an unrelated later response.',
+        );
+    }
+
+    public function test_it_is_a_no_op_when_the_context_is_empty(): void
+    {
+        $response = $this->subject->intercept($this->bindResponse());
+
+        self::assertCount(
+            0,
+            $response->controls()->toArray(),
+        );
+    }
+
+    public function test_it_is_a_no_op_for_a_payload_free_outcome(): void
+    {
+        $this->context->setOutcome(PasswordPolicyOutcome::allow());
+
+        $response = $this->subject->intercept($this->bindResponse());
+
+        self::assertCount(
+            0,
+            $response->controls()->toArray(),
+        );
+        self::assertNotNull(
+            $this->context->getOutcome(),
+            'A payload-free outcome is left intact since nothing was attached.',
+        );
+    }
+
+    private function bindResponse(): LdapMessageResponse
+    {
+        return new LdapMessageResponse(
+            1,
+            new BindResponse(new LdapResult(ResultCode::SUCCESS)),
+        );
+    }
+}

--- a/tests/unit/Protocol/Queue/ServerQueueTest.php
+++ b/tests/unit/Protocol/Queue/ServerQueueTest.php
@@ -31,6 +31,8 @@ use FreeDSx\Socket\Queue\Buffer;
 use FreeDSx\Socket\Socket;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Middleware\CallLog;
+use Tests\Support\FreeDSx\Ldap\Protocol\Queue\Response\RecordingInterceptor;
 
 final class ServerQueueTest extends TestCase
 {
@@ -285,6 +287,80 @@ final class ServerQueueTest extends TestCase
         self::assertSame(
             5,
             $queue->getMessage()->getMessageId(),
+        );
+    }
+
+    public function test_it_applies_interceptors_to_a_sent_message(): void
+    {
+        $this->mockEncoder
+            ->method('encode')
+            ->willReturn('foo');
+        $this->mockSocket
+            ->expects($this->once())
+            ->method('write');
+
+        $queue = new ServerQueue(
+            $this->mockSocket,
+            $this->mockEncoder,
+            interceptors: [new RecordingInterceptor(new CallLog(), '1.2.3.4')],
+        );
+
+        $message = new LdapMessageResponse(
+            1,
+            new DeleteResponse(0),
+        );
+        $queue->sendMessage($message);
+
+        self::assertTrue($message->controls()->has('1.2.3.4'));
+    }
+
+    public function test_it_applies_interceptors_to_each_streamed_message(): void
+    {
+        $this->mockEncoder
+            ->method('encode')
+            ->willReturn('foo');
+
+        $queue = new ServerQueue(
+            $this->mockSocket,
+            $this->mockEncoder,
+            interceptors: [new RecordingInterceptor(new CallLog(), '1.2.3.4')],
+        );
+
+        $messages = [
+            new LdapMessageResponse(1, new DeleteResponse(0)),
+            new LdapMessageResponse(2, new DeleteResponse(0)),
+        ];
+        $queue->sendMessages($messages);
+
+        foreach ($messages as $message) {
+            self::assertTrue($message->controls()->has('1.2.3.4'));
+        }
+    }
+
+    public function test_it_runs_interceptors_in_order(): void
+    {
+        $this->mockEncoder
+            ->method('encode')
+            ->willReturn('foo');
+
+        $log = new CallLog();
+        $queue = new ServerQueue(
+            $this->mockSocket,
+            $this->mockEncoder,
+            interceptors: [
+                new RecordingInterceptor($log, 'a'),
+                new RecordingInterceptor($log, 'b'),
+            ],
+        );
+
+        $queue->sendMessage(new LdapMessageResponse(
+            1,
+            new DeleteResponse(0),
+        ));
+
+        self::assertSame(
+            ['a', 'b'],
+            $log->entries,
         );
     }
 

--- a/tests/unit/Server/Backend/Auth/SaslBindPolicyEnforcerTest.php
+++ b/tests/unit/Server/Backend/Auth/SaslBindPolicyEnforcerTest.php
@@ -64,7 +64,8 @@ final class SaslBindPolicyEnforcerTest extends TestCase
         );
 
         self::assertNull($this->context->getOutcome());
-        self::assertNull($enforcer->responseControl());
+        self::assertNull($this->context->buildResponseControl());
+        self::assertFalse($enforcer->mustChangePassword());
     }
 
     public function test_null_username_failure_is_ignored(): void
@@ -115,7 +116,7 @@ final class SaslBindPolicyEnforcerTest extends TestCase
         );
     }
 
-    public function test_must_change_surfaces_a_response_control(): void
+    public function test_must_change_flags_the_context_and_surfaces_a_control(): void
     {
         $enforcer = $this->enforcer(
             new PasswordPolicy(),
@@ -127,7 +128,9 @@ final class SaslBindPolicyEnforcerTest extends TestCase
             new Dn(self::USER_DN),
         );
 
-        $control = $enforcer->responseControl();
+        self::assertTrue($enforcer->mustChangePassword());
+
+        $control = $this->context->buildResponseControl();
         self::assertInstanceOf(
             PwdPolicyResponseControl::class,
             $control,
@@ -135,10 +138,6 @@ final class SaslBindPolicyEnforcerTest extends TestCase
         self::assertSame(
             PwdPolicyError::CHANGE_AFTER_RESET,
             $control->getError(),
-        );
-        self::assertNull(
-            $this->context->getOutcome(),
-            'responseControl() should clear the context.',
         );
     }
 
@@ -151,7 +150,8 @@ final class SaslBindPolicyEnforcerTest extends TestCase
             new Dn(self::USER_DN),
         );
 
-        self::assertNull($enforcer->responseControl());
+        self::assertNull($this->context->buildResponseControl());
+        self::assertFalse($enforcer->mustChangePassword());
     }
 
     /**


### PR DESCRIPTION
This adds a response interceptor design to the server queue. This will help consolidate some logic that got repeated in different spots in the codebase. It will have other uses, but just implementing this for now.