### PR TITLE
[1.0.0] Add OperationErrorMiddleware to handle OperationException in one place.

### DIFF
--- a/src/FreeDSx/Ldap/Exception/SchemaRuleException.php
+++ b/src/FreeDSx/Ldap/Exception/SchemaRuleException.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Exception;
+
+use FreeDSx\Ldap\Server\Backend\Write\SchemaViolations;
+
+/**
+ * A rejected schema violation that carries the violations collected during the write so they can be audited.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class SchemaRuleException extends OperationException
+{
+    public function __construct(
+        OperationException $violation,
+        private readonly SchemaViolations $violations,
+    ) {
+        parent::__construct(
+            $violation->getMessage(),
+            $violation->getCode(),
+            $violation,
+            $violation->getMatchedDn(),
+        );
+    }
+
+    public function getViolations(): SchemaViolations
+    {
+        return $this->violations;
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -77,26 +77,17 @@ class ServerProtocolHandler
                     break;
                 }
             }
-        } catch (ResponseAlreadySentException $e) {
-            # The handler already sent the response (e.g. SASL, which needs the correct multi-round message ID), so
-            # only the audit log below applies here.
-            $this->logCriticalControlRejection(
-                $e,
-                $message,
-            );
+        } catch (ResponseAlreadySentException) {
+            # The handler already sent the response (e.g. SASL, which needs the correct multi-round message ID),
+            # so there is nothing further to do here.
         } catch (OperationException $e) {
-            # OperationExceptions may be thrown by any handler and will be sent back to the client as the response
-            # specific error code and message associated with the exception.
+            # Bind / authorization runs outside the request pipeline; its failures are turned into the response here.
+            # Pipeline operations are handled by OperationErrorMiddleware instead.
             $this->queue->sendMessage($this->responseFactory->getStandardResponse(
                 $message,
                 $e->getCode(),
                 $e->getMessage(),
             ));
-
-            $this->logCriticalControlRejection(
-                $e,
-                $message,
-            );
         } catch (ConnectionException) {
             # Connection closure is recorded by the runner's lifecycle logging; no audit event for normal client disconnects.
         } catch (EncoderException|ProtocolException) {
@@ -171,25 +162,11 @@ class ServerProtocolHandler
             return;
         }
 
-        # A pipeline gate (critical-control, authorization, assertion) rejects per-operation by throwing
-        # We need to catch here and send the response.
-        try {
-            $this->requestPipeline->handle(new ServerRequestContext(
-                $message,
-                $authorization->token(),
-                $this->connectionContext,
-            ));
-        } catch (OperationException $e) {
-            $this->queue->sendMessage($this->responseFactory->getStandardResponse(
-                $message,
-                $e->getCode(),
-                $e->getMessage(),
-            ));
-            $this->logCriticalControlRejection(
-                $e,
-                $message,
-            );
-        }
+        $this->requestPipeline->handle(new ServerRequestContext(
+            $message,
+            $authorization->token(),
+            $this->connectionContext,
+        ));
     }
 
     /**
@@ -250,27 +227,6 @@ class ServerProtocolHandler
         }
 
         return $this->authenticator->bind($message);
-    }
-
-    /**
-     * Handlers without their own catch (StartTLS, WhoAmI, RootDse, etc.) only reach the audit log via this path.
-     *
-     * Critical-control rejection is the realistic case; other codes are direction-dependent or already covered.
-     */
-    private function logCriticalControlRejection(
-        OperationException $exception,
-        ?LdapMessageRequest $message,
-    ): void {
-        if ($exception->getCode() !== ResultCode::UNAVAILABLE_CRITICAL_EXTENSION) {
-            return;
-        }
-
-        $this->eventLogger->recordFailure(
-            ServerEvent::CriticalControlRejected,
-            $exception,
-            subject: $this->authorizer->getToken(),
-            message: $message,
-        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -45,8 +45,6 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  */
 readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
 {
-    use MatchedDnAccessFilterTrait;
-
     private ReadEntryControlHandler $readEntryControlHandler;
 
     public function __construct(
@@ -68,6 +66,7 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
      * {@inheritDoc}
      *
      * @throws EncoderException
+     * @throws OperationException
      */
     public function handleRequest(
         LdapMessageRequest $message,
@@ -77,29 +76,20 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
         $request = $message->getRequest();
         $controls = $message->controls();
 
-        try {
-            if ($request instanceof Request\CompareRequest) {
-                return $this->handleCompare(
-                    $message,
-                    $request,
-                );
-            }
-
-            return $this->handleWrite(
+        if ($request instanceof Request\CompareRequest) {
+            return $this->handleCompare(
                 $message,
                 $request,
-                $controls,
-                $token,
-                $schemaViolations,
-            );
-        } catch (OperationException $e) {
-            return $this->handleFailure(
-                $message,
-                $e,
-                $token,
-                $schemaViolations,
             );
         }
+
+        return $this->handleWrite(
+            $message,
+            $request,
+            $controls,
+            $token,
+            $schemaViolations,
+        );
     }
 
     /**
@@ -224,34 +214,6 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
                     $dn,
                 );
             },
-        );
-    }
-
-    /**
-     * @throws EncoderException
-     */
-    private function handleFailure(
-        LdapMessageRequest $message,
-        OperationException $e,
-        TokenInterface $token,
-        SchemaViolations $schemaViolations,
-    ): OperationResult {
-        $this->queue->sendMessage($this->responseFactory->getStandardResponse(
-            $message,
-            $e->getCode(),
-            $e->getMessage(),
-            $this->filterMatchedDn(
-                $e->getMatchedDn(),
-                $token,
-                $this->backend,
-                $this->accessControl,
-            ),
-        ));
-
-        return WriteOperationResult::failure(
-            $message,
-            $e,
-            $schemaViolations,
         );
     }
 

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -15,7 +15,6 @@ namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Control\Sorting\SortingResponseControl;
 use FreeDSx\Ldap\Entry\Entry;
-use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\CancelRequest;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
@@ -41,8 +40,6 @@ use Generator;
 class ServerSearchHandler implements ServerProtocolHandlerInterface
 {
     use ServerSearchTrait;
-    use MatchedDnAccessFilterTrait;
-
 
     private const CANCEL_CHECK_INTERVAL = 50;
 
@@ -64,49 +61,31 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
     ): OperationResult {
         $request = $this->getSearchRequestFromMessage($message);
         $state = new SearchResultState();
-        $failure = null;
 
-        try {
-            $this->assertBaseDnProvided($request);
+        $this->assertBaseDnProvided($request);
 
-            $backendResult = $this->backend->search(
+        $backendResult = $this->backend->search(
+            $request,
+            $this->controlsForBackend($message),
+        );
+
+        $projection = AttributeProjection::forRequest(
+            $request->getAttributes(),
+            $request->getAttributesOnly(),
+            $this->schema,
+        );
+        $searchResult = SearchResult::makeSuccessResult(
+            $this->filteredEntryStream(
+                $backendResult,
                 $request,
-                $this->controlsForBackend($message),
-            );
-
-            $projection = AttributeProjection::forRequest(
-                $request->getAttributes(),
-                $request->getAttributesOnly(),
-                $this->schema,
-            );
-            $searchResult = SearchResult::makeSuccessResult(
-                $this->filteredEntryStream(
-                    $backendResult,
-                    $request,
-                    $state,
-                    $token,
-                    $message->getMessageId(),
-                    $projection,
-                ),
-                (string) $request->getBaseDn(),
                 $state,
-            );
-        } catch (OperationException $e) {
-            $failure = $e;
-            $matchedDn = $this->filterMatchedDn(
-                $e->getMatchedDn(),
                 $token,
-                $this->backend,
-                $this->accessControl,
-            );
-            $searchResult = SearchResult::makeErrorResult(
-                $e->getCode(),
-                $matchedDn !== null
-                    ? $matchedDn->toString()
-                    : '',
-                $e->getMessage(),
-            );
-        }
+                $message->getMessageId(),
+                $projection,
+            ),
+            (string) $request->getBaseDn(),
+            $state,
+        );
 
         $sortControl = $this->sortingControl($message);
         $responseControls = $sortControl !== null
@@ -120,15 +99,10 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
             ...$responseControls,
         );
 
-        return $failure !== null
-            ? SearchOperationResult::failure(
-                $message,
-                $failure,
-            )
-            : SearchOperationResult::success(
-                $message,
-                $state->entriesReturned,
-            );
+        return SearchOperationResult::success(
+            $message,
+            $state->entriesReturned,
+        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Exception\SchemaRuleException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Operation\WriteEntryOperationHandler;
@@ -447,7 +448,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         );
 
         if ($disposition === SchemaViolationDisposition::Rejected) {
-            throw $violation;
+            throw new SchemaRuleException(
+                $violation,
+                $context->schemaViolations(),
+            );
         }
     }
 

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuditMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuditMiddleware.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Middleware;
 
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Exception\SchemaRuleException;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Server\Logging\OperationAuditor;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
@@ -21,7 +24,7 @@ use FreeDSx\Ldap\Server\Operation\AuditableResult;
 use FreeDSx\Ldap\Server\Operation\OperationResult;
 
 /**
- * Audits the operation outcome the handler propagates back up the pipeline.
+ * Audits every operation outcome (the success result, or a thrown failure) the pipeline propagates back up.
  *
  * @internal
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
@@ -30,11 +33,23 @@ final readonly class OperationAuditMiddleware implements MiddlewareInterface
 {
     public function __construct(private OperationAuditor $auditor) {}
 
+    /**
+     * @throws OperationException
+     */
     public function process(
         ServerRequestContext $context,
         MiddlewareHandlerInterface $next,
     ): OperationResult {
-        $result = $next->handle($context);
+        try {
+            $result = $next->handle($context);
+        } catch (OperationException $e) {
+            $this->recordFailure(
+                $context,
+                $e,
+            );
+
+            throw $e;
+        }
 
         if ($result instanceof AuditableResult) {
             $result->record(
@@ -44,5 +59,34 @@ final readonly class OperationAuditMiddleware implements MiddlewareInterface
         }
 
         return $result;
+    }
+
+    private function recordFailure(
+        ServerRequestContext $context,
+        OperationException $e,
+    ): void {
+        if ($e instanceof SchemaRuleException) {
+            $this->auditor->recordSchemaViolations(
+                $e->getViolations(),
+                $context->message,
+                $context->token,
+            );
+        }
+
+        if ($context->message->getRequest() instanceof SearchRequest) {
+            $this->auditor->recordSearchFailure(
+                $context->message,
+                $e,
+                $context->token,
+            );
+
+            return;
+        }
+
+        $this->auditor->recordFailure(
+            $context->message,
+            $e,
+            $context->token,
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
@@ -28,8 +28,6 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\OperationTargetDn;
 use FreeDSx\Ldap\Server\AccessControl\OperationType;
-use FreeDSx\Ldap\Server\Logging\EventLogger;
-use FreeDSx\Ldap\Server\Logging\OperationAuditor;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
@@ -44,19 +42,14 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  */
 final readonly class OperationAuthorizationMiddleware implements MiddlewareInterface
 {
-    private OperationAuditor $auditor;
-
     /**
      * @param list<string> $privilegedControls Control OIDs that require an explicit ControlRule grant before use on a write.
      */
     public function __construct(
         private HandlerRouteResolverInterface $routeResolver,
         private AccessControlInterface $accessControl,
-        EventLogger $eventLogger = new EventLogger(null),
         private array $privilegedControls = [Control::OID_RELAX_RULES],
-    ) {
-        $this->auditor = new OperationAuditor($eventLogger);
-    }
+    ) {}
 
     /**
      * @throws OperationException
@@ -104,21 +97,11 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
             return;
         }
 
-        try {
-            $this->accessControl->authorizeOperation(
-                OperationType::Search,
-                $token,
-                $baseDn,
-            );
-        } catch (OperationException $e) {
-            $this->auditor->recordSearchFailure(
-                $message,
-                $e,
-                $token,
-            );
-
-            throw $e;
-        }
+        $this->accessControl->authorizeOperation(
+            OperationType::Search,
+            $token,
+            $baseDn,
+        );
     }
 
     /**
@@ -130,40 +113,30 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
     ): void {
         $request = $message->getRequest();
 
-        try {
-            $this->authorizeRequest(
-                $request,
-                $token,
-            );
-            $this->authorizeWriteAttributes(
-                $request,
-                $token,
-            );
+        $this->authorizeRequest(
+            $request,
+            $token,
+        );
+        $this->authorizeWriteAttributes(
+            $request,
+            $token,
+        );
 
-            if ($request instanceof CompareRequest) {
-                $this->accessControl->authorizeAttribute(
-                    $token,
-                    $request->getDn(),
-                    $request->getFilter()->getAttribute(),
-                );
-
-                return;
-            }
-
-            $this->authorizeControls(
-                $request,
-                $message->controls(),
+        if ($request instanceof CompareRequest) {
+            $this->accessControl->authorizeAttribute(
                 $token,
-            );
-        } catch (OperationException $e) {
-            $this->auditor->recordFailure(
-                $message,
-                $e,
-                $token,
+                $request->getDn(),
+                $request->getFilter()->getAttribute(),
             );
 
-            throw $e;
+            return;
         }
+
+        $this->authorizeControls(
+            $request,
+            $message->controls(),
+            $token,
+        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationErrorMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationErrorMiddleware.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\ServerProtocolHandler\MatchedDnAccessFilterTrait;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+
+/**
+ * Translates an OperationException thrown anywhere below into the matching response.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class OperationErrorMiddleware implements MiddlewareInterface
+{
+    use MatchedDnAccessFilterTrait;
+
+    public function __construct(
+        private ServerQueue $queue,
+        private LdapBackendInterface $backend,
+        private AccessControlInterface $accessControl,
+        private ResponseFactory $responseFactory = new ResponseFactory(),
+    ) {}
+
+    /**
+     * @throws EncoderException
+     */
+    public function process(
+        ServerRequestContext $context,
+        MiddlewareHandlerInterface $next,
+    ): OperationResult {
+        try {
+            return $next->handle($context);
+        } catch (OperationException $e) {
+            $this->queue->sendMessage($this->responseFactory->getStandardResponse(
+                $context->message,
+                $e->getCode(),
+                $e->getMessage(),
+                $this->filterMatchedDn(
+                    $e->getMatchedDn(),
+                    $context->token,
+                    $this->backend,
+                    $this->accessControl,
+                ),
+            ));
+
+            return OperationOutcomeResult::failed();
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -45,6 +45,7 @@ use FreeDSx\Ldap\Server\Middleware\AssertionMiddleware;
 use FreeDSx\Ldap\Server\Middleware\CriticalControlMiddleware;
 use FreeDSx\Ldap\Server\Middleware\OperationAuditMiddleware;
 use FreeDSx\Ldap\Server\Middleware\OperationAuthorizationMiddleware;
+use FreeDSx\Ldap\Server\Middleware\OperationErrorMiddleware;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\HandlerInvoker;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareChain;
 use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyBindGuard;
@@ -167,18 +168,22 @@ class ServerProtocolFactory implements ServerProtocolFactoryInterface
             queue: $serverQueue,
             requestPipeline: new MiddlewareChain(
                 [
+                    new OperationErrorMiddleware(
+                        $serverQueue,
+                        $backend,
+                        $this->options->getAccessControl(),
+                    ),
+                    new OperationAuditMiddleware(new OperationAuditor($eventLogger)),
                     new CriticalControlMiddleware($this->routeResolver),
                     new OperationAuthorizationMiddleware(
                         $this->routeResolver,
                         $this->options->getAccessControl(),
-                        $eventLogger,
                         $this->options->getPrivilegedControls(),
                     ),
                     new AssertionMiddleware(new AssertionEvaluator(
                         $this->options->getFilterEvaluator(),
                         $backend,
                     )),
-                    new OperationAuditMiddleware(new OperationAuditor($eventLogger)),
                 ],
                 new HandlerInvoker($handlerProvider),
             ),

--- a/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
 use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
@@ -81,22 +82,20 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
             [PasswordPolicyOid::NAME_PWD_HISTORY => $this->historyValue('previous-pass')],
         );
 
-        $handler->handleRequest(
-            $this->modify('previous-pass'),
-            $this->token(),
-        );
+        try {
+            $handler->handleRequest(
+                $this->modify('previous-pass'),
+                $this->token(),
+            );
+            self::fail('Expected the reused password to be rejected.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::CONSTRAINT_VIOLATION,
+                $e->getCode(),
+            );
+        }
 
-        $response = $this->response?->getResponse();
-        self::assertInstanceOf(
-            LdapResult::class,
-            $response,
-        );
-        self::assertSame(
-            ResultCode::CONSTRAINT_VIOLATION,
-            $response->getResultCode(),
-        );
-
-        $control = $this->response?->controls()->getByClass(PwdPolicyResponseControl::class);
+        $control = $this->context->buildResponseControl();
         self::assertInstanceOf(
             PwdPolicyResponseControl::class,
             $control,
@@ -153,22 +152,20 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
             )),
         );
 
-        $handler->handleRequest(
-            $this->modify('{SSHA}' . base64_encode('cannot-introspect-this')),
-            $this->token(),
-        );
+        try {
+            $handler->handleRequest(
+                $this->modify('{SSHA}' . base64_encode('cannot-introspect-this')),
+                $this->token(),
+            );
+            self::fail('Expected the prehashed value to be rejected.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::CONSTRAINT_VIOLATION,
+                $e->getCode(),
+            );
+        }
 
-        $response = $this->response?->getResponse();
-        self::assertInstanceOf(
-            LdapResult::class,
-            $response,
-        );
-        self::assertSame(
-            ResultCode::CONSTRAINT_VIOLATION,
-            $response->getResultCode(),
-        );
-
-        $control = $this->response?->controls()->getByClass(PwdPolicyResponseControl::class);
+        $control = $this->context->buildResponseControl();
         self::assertInstanceOf(
             PwdPolicyResponseControl::class,
             $control,
@@ -185,20 +182,18 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
             new PasswordPolicy(change: new PasswordChangeRules(safeModify: true)),
         );
 
-        $handler->handleRequest(
-            $this->modifyWithOld('wrong-old', 'a-fresh-password'),
-            $this->token(),
-        );
-
-        $response = $this->response?->getResponse();
-        self::assertInstanceOf(
-            LdapResult::class,
-            $response,
-        );
-        self::assertSame(
-            ResultCode::INVALID_CREDENTIALS,
-            $response->getResultCode(),
-        );
+        try {
+            $handler->handleRequest(
+                $this->modifyWithOld('wrong-old', 'a-fresh-password'),
+                $this->token(),
+            );
+            self::fail('Expected the safe-modify to be rejected.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INVALID_CREDENTIALS,
+                $e->getCode(),
+            );
+        }
 
         $entry = $this->backend->get(new Dn(self::USER_DN));
         self::assertSame(

--- a/tests/support/Middleware/StubMiddlewareHandler.php
+++ b/tests/support/Middleware/StubMiddlewareHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Support\FreeDSx\Ldap\Middleware;
+
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+
+/**
+ * Terminal handler that returns a preconfigured result.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class StubMiddlewareHandler implements MiddlewareHandlerInterface
+{
+    public function __construct(private OperationResult $result) {}
+
+    public function handle(ServerRequestContext $context): OperationResult
+    {
+        return $this->result;
+    }
+}

--- a/tests/support/Middleware/ThrowingMiddlewareHandler.php
+++ b/tests/support/Middleware/ThrowingMiddlewareHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Support\FreeDSx\Ldap\Middleware;
+
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+use Throwable;
+
+/**
+ * Terminal handler that throws the given throwable instead of producing a result.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ThrowingMiddlewareHandler implements MiddlewareHandlerInterface
+{
+    public function __construct(private Throwable $throwable) {}
+
+    public function handle(ServerRequestContext $context): OperationResult
+    {
+        throw $this->throwable;
+    }
+}

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
@@ -16,16 +16,13 @@ namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
-use FreeDSx\Ldap\Operation\Response\DeleteResponse;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Operation\Request\CompareRequest;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
-use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerDispatchHandler;
 use FreeDSx\Ldap\Schema\Schema;
@@ -100,7 +97,7 @@ final class ServerDispatchHandlerTest extends TestCase
         );
     }
 
-    public function test_it_sends_error_response_for_operation_exceptions_from_the_write_handler(): void
+    public function test_it_lets_operation_exceptions_from_the_write_handler_bubble(): void
     {
         $add = new LdapMessageRequest(1, new AddRequest(Entry::create('cn=foo,dc=bar')));
 
@@ -111,22 +108,10 @@ final class ServerDispatchHandlerTest extends TestCase
                 ResultCode::ENTRY_ALREADY_EXISTS,
             ));
 
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->with(self::callback(function (LdapMessageResponse $msg): bool {
-                return $msg->getResponse() instanceof LdapResult
-                    && $msg->getResponse()->getResultCode() === ResultCode::ENTRY_ALREADY_EXISTS;
-            }))
-            ->willReturnSelf();
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::ENTRY_ALREADY_EXISTS);
 
-        $result = $this->subject->handleRequest($add, $this->mockToken);
-
-        self::assertInstanceOf(WriteOperationResult::class, $result);
-        self::assertSame(
-            OperationOutcome::Failed,
-            $result->outcome(),
-        );
+        $this->subject->handleRequest($add, $this->mockToken);
     }
 
     public function test_it_delegates_compare_to_the_backend(): void
@@ -152,7 +137,7 @@ final class ServerDispatchHandlerTest extends TestCase
         self::assertInstanceOf(CompareOperationResult::class, $result);
     }
 
-    public function test_it_sends_error_response_for_operation_exceptions_from_backend_compare(): void
+    public function test_it_lets_operation_exceptions_from_backend_compare_bubble(): void
     {
         $compare = new LdapMessageRequest(1, new CompareRequest('cn=foo,dc=bar', Filters::equal('foo', 'bar')));
 
@@ -163,19 +148,13 @@ final class ServerDispatchHandlerTest extends TestCase
                 ResultCode::NO_SUCH_OBJECT,
             ));
 
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->with(self::callback(function (LdapMessageResponse $msg): bool {
-                return $msg->getResponse() instanceof LdapResult
-                    && $msg->getResponse()->getResultCode() === ResultCode::NO_SUCH_OBJECT;
-            }))
-            ->willReturnSelf();
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::NO_SUCH_OBJECT);
 
         $this->subject->handleRequest($compare, $this->mockToken);
     }
 
-    public function test_it_sends_error_response_when_no_write_handler_supports_the_operation(): void
+    public function test_it_throws_when_no_write_handler_supports_the_operation(): void
     {
         $subject = new ServerDispatchHandler(
             queue: $this->mockQueue,
@@ -187,26 +166,17 @@ final class ServerDispatchHandlerTest extends TestCase
 
         $add = new LdapMessageRequest(1, new AddRequest(Entry::create('cn=foo,dc=bar')));
 
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->with(self::callback(function (LdapMessageResponse $msg): bool {
-                return $msg->getResponse() instanceof LdapResult
-                    && $msg->getResponse()->getResultCode() === ResultCode::UNWILLING_TO_PERFORM;
-            }))
-            ->willReturnSelf();
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
 
         $subject->handleRequest($add, $this->mockToken);
     }
 
-    public function test_it_sends_error_response_for_unsupported_requests(): void
+    public function test_it_throws_for_unsupported_requests(): void
     {
         $request = new LdapMessageRequest(2, new AbandonRequest(1));
 
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->willReturnSelf();
+        $this->expectException(OperationException::class);
 
         $this->subject->handleRequest($request, $this->mockToken);
     }
@@ -221,128 +191,6 @@ final class ServerDispatchHandlerTest extends TestCase
             ->with(self::isInstanceOf(WriteRequestInterface::class));
 
         $this->subject->handleRequest($delete, $this->mockToken);
-    }
-
-    public function test_matched_dn_from_exception_is_used_in_write_response(): void
-    {
-        $matchedDn = new Dn('dc=bar');
-        $matchedEntry = Entry::create('dc=bar');
-        $delete = new LdapMessageRequest(1, new DeleteRequest('cn=Missing,dc=bar'));
-
-        $this->mockWriteHandler
-            ->method('handle')
-            ->willThrowException(new OperationException(
-                'No such object.',
-                ResultCode::NO_SUCH_OBJECT,
-                null,
-                $matchedDn,
-            ));
-
-        $this->mockBackend
-            ->method('get')
-            ->willReturn($matchedEntry);
-        $this->mockAccessControl
-            ->method('filterEntry')
-            ->willReturn($matchedEntry);
-
-        $captured = null;
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->willReturnCallback(function (LdapMessageResponse $msg) use (&$captured): LdapMessageResponse {
-                $captured = $msg;
-
-                return $msg;
-            });
-
-        $this->subject->handleRequest($delete, $this->mockToken);
-
-        $response = $captured?->getResponse();
-        self::assertInstanceOf(DeleteResponse::class, $response);
-        self::assertSame(
-            'dc=bar',
-            $response->getDn()->toString(),
-        );
-    }
-
-    public function test_matched_dn_is_dropped_when_access_control_hides_ancestor(): void
-    {
-        $matchedDn = new Dn('dc=bar');
-        $matchedEntry = Entry::create('dc=bar');
-        $delete = new LdapMessageRequest(1, new DeleteRequest('cn=Missing,dc=bar'));
-
-        $this->mockWriteHandler
-            ->method('handle')
-            ->willThrowException(new OperationException(
-                'No such object.',
-                ResultCode::NO_SUCH_OBJECT,
-                null,
-                $matchedDn,
-            ));
-
-        $this->mockBackend
-            ->method('get')
-            ->willReturn($matchedEntry);
-        $this->mockAccessControl
-            ->method('filterEntry')
-            ->willReturn(null);
-
-        $captured = null;
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->willReturnCallback(function (LdapMessageResponse $msg) use (&$captured): LdapMessageResponse {
-                $captured = $msg;
-
-                return $msg;
-            });
-
-        $this->subject->handleRequest($delete, $this->mockToken);
-
-        $response = $captured?->getResponse();
-        self::assertInstanceOf(DeleteResponse::class, $response);
-        self::assertSame(
-            '',
-            $response->getDn()->toString(),
-        );
-    }
-
-    public function test_matched_dn_is_dropped_when_backend_returns_no_entry_for_ancestor(): void
-    {
-        $matchedDn = new Dn('dc=bar');
-        $delete = new LdapMessageRequest(1, new DeleteRequest('cn=Missing,dc=bar'));
-
-        $this->mockWriteHandler
-            ->method('handle')
-            ->willThrowException(new OperationException(
-                'No such object.',
-                ResultCode::NO_SUCH_OBJECT,
-                null,
-                $matchedDn,
-            ));
-
-        $this->mockBackend
-            ->method('get')
-            ->willReturn(null);
-
-        $captured = null;
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->willReturnCallback(function (LdapMessageResponse $msg) use (&$captured): LdapMessageResponse {
-                $captured = $msg;
-
-                return $msg;
-            });
-
-        $this->subject->handleRequest($delete, $this->mockToken);
-
-        $response = $captured?->getResponse();
-        self::assertInstanceOf(DeleteResponse::class, $response);
-        self::assertSame(
-            '',
-            $response->getDn()->toString(),
-        );
     }
 
     public function test_non_critical_unsupported_control_does_not_cause_an_error(): void

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
@@ -17,7 +17,6 @@ use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\Sorting\SortKey;
 use FreeDSx\Ldap\Control\Sorting\SortingControl;
 use FreeDSx\Ldap\Control\Sorting\SortingResponseControl;
-use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\LdapResult;
@@ -202,7 +201,7 @@ final class ServerSearchHandlerTest extends TestCase
         ]);
     }
 
-    public function test_it_should_send_a_SearchResultDone_with_an_operation_exception_thrown_from_the_backend(): void
+    public function test_it_lets_an_operation_exception_from_the_backend_bubble(): void
     {
         $search = new LdapMessageRequest(
             2,
@@ -221,25 +220,12 @@ final class ServerSearchHandlerTest extends TestCase
                 ),
             );
 
-        $result = $this->subject->handleRequest(
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::OPERATIONS_ERROR);
+
+        $this->subject->handleRequest(
             $search,
             $this->mockToken,
-        );
-
-        $this->assertSentMessages([
-            new LdapMessageResponse(
-                2,
-                new SearchResultDone(
-                    ResultCode::OPERATIONS_ERROR,
-                    '',
-                    "Fail",
-                ),
-            ),
-        ]);
-        self::assertInstanceOf(SearchOperationResult::class, $result);
-        self::assertSame(
-            OperationOutcome::Failed,
-            $result->outcome(),
         );
     }
 
@@ -674,100 +660,6 @@ final class ServerSearchHandlerTest extends TestCase
             0,
             $sortControl->getResult(),
         );
-    }
-
-    public function test_matched_dn_from_exception_is_used_in_SearchResultDone_on_error(): void
-    {
-        $matchedDn = new Dn('dc=foo,dc=bar');
-        $matchedEntry = Entry::create('dc=foo,dc=bar');
-
-        $search = new LdapMessageRequest(
-            2,
-            (new SearchRequest(Filters::equal('foo', 'bar')))->base('cn=Missing,dc=foo,dc=bar'),
-        );
-
-        $this->mockBackend
-            ->method('search')
-            ->willThrowException(new OperationException(
-                'No such object.',
-                ResultCode::NO_SUCH_OBJECT,
-                null,
-                $matchedDn,
-            ));
-        $this->mockBackend
-            ->method('get')
-            ->willReturn($matchedEntry);
-        $this->mockAccessControl
-            ->method('filterEntry')
-            ->willReturn($matchedEntry);
-
-        $this->subject->handleRequest(
-            $search,
-            $this->mockToken,
-        );
-
-        $this->assertSentMessages([
-            new LdapMessageResponse(
-                2,
-                new SearchResultDone(
-                    ResultCode::NO_SUCH_OBJECT,
-                    'dc=foo,dc=bar',
-                    'No such object.',
-                ),
-            ),
-        ]);
-    }
-
-    public function test_matched_dn_is_dropped_when_access_control_hides_ancestor_on_search(): void
-    {
-        $matchedDn = new Dn('dc=foo,dc=bar');
-        $matchedEntry = Entry::create('dc=foo,dc=bar');
-
-        $search = new LdapMessageRequest(
-            2,
-            (new SearchRequest(Filters::equal('foo', 'bar')))->base('cn=Missing,dc=foo,dc=bar'),
-        );
-
-        $this->mockBackend
-            ->method('search')
-            ->willThrowException(new OperationException(
-                'No such object.',
-                ResultCode::NO_SUCH_OBJECT,
-                null,
-                $matchedDn,
-            ));
-        $this->mockBackend
-            ->method('get')
-            ->willReturn($matchedEntry);
-
-        $mockAccessControl = $this->createMock(AccessControlInterface::class);
-        $mockAccessControl
-            ->method('filterEntry')
-            ->willReturn(null);
-
-        $subject = new ServerSearchHandler(
-            queue: $this->mockQueue,
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $mockAccessControl,
-            schema: $this->schema,
-        );
-
-        $subject->handleRequest(
-            $search,
-            $this->mockToken,
-        );
-
-        $this->assertSentMessages([
-            new LdapMessageResponse(
-                2,
-                new SearchResultDone(
-                    ResultCode::NO_SUCH_OBJECT,
-                    '',
-                    'No such object.',
-                ),
-            ),
-        ]);
     }
 
     public function test_no_sort_control_does_not_append_sorting_response_control(): void

--- a/tests/unit/Protocol/ServerProtocolHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandlerTest.php
@@ -506,51 +506,6 @@ final class ServerProtocolHandlerTest extends TestCase
         self::assertNotEmpty($disconnectRecord['context']['exception_trace']);
     }
 
-    public function test_propagated_critical_control_rejection_emits_structured_event(): void
-    {
-        $recordingLogger = new RecordingLogger();
-        $subject = $this->makeSubjectWithEventLogger(new EventLogger(
-            $recordingLogger,
-            EventLogPolicy::default(),
-        ));
-
-        $messages = [
-            new LdapMessageRequest(7, new ExtendedRequest(ExtendedRequest::OID_START_TLS)),
-        ];
-        $this->mockQueue
-            ->method('getMessage')
-            ->willReturnCallback(static function () use (&$messages): LdapMessageRequest {
-                if ($messages === []) {
-                    throw new ConnectionException();
-                }
-
-                return array_shift($messages);
-            });
-
-        $this->mockProtocolHandler
-            ->expects(self::once())
-            ->method('handleRequest')
-            ->willThrowException(new OperationException(
-                'Critical control 1.2.3.4 is not supported.',
-                ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
-            ));
-
-        $subject->handle();
-
-        $record = $this->findRecord(
-            $recordingLogger,
-            'control.critical.rejected',
-        );
-        self::assertSame(
-            7,
-            $record['context']['message_id'],
-        );
-        self::assertSame(
-            ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
-            $record['context']['result_code'],
-        );
-    }
-
     public function test_a_must_change_token_blocks_other_operations(): void
     {
         $token = BindToken::fromDn(

--- a/tests/unit/Server/Middleware/OperationAuditMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationAuditMiddlewareTest.php
@@ -15,21 +15,28 @@ namespace Tests\Unit\FreeDSx\Ldap\Server\Middleware;
 
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Exception\SchemaRuleException;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\Backend\Write\SchemaViolationDisposition;
 use FreeDSx\Ldap\Server\Backend\Write\SchemaViolations;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
 use FreeDSx\Ldap\Server\Logging\OperationAuditor;
 use FreeDSx\Ldap\Server\Middleware\OperationAuditMiddleware;
-use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Operation\WriteOperationResult;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use PHPUnit\Framework\TestCase;
 use Tests\Support\FreeDSx\Ldap\Logging\RecordingLogger;
+use Tests\Support\FreeDSx\Ldap\Middleware\StubMiddlewareHandler;
+use Tests\Support\FreeDSx\Ldap\Middleware\ThrowingMiddlewareHandler;
 
 final class OperationAuditMiddlewareTest extends TestCase
 {
@@ -60,7 +67,7 @@ final class OperationAuditMiddlewareTest extends TestCase
     {
         $this->subject->process(
             $this->context,
-            $this->handlerReturning(WriteOperationResult::success(
+            new StubMiddlewareHandler(WriteOperationResult::success(
                 $this->context->message,
                 new SchemaViolations(),
             )),
@@ -76,7 +83,7 @@ final class OperationAuditMiddlewareTest extends TestCase
     {
         $this->subject->process(
             $this->context,
-            $this->handlerReturning(OperationOutcomeResult::succeeded()),
+            new StubMiddlewareHandler(OperationOutcomeResult::succeeded()),
         );
 
         self::assertSame(
@@ -93,20 +100,117 @@ final class OperationAuditMiddlewareTest extends TestCase
             $result,
             $this->subject->process(
                 $this->context,
-                $this->handlerReturning($result),
+                new StubMiddlewareHandler($result),
             ),
         );
     }
 
-    private function handlerReturning(OperationResult $result): MiddlewareHandlerInterface
+    public function test_it_audits_a_write_authorization_denial_and_rethrows(): void
     {
-        return new class ($result) implements MiddlewareHandlerInterface {
-            public function __construct(private readonly OperationResult $result) {}
+        $exception = new OperationException(
+            'Denied.',
+            ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+        );
 
-            public function handle(ServerRequestContext $context): OperationResult
-            {
-                return $this->result;
+        $this->processThrowing($this->context, $exception);
+
+        self::assertTrue($this->wasLogged('authz.denied.write'));
+    }
+
+    public function test_it_audits_a_search_authorization_denial(): void
+    {
+        $context = $this->contextFor((new SearchRequest(Filters::present('cn')))->base('dc=bar'));
+        $exception = new OperationException(
+            'Denied.',
+            ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+        );
+
+        $this->processThrowing($context, $exception);
+
+        self::assertTrue($this->wasLogged('authz.denied.read'));
+    }
+
+    public function test_it_audits_a_critical_control_rejection(): void
+    {
+        $exception = new OperationException(
+            'Critical control 1.2.3.4 is not supported.',
+            ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
+        );
+
+        $this->processThrowing($this->context, $exception);
+
+        self::assertTrue($this->wasLogged('control.critical.rejected'));
+    }
+
+    public function test_it_records_schema_violations_from_a_schema_rule_exception(): void
+    {
+        $violations = new SchemaViolations();
+        $violations->record(
+            new OperationException(
+                'objectClass violation.',
+                ResultCode::OBJECT_CLASS_VIOLATION,
+            ),
+            SchemaViolationDisposition::Rejected,
+        );
+        $exception = new SchemaRuleException(
+            new OperationException(
+                'objectClass violation.',
+                ResultCode::OBJECT_CLASS_VIOLATION,
+            ),
+            $violations,
+        );
+
+        $this->processThrowing($this->context, $exception);
+
+        self::assertTrue($this->wasLogged('schema.violation'));
+    }
+
+    public function test_it_rethrows_the_caught_operation_exception(): void
+    {
+        $exception = new OperationException('Boom.');
+
+        $this->expectExceptionObject($exception);
+
+        $this->subject->process(
+            $this->context,
+            new ThrowingMiddlewareHandler($exception),
+        );
+    }
+
+    private function processThrowing(
+        ServerRequestContext $context,
+        OperationException $exception,
+    ): void {
+        try {
+            $this->subject->process(
+                $context,
+                new ThrowingMiddlewareHandler($exception),
+            );
+            self::fail('Expected the OperationException to be re-thrown.');
+        } catch (OperationException) {
+        }
+    }
+
+    private function wasLogged(string $event): bool
+    {
+        foreach ($this->logger->records as $record) {
+            if ($record['message'] === $event) {
+                return true;
             }
-        };
+        }
+
+        return false;
+    }
+
+    private function contextFor(RequestInterface $request): ServerRequestContext
+    {
+        return new ServerRequestContext(
+            new LdapMessageRequest(1, $request),
+            new BindToken(
+                'cn=alice,dc=bar',
+                'secret',
+                new Dn('cn=alice,dc=bar'),
+            ),
+        );
     }
 }

--- a/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
@@ -30,15 +30,12 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\OperationType;
-use FreeDSx\Ldap\Server\Logging\EventLogger;
-use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
 use FreeDSx\Ldap\Server\Middleware\OperationAuthorizationMiddleware;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Tests\Support\FreeDSx\Ldap\Logging\RecordingLogger;
 use Tests\Support\FreeDSx\Ldap\Middleware\CallLog;
 use Tests\Support\FreeDSx\Ldap\Middleware\RecordingMiddlewareHandler;
 
@@ -47,8 +44,6 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
     private HandlerRouteResolverInterface&MockObject $resolver;
 
     private AccessControlInterface&MockObject $accessControl;
-
-    private RecordingLogger $logger;
 
     private TokenInterface&MockObject $token;
 
@@ -60,15 +55,10 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
     {
         $this->resolver = $this->createMock(HandlerRouteResolverInterface::class);
         $this->accessControl = $this->createMock(AccessControlInterface::class);
-        $this->logger = new RecordingLogger();
         $this->token = $this->createMock(TokenInterface::class);
         $this->subject = new OperationAuthorizationMiddleware(
             $this->resolver,
             $this->accessControl,
-            new EventLogger(
-                $this->logger,
-                EventLogPolicy::default(),
-            ),
         );
         $this->next = new RecordingMiddlewareHandler(new CallLog());
     }
@@ -93,7 +83,7 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
         self::assertNotNull($this->next->received);
     }
 
-    public function test_search_route_denial_audits_a_read_denial_and_blocks_dispatch(): void
+    public function test_search_route_denial_blocks_dispatch(): void
     {
         $this->routeResolvesTo(HandlerId::Paging);
         $this->accessControl
@@ -117,7 +107,6 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
             $this->next->received,
             'Dispatch must be blocked on denial.',
         );
-        self::assertTrue($this->wasLogged('authz.denied.read'));
     }
 
     public function test_dispatch_route_authorizes_modify_dn_against_source_only(): void
@@ -160,7 +149,7 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
         self::assertNotNull($this->next->received);
     }
 
-    public function test_dispatch_route_add_attribute_denial_audits_a_write_denial_and_blocks_dispatch(): void
+    public function test_dispatch_route_add_attribute_denial_blocks_dispatch(): void
     {
         $this->routeResolvesTo(HandlerId::Dispatch);
         $this->accessControl
@@ -183,7 +172,6 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
         }
 
         self::assertNull($this->next->received);
-        self::assertTrue($this->wasLogged('authz.denied.write'));
     }
 
     public function test_dispatch_route_compare_attribute_denial_blocks_dispatch(): void
@@ -238,10 +226,6 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
         $subject = new OperationAuthorizationMiddleware(
             $this->resolver,
             $this->accessControl,
-            new EventLogger(
-                $this->logger,
-                EventLogPolicy::default(),
-            ),
             [Control::OID_SUBTREE_DELETE],
         );
         $this->routeResolvesTo(HandlerId::Dispatch);
@@ -339,16 +323,5 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
             'Access denied.',
             ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
         );
-    }
-
-    private function wasLogged(string $event): bool
-    {
-        foreach ($this->logger->records as $record) {
-            if ($record['message'] === $event) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/tests/unit/Server/Middleware/OperationErrorMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationErrorMiddlewareTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\DeleteRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Response\DeleteResponse;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Middleware\OperationErrorMiddleware;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationOutcome;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Middleware\StubMiddlewareHandler;
+use Tests\Support\FreeDSx\Ldap\Middleware\ThrowingMiddlewareHandler;
+
+final class OperationErrorMiddlewareTest extends TestCase
+{
+    private ServerQueue&MockObject $mockQueue;
+
+    private LdapBackendInterface&MockObject $mockBackend;
+
+    private AccessControlInterface&MockObject $mockAccessControl;
+
+    private TokenInterface&MockObject $mockToken;
+
+    private OperationErrorMiddleware $subject;
+
+    private ?LdapMessageResponse $sent = null;
+
+    protected function setUp(): void
+    {
+        $this->mockQueue = $this->createMock(ServerQueue::class);
+        $this->mockBackend = $this->createMock(LdapBackendInterface::class);
+        $this->mockAccessControl = $this->createMock(AccessControlInterface::class);
+        $this->mockToken = $this->createMock(TokenInterface::class);
+
+        $this->mockQueue
+            ->method('sendMessage')
+            ->willReturnCallback(function (LdapMessageResponse $response): ServerQueue {
+                $this->sent = $response;
+
+                return $this->mockQueue;
+            });
+
+        $this->subject = new OperationErrorMiddleware(
+            $this->mockQueue,
+            $this->mockBackend,
+            $this->mockAccessControl,
+        );
+    }
+
+    public function test_it_passes_a_successful_result_through_without_sending(): void
+    {
+        $this->mockQueue
+            ->expects(self::never())
+            ->method('sendMessage');
+
+        $result = OperationOutcomeResult::succeeded();
+
+        self::assertSame(
+            $result,
+            $this->subject->process(
+                $this->contextFor(new DeleteRequest('cn=foo,dc=bar')),
+                new StubMiddlewareHandler($result),
+            ),
+        );
+    }
+
+    public function test_it_renders_the_response_for_a_thrown_exception_and_does_not_rethrow(): void
+    {
+        $result = $this->subject->process(
+            $this->contextFor(new DeleteRequest('cn=foo,dc=bar')),
+            new ThrowingMiddlewareHandler(new OperationException(
+                'Unwilling.',
+                ResultCode::UNWILLING_TO_PERFORM,
+            )),
+        );
+
+        self::assertSame(
+            OperationOutcome::Failed,
+            $result->outcome(),
+        );
+
+        $response = $this->sent?->getResponse();
+        self::assertInstanceOf(DeleteResponse::class, $response);
+        self::assertSame(
+            ResultCode::UNWILLING_TO_PERFORM,
+            $response->getResultCode(),
+        );
+    }
+
+    public function test_it_keeps_a_matched_dn_the_token_may_see(): void
+    {
+        $this->mockBackend
+            ->method('get')
+            ->willReturn(Entry::create('dc=bar'));
+        $this->mockAccessControl
+            ->method('filterEntry')
+            ->willReturn(Entry::create('dc=bar'));
+
+        $this->subject->process(
+            $this->contextFor(new DeleteRequest('cn=missing,dc=bar')),
+            new ThrowingMiddlewareHandler($this->noSuchObject(new Dn('dc=bar'))),
+        );
+
+        $response = $this->sent?->getResponse();
+        self::assertInstanceOf(DeleteResponse::class, $response);
+        self::assertSame(
+            'dc=bar',
+            $response->getDn()->toString(),
+        );
+    }
+
+    public function test_it_drops_a_matched_dn_the_access_control_hides(): void
+    {
+        $this->mockBackend
+            ->method('get')
+            ->willReturn(Entry::create('dc=bar'));
+        $this->mockAccessControl
+            ->method('filterEntry')
+            ->willReturn(null);
+
+        $this->subject->process(
+            $this->contextFor(new DeleteRequest('cn=missing,dc=bar')),
+            new ThrowingMiddlewareHandler($this->noSuchObject(new Dn('dc=bar'))),
+        );
+
+        $response = $this->sent?->getResponse();
+        self::assertInstanceOf(DeleteResponse::class, $response);
+        self::assertSame(
+            '',
+            $response->getDn()->toString(),
+        );
+    }
+
+    public function test_it_drops_a_matched_dn_when_the_backend_has_no_ancestor(): void
+    {
+        $this->mockBackend
+            ->method('get')
+            ->willReturn(null);
+
+        $this->subject->process(
+            $this->contextFor(new DeleteRequest('cn=missing,dc=bar')),
+            new ThrowingMiddlewareHandler($this->noSuchObject(new Dn('dc=bar'))),
+        );
+
+        $response = $this->sent?->getResponse();
+        self::assertInstanceOf(DeleteResponse::class, $response);
+        self::assertSame(
+            '',
+            $response->getDn()->toString(),
+        );
+    }
+
+    private function noSuchObject(Dn $matchedDn): OperationException
+    {
+        return new OperationException(
+            'No such object.',
+            ResultCode::NO_SUCH_OBJECT,
+            null,
+            $matchedDn,
+        );
+    }
+
+    private function contextFor(RequestInterface $request): ServerRequestContext
+    {
+        return new ServerRequestContext(
+            new LdapMessageRequest(1, $request),
+            $this->mockToken,
+        );
+    }
+}


### PR DESCRIPTION
Currently OperationException handling is all over the place, and it makes things hard to reason about. This makes it so it's mostly consolidated to one spot in the middleware. This also moves all the audit logging to one spot in the middleware as well. So now code can generally just throw OperationException and it will get handled properly regardless of where it happens in the process. This cleans up a lot of spots.