### PR TITLE
[1.0.0] Add assertion middleware to consolidate where the check happens.

### DIFF
--- a/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
@@ -132,7 +132,6 @@ final readonly class ProtocolHandlerProvider implements ProtocolHandlerProviderI
                 ? $this->handlerFactory->makeWriteDispatcher($policyWriteHandler)
                 : $this->writeDispatcher,
             accessControl: $this->options->getAccessControl(),
-            filterEvaluator: $this->options->getFilterEvaluator(),
             schema: $this->options->getSchema(),
         );
     }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -171,11 +171,25 @@ class ServerProtocolHandler
             return;
         }
 
-        $this->requestPipeline->handle(new ServerRequestContext(
-            $message,
-            $authorization->token(),
-            $this->connectionContext,
-        ));
+        # A pipeline gate (critical-control, authorization, assertion) rejects per-operation by throwing
+        # We need to catch here and send the response.
+        try {
+            $this->requestPipeline->handle(new ServerRequestContext(
+                $message,
+                $authorization->token(),
+                $this->connectionContext,
+            ));
+        } catch (OperationException $e) {
+            $this->queue->sendMessage($this->responseFactory->getStandardResponse(
+                $message,
+                $e->getCode(),
+                $e->getMessage(),
+            ));
+            $this->logCriticalControlRejection(
+                $e,
+                $message,
+            );
+        }
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -25,10 +25,8 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\AccessControl\OperationTargetDn;
 use FreeDSx\Ldap\Server\AccessControl\OperationType;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
 use FreeDSx\Ldap\Server\Backend\Write\SchemaViolations;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
@@ -49,8 +47,6 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
 {
     use MatchedDnAccessFilterTrait;
 
-    private AssertionEvaluator $assertionEvaluator;
-
     private ReadEntryControlHandler $readEntryControlHandler;
 
     public function __construct(
@@ -58,15 +54,10 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
         private LdapBackendInterface $backend,
         private WriteOperationDispatcher $writeDispatcher,
         private AccessControlInterface $accessControl,
-        FilterEvaluatorInterface $filterEvaluator,
         Schema $schema,
         private WriteCommandFactory $commandFactory = new WriteCommandFactory(),
         private ResponseFactory $responseFactory = new ResponseFactory(),
     ) {
-        $this->assertionEvaluator = new AssertionEvaluator(
-            $filterEvaluator,
-            $this->backend,
-        );
         $this->readEntryControlHandler = new ReadEntryControlHandler(
             $this->backend,
             $schema,
@@ -87,14 +78,6 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
         $controls = $message->controls();
 
         try {
-            $target = OperationTargetDn::of($request);
-            if ($target !== null) {
-                $this->assertionEvaluator->assertSatisfied(
-                    $target,
-                    $controls,
-                );
-            }
-
             if ($request instanceof Request\CompareRequest) {
                 return $this->handleCompare(
                     $message,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -48,8 +48,6 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
     use ServerSearchTrait;
     use MatchedDnAccessFilterTrait;
 
-    private readonly AssertionEvaluator $assertionEvaluator;
-
     public function __construct(
         private readonly ServerQueue $queue,
         private readonly LdapBackendInterface $backend,
@@ -59,12 +57,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         private readonly Schema $schema,
         private readonly PagingRequestComparator $requestComparator = new PagingRequestComparator(),
         private readonly SearchLimits $limits = new SearchLimits(),
-    ) {
-        $this->assertionEvaluator = new AssertionEvaluator(
-            $this->filterEvaluator,
-            $this->backend,
-        );
-    }
+    ) {}
 
     /**
      * @inheritDoc
@@ -83,14 +76,6 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         $failure = null;
         try {
             $this->assertBaseDnProvided($searchRequest);
-
-            $baseDn = $searchRequest->getBaseDn();
-            if ($pagingRequest->isPagingStart() && $baseDn !== null) {
-                $this->assertionEvaluator->assertSatisfied(
-                    $baseDn,
-                    $message->controls(),
-                );
-            }
 
             $response = $this->handlePaging(
                 $pagingRequest,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -46,8 +46,6 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
 
     private const CANCEL_CHECK_INTERVAL = 50;
 
-    private readonly AssertionEvaluator $assertionEvaluator;
-
     public function __construct(
         private readonly ServerQueue $queue,
         private readonly LdapBackendInterface $backend,
@@ -55,12 +53,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         private readonly AccessControlInterface $accessControl,
         private readonly Schema $schema,
         private readonly SearchLimits $limits = new SearchLimits(),
-    ) {
-        $this->assertionEvaluator = new AssertionEvaluator(
-            $this->filterEvaluator,
-            $this->backend,
-        );
-    }
+    ) {}
 
     /**
      * @inheritDoc
@@ -75,14 +68,6 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
 
         try {
             $this->assertBaseDnProvided($request);
-
-            $baseDn = $request->getBaseDn();
-            if ($baseDn !== null) {
-                $this->assertionEvaluator->assertSatisfied(
-                    $baseDn,
-                    $message->controls(),
-                );
-            }
 
             $backendResult = $this->backend->search(
                 $request,

--- a/src/FreeDSx/Ldap/Server/Middleware/AssertionMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/AssertionMiddleware.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\PagingControl;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Protocol\ServerProtocolHandler\AssertionEvaluator;
+use FreeDSx\Ldap\Server\AccessControl\OperationTargetDn;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+
+/**
+ * Rejects an operation whose RFC 4528 assertion control does not match its target entry, before dispatch.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class AssertionMiddleware implements MiddlewareInterface
+{
+    public function __construct(private AssertionEvaluator $evaluator) {}
+
+    /**
+     * @throws OperationException
+     */
+    public function process(
+        ServerRequestContext $context,
+        MiddlewareHandlerInterface $next,
+    ): OperationResult {
+        $message = $context->message;
+        $request = $message->getRequest();
+
+        # Paged search runs once at the start; continuation pages resume the same operation, so the assertion
+        # (a precondition of that single execution) is only evaluated on the first page.
+        $paging = $message->controls()->get(Control::OID_PAGING);
+        if ($paging instanceof PagingControl && $paging->getCookie() !== '') {
+            return $next->handle($context);
+        }
+
+        $target = $request instanceof SearchRequest
+            ? $request->getBaseDn()
+            : OperationTargetDn::of($request);
+
+        if ($target !== null) {
+            $this->evaluator->assertSatisfied(
+                $target,
+                $message->controls(),
+            );
+        }
+
+        return $next->handle($context);
+    }
+}

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -40,6 +40,8 @@ use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\OperationAuditor;
+use FreeDSx\Ldap\Protocol\ServerProtocolHandler\AssertionEvaluator;
+use FreeDSx\Ldap\Server\Middleware\AssertionMiddleware;
 use FreeDSx\Ldap\Server\Middleware\CriticalControlMiddleware;
 use FreeDSx\Ldap\Server\Middleware\OperationAuditMiddleware;
 use FreeDSx\Ldap\Server\Middleware\OperationAuthorizationMiddleware;
@@ -172,6 +174,10 @@ class ServerProtocolFactory implements ServerProtocolFactoryInterface
                         $eventLogger,
                         $this->options->getPrivilegedControls(),
                     ),
+                    new AssertionMiddleware(new AssertionEvaluator(
+                        $this->options->getFilterEvaluator(),
+                        $backend,
+                    )),
                     new OperationAuditMiddleware(new OperationAuditor($eventLogger)),
                 ],
                 new HandlerInvoker($handlerProvider),

--- a/tests/integration/Controls/ServerControlsTest.php
+++ b/tests/integration/Controls/ServerControlsTest.php
@@ -89,6 +89,39 @@ final class ServerControlsTest extends ServerTestCase
         self::assertSame('Smith', $this->readValue($dn, 'sn'));
     }
 
+    public function test_assertion_allows_a_search_when_it_matches(): void
+    {
+        $this->bind();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'))->base('dc=foo,dc=bar'),
+            Controls::assertion(Filters::equal('dc', 'foo')),
+        );
+
+        self::assertGreaterThan(0, $entries->count());
+    }
+
+    public function test_assertion_fails_a_search_when_it_does_not_match(): void
+    {
+        $this->bind();
+
+        try {
+            $this->ldapClient()->search(
+                Operations::search(Filters::present('objectClass'))->base('dc=foo,dc=bar'),
+                Controls::assertion(Filters::equal('dc', 'nope')),
+            );
+            self::fail('Expected an OperationException was not thrown.');
+        } catch (OperationException $e) {
+            self::assertSame(ResultCode::ASSERTION_FAILED, $e->getCode());
+        }
+
+        # The connection survives the per-operation rejection: a follow-up search still succeeds.
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'))->base('dc=foo,dc=bar'),
+        );
+        self::assertGreaterThan(0, $entries->count());
+    }
+
     public function test_pre_read_and_post_read_capture_state_around_a_modify(): void
     {
         $this->bind();

--- a/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
@@ -30,7 +30,6 @@ use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
-use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluator;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Server\Backend\Write\PasswordPolicyWriteHandler;
 use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
@@ -320,7 +319,6 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
                 $this->backend,
             ),
             accessControl: $this->createMock(AccessControlInterface::class),
-            filterEvaluator: new FilterEvaluator(),
             schema: new Schema(),
         );
     }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
@@ -31,7 +31,6 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerDispatchHandler;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Search\Filters;
-use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluator;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
@@ -79,7 +78,6 @@ final class ServerDispatchHandlerTest extends TestCase
             backend: $this->mockBackend,
             writeDispatcher: new WriteOperationDispatcher($this->mockWriteHandler),
             accessControl: $this->mockAccessControl,
-            filterEvaluator: new FilterEvaluator(),
             schema: new Schema(),
         );
     }
@@ -184,7 +182,6 @@ final class ServerDispatchHandlerTest extends TestCase
             backend: $this->mockBackend,
             writeDispatcher: new WriteOperationDispatcher(),
             accessControl: $this->mockAccessControl,
-            filterEvaluator: new FilterEvaluator(),
             schema: new Schema(),
         );
 

--- a/tests/unit/Protocol/ServerProtocolHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandlerTest.php
@@ -380,7 +380,7 @@ final class ServerProtocolHandlerTest extends TestCase
     {
         $this->mockQueue
             ->method('isConnected')
-            ->willReturnOnConsecutiveCalls(true, false);
+            ->willReturn(true);
 
         $messages = [
             new LdapMessageRequest(1, new SimpleBindRequest('foo@bar', 'bar')),

--- a/tests/unit/Server/Middleware/AssertionMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/AssertionMiddlewareTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\PagingControl;
+use FreeDSx\Ldap\Controls;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\DeleteRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\ServerProtocolHandler\AssertionEvaluator;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluator;
+use FreeDSx\Ldap\Server\Middleware\AssertionMiddleware;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Middleware\CallLog;
+use Tests\Support\FreeDSx\Ldap\Middleware\RecordingMiddlewareHandler;
+
+final class AssertionMiddlewareTest extends TestCase
+{
+    private LdapBackendInterface&MockObject $backend;
+
+    private AssertionMiddleware $subject;
+
+    private RecordingMiddlewareHandler $next;
+
+    protected function setUp(): void
+    {
+        $this->backend = $this->createMock(LdapBackendInterface::class);
+        $this->backend
+            ->method('get')
+            ->willReturn(Entry::fromArray(
+                'cn=foo,dc=bar',
+                ['cn' => ['foo']],
+            ));
+
+        $this->subject = new AssertionMiddleware(new AssertionEvaluator(
+            new FilterEvaluator(),
+            $this->backend,
+        ));
+        $this->next = new RecordingMiddlewareHandler(new CallLog());
+    }
+
+    public function test_it_delegates_when_no_assertion_control_is_present(): void
+    {
+        $this->subject->process(
+            $this->contextFor(new DeleteRequest('cn=foo,dc=bar')),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    public function test_it_delegates_when_the_assertion_matches(): void
+    {
+        $this->subject->process(
+            $this->contextFor(
+                new DeleteRequest('cn=foo,dc=bar'),
+                Controls::assertion(Filters::equal('cn', 'foo')),
+            ),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    public function test_it_throws_and_stops_the_chain_when_the_assertion_does_not_match(): void
+    {
+        try {
+            $this->subject->process(
+                $this->contextFor(
+                    new DeleteRequest('cn=foo,dc=bar'),
+                    Controls::assertion(Filters::equal('cn', 'nope')),
+                ),
+                $this->next,
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::ASSERTION_FAILED,
+                $e->getCode(),
+            );
+        }
+
+        self::assertNull(
+            $this->next->received,
+            'The next handler must not be reached when the assertion fails.',
+        );
+    }
+
+    public function test_it_resolves_the_search_base_as_the_target(): void
+    {
+        $search = (new SearchRequest(Filters::equal('cn', 'foo')))
+            ->base('cn=foo,dc=bar');
+
+        $this->expectException(OperationException::class);
+
+        $this->subject->process(
+            $this->contextFor(
+                $search,
+                Controls::assertion(Filters::equal('cn', 'nope')),
+            ),
+            $this->next,
+        );
+    }
+
+    public function test_it_skips_assertion_on_a_paging_continuation(): void
+    {
+        $search = (new SearchRequest(Filters::equal('cn', 'foo')))
+            ->base('cn=foo,dc=bar');
+
+        $this->subject->process(
+            $this->contextFor(
+                $search,
+                Controls::assertion(Filters::equal('cn', 'nope')),
+                new PagingControl(10, 'continuation-cookie'),
+            ),
+            $this->next,
+        );
+
+        self::assertNotNull(
+            $this->next->received,
+            'A non-matching assertion on a continuation page is not re-evaluated, so the chain proceeds.',
+        );
+    }
+
+    private function contextFor(
+        RequestInterface $request,
+        Control ...$controls,
+    ): ServerRequestContext {
+        return new ServerRequestContext(
+            new LdapMessageRequest(
+                1,
+                $request,
+                ...$controls,
+            ),
+            $this->createMock(TokenInterface::class),
+        );
+    }
+}


### PR DESCRIPTION
The current assertion control check is done across many spots. This moves it into the middleware, as it's a cross-cutting check across many operations. This also exposed that we really need a middleware that handles operation exception handling so it's done in one spot. When I implemented the middleware I didn't put a try / catch for operation exception in the dispatcher, so that wasn't being handled properly. A test ended up exposing it though. I will follow up with an error handling middleware.