### PR TITLE
[1.0.0] Speed up unit / integration tests.

### DIFF
--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordHashService.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordHashService.php
@@ -34,8 +34,12 @@ final readonly class PasswordHashService
         '{SMD5}',
     ];
 
+    /**
+     * @param int|null $hashCost bcrypt cost forwarded to password_hash(); null uses the PHP default (10). Does not apply to argon2.
+     */
     public function __construct(
         private PasswordHashScheme $scheme = PasswordHashScheme::Bcrypt,
+        private ?int $hashCost = null,
     ) {}
 
     /**
@@ -154,6 +158,9 @@ final readonly class PasswordHashService
         $hash = password_hash(
             $plain,
             $algo,
+            $this->hashCost !== null
+                ? ['cost' => $this->hashCost]
+                : [],
         );
 
         return $scheme->value . $hash;

--- a/tests/integration/LdapPasswordModifyServerTest.php
+++ b/tests/integration/LdapPasswordModifyServerTest.php
@@ -65,6 +65,7 @@ final class LdapPasswordModifyServerTest extends ServerTestCase
             self::USER_DN,
             ['userPassword'],
         );
+        $verifyClient->unbind();
 
         $this->assertNotNull($entry);
         $this->assertStringStartsWith(
@@ -108,6 +109,7 @@ final class LdapPasswordModifyServerTest extends ServerTestCase
             self::USER_DN,
             ['userPassword'],
         );
+        $verifyClient->unbind();
 
         $this->assertNotNull($entry);
         $this->assertStringStartsWith(
@@ -137,6 +139,7 @@ final class LdapPasswordModifyServerTest extends ServerTestCase
             self::USER_DN,
             ['userPassword'],
         );
+        $verifyClient->unbind();
 
         $this->assertNotNull($entry);
         $this->assertStringStartsWith(

--- a/tests/integration/Security/PasswordPolicyChangeEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyChangeEnforcementTest.php
@@ -160,7 +160,7 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
         $entry = $this->backend->get(new Dn(self::USER_DN));
         self::assertNotNull($entry);
         self::assertTrue(
-            (new PasswordHashService())->verify(
+            (new PasswordHashService(hashCost: 4))->verify(
                 'a-fresh-password',
                 (string) $entry->get('userPassword')?->firstValue(),
             ),
@@ -311,7 +311,7 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
                 new SafeModifyConstraint(),
                 new MinAgeConstraint($this->clock),
                 new QualityConstraint(new DefaultPasswordQualityChecker()),
-                new HistoryConstraint(new PasswordHashService()),
+                new HistoryConstraint(new PasswordHashService(hashCost: 4)),
             ]),
         );
     }
@@ -375,7 +375,7 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
     {
         return HistoryEntry::forStoredPassword(
             $this->clock->now(),
-            '{BCRYPT}' . password_hash($plaintext, PASSWORD_BCRYPT),
+            '{BCRYPT}' . password_hash($plaintext, PASSWORD_BCRYPT, ['cost' => 4]),
         )->encode();
     }
 

--- a/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
@@ -131,7 +131,7 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
         $entry = $this->backend->get(new Dn(self::USER_DN));
         self::assertNotNull($entry);
         self::assertTrue(
-            (new PasswordHashService())->verify(
+            (new PasswordHashService(hashCost: 4))->verify(
                 'a-fresh-password',
                 (string) $entry->get('userPassword')?->firstValue(),
             ),
@@ -289,7 +289,7 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
                     new SafeModifyConstraint(),
                     new MinAgeConstraint($this->clock),
                     new QualityConstraint(new DefaultPasswordQualityChecker()),
-                    new HistoryConstraint(new PasswordHashService()),
+                    new HistoryConstraint(new PasswordHashService(hashCost: 4)),
                 ]),
             ),
             new PasswordPolicyResolver(
@@ -370,7 +370,7 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
     {
         return HistoryEntry::forStoredPassword(
             $this->clock->now(),
-            '{BCRYPT}' . password_hash($plaintext, PASSWORD_BCRYPT),
+            '{BCRYPT}' . password_hash($plaintext, PASSWORD_BCRYPT, ['cost' => 4]),
         )->encode();
     }
 }

--- a/tests/integration/ServerTestCase.php
+++ b/tests/integration/ServerTestCase.php
@@ -25,6 +25,11 @@ class ServerTestCase extends LdapTestCase
     private const SERVER_POLL_INTERVAL_US = 15_000; // 15ms
 
     /**
+     * Caps the SIGTERM grace period so a lingering client connection can't stall teardown for Symfony's default 10s.
+     */
+    private const SERVER_STOP_TIMEOUT_SECONDS = 0.5;
+
+    /**
      * Shared server process — started once per test class via setUpBeforeClass.
      */
     private static ?Process $sharedProcess = null;
@@ -86,7 +91,7 @@ class ServerTestCase extends LdapTestCase
         $this->client = null;
 
         if ($this->overrideProcess !== null) {
-            $this->overrideProcess->stop();
+            $this->overrideProcess->stop(self::SERVER_STOP_TIMEOUT_SECONDS);
             $this->overrideProcess = null;
         }
 
@@ -120,7 +125,7 @@ class ServerTestCase extends LdapTestCase
 
     protected static function tearDownSharedServer(): void
     {
-        self::$sharedProcess?->stop();
+        self::$sharedProcess?->stop(self::SERVER_STOP_TIMEOUT_SECONDS);
         self::$sharedProcess = null;
     }
 
@@ -159,10 +164,10 @@ class ServerTestCase extends LdapTestCase
         $this->client = null;
 
         if ($this->overrideProcess !== null) {
-            $this->overrideProcess->stop();
+            $this->overrideProcess->stop(self::SERVER_STOP_TIMEOUT_SECONDS);
             $this->overrideProcess = null;
         } elseif (self::$sharedProcess !== null) {
-            self::$sharedProcess->stop();
+            self::$sharedProcess->stop(self::SERVER_STOP_TIMEOUT_SECONDS);
             self::$sharedProcess = null;
             $this->needsSharedRestart = true;
         }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordModifyHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordModifyHandlerTest.php
@@ -25,6 +25,7 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerPasswordModifyHandler;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
@@ -80,6 +81,7 @@ final class ServerPasswordModifyHandlerTest extends TestCase
                 ),
                 accessControl: $this->createMock(AccessControlInterface::class),
                 writeDispatcher: new WriteOperationDispatcher($mockWriteHandler),
+                hashService: new PasswordHashService(hashCost: 4),
             ),
         );
     }

--- a/tests/unit/Server/Backend/Auth/PasswordHashServiceTest.php
+++ b/tests/unit/Server/Backend/Auth/PasswordHashServiceTest.php
@@ -24,7 +24,7 @@ final class PasswordHashServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->subject = new PasswordHashService();
+        $this->subject = new PasswordHashService(hashCost: 4);
     }
 
     public function test_default_scheme_is_bcrypt(): void
@@ -55,7 +55,7 @@ final class PasswordHashServiceTest extends TestCase
         PasswordHashScheme $scheme,
         string $expectedPrefix,
     ): void {
-        $hashed = (new PasswordHashService($scheme))->hash('secret');
+        $hashed = (new PasswordHashService($scheme, hashCost: 4))->hash('secret');
 
         self::assertStringStartsWith(
             $expectedPrefix,
@@ -67,7 +67,7 @@ final class PasswordHashServiceTest extends TestCase
     public function test_each_scheme_round_trips(
         PasswordHashScheme $scheme,
     ): void {
-        $hashed = (new PasswordHashService($scheme))->hash('mypassword');
+        $hashed = (new PasswordHashService($scheme, hashCost: 4))->hash('mypassword');
 
         self::assertTrue($this->subject->verify(
             'mypassword',
@@ -79,7 +79,7 @@ final class PasswordHashServiceTest extends TestCase
     public function test_wrong_password_does_not_verify_a_freshly_hashed_value(
         PasswordHashScheme $scheme,
     ): void {
-        $hashed = (new PasswordHashService($scheme))->hash('mypassword');
+        $hashed = (new PasswordHashService($scheme, hashCost: 4))->hash('mypassword');
 
         self::assertFalse($this->subject->verify(
             'wrong',
@@ -91,7 +91,7 @@ final class PasswordHashServiceTest extends TestCase
     public function test_two_hashes_of_same_input_differ_due_to_random_salt(
         PasswordHashScheme $scheme,
     ): void {
-        $hasher = new PasswordHashService($scheme);
+        $hasher = new PasswordHashService($scheme, hashCost: 4);
 
         self::assertNotSame(
             $hasher->hash('password'),
@@ -175,7 +175,7 @@ final class PasswordHashServiceTest extends TestCase
 
     public function test_bcrypt_format_verifies(): void
     {
-        $hashed = '{BCRYPT}' . password_hash('mypassword', PASSWORD_BCRYPT);
+        $hashed = '{BCRYPT}' . password_hash('mypassword', PASSWORD_BCRYPT, ['cost' => 4]);
 
         self::assertTrue($this->subject->verify(
             'mypassword',
@@ -201,7 +201,7 @@ final class PasswordHashServiceTest extends TestCase
         return [
             '{SHA}'    => ['{SHA}' . base64_encode(sha1('mypassword', true))],
             '{MD5}'    => ['{MD5}' . base64_encode(md5('mypassword', true))],
-            '{BCRYPT}' => ['{BCRYPT}' . password_hash('mypassword', PASSWORD_BCRYPT)],
+            '{BCRYPT}' => ['{BCRYPT}' . password_hash('mypassword', PASSWORD_BCRYPT, ['cost' => 4])],
             '{ARGON2}' => ['{ARGON2}' . password_hash('mypassword', PASSWORD_ARGON2ID)],
         ];
     }

--- a/tests/unit/Server/Backend/Write/PasswordPolicyWriteHandlerTest.php
+++ b/tests/unit/Server/Backend/Write/PasswordPolicyWriteHandlerTest.php
@@ -321,7 +321,7 @@ final class PasswordPolicyWriteHandlerTest extends TestCase
                     new SafeModifyConstraint(),
                     new MinAgeConstraint($this->clock),
                     new QualityConstraint(new DefaultPasswordQualityChecker()),
-                    new HistoryConstraint(new PasswordHashService()),
+                    new HistoryConstraint(new PasswordHashService(hashCost: 4)),
                 ]),
             ),
             new PasswordPolicyResolver(
@@ -355,7 +355,7 @@ final class PasswordPolicyWriteHandlerTest extends TestCase
     {
         return HistoryEntry::forStoredPassword(
             $this->clock->now(),
-            '{BCRYPT}' . password_hash($plaintext, PASSWORD_BCRYPT),
+            '{BCRYPT}' . password_hash($plaintext, PASSWORD_BCRYPT, ['cost' => 4]),
         )->encode();
     }
 }

--- a/tests/unit/Server/PasswordModify/PasswordModifyServiceTest.php
+++ b/tests/unit/Server/PasswordModify/PasswordModifyServiceTest.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Operation\Request\PasswordModifyRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
+use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
@@ -76,6 +77,7 @@ final class PasswordModifyServiceTest extends TestCase
             ),
             accessControl: $this->accessControl,
             writeDispatcher: new WriteOperationDispatcher($writeHandler),
+            hashService: new PasswordHashService(hashCost: 4),
             passwordPolicyContext: $this->context,
         );
     }

--- a/tests/unit/Server/PasswordPolicy/Constraint/HistoryConstraintTest.php
+++ b/tests/unit/Server/PasswordPolicy/Constraint/HistoryConstraintTest.php
@@ -31,7 +31,7 @@ final class HistoryConstraintTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->subject = new HistoryConstraint(new PasswordHashService());
+        $this->subject = new HistoryConstraint(new PasswordHashService(hashCost: 4));
     }
 
     public function test_zero_depth_skips(): void
@@ -130,7 +130,7 @@ final class HistoryConstraintTest extends TestCase
                     '2026-05-15T00:00:00Z',
                     new DateTimeZone('UTC'),
                 ),
-                '{BCRYPT}' . password_hash($plain, PASSWORD_BCRYPT),
+                '{BCRYPT}' . password_hash($plain, PASSWORD_BCRYPT, ['cost' => 4]),
             ),
             $historyPlaintexts,
         ));

--- a/tests/unit/Server/PasswordPolicy/Guard/PasswordPolicyChangeGuardTest.php
+++ b/tests/unit/Server/PasswordPolicy/Guard/PasswordPolicyChangeGuardTest.php
@@ -143,7 +143,7 @@ final class PasswordPolicyChangeGuardTest extends TestCase
         ))->enforce($this->attempt(
             $this->entry([PasswordPolicyOid::NAME_PWD_RESET => 'TRUE']),
             'a-fresh-password',
-            '{BCRYPT}' . password_hash('a-fresh-password', PASSWORD_BCRYPT),
+            '{BCRYPT}' . password_hash('a-fresh-password', PASSWORD_BCRYPT, ['cost' => 4]),
         ));
 
         self::assertNull($this->context->getOutcome());
@@ -234,7 +234,7 @@ final class PasswordPolicyChangeGuardTest extends TestCase
                 new SafeModifyConstraint(),
                 new MinAgeConstraint($this->clock),
                 new QualityConstraint(new DefaultPasswordQualityChecker()),
-                new HistoryConstraint(new PasswordHashService()),
+                new HistoryConstraint(new PasswordHashService(hashCost: 4)),
             ]),
         );
 
@@ -280,7 +280,7 @@ final class PasswordPolicyChangeGuardTest extends TestCase
     {
         return HistoryEntry::forStoredPassword(
             $this->clock->now(),
-            '{BCRYPT}' . password_hash($plaintext, PASSWORD_BCRYPT),
+            '{BCRYPT}' . password_hash($plaintext, PASSWORD_BCRYPT, ['cost' => 4]),
         )->encode();
     }
 


### PR DESCRIPTION
Lower bcrypt hash cost for tests only. Lower the timeout for symfony process stop (defaults to 10s).

This drastically decrease the time the tests currently take. They have crept up as I added password hash related tests and as I've added more integration tests over time.