### PR TITLE
[1.0.0] Add support for reloading the server configuration on SIGHUP.

### DIFF
--- a/docs/Server/General-Usage.md
+++ b/docs/Server/General-Usage.md
@@ -6,6 +6,7 @@ General LDAP Server Usage
   * [File-Backed Server with Custom Bind Names](#file-backed-server-with-custom-bind-names)
   * [Challenge SASL with a Custom Authenticator](#challenge-sasl-with-a-custom-authenticator)
 * [Running the Server](#running-the-server)
+* [Reloading Configuration on SIGHUP](#reloading-configuration-on-sighup)
 * [Creating a Proxy Server](#creating-a-proxy-server)
 * [Providing a Backend](#providing-a-backend)
   * [Built-In Storage Implementations](#built-in-storage-implementations)
@@ -171,6 +172,70 @@ use FreeDSx\Ldap\LdapServer;
 
 $server = (new LdapServer())->run();
 ```
+
+## Reloading Configuration on SIGHUP
+
+A running server can reload its configuration on a `SIGHUP` signal without dropping connections. New connections
+accepted after the reload use the updated configuration. Connections already in flight keep the configuration they
+started with. This works on both the PCNTL and Swoole runners.
+
+By default `SIGHUP` is a logged no-op. To opt in, register a reloader via `LdapServer::onReload()`. The reloader is
+invoked on each `SIGHUP` and returns the `ServerOptions` the server should adopt going forward:
+
+```php
+use FreeDSx\Ldap\Server\Configuration\ConfigReloaderInterface;
+use FreeDSx\Ldap\ServerOptions;
+
+final class FileConfigReloader implements ConfigReloaderInterface
+{
+    public function __construct(private readonly string $configFile)
+    {
+    }
+
+    public function reload(ServerOptions $current): ServerOptions
+    {
+        $config = json_decode((string) file_get_contents($this->configFile), true);
+
+        // Clone the current options so the backend and other wiring carry forward,
+        // then apply just the settings your config file controls.
+        return (clone $current)
+            ->setAllowAnonymous($config['allow_anonymous'] ?? false)
+            ->setMaxSearchSize($config['max_search_size'] ?? 1000);
+    }
+}
+```
+
+```php
+use FreeDSx\Ldap\LdapServer;
+
+$server = (new LdapServer())
+    ->useStorage($storage)
+    ->onReload(new FileConfigReloader('/etc/myapp/ldap.json'));
+
+$server->run();
+```
+
+Trigger a reload by sending a signal to the server process, e.g. `kill -HUP <pid>`.
+
+**Cloning the current options** (`clone $current`) is the simplest way to write a reloader. It preserves the backend
+and everything else already configured while you change only the settings you care about. Returning a brand-new
+`ServerOptions` would drop that wiring.
+
+**What reloads.** Anything resolved per connection:
+
+* **Authorization:** access control rules and privileged controls
+* **Schema and validation:** schema, validation mode, and password policy
+* **Limits and logging:** search limits, logger, and event-log policy
+* **Session and capabilities:** SASL mechanisms, RootDSE settings, and the authentication flags (require-authentication, allow-anonymous)
+
+**What does not reload.** The listening socket is fixed once the server is running:
+
+* Bind IP, port, transport, and unix socket path
+* The choice of runner (PCNTL vs Swoole)
+* A StartTLS certificate change applies to new connections only
+
+**On failure:** if the reloader throws, the error is logged and the server keeps its current configuration. The bad
+reload is discarded rather than taking the server down.
 
 ## Creating a Proxy Server
 

--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap;
 
+use Closure;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 use FreeDSx\Ldap\Protocol\Factory\ClientProtocolHandlerFactory;
@@ -350,20 +351,45 @@ class Container
     private function makeServerRunner(): ServerRunnerInterface
     {
         $options = $this->get(ServerOptions::class);
+        $protocolFactoryProvider = $this->makeProtocolFactoryProvider();
 
         if ($options->getUseSwooleRunner()) {
             return new SwooleServerRunner(
-                serverProtocolFactory: $this->get(ServerProtocolFactoryInterface::class),
+                serverProtocolFactory: $protocolFactoryProvider($options),
                 options: $options,
                 socketServerFactory: $this->get(SocketServerFactory::class),
+                protocolFactoryProvider: $protocolFactoryProvider,
             );
         }
 
         return new PcntlServerRunner(
-            serverProtocolFactory: $this->get(ServerProtocolFactoryInterface::class),
+            serverProtocolFactory: $protocolFactoryProvider($options),
             options: $options,
             socketServerFactory: $this->get(SocketServerFactory::class),
+            protocolFactoryProvider: $protocolFactoryProvider,
         );
+    }
+
+    /**
+     * Builds a protocol factory from a (possibly reloaded) set of options via a fresh container.
+     *
+     * @return Closure(ServerOptions): ServerProtocolFactoryInterface
+     */
+    private function makeProtocolFactoryProvider(): Closure
+    {
+        $proxyOptions = $this->has(ProxyOptions::class)
+            ? $this->get(ProxyOptions::class)
+            : null;
+
+        return static function (ServerOptions $options) use ($proxyOptions): ServerProtocolFactoryInterface {
+            $instances = [ServerOptions::class => $options];
+
+            if ($proxyOptions !== null) {
+                $instances[ProxyOptions::class] = $proxyOptions;
+            }
+
+            return (new Container($instances))->get(ServerProtocolFactoryInterface::class);
+        };
     }
 
     private function makeSocketServerFactory(): SocketServerFactory

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -33,6 +33,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\OperationalAttributeGenerator;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Configuration\ConfigReloaderInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Export\DirectoryDumper;
 use FreeDSx\Ldap\Server\Backend\Storage\Export\DumpOptions;
 use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
@@ -334,6 +335,16 @@ class LdapServer
     public function useLogger(LoggerInterface $logger): self
     {
         $this->options->setLogger($logger);
+
+        return $this;
+    }
+
+    /**
+     * Register a reloader that supplies fresh ServerOptions on a SIGHUP reload. New connections use the result.
+     */
+    public function onReload(ConfigReloaderInterface $configReloader): self
+    {
+        $this->options->setConfigReloader($configReloader);
 
         return $this;
     }

--- a/src/FreeDSx/Ldap/Server/Configuration/ConfigReloaderInterface.php
+++ b/src/FreeDSx/Ldap/Server/Configuration/ConfigReloaderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Configuration;
+
+use FreeDSx\Ldap\ServerOptions;
+
+/**
+ * Produces the ServerOptions to use going forward when the server is asked to reload (e.g. on SIGHUP).
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface ConfigReloaderInterface
+{
+    /**
+     * Returns the options the server should adopt for new connections. In-flight connections keep their current options.
+     */
+    public function reload(ServerOptions $current): ServerOptions;
+}

--- a/src/FreeDSx/Ldap/Server/Configuration/ReloadCoordinator.php
+++ b/src/FreeDSx/Ldap/Server/Configuration/ReloadCoordinator.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Configuration;
+
+use Closure;
+use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
+use FreeDSx\Ldap\ServerOptions;
+use Psr\Log\LogLevel;
+use Throwable;
+
+/**
+ * Drives the config reload process.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class ReloadCoordinator
+{
+    /**
+     * Returns the options and factory to adopt for new connections, or null on a no-op (no reloader) or failure.
+     *
+     * @param Closure(ServerOptions): ServerProtocolFactoryInterface $protocolFactoryProvider
+     * @param array<string, mixed> $context
+     */
+    public function reload(
+        ServerOptions $current,
+        Closure $protocolFactoryProvider,
+        array $context = [],
+    ): ?ReloadResult {
+        $reloader = $current->getConfigReloader();
+
+        if ($reloader === null) {
+            $current->getLogger()?->log(
+                LogLevel::INFO,
+                'Received a reload signal, but no configuration reloader is configured. Ignoring.',
+                $context,
+            );
+
+            return null;
+        }
+
+        try {
+            $newOptions = $reloader->reload($current);
+            $protocolFactory = $protocolFactoryProvider($newOptions);
+            $current->getLogger()?->log(
+                LogLevel::INFO,
+                'Server configuration reloaded. New connections will use the updated configuration.',
+                $context,
+            );
+
+            return new ReloadResult(
+                $newOptions,
+                $protocolFactory,
+            );
+        } catch (Throwable $e) {
+            $current->getLogger()?->log(
+                LogLevel::ERROR,
+                'Configuration reload failed. Keeping the current configuration.',
+                array_merge(
+                    $context,
+                    [
+                        'exception_message' => $e->getMessage(),
+                        'exception_class' => $e::class,
+                    ],
+                ),
+            );
+
+            return null;
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Configuration/ReloadResult.php
+++ b/src/FreeDSx/Ldap/Server/Configuration/ReloadResult.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Configuration;
+
+use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
+use FreeDSx\Ldap\ServerOptions;
+
+/**
+ * The configuration a runner should adopt for new connections after a successful reload.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ReloadResult
+{
+    public function __construct(
+        public ServerOptions $options,
+        public ServerProtocolFactoryInterface $protocolFactory,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -24,6 +24,7 @@ use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Socket\Socket;
 use FreeDSx\Socket\SocketServer;
 use FreeDSx\Ldap\ServerOptions;
+use Closure;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Throwable;
@@ -36,6 +37,7 @@ use Throwable;
 class PcntlServerRunner implements ServerRunnerInterface
 {
     use ServerRunnerLoggerTrait;
+    use ReloadsConfigurationTrait;
 
     private SocketServer $server;
 
@@ -53,8 +55,6 @@ class PcntlServerRunner implements ServerRunnerInterface
 
     private bool $isPosixExtLoaded;
 
-    private bool $isServerSignalsInstalled = false;
-
     private bool $isShuttingDown = false;
 
     /**
@@ -66,15 +66,20 @@ class PcntlServerRunner implements ServerRunnerInterface
      * @throws RuntimeException
      */
     public function __construct(
-        private readonly ServerProtocolFactoryInterface $serverProtocolFactory,
-        private readonly ServerOptions $options,
+        ServerProtocolFactoryInterface $serverProtocolFactory,
+        ServerOptions $options,
         private readonly SocketServerFactory $socketServerFactory,
+        Closure $protocolFactoryProvider,
     ) {
         if (!extension_loaded('pcntl')) {
             throw new RuntimeException(
                 'The PCNTL extension is needed to fork incoming requests, which is only available on Linux.',
             );
         }
+
+        $this->serverProtocolFactory = $serverProtocolFactory;
+        $this->options = $options;
+        $this->protocolFactoryProvider = $protocolFactoryProvider;
 
         // posix_kill needs this...we cannot clean up child processes without it on shutdown...
         $this->isPosixExtLoaded = extension_loaded('posix');
@@ -148,6 +153,7 @@ class PcntlServerRunner implements ServerRunnerInterface
      */
     private function acceptClients(): void
     {
+        $this->installServerSignalHandlers();
         $this->logServerStarted($this->defaultContext);
         $this->options->getOnServerReady()?->__invoke();
 
@@ -251,7 +257,7 @@ class PcntlServerRunner implements ServerRunnerInterface
     private function installServerSignalHandlers(): void
     {
         foreach ($this->handledSignals as $signal) {
-            $this->isServerSignalsInstalled = pcntl_signal(
+            pcntl_signal(
                 $signal,
                 function () {
                     $this->handleServerShutdown();
@@ -261,10 +267,7 @@ class PcntlServerRunner implements ServerRunnerInterface
         pcntl_signal(
             SIGHUP,
             function () {
-                $this->logInfo(
-                    'Received SIGHUP. Configuration reload is not yet implemented.',
-                    $this->defaultContext,
-                );
+                $this->reloadConfiguration($this->defaultContext);
             },
         );
     }
@@ -396,17 +399,13 @@ class PcntlServerRunner implements ServerRunnerInterface
     /**
      * When a new Socket is received, we do the following:
      *
-     *     1. If the server has not installed its signal handlers, do that first.
-     *     2. Add the ChildProcess to the list of running child processes.
-     *     3. Clean-up any currently running child processes.
+     *     1. Add the ChildProcess to the list of running child processes.
+     *     2. Clean-up any currently running child processes.
      */
     private function runAfterChildStarted(
         int $pid,
         Socket $socket,
     ): void {
-        if (!$this->isServerSignalsInstalled) {
-            $this->installServerSignalHandlers();
-        }
         $this->childProcesses[] = new ChildProcess(
             $pid,
             $socket,

--- a/src/FreeDSx/Ldap/Server/ServerRunner/ReloadsConfigurationTrait.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/ReloadsConfigurationTrait.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\ServerRunner;
+
+use Closure;
+use FreeDSx\Ldap\Server\Configuration\ReloadCoordinator;
+use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
+use FreeDSx\Ldap\ServerOptions;
+
+/**
+ * Holds a runner's live configuration and adopts a reloaded one when the ReloadCoordinator produces it.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+trait ReloadsConfigurationTrait
+{
+    private ServerOptions $options;
+
+    private ServerProtocolFactoryInterface $serverProtocolFactory;
+
+    /**
+     * @var Closure(ServerOptions): ServerProtocolFactoryInterface
+     */
+    private Closure $protocolFactoryProvider;
+
+    /**
+     * Adopts a reloaded configuration for new connections. In-flight connections keep their current config.
+     *
+     * @param array<string, mixed> $context
+     */
+    private function reloadConfiguration(array $context = []): void
+    {
+        $result = (new ReloadCoordinator())->reload(
+            $this->options,
+            $this->protocolFactoryProvider,
+            $context,
+        );
+
+        if ($result === null) {
+            return;
+        }
+
+        $this->options = $result->options;
+        $this->serverProtocolFactory = $result->protocolFactory;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/ServerRunner/SwooleServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/SwooleServerRunner.php
@@ -21,6 +21,7 @@ use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\Socket;
 use FreeDSx\Socket\SocketServer;
+use Closure;
 use Psr\Log\LoggerInterface;
 use Swoole\Coroutine;
 use Swoole\Coroutine\WaitGroup;
@@ -47,6 +48,7 @@ use Throwable;
 class SwooleServerRunner implements ServerRunnerInterface
 {
     use ServerRunnerLoggerTrait;
+    use ReloadsConfigurationTrait;
 
     private SocketServer $server;
 
@@ -73,9 +75,10 @@ class SwooleServerRunner implements ServerRunnerInterface
     private WaitGroup $waitGroup;
 
     public function __construct(
-        private readonly ServerProtocolFactoryInterface $serverProtocolFactory,
-        private readonly ServerOptions $options,
+        ServerProtocolFactoryInterface $serverProtocolFactory,
+        ServerOptions $options,
         private readonly SocketServerFactory $socketServerFactory,
+        Closure $protocolFactoryProvider,
     ) {
         if (!extension_loaded('swoole')) {
             throw new RuntimeException(
@@ -84,6 +87,10 @@ class SwooleServerRunner implements ServerRunnerInterface
                 . '(^5.1 for PHP 8.3/8.4, ^6.0 for PHP 8.5+)',
             );
         }
+
+        $this->serverProtocolFactory = $serverProtocolFactory;
+        $this->options = $options;
+        $this->protocolFactoryProvider = $protocolFactoryProvider;
 
         Runtime::enableCoroutine(SWOOLE_HOOK_ALL);
         $this->waitGroup = new WaitGroup();
@@ -110,7 +117,6 @@ class SwooleServerRunner implements ServerRunnerInterface
         Process::signal(SIGTERM, $this->handleShutdownSignal(...));
         Process::signal(SIGINT, $this->handleShutdownSignal(...));
         Process::signal(SIGQUIT, $this->handleShutdownSignal(...));
-        // SIGHUP is reserved for configuration reload, not shutdown. Stub it.
         Process::signal(
             SIGHUP,
             $this->handleReloadSignal(...),
@@ -119,10 +125,7 @@ class SwooleServerRunner implements ServerRunnerInterface
 
     private function handleReloadSignal(int $signal): void
     {
-        $this->getRunnerLogger()?->info(
-            'Received SIGHUP. Configuration reload is not yet implemented.',
-            ['signal' => $signal],
-        );
+        $this->reloadConfiguration(['signal' => $signal]);
     }
 
     private function handleShutdownSignal(int $signal): void

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -33,6 +33,7 @@ use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\AclRules;
 use FreeDSx\Ldap\Server\AccessControl\SimpleAccessControl;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
+use FreeDSx\Ldap\Server\Configuration\ConfigReloaderInterface;
 use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
 use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
 use FreeDSx\Ldap\Server\SearchLimits;
@@ -178,6 +179,8 @@ final class ServerOptions
     private int $maxSearchPageSize = 1000;
 
     private ?Closure $onServerReady = null;
+
+    private ?ConfigReloaderInterface $configReloader = null;
 
     private int $shutdownTimeout = 15;
 
@@ -783,6 +786,18 @@ final class ServerOptions
     public function setOnServerReady(?Closure $onServerReady): self
     {
         $this->onServerReady = $onServerReady;
+
+        return $this;
+    }
+
+    public function getConfigReloader(): ?ConfigReloaderInterface
+    {
+        return $this->configReloader;
+    }
+
+    public function setConfigReloader(?ConfigReloaderInterface $configReloader): self
+    {
+        $this->configReloader = $configReloader;
 
         return $this;
     }

--- a/tests/integration/LdapServerReloadTest.php
+++ b/tests/integration/LdapServerReloadTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap;
+
+use FreeDSx\Ldap\Exception\BindException;
+use FreeDSx\Ldap\Operation\Response\BindResponse;
+use FreeDSx\Ldap\Operations;
+
+final class LdapServerReloadTest extends ServerTestCase
+{
+    private string $reloadFlagFile;
+
+    public function setUp(): void
+    {
+        $this->setServerMode('ldap-server');
+
+        $this->reloadFlagFile = sys_get_temp_dir() . '/ldap_reload_flag_' . getmypid() . '.txt';
+        @unlink($this->reloadFlagFile);
+
+        parent::setUp();
+
+        $this->createServerProcess(
+            'tcp',
+            ['--reload-flag-file=' . $this->reloadFlagFile],
+        );
+    }
+
+    public function tearDown(): void
+    {
+        @unlink($this->reloadFlagFile);
+
+        parent::tearDown();
+    }
+
+    public function testSighupReloadEnablesAnonymousBindForNewConnections(): void
+    {
+        $this->expectException(BindException::class);
+
+        $this->ldapClient()->send(Operations::bindAnonymously());
+    }
+
+    public function testSighupReloadAppliesTheFileDrivenConfiguration(): void
+    {
+        file_put_contents(
+            $this->reloadFlagFile,
+            'allow-anonymous',
+        );
+
+        $this->sendServerSignal(SIGHUP);
+        $this->waitForServerOutput('configuration reloaded...');
+
+        $client = $this->buildClient('tcp');
+        $response = $client
+            ->send(Operations::bindAnonymously())
+            ?->getResponse();
+        $client->unbind();
+
+        $this->assertInstanceOf(
+            BindResponse::class,
+            $response,
+        );
+        $this->assertSame(
+            0,
+            $response->getResultCode(),
+        );
+    }
+}

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -15,6 +15,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqliteStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
 use FreeDSx\Ldap\ServerOptions;
+use Tests\Support\FreeDSx\Ldap\Server\Configuration\FileFlagConfigReloader;
 use PDO;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -97,6 +98,13 @@ final class LdapServerCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'After seeding/applying changes, dump the directory to an LDIF file via LdapServer::dump()',
                 '',
+            )
+            ->addOption(
+                'reload-flag-file',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'On SIGHUP, re-read this file and enable anonymous bind when it contains "allow-anonymous"',
+                '',
             );
     }
 
@@ -114,6 +122,7 @@ final class LdapServerCommand extends Command
         $seedFile = $this->getStringOption($input, 'seed');
         $changesFile = $this->getStringOption($input, 'changes');
         $dumpFile = $this->getStringOption($input, 'dump');
+        $reloadFlagFile = $this->getStringOption($input, 'reload-flag-file');
         $useSsl = false;
 
         if (!in_array($storageType, self::VALID_STORAGE, true)) {
@@ -153,6 +162,10 @@ final class LdapServerCommand extends Command
             ->setAllowAnonymous($allowAnonymous)
             ->setSocketAcceptTimeout(0.1)
             ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL));
+
+        if ($reloadFlagFile !== '') {
+            $options->setConfigReloader(new FileFlagConfigReloader($reloadFlagFile));
+        }
 
         $server = new LdapServer($options);
 

--- a/tests/support/Server/Configuration/FileFlagConfigReloader.php
+++ b/tests/support/Server/Configuration/FileFlagConfigReloader.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Support\FreeDSx\Ldap\Server\Configuration;
+
+use FreeDSx\Ldap\Server\Configuration\ConfigReloaderInterface;
+use FreeDSx\Ldap\ServerOptions;
+
+/**
+ * Reloads from a flag file: anonymous bind is enabled when the file contains "allow-anonymous".
+ */
+final readonly class FileFlagConfigReloader implements ConfigReloaderInterface
+{
+    public function __construct(private string $flagFile) {}
+
+    public function reload(ServerOptions $current): ServerOptions
+    {
+        $enabled = is_file($this->flagFile)
+            && trim((string) file_get_contents($this->flagFile)) === 'allow-anonymous';
+
+        fwrite(STDOUT, 'configuration reloaded...' . PHP_EOL);
+
+        return (clone $current)->setAllowAnonymous($enabled);
+    }
+}

--- a/tests/unit/Server/Configuration/ReloadCoordinatorTest.php
+++ b/tests/unit/Server/Configuration/ReloadCoordinatorTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Configuration;
+
+use FreeDSx\Ldap\Server\Configuration\ConfigReloaderInterface;
+use FreeDSx\Ldap\Server\Configuration\ReloadCoordinator;
+use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
+use FreeDSx\Ldap\ServerOptions;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use RuntimeException;
+
+final class ReloadCoordinatorTest extends TestCase
+{
+    private ReloadCoordinator $subject;
+
+    private ServerProtocolFactoryInterface $reloadedFactory;
+
+    protected function setUp(): void
+    {
+        $this->subject = new ReloadCoordinator();
+        $this->reloadedFactory = $this->createMock(ServerProtocolFactoryInterface::class);
+    }
+
+    public function test_reload_returns_the_new_options_and_a_factory_rebuilt_from_them(): void
+    {
+        $newOptions = (new ServerOptions())->setMaxConnections(123);
+        $reloader = $this->createMock(ConfigReloaderInterface::class);
+        $reloader
+            ->expects(self::once())
+            ->method('reload')
+            ->willReturn($newOptions);
+
+        $rebuiltFrom = null;
+        $result = $this->subject->reload(
+            (new ServerOptions())->setConfigReloader($reloader),
+            function (ServerOptions $options) use (&$rebuiltFrom): ServerProtocolFactoryInterface {
+                $rebuiltFrom = $options;
+
+                return $this->reloadedFactory;
+            },
+        );
+
+        self::assertNotNull($result);
+        self::assertSame(
+            $newOptions,
+            $result->options,
+        );
+        self::assertSame(
+            $this->reloadedFactory,
+            $result->protocolFactory,
+        );
+        self::assertSame(
+            $newOptions,
+            $rebuiltFrom,
+        );
+    }
+
+    public function test_a_missing_config_reloader_is_a_logged_no_op(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects(self::once())
+            ->method('log')
+            ->with(
+                LogLevel::INFO,
+                self::stringContains('no configuration reloader'),
+                self::anything(),
+            );
+
+        $result = $this->subject->reload(
+            (new ServerOptions())->setLogger($logger),
+            fn(ServerOptions $options) => $this->reloadedFactory,
+        );
+
+        self::assertNull($result);
+    }
+
+    public function test_a_failing_reload_returns_null_and_logs_an_error(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects(self::once())
+            ->method('log')
+            ->with(
+                LogLevel::ERROR,
+                self::stringContains('reload failed'),
+                self::anything(),
+            );
+
+        $reloader = $this->createMock(ConfigReloaderInterface::class);
+        $reloader
+            ->method('reload')
+            ->willThrowException(new RuntimeException('Bad configuration.'));
+
+        $result = $this->subject->reload(
+            (new ServerOptions())
+                ->setLogger($logger)
+                ->setConfigReloader($reloader),
+            fn(ServerOptions $options) => $this->reloadedFactory,
+        );
+
+        self::assertNull($result);
+    }
+}

--- a/tests/unit/Server/ServerRunner/SwooleServerRunnerTest.php
+++ b/tests/unit/Server/ServerRunner/SwooleServerRunnerTest.php
@@ -31,10 +31,13 @@ final class SwooleServerRunnerTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches('/Swoole extension/');
 
+        $factory = $this->createMock(ServerProtocolFactory::class);
+
         new SwooleServerRunner(
-            serverProtocolFactory: $this->createMock(ServerProtocolFactory::class),
+            serverProtocolFactory: $factory,
             options: new ServerOptions(),
             socketServerFactory: $this->createMock(SocketServerFactory::class),
+            protocolFactoryProvider: static fn(ServerOptions $options) => $factory,
         );
     }
 }


### PR DESCRIPTION
This adds basic support for reloading the configuration in some way via standard SIGHUP. I deliberately kept this simple for now. Ideally we'd support some kind of actual configuration that expresses what the server options are and you'd just point it to a file. But I'm not sure what I want to do with the configuration for the server yet (beyond what exists already with the server options).