### PR TITLE
[1.0.0] Move authentication / authorization / validation to middleware.

### DIFF
--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -286,7 +286,6 @@ class Container
         return new ServerProtocolFactory(
             handlerFactory: $this->get(HandlerFactoryInterface::class),
             options: $this->get(ServerOptions::class),
-            serverAuthorization: $this->get(ServerAuthorization::class),
             passwordPolicyEngine: $this->get(PasswordPolicyEngine::class),
             routeResolver: $this->get(ServerProtocolHandlerFactory::class),
             targetResolver: $this->get(PasswordModifyTargetResolver::class),

--- a/src/FreeDSx/Ldap/Exception/RequestValidationException.php
+++ b/src/FreeDSx/Ldap/Exception/RequestValidationException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Exception;
+
+/**
+ * Thrown when an inbound request is structurally invalid, such as a zero or reused message ID.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class RequestValidationException extends ProtocolException {}

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -14,15 +14,12 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol;
 
 use FreeDSx\Asn1\Exception\EncoderException;
-use FreeDSx\Ldap\Control\PwdPolicyError;
-use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\ProtocolException;
+use FreeDSx\Ldap\Exception\RequestValidationException;
 use FreeDSx\Ldap\Exception\ResponseAlreadySentException;
-use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
-use FreeDSx\Ldap\Protocol\Authorization\DispatchAuthorizer;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
@@ -31,33 +28,22 @@ use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
-use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Socket\Exception\ConnectionException;
 use Throwable;
-
-use function in_array;
 
 /**
  * Handles server-client specific protocol interactions.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class ServerProtocolHandler
+readonly class ServerProtocolHandler
 {
-    /**
-     * @var int[]
-     */
-    private array $messageIds = [];
-
     public function __construct(
-        private readonly ServerQueue $queue,
-        private readonly MiddlewareHandlerInterface $requestPipeline,
-        private readonly ServerAuthorization $authorizer,
-        private readonly Authenticator $authenticator,
-        private readonly DispatchAuthorizer $dispatchAuthorizer,
-        private readonly EventLogger $eventLogger = new EventLogger(null),
-        private readonly ResponseFactory $responseFactory = new ResponseFactory(),
-        private readonly ConnectionContext $connectionContext = new ConnectionContext(),
+        private ServerQueue $queue,
+        private MiddlewareHandlerInterface $requestPipeline,
+        private EventLogger $eventLogger = new EventLogger(null),
+        private ResponseFactory $responseFactory = new ResponseFactory(),
+        private ConnectionContext $connectionContext = new ConnectionContext(),
     ) {}
 
     /**
@@ -67,8 +53,6 @@ class ServerProtocolHandler
      */
     public function handle(): void
     {
-        $message = null;
-
         try {
             while ($message = $this->queue->getMessage()) {
                 $this->dispatchRequest($message);
@@ -77,17 +61,10 @@ class ServerProtocolHandler
                     break;
                 }
             }
-        } catch (ResponseAlreadySentException) {
-            # The handler already sent the response (e.g. SASL, which needs the correct multi-round message ID),
-            # so there is nothing further to do here.
-        } catch (OperationException $e) {
-            # Bind / authorization runs outside the request pipeline; its failures are turned into the response here.
-            # Pipeline operations are handled by OperationErrorMiddleware instead.
-            $this->queue->sendMessage($this->responseFactory->getStandardResponse(
-                $message,
-                $e->getCode(),
-                $e->getMessage(),
-            ));
+        } catch (RequestValidationException $e) {
+            # The message ID could not be used (zero or reused). Per RFC 4511 §4.1.1 the server cannot frame a
+            # solicited response, so it sends a Notice of Disconnection and terminates the session.
+            $this->sendNoticeOfDisconnect($e->getMessage());
         } catch (ConnectionException) {
             # Connection closure is recorded by the runner's lifecycle logging; no audit event for normal client disconnects.
         } catch (EncoderException|ProtocolException) {
@@ -121,112 +98,30 @@ class ServerProtocolHandler
     }
 
     /**
-     * Routes requests from the message queue based off the current authorization state and what protocol handler the
-     * request is mapped to.
+     * Runs a single request through the pipeline, answering recoverable failures while keeping the session open.
      *
-     * @throws OperationException
      * @throws EncoderException
-     * @throws RuntimeException
-     * @throws ConnectionException
      */
     private function dispatchRequest(LdapMessageRequest $message): void
     {
-        if (!$this->isValidRequest($message)) {
-            return;
-        }
-
-        $this->messageIds[] = $message->getMessageId();
-
-        # Send auth requests to the specific handler for it...
-        if ($this->authorizer->isAuthenticationRequest($message->getRequest())) {
-            $this->authorizer->setToken($this->handleAuthRequest($message));
-
-            return;
-        }
-
-        $authorization = $this->dispatchAuthorizer->authorize($message);
-
-        if ($authorization->requiresAuthentication()) {
+        try {
+            $this->requestPipeline->handle(new ServerRequestContext(
+                $message,
+                null,
+                $this->connectionContext,
+            ));
+        } catch (ResponseAlreadySentException) {
+            # A handler already sent the response (e.g. SASL, which needs the correct multi-round message ID), so
+            # there is nothing further to do for this message.
+        } catch (OperationException $e) {
+            # A pre-pipeline bind/authorization failure. Answer it and keep the session open — a failed bind does not
+            # terminate the connection (RFC 4511 §4.2.1). Operation failures are handled by OperationErrorMiddleware.
             $this->queue->sendMessage($this->responseFactory->getStandardResponse(
                 $message,
-                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
-                'Authentication required.',
+                $e->getCode(),
+                $e->getMessage(),
             ));
-
-            return;
         }
-
-        if ($authorization->requiresPasswordChange()) {
-            $this->rejectUntilPasswordChanged($message);
-
-            return;
-        }
-
-        $this->requestPipeline->handle(new ServerRequestContext(
-            $message,
-            $authorization->token(),
-            $this->connectionContext,
-        ));
-    }
-
-    /**
-     * @throws EncoderException
-     */
-    private function rejectUntilPasswordChanged(LdapMessageRequest $message): void
-    {
-        $this->queue->sendMessage($this->responseFactory->getStandardResponse(
-            $message,
-            ResultCode::UNWILLING_TO_PERFORM,
-            'The password must be changed before any other operation is permitted.',
-            null,
-            new PwdPolicyResponseControl(error: PwdPolicyError::CHANGE_AFTER_RESET),
-        ));
-    }
-
-    /**
-     * Checks that the message ID is valid. It cannot be zero or a message ID that was already used.
-     *
-     * @throws EncoderException
-     * @throws EncoderException
-     */
-    private function isValidRequest(LdapMessageRequest $message): bool
-    {
-        if ($message->getMessageId() === 0) {
-            $this->queue->sendMessage($this->responseFactory->getExtendedError(
-                'The message ID 0 cannot be used in a client request.',
-                ResultCode::PROTOCOL_ERROR,
-            ));
-
-            return false;
-        }
-        if (in_array($message->getMessageId(), $this->messageIds, true)) {
-            $this->queue->sendMessage($this->responseFactory->getExtendedError(
-                sprintf('The message ID %s is not valid.', $message->getMessageId()),
-                ResultCode::PROTOCOL_ERROR,
-            ));
-
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Sends a bind request to the bind handler and returns the token.
-     *
-     * @throws OperationException
-     * @throws RuntimeException
-     */
-    private function handleAuthRequest(LdapMessageRequest $message): TokenInterface
-    {
-        if (!$this->authorizer->isAuthenticationTypeSupported($message->getRequest())) {
-            throw new OperationException(
-                'The requested authentication type is not supported.',
-                ResultCode::AUTH_METHOD_UNSUPPORTED,
-            );
-        }
-
-        return $this->authenticator->bind($message);
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Middleware/AuthorizationResolutionMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/AuthorizationResolutionMiddleware.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Authorization\DispatchAuthorizer;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+use FreeDSx\Ldap\Server\PasswordPolicy\Decision\PasswordPolicyOutcome;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+
+/**
+ * Resolves the effective identity for an operation, rejecting requests that need authentication or a password change.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class AuthorizationResolutionMiddleware implements MiddlewareInterface
+{
+    private const PASSWORD_CHANGE_REQUIRED = 'The password must be changed before any other operation is permitted.';
+
+    public function __construct(
+        private DispatchAuthorizer $dispatchAuthorizer,
+        private ?PasswordPolicyContext $passwordPolicyContext = null,
+    ) {}
+
+    /**
+     * @throws OperationException
+     */
+    public function process(
+        ServerRequestContext $context,
+        MiddlewareHandlerInterface $next,
+    ): OperationResult {
+        $authorization = $this->dispatchAuthorizer->authorize($context->message);
+
+        if ($authorization->requiresAuthentication()) {
+            throw new OperationException(
+                'Authentication required.',
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+            );
+        }
+
+        if ($authorization->requiresPasswordChange()) {
+            throw $this->passwordChangeRequired();
+        }
+
+        return $next->handle($context->withToken($authorization->token()));
+    }
+
+    /**
+     * The response control rides out via {@see \FreeDSx\Ldap\Protocol\Queue\Response\PasswordPolicyResponseInterceptor}.
+     */
+    private function passwordChangeRequired(): OperationException
+    {
+        $this->passwordPolicyContext?->setOutcome(PasswordPolicyOutcome::deny(
+            PwdPolicyError::CHANGE_AFTER_RESET,
+            ResultCode::UNWILLING_TO_PERFORM,
+            self::PASSWORD_CHANGE_REQUIRED,
+        ));
+
+        return new OperationException(
+            self::PASSWORD_CHANGE_REQUIRED,
+            ResultCode::UNWILLING_TO_PERFORM,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Middleware/BindMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/BindMiddleware.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Authenticator;
+use FreeDSx\Ldap\Protocol\ServerAuthorization;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+use FreeDSx\Ldap\Server\Token\AnonToken;
+
+/**
+ * Routes bind requests to the authenticator and stores the resulting token on the connection's authorization state.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class BindMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private ServerAuthorization $authorization,
+        private Authenticator $authenticator,
+    ) {}
+
+    /**
+     * @throws OperationException
+     */
+    public function process(
+        ServerRequestContext $context,
+        MiddlewareHandlerInterface $next,
+    ): OperationResult {
+        $request = $context->message->getRequest();
+
+        if (!$this->authorization->isAuthenticationRequest($request)) {
+            return $next->handle($context);
+        }
+
+        // RFC 4511 §4.2.1: a bind discards any prior authentication; a failed bind leaves the session anonymous.
+        $this->authorization->setToken(new AnonToken());
+
+        if (!$this->authorization->isAuthenticationTypeSupported($request)) {
+            throw new OperationException(
+                'The requested authentication type is not supported.',
+                ResultCode::AUTH_METHOD_UNSUPPORTED,
+            );
+        }
+
+        $this->authorization->setToken($this->authenticator->bind($context->message));
+
+        return OperationOutcomeResult::succeeded();
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuditMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuditMiddleware.php
@@ -54,7 +54,7 @@ final readonly class OperationAuditMiddleware implements MiddlewareInterface
         if ($result instanceof AuditableResult) {
             $result->record(
                 $this->auditor,
-                $context->token,
+                $context->tokenOrFail(),
             );
         }
 
@@ -69,7 +69,7 @@ final readonly class OperationAuditMiddleware implements MiddlewareInterface
             $this->auditor->recordSchemaViolations(
                 $e->getViolations(),
                 $context->message,
-                $context->token,
+                $context->tokenOrFail(),
             );
         }
 
@@ -77,7 +77,7 @@ final readonly class OperationAuditMiddleware implements MiddlewareInterface
             $this->auditor->recordSearchFailure(
                 $context->message,
                 $e,
-                $context->token,
+                $context->tokenOrFail(),
             );
 
             return;
@@ -86,7 +86,7 @@ final readonly class OperationAuditMiddleware implements MiddlewareInterface
         $this->auditor->recordFailure(
             $context->message,
             $e,
-            $context->token,
+            $context->tokenOrFail(),
         );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
@@ -66,12 +66,12 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
         if ($routeId === HandlerId::Search || $routeId === HandlerId::Paging) {
             $this->authorizeSearch(
                 $context->message,
-                $context->token,
+                $context->tokenOrFail(),
             );
         } elseif ($routeId === HandlerId::Dispatch) {
             $this->authorizeDispatch(
                 $context->message,
-                $context->token,
+                $context->tokenOrFail(),
             );
         }
 

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationErrorMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationErrorMiddleware.php
@@ -59,7 +59,7 @@ final readonly class OperationErrorMiddleware implements MiddlewareInterface
                 $e->getMessage(),
                 $this->filterMatchedDn(
                     $e->getMatchedDn(),
-                    $context->token,
+                    $context->tokenOrFail(),
                     $this->backend,
                     $this->accessControl,
                 ),

--- a/src/FreeDSx/Ldap/Server/Middleware/Pipeline/HandlerInvoker.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/Pipeline/HandlerInvoker.php
@@ -35,7 +35,7 @@ final readonly class HandlerInvoker implements MiddlewareHandlerInterface
 
         return $handler->handleRequest(
             $context->message,
-            $context->token,
+            $context->tokenOrFail(),
         );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Middleware/Pipeline/ServerRequestContext.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/Pipeline/ServerRequestContext.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Middleware\Pipeline;
 
+use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -27,7 +28,34 @@ final readonly class ServerRequestContext
 {
     public function __construct(
         public LdapMessageRequest $message,
-        public TokenInterface $token,
+        private ?TokenInterface $token = null,
         public ConnectionContext $connectionContext = new ConnectionContext(),
     ) {}
+
+    /**
+     * The resolved identity, or null before authorization runs. Callers opting into this accept its absence.
+     */
+    public function token(): ?TokenInterface
+    {
+        return $this->token;
+    }
+
+    /**
+     * The resolved identity for stages that run after authorization.
+     *
+     * @throws RuntimeException when no token has been resolved yet.
+     */
+    public function tokenOrFail(): TokenInterface
+    {
+        return $this->token ?? throw new RuntimeException('No token has been resolved for this request.');
+    }
+
+    public function withToken(TokenInterface $token): self
+    {
+        return new self(
+            $this->message,
+            $token,
+            $this->connectionContext,
+        );
+    }
 }

--- a/src/FreeDSx/Ldap/Server/Middleware/RequestValidationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/RequestValidationMiddleware.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Exception\RequestValidationException;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+
+use function in_array;
+use function sprintf;
+
+/**
+ * Rejects a message whose ID is zero or already used on this connection (RFC 4511 §4.1.1.1).
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class RequestValidationMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var int[]
+     */
+    private array $messageIds = [];
+
+    /**
+     * @throws RequestValidationException
+     */
+    public function process(
+        ServerRequestContext $context,
+        MiddlewareHandlerInterface $next,
+    ): OperationResult {
+        $messageId = $context->message->getMessageId();
+
+        if ($messageId === 0) {
+            throw new RequestValidationException('The message ID 0 cannot be used in a client request.');
+        }
+
+        // Stricter than RFC 4511 §4.1.1.1, which only forbids reusing an ID that is still outstanding. Since the
+        // server processes a connection's messages serially, rejecting any reused ID is safe and simpler.
+        if (in_array($messageId, $this->messageIds, true)) {
+            throw new RequestValidationException(sprintf('The message ID %s is not valid.', $messageId));
+        }
+
+        $this->messageIds[] = $messageId;
+
+        return $next->handle($context);
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyProtocolFactory.php
@@ -22,6 +22,10 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerStartTlsHandler;
 use FreeDSx\Ldap\ProxyOptions;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
+use FreeDSx\Ldap\Server\Middleware\AuthorizationResolutionMiddleware;
+use FreeDSx\Ldap\Server\Middleware\BindMiddleware;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareChain;
+use FreeDSx\Ldap\Server\Middleware\RequestValidationMiddleware;
 use FreeDSx\Ldap\Server\ServerConnectionScaffoldingTrait;
 use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
 use FreeDSx\Ldap\ServerOptions;
@@ -70,24 +74,33 @@ final class ProxyProtocolFactory implements ServerProtocolFactoryInterface
             ),
         ];
 
-        $pipeline = new ProxyRequestPipeline(
-            new ServerStartTlsHandler(
-                $this->options,
-                $queue,
-                $eventLogger,
-            ),
-            new ProxyRequestForwarder(
-                $upstream,
-                $queue,
+        $pipeline = new MiddlewareChain(
+            [
+                new RequestValidationMiddleware(),
+                new BindMiddleware(
+                    $serverAuthorization,
+                    new Authenticator($authenticators),
+                ),
+                new AuthorizationResolutionMiddleware(
+                    new DispatchAuthorizer($serverAuthorization),
+                ),
+            ],
+            new ProxyRequestPipeline(
+                new ServerStartTlsHandler(
+                    $this->options,
+                    $queue,
+                    $eventLogger,
+                ),
+                new ProxyRequestForwarder(
+                    $upstream,
+                    $queue,
+                ),
             ),
         );
 
         return new ServerProtocolHandler(
             queue: $queue,
             requestPipeline: $pipeline,
-            authorizer: $serverAuthorization,
-            authenticator: new Authenticator($authenticators),
-            dispatchAuthorizer: new DispatchAuthorizer($serverAuthorization),
             eventLogger: $eventLogger,
             connectionContext: $context,
         );

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyRequestPipeline.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyRequestPipeline.php
@@ -41,7 +41,7 @@ final readonly class ProxyRequestPipeline implements MiddlewareHandlerInterface
         if ($request instanceof ExtendedRequest && $request->getName() === ExtendedRequest::OID_START_TLS) {
             return $this->startTlsHandler->handleRequest(
                 $context->message,
-                $context->token,
+                $context->tokenOrFail(),
             );
         }
 

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -42,10 +42,13 @@ use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\OperationAuditor;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\AssertionEvaluator;
 use FreeDSx\Ldap\Server\Middleware\AssertionMiddleware;
+use FreeDSx\Ldap\Server\Middleware\AuthorizationResolutionMiddleware;
+use FreeDSx\Ldap\Server\Middleware\BindMiddleware;
 use FreeDSx\Ldap\Server\Middleware\CriticalControlMiddleware;
 use FreeDSx\Ldap\Server\Middleware\OperationAuditMiddleware;
 use FreeDSx\Ldap\Server\Middleware\OperationAuthorizationMiddleware;
 use FreeDSx\Ldap\Server\Middleware\OperationErrorMiddleware;
+use FreeDSx\Ldap\Server\Middleware\RequestValidationMiddleware;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\HandlerInvoker;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareChain;
 use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyBindGuard;
@@ -64,7 +67,6 @@ class ServerProtocolFactory implements ServerProtocolFactoryInterface
     public function __construct(
         private readonly HandlerFactoryInterface $handlerFactory,
         private readonly ServerOptions $options,
-        private readonly ServerAuthorization $serverAuthorization,
         private readonly PasswordPolicyEngine $passwordPolicyEngine,
         private readonly ServerProtocolHandlerFactory $routeResolver,
         private readonly PasswordModifyTargetResolver $targetResolver,
@@ -139,8 +141,11 @@ class ServerProtocolFactory implements ServerProtocolFactoryInterface
             );
         }
 
+        // Per connection: the bound-token state must not be shared across connections (e.g., coroutines).
+        $authorization = new ServerAuthorization($this->options);
+
         $dispatchAuthorizer = new DispatchAuthorizer(
-            $this->serverAuthorization,
+            $authorization,
             new PasswordResetGate(),
             new ProxiedAuthorizationResolver(
                 $this->options->getAccessControl(),
@@ -168,6 +173,17 @@ class ServerProtocolFactory implements ServerProtocolFactoryInterface
             queue: $serverQueue,
             requestPipeline: new MiddlewareChain(
                 [
+                    // Order matters: AuthorizationResolutionMiddleware injects the token via withToken(), so
+                    // every middleware after it may rely on tokenOrFail(). Keep token consumers below it.
+                    new RequestValidationMiddleware(),
+                    new BindMiddleware(
+                        $authorization,
+                        new Authenticator($authenticators),
+                    ),
+                    new AuthorizationResolutionMiddleware(
+                        $dispatchAuthorizer,
+                        $policyContext,
+                    ),
                     new OperationErrorMiddleware(
                         $serverQueue,
                         $backend,
@@ -187,9 +203,6 @@ class ServerProtocolFactory implements ServerProtocolFactoryInterface
                 ],
                 new HandlerInvoker($handlerProvider),
             ),
-            authorizer: $this->serverAuthorization,
-            authenticator: new Authenticator($authenticators),
-            dispatchAuthorizer: $dispatchAuthorizer,
             eventLogger: $eventLogger,
             connectionContext: $context,
         );

--- a/tests/unit/Protocol/ServerProtocolHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandlerTest.php
@@ -14,605 +14,259 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Protocol;
 
 use FreeDSx\Asn1\Exception\EncoderException;
-use FreeDSx\Ldap\Control\PwdPolicyError;
-use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
-use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Exception\RequestSizeExceededException;
+use FreeDSx\Ldap\Exception\RequestValidationException;
 use FreeDSx\Ldap\Exception\ResponseAlreadySentException;
 use FreeDSx\Ldap\Operation\LdapResult;
-use FreeDSx\Ldap\Operation\Request\AnonBindRequest;
-use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
-use FreeDSx\Ldap\Operation\Request\ModifyRequest;
-use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
-use FreeDSx\Ldap\Operation\Response\BindResponse;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\Response\ModifyDnResponse;
-use FreeDSx\Ldap\Operation\Response\ModifyResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
-use FreeDSx\Ldap\Protocol\Authenticator;
-use FreeDSx\Ldap\Protocol\Authorization\DispatchAuthorizer;
-use FreeDSx\Ldap\Protocol\Factory\ProtocolHandlerProviderInterface;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
-use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
-use FreeDSx\Ldap\Server\Middleware\Pipeline\HandlerInvoker;
-use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareChain;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
-use FreeDSx\Ldap\Server\Token\BindToken;
-use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
 use FreeDSx\Socket\Exception\ConnectionException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Tests\Support\FreeDSx\Ldap\Logging\RecordingLogger;
+use Tests\Support\FreeDSx\Ldap\Middleware\StubMiddlewareHandler;
+use Tests\Support\FreeDSx\Ldap\Middleware\ThrowingMiddlewareHandler;
 
 final class ServerProtocolHandlerTest extends TestCase
 {
-    private ServerProtocolHandler $subject;
-
     private ServerQueue&MockObject $mockQueue;
-
-    private ProtocolHandlerProviderInterface&MockObject $mockProtocolHandlerProvider;
-
-    private MiddlewareHandlerInterface $requestPipeline;
-
-    private Authenticator&MockObject $mockAuthenticator;
-
-    private ServerProtocolHandler\ServerProtocolHandlerInterface&MockObject $mockProtocolHandler;
 
     protected function setUp(): void
     {
         $this->mockQueue = $this->createMock(ServerQueue::class);
-        $this->mockProtocolHandlerProvider = $this->createMock(ProtocolHandlerProviderInterface::class);
-        $this->mockAuthenticator = $this->createMock(Authenticator::class);
-        $this->mockProtocolHandler = $this->createMock(ServerProtocolHandler\ServerProtocolHandlerInterface::class);
-
         $this->mockQueue
             ->method('isConnected')
             ->willReturn(true);
         $this->mockQueue
-            ->method('isEncrypted')
-            ->willReturn(false);
-
-        $this->mockQueue
             ->method('sendMessage')
             ->willReturnSelf();
-
-        $this->mockProtocolHandlerProvider
-            ->method('get')
-            ->willReturn($this->mockProtocolHandler);
-
-        $this->requestPipeline = new MiddlewareChain(
-            [],
-            new HandlerInvoker($this->mockProtocolHandlerProvider),
-        );
-
-        $authorizer = new ServerAuthorization(new ServerOptions());
-        $this->subject = new ServerProtocolHandler(
-            $this->mockQueue,
-            $this->requestPipeline,
-            $authorizer,
-            $this->mockAuthenticator,
-            new DispatchAuthorizer($authorizer),
-        );
     }
 
-    public function test_it_should_enforce_anonymous_bind_requirements(): void
+    public function test_it_delegates_each_message_to_the_request_pipeline(): void
     {
-        $messages = [new LdapMessageRequest(1, new AnonBindRequest('foo'))];
-        $this->mockQueue
-            ->method('getMessage')
-            ->willReturnCallback(static function () use (&$messages): LdapMessageRequest {
-                if ($messages === []) {
-                    throw new ConnectionException();
-                }
+        $this->queueReturns([
+            new LdapMessageRequest(1, new ModifyDnRequest('cn=foo,dc=bar', 'cn=bar', true)),
+        ]);
 
-                return array_shift($messages);
-            });
+        $this->mockQueue
+            ->expects(self::never())
+            ->method('sendMessage');
+
+        $this->handlerWith(new StubMiddlewareHandler(OperationOutcomeResult::succeeded()))
+            ->handle();
+    }
+
+    public function test_a_request_validation_failure_sends_a_notice_of_disconnect(): void
+    {
+        $this->queueReturns([
+            new LdapMessageRequest(1, new ModifyDnRequest('cn=foo,dc=bar', 'cn=bar', true)),
+        ]);
 
         $this->mockQueue
             ->expects(self::once())
             ->method('sendMessage')
-            ->with($this->equalTo(
-                new LdapMessageResponse(
-                    1,
-                    new BindResponse(new LdapResult(
-                        ResultCode::AUTH_METHOD_UNSUPPORTED,
-                        '',
-                        'The requested authentication type is not supported.',
-                    )),
-                ),
-            ));
-
-        $this->mockProtocolHandlerProvider
-            ->expects(self::never())
-            ->method('get');
-
-        $this->subject->handle();
-    }
-
-    public function test_it_should_not_allow_a_previous_message_ID_from_a_new_request(): void
-    {
-        $messages = [
-            new LdapMessageRequest(1, new SimpleBindRequest('foo', 'bar')),
-            new LdapMessageRequest(1, new ExtendedRequest(ExtendedRequest::OID_WHOAMI)),
-        ];
-        $this->mockQueue
-            ->method('getMessage')
-            ->willReturnCallback(static function () use (&$messages): LdapMessageRequest {
-                if ($messages === []) {
-                    throw new ConnectionException();
-                }
-
-                return array_shift($messages);
-            });
-
-        $this->mockAuthenticator
-            ->method('bind')
-            ->willReturn(BindToken::fromDn(
-                'foo',
-                'bar',
-            ));
-
-        $this->mockProtocolHandler
-            ->expects($this->never())
-            ->method('handleRequest');
-
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with($this->equalTo(new LdapMessageResponse(
+            ->with(self::equalTo(new LdapMessageResponse(
                 0,
-                new ExtendedResponse(new LdapResult(
-                    ResultCode::PROTOCOL_ERROR,
-                    '',
-                    'The message ID 1 is not valid.',
-                )),
+                new ExtendedResponse(
+                    new LdapResult(
+                        ResultCode::PROTOCOL_ERROR,
+                        '',
+                        'The message ID 1 is not valid.',
+                    ),
+                    ExtendedResponse::OID_NOTICE_OF_DISCONNECTION,
+                ),
             )));
 
-        $this->subject->handle();
+        $this->handlerWith(new ThrowingMiddlewareHandler(
+            new RequestValidationException('The message ID 1 is not valid.'),
+        ))->handle();
     }
 
-    public function test_it_should_enforce_authentication_requirements(): void
+    public function test_a_pre_pipeline_operation_error_is_answered_and_the_session_stays_open(): void
     {
+        $captured = [];
         $this->mockQueue
-            ->method('isConnected')
-            ->willReturn(true);
-        $messages = [
-            new LdapMessageRequest(1, new ModifyDnRequest('cn=foo,dc=bar', 'cn=bar', true)),
-        ];
-        $this->mockQueue
-            ->method('getMessage')
-            ->willReturnCallback(static function () use (&$messages): LdapMessageRequest {
-                if ($messages === []) {
-                    throw new ConnectionException();
-                }
-
-                return array_shift($messages);
-            });
-
-        $this->mockQueue
-            ->expects($this->atLeast(1))
             ->method('sendMessage')
-            ->with($this->equalTo(new LdapMessageResponse(
-                1,
-                new ModifyDnResponse(
+            ->willReturnCallback(function (LdapMessageResponse $response) use (&$captured): ServerQueue {
+                $captured[] = $response;
+
+                return $this->mockQueue;
+            });
+        $this->queueReturns([
+            new LdapMessageRequest(1, new ModifyDnRequest('cn=a,dc=bar', 'cn=b', true)),
+            new LdapMessageRequest(2, new ModifyDnRequest('cn=c,dc=bar', 'cn=d', true)),
+        ]);
+
+        $this->handlerWith(new ThrowingMiddlewareHandler(new OperationException(
+            'Authentication required.',
+            ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+        )))->handle();
+
+        // Both messages were answered — the connection was not torn down after the first failure.
+        self::assertEquals(
+            [
+                new LdapMessageResponse(1, new ModifyDnResponse(
                     ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
                     '',
                     'Authentication required.',
-                ),
-            )))
-            ->willReturnSelf();
-
-        $this->mockProtocolHandler
-            ->expects($this->never())
-            ->method('handleRequest');
-
-        $this->subject->handle();
+                )),
+                new LdapMessageResponse(2, new ModifyDnResponse(
+                    ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+                    '',
+                    'Authentication required.',
+                )),
+            ],
+            $captured,
+        );
     }
 
-    public function test_it_should_send_a_notice_of_disconnect_on_a_protocol_exception_from_the_message_queue(): void
+    public function test_it_does_not_resend_when_a_handler_already_sent_the_response(): void
+    {
+        $this->queueReturns([
+            new LdapMessageRequest(1, new ModifyDnRequest('cn=foo,dc=bar', 'cn=bar', true)),
+        ]);
+
+        $this->mockQueue
+            ->expects(self::never())
+            ->method('sendMessage');
+
+        $this->handlerWith(new ThrowingMiddlewareHandler(new ResponseAlreadySentException()))
+            ->handle();
+    }
+
+    public function test_it_sends_a_notice_of_disconnect_on_a_protocol_exception_from_the_message_queue(): void
     {
         $this->mockQueue
             ->method('getMessage')
             ->willThrowException(new ProtocolException());
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with($this->equalTo(
-                new LdapMessageResponse(0, new ExtendedResponse(
-                    new LdapResult(ResultCode::PROTOCOL_ERROR, '', 'The message could not be processed.'),
-                    ExtendedResponse::OID_NOTICE_OF_DISCONNECTION,
-                )),
-            ));
+        $this->expectNoticeOfDisconnect('The message could not be processed.');
 
-        $this->subject->handle();
+        $this->handlerWith(new StubMiddlewareHandler(OperationOutcomeResult::succeeded()))
+            ->handle();
     }
 
-    public function test_it_should_send_a_notice_of_disconnect_when_a_request_exceeds_the_max_size(): void
+    public function test_it_sends_a_notice_of_disconnect_when_a_request_exceeds_the_max_size(): void
     {
         $this->mockQueue
             ->method('getMessage')
             ->willThrowException(new RequestSizeExceededException('too big'));
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with($this->equalTo(
-                new LdapMessageResponse(0, new ExtendedResponse(
-                    new LdapResult(ResultCode::PROTOCOL_ERROR, '', 'The message could not be processed.'),
-                    ExtendedResponse::OID_NOTICE_OF_DISCONNECTION,
-                )),
-            ));
+        $this->expectNoticeOfDisconnect('The message could not be processed.');
 
-        $this->subject->handle();
+        $this->handlerWith(new StubMiddlewareHandler(OperationOutcomeResult::succeeded()))
+            ->handle();
     }
 
-    public function test_it_should_handle_a_socket_exception_from_the_message_queue_and_end_normally(): void
-    {
-        $this->mockQueue
-            ->method('getMessage')
-            ->willThrowException(new ConnectionException("Foo"));
-
-        $this->mockQueue
-            ->expects($this->never())
-            ->method('sendMessage');
-
-        $this->subject->handle();
-    }
-
-    public function test_it_should_send_a_notice_of_disconnect_on_an_encoder_exception_from_the_message_queue(): void
+    public function test_it_sends_a_notice_of_disconnect_on_an_encoder_exception_from_the_message_queue(): void
     {
         $this->mockQueue
             ->method('getMessage')
             ->willThrowException(new EncoderException());
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with($this->equalTo(
-                new LdapMessageResponse(0, new ExtendedResponse(
-                    new LdapResult(ResultCode::PROTOCOL_ERROR, '', 'The message could not be processed.'),
-                    ExtendedResponse::OID_NOTICE_OF_DISCONNECTION,
-                )),
-            ));
+        $this->expectNoticeOfDisconnect('The message could not be processed.');
 
-        $this->subject->handle();
+        $this->handlerWith(new StubMiddlewareHandler(OperationOutcomeResult::succeeded()))
+            ->handle();
     }
 
-    public function test_it_should_not_allow_a_message_with_an_ID_of_zero(): void
+    public function test_it_ends_normally_on_a_socket_exception_from_the_message_queue(): void
     {
-        $messages = [
-            new LdapMessageRequest(0, new ExtendedRequest(ExtendedRequest::OID_START_TLS)),
-        ];
         $this->mockQueue
             ->method('getMessage')
-            ->willReturnCallback(static function () use (&$messages): LdapMessageRequest {
-                if ($messages === []) {
-                    throw new ConnectionException();
-                }
-
-                return array_shift($messages);
-            });
-
-        $this->mockQueue
-            ->expects($this->atLeast(1))
-            ->method('sendMessage')
-            ->with($this->equalTo(
-                new LdapMessageResponse(0, new ExtendedResponse(new LdapResult(
-                    ResultCode::PROTOCOL_ERROR,
-                    '',
-                    'The message ID 0 cannot be used in a client request.',
-                ))),
-            ));
-
-        $this->subject->handle();
-    }
-
-    public function test_it_should_send_a_bind_request_to_the_bind_request_handler(): void
-    {
-        $messages = [
-            new LdapMessageRequest(1, new SimpleBindRequest('foo@bar', 'bar')),
-        ];
-        $this->mockQueue
-            ->method('getMessage')
-            ->willReturnCallback(static function () use (&$messages): LdapMessageRequest {
-                if ($messages === []) {
-                    throw new ConnectionException();
-                }
-
-                return array_shift($messages);
-            });
-
-        $this->mockAuthenticator
-            ->expects($this->once())
-            ->method('bind')
-            ->willReturn(BindToken::fromDn(
-                'foo@bar',
-                'bar',
-            ));
-
-        $this->mockProtocolHandler
-            ->expects($this->never())
-            ->method('handleRequest');
-
-        $this->subject->handle();
-    }
-
-    public function test_it_does_not_resend_when_a_handler_already_sent_the_response(): void
-    {
-        $messages = [
-            new LdapMessageRequest(1, new SimpleBindRequest('foo@bar', 'bar')),
-        ];
-        $this->mockQueue
-            ->method('getMessage')
-            ->willReturnCallback(static function () use (&$messages): LdapMessageRequest {
-                if ($messages === []) {
-                    throw new ConnectionException();
-                }
-
-                return array_shift($messages);
-            });
-
-        $this->mockAuthenticator
-            ->method('bind')
-            ->willThrowException(new ResponseAlreadySentException(
-                'Invalid credentials.',
-                ResultCode::INVALID_CREDENTIALS,
-            ));
+            ->willThrowException(new ConnectionException('Foo'));
 
         $this->mockQueue
             ->expects(self::never())
             ->method('sendMessage');
 
-        $this->subject->handle();
+        $this->handlerWith(new StubMiddlewareHandler(OperationOutcomeResult::succeeded()))
+            ->handle();
     }
 
-    public function test_it_should_handle_operation_errors_thrown_from_the_request_handlers(): void
+    public function test_it_sends_a_notice_of_disconnect_and_closes_the_queue_on_shutdown(): void
     {
         $this->mockQueue
-            ->method('isConnected')
-            ->willReturn(true);
-
-        $messages = [
-            new LdapMessageRequest(1, new SimpleBindRequest('foo@bar', 'bar')),
-            new LdapMessageRequest(2, new ModifyRequest('cn=foo,dc=bar')),
-        ];
-        $this->mockQueue
-            ->method('getMessage')
-            ->willReturnCallback(static function () use (&$messages): LdapMessageRequest {
-                if ($messages === []) {
-                    throw new ConnectionException();
-                }
-
-                return array_shift($messages);
-            });
-
-        $this->mockAuthenticator
-            ->expects($this->once())
-            ->method('bind')
-            ->willReturn(BindToken::fromDn(
-                'foo@bar',
-                'bar',
-            ));
-
-        $this->mockProtocolHandler
-            ->expects($this->once())
-            ->method('handleRequest')
-            ->willThrowException(new OperationException(
-                'Foo.',
-                ResultCode::CONFIDENTIALITY_REQUIRED,
-            ));
-
-        $this->mockQueue
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('sendMessage')
-            ->with($this->equalTo(
-                new LdapMessageResponse(
-                    2,
-                    new ModifyResponse(
-                        ResultCode::CONFIDENTIALITY_REQUIRED,
-                        '',
-                        'Foo.',
-                    ),
-                ),
-            ));
-
-        $this->subject->handle();
-    }
-
-    public function test_it_should_send_a_notice_of_disconnect_and_close_the_queue_on_shutdown(): void
-    {
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with($this->equalTo(
-                new LdapMessageResponse(0, new ExtendedResponse(
+            ->with(self::equalTo(new LdapMessageResponse(
+                0,
+                new ExtendedResponse(
                     new LdapResult(ResultCode::UNAVAILABLE, '', 'The server is shutting down.'),
                     ExtendedResponse::OID_NOTICE_OF_DISCONNECTION,
-                )),
-            ));
-
+                ),
+            )));
         $this->mockQueue
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('close');
 
-        $this->subject->shutdown();
+        $this->handlerWith(new StubMiddlewareHandler(OperationOutcomeResult::succeeded()))
+            ->shutdown();
     }
 
-    public function test_unexpected_throwable_emits_notice_of_disconnect_with_exception_context(): void
+    public function test_an_unexpected_throwable_emits_a_notice_of_disconnect_with_exception_context(): void
     {
         $recordingLogger = new RecordingLogger();
-        $subject = $this->makeSubjectWithEventLogger(new EventLogger(
-            $recordingLogger,
-            EventLogPolicy::default(),
-        ));
-
         $this->mockQueue
             ->method('getMessage')
             ->willThrowException(new RuntimeException('boom'));
 
-        $subject->handle();
+        $this->handlerWith(
+            new StubMiddlewareHandler(OperationOutcomeResult::succeeded()),
+            new EventLogger($recordingLogger, EventLogPolicy::default()),
+        )->handle();
 
-        $disconnectRecord = $this->findRecord(
-            $recordingLogger,
-            'session.disconnect_notice',
-        );
+        $record = $this->findRecord($recordingLogger, 'session.disconnect_notice');
         self::assertSame(
             RuntimeException::class,
-            $disconnectRecord['context']['exception_class'],
+            $record['context']['exception_class'],
         );
         self::assertSame(
             'boom',
-            $disconnectRecord['context']['exception_message'],
-        );
-        self::assertArrayHasKey(
-            'exception_origin',
-            $disconnectRecord['context'],
+            $record['context']['exception_message'],
         );
         self::assertArrayNotHasKey(
             'exception_trace',
-            $disconnectRecord['context'],
+            $record['context'],
             'Trace must not appear with the default policy.',
         );
     }
 
-    public function test_unexpected_throwable_includes_trace_when_policy_opts_in(): void
+    public function test_an_unexpected_throwable_includes_the_trace_when_policy_opts_in(): void
     {
         $recordingLogger = new RecordingLogger();
-        $subject = $this->makeSubjectWithEventLogger(new EventLogger(
-            $recordingLogger,
-            EventLogPolicy::default()->withExceptionTraces(),
-        ));
-
         $this->mockQueue
             ->method('getMessage')
             ->willThrowException(new RuntimeException('boom'));
 
-        $subject->handle();
+        $this->handlerWith(
+            new StubMiddlewareHandler(OperationOutcomeResult::succeeded()),
+            new EventLogger($recordingLogger, EventLogPolicy::default()->withExceptionTraces()),
+        )->handle();
 
-        $disconnectRecord = $this->findRecord(
-            $recordingLogger,
-            'session.disconnect_notice',
-        );
-        self::assertNotEmpty($disconnectRecord['context']['exception_trace']);
-    }
-
-    public function test_a_must_change_token_blocks_other_operations(): void
-    {
-        $token = BindToken::fromDn(
-            'cn=user,dc=foo,dc=bar',
-            'secret',
-        );
-        $token->markMustChangePassword();
-
-        $this->mockProtocolHandler
-            ->expects(self::never())
-            ->method('handleRequest');
-
-        $captured = $this->runWithToken(
-            $token,
-            [
-                new LdapMessageRequest(1, new SimpleBindRequest('cn=user,dc=foo,dc=bar', 'secret')),
-                new LdapMessageRequest(2, new ModifyRequest(
-                    'cn=user,dc=foo,dc=bar',
-                    Change::replace('description', 'nope'),
-                )),
-            ],
-        );
-
-        self::assertCount(
-            1,
-            $captured,
-        );
-        $response = $captured[0]->getResponse();
-        self::assertInstanceOf(
-            LdapResult::class,
-            $response,
-        );
-        self::assertSame(
-            ResultCode::UNWILLING_TO_PERFORM,
-            $response->getResultCode(),
-        );
-
-        $control = $captured[0]->controls()->getByClass(PwdPolicyResponseControl::class);
-        self::assertInstanceOf(
-            PwdPolicyResponseControl::class,
-            $control,
-        );
-        self::assertSame(
-            PwdPolicyError::CHANGE_AFTER_RESET,
-            $control->getError(),
-        );
-    }
-
-    public function test_a_must_change_token_allows_the_password_modify_operation(): void
-    {
-        $token = BindToken::fromDn(
-            'cn=user,dc=foo,dc=bar',
-            'secret',
-        );
-        $token->markMustChangePassword();
-
-        $this->mockProtocolHandler
-            ->expects(self::once())
-            ->method('handleRequest');
-
-        $this->runWithToken(
-            $token,
-            [
-                new LdapMessageRequest(1, new SimpleBindRequest('cn=user,dc=foo,dc=bar', 'secret')),
-                new LdapMessageRequest(2, new ExtendedRequest(ExtendedRequest::OID_PWD_MODIFY)),
-            ],
-        );
-    }
-
-    public function test_a_must_change_token_allows_a_self_password_modify(): void
-    {
-        $token = BindToken::fromDn(
-            'cn=user,dc=foo,dc=bar',
-            'secret',
-        );
-        $token->markMustChangePassword();
-
-        $this->mockProtocolHandler
-            ->expects(self::once())
-            ->method('handleRequest');
-
-        $this->runWithToken(
-            $token,
-            [
-                new LdapMessageRequest(1, new SimpleBindRequest('cn=user,dc=foo,dc=bar', 'secret')),
-                new LdapMessageRequest(2, new ModifyRequest(
-                    'cn=user,dc=foo,dc=bar',
-                    Change::replace('userPassword', 'a-fresh-password'),
-                )),
-            ],
-        );
+        $record = $this->findRecord($recordingLogger, 'session.disconnect_notice');
+        self::assertNotEmpty($record['context']['exception_trace']);
     }
 
     /**
      * @param list<LdapMessageRequest> $messages
-     * @return list<LdapMessageResponse>
      */
-    private function runWithToken(
-        BindToken $token,
-        array $messages,
-    ): array {
-        $captured = [];
-        $queue = $this->createMock(ServerQueue::class);
-        $queue
-            ->method('isConnected')
-            ->willReturn(true);
-        $queue
+    private function queueReturns(array $messages): void
+    {
+        $this->mockQueue
             ->method('getMessage')
             ->willReturnCallback(static function () use (&$messages): LdapMessageRequest {
                 if ($messages === []) {
@@ -621,43 +275,31 @@ final class ServerProtocolHandlerTest extends TestCase
 
                 return array_shift($messages);
             });
-        $queue
-            ->method('sendMessage')
-            ->willReturnCallback(function (LdapMessageResponse $response) use (&$captured, $queue): ServerQueue {
-                $captured[] = $response;
-
-                return $queue;
-            });
-
-        $this->mockAuthenticator
-            ->method('bind')
-            ->willReturn($token);
-
-        $authorizer = new ServerAuthorization(new ServerOptions());
-        $subject = new ServerProtocolHandler(
-            $queue,
-            $this->requestPipeline,
-            $authorizer,
-            $this->mockAuthenticator,
-            new DispatchAuthorizer($authorizer),
-        );
-        $subject->handle();
-
-        return $captured;
     }
 
-    private function makeSubjectWithEventLogger(EventLogger $eventLogger): ServerProtocolHandler
-    {
-        $authorizer = new ServerAuthorization(new ServerOptions());
-
+    private function handlerWith(
+        MiddlewareHandlerInterface $pipeline,
+        ?EventLogger $eventLogger = null,
+    ): ServerProtocolHandler {
         return new ServerProtocolHandler(
             $this->mockQueue,
-            $this->requestPipeline,
-            $authorizer,
-            $this->mockAuthenticator,
-            new DispatchAuthorizer($authorizer),
-            $eventLogger,
+            $pipeline,
+            $eventLogger ?? new EventLogger(null),
         );
+    }
+
+    private function expectNoticeOfDisconnect(string $message): void
+    {
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('sendMessage')
+            ->with(self::equalTo(new LdapMessageResponse(
+                0,
+                new ExtendedResponse(
+                    new LdapResult(ResultCode::PROTOCOL_ERROR, '', $message),
+                    ExtendedResponse::OID_NOTICE_OF_DISCONNECTION,
+                ),
+            )));
     }
 
     /**

--- a/tests/unit/Server/Middleware/AuthorizationResolutionMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/AuthorizationResolutionMiddlewareTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Control\PwdPolicyError;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Authorization\DispatchAuthorizer;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\ServerAuthorization;
+use FreeDSx\Ldap\Server\Middleware\AuthorizationResolutionMiddleware;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use FreeDSx\Ldap\ServerOptions;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Middleware\CallLog;
+use Tests\Support\FreeDSx\Ldap\Middleware\RecordingMiddlewareHandler;
+
+final class AuthorizationResolutionMiddlewareTest extends TestCase
+{
+    private ServerAuthorization $authorization;
+
+    private PasswordPolicyContext $passwordPolicyContext;
+
+    private RecordingMiddlewareHandler $next;
+
+    protected function setUp(): void
+    {
+        $this->authorization = new ServerAuthorization(new ServerOptions());
+        $this->passwordPolicyContext = new PasswordPolicyContext();
+        $this->next = new RecordingMiddlewareHandler(new CallLog());
+    }
+
+    public function test_a_request_requiring_authentication_is_rejected(): void
+    {
+        try {
+            $this->subject()->process(
+                $this->context(),
+                $this->next,
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+                $e->getCode(),
+            );
+        }
+
+        self::assertNull($this->next->received);
+    }
+
+    public function test_a_request_requiring_a_password_change_is_rejected_and_stashes_the_control(): void
+    {
+        $token = BindToken::fromDn('cn=user,dc=foo,dc=bar', 'secret');
+        $token->markMustChangePassword();
+        $this->authorization->setToken($token);
+
+        try {
+            $this->subject()->process(
+                $this->context(),
+                $this->next,
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::UNWILLING_TO_PERFORM,
+                $e->getCode(),
+            );
+        }
+
+        self::assertSame(
+            PwdPolicyError::CHANGE_AFTER_RESET,
+            $this->passwordPolicyContext->getOutcome()?->errorCode,
+        );
+        self::assertNull($this->next->received);
+    }
+
+    public function test_an_authorized_request_is_delegated_with_the_resolved_token(): void
+    {
+        $token = BindToken::fromDn('cn=user,dc=foo,dc=bar', 'secret');
+        $this->authorization->setToken($token);
+
+        $this->subject()->process(
+            $this->context(),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+        self::assertSame(
+            $token,
+            $this->next->received->tokenOrFail(),
+        );
+    }
+
+    private function subject(): AuthorizationResolutionMiddleware
+    {
+        return new AuthorizationResolutionMiddleware(
+            new DispatchAuthorizer($this->authorization),
+            $this->passwordPolicyContext,
+        );
+    }
+
+    private function context(): ServerRequestContext
+    {
+        return new ServerRequestContext(new LdapMessageRequest(
+            1,
+            new ModifyDnRequest('cn=foo,dc=bar', 'cn=bar', true),
+        ));
+    }
+}

--- a/tests/unit/Server/Middleware/BindMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/BindMiddlewareTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\AnonBindRequest;
+use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
+use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Authenticator;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\ServerAuthorization;
+use FreeDSx\Ldap\Server\Middleware\BindMiddleware;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationOutcome;
+use FreeDSx\Ldap\Server\Token\AnonToken;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use FreeDSx\Ldap\ServerOptions;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Middleware\CallLog;
+use Tests\Support\FreeDSx\Ldap\Middleware\RecordingMiddlewareHandler;
+
+final class BindMiddlewareTest extends TestCase
+{
+    private ServerAuthorization $authorization;
+
+    private Authenticator&MockObject $authenticator;
+
+    private RecordingMiddlewareHandler $next;
+
+    protected function setUp(): void
+    {
+        $this->authorization = new ServerAuthorization(new ServerOptions());
+        $this->authenticator = $this->createMock(Authenticator::class);
+        $this->next = new RecordingMiddlewareHandler(new CallLog());
+    }
+
+    public function test_a_non_bind_request_is_delegated(): void
+    {
+        $this->authenticator
+            ->expects(self::never())
+            ->method('bind');
+
+        $this->subject()->process(
+            new ServerRequestContext(new LdapMessageRequest(
+                1,
+                new ExtendedRequest(ExtendedRequest::OID_WHOAMI),
+            )),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    public function test_a_successful_bind_stores_the_token_and_short_circuits(): void
+    {
+        $token = BindToken::fromDn('cn=user,dc=foo,dc=bar', 'secret');
+        $this->authenticator
+            ->method('bind')
+            ->willReturn($token);
+
+        $result = $this->subject()->process(
+            new ServerRequestContext(new LdapMessageRequest(
+                1,
+                new SimpleBindRequest('cn=user,dc=foo,dc=bar', 'secret'),
+            )),
+            $this->next,
+        );
+
+        self::assertSame(
+            $token,
+            $this->authorization->getToken(),
+        );
+        self::assertNull(
+            $this->next->received,
+            'A bind must not be delegated to the rest of the pipeline.',
+        );
+        self::assertSame(
+            OperationOutcome::Succeeded,
+            $result->outcome(),
+        );
+    }
+
+    public function test_an_unsupported_authentication_type_is_rejected(): void
+    {
+        // Anonymous binds are disabled by default.
+        $this->authenticator
+            ->expects(self::never())
+            ->method('bind');
+
+        try {
+            $this->subject()->process(
+                new ServerRequestContext(new LdapMessageRequest(
+                    1,
+                    new AnonBindRequest('foo'),
+                )),
+                $this->next,
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::AUTH_METHOD_UNSUPPORTED,
+                $e->getCode(),
+            );
+        }
+    }
+
+    public function test_a_failed_rebind_resets_an_authenticated_session_to_anonymous(): void
+    {
+        $this->authorization->setToken(BindToken::fromDn('cn=admin,dc=foo,dc=bar', 'secret'));
+        $this->authenticator
+            ->method('bind')
+            ->willThrowException(new OperationException(
+                'Invalid credentials.',
+                ResultCode::INVALID_CREDENTIALS,
+            ));
+
+        try {
+            $this->subject()->process(
+                new ServerRequestContext(new LdapMessageRequest(
+                    1,
+                    new SimpleBindRequest('cn=user,dc=foo,dc=bar', 'wrong'),
+                )),
+                $this->next,
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException) {
+        }
+
+        self::assertInstanceOf(
+            AnonToken::class,
+            $this->authorization->getToken(),
+            'A failed re-bind must drop the prior identity (RFC 4511 §4.2.1).',
+        );
+    }
+
+    private function subject(): BindMiddleware
+    {
+        return new BindMiddleware(
+            $this->authorization,
+            $this->authenticator,
+        );
+    }
+}

--- a/tests/unit/Server/Middleware/Pipeline/ServerRequestContextTest.php
+++ b/tests/unit/Server/Middleware/Pipeline/ServerRequestContextTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Middleware\Pipeline;
+
+use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use PHPUnit\Framework\TestCase;
+
+final class ServerRequestContextTest extends TestCase
+{
+    private ServerRequestContext $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new ServerRequestContext(new LdapMessageRequest(
+            1,
+            new ExtendedRequest(ExtendedRequest::OID_WHOAMI),
+        ));
+    }
+
+    public function test_the_token_is_null_until_resolved(): void
+    {
+        self::assertNull($this->subject->token());
+    }
+
+    public function test_token_or_fail_throws_when_no_token_is_resolved(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->subject->tokenOrFail();
+    }
+
+    public function test_with_token_returns_a_new_context_carrying_the_token(): void
+    {
+        $token = BindToken::fromDn('cn=user,dc=foo,dc=bar', 'secret');
+
+        $withToken = $this->subject->withToken($token);
+
+        self::assertNotSame(
+            $this->subject,
+            $withToken,
+        );
+        self::assertNull($this->subject->token());
+        self::assertSame(
+            $token,
+            $withToken->token(),
+        );
+        self::assertSame(
+            $token,
+            $withToken->tokenOrFail(),
+        );
+        self::assertSame(
+            $this->subject->message,
+            $withToken->message,
+        );
+    }
+}

--- a/tests/unit/Server/Middleware/RequestValidationMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/RequestValidationMiddlewareTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Exception\RequestValidationException;
+use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Middleware\RequestValidationMiddleware;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Middleware\CallLog;
+use Tests\Support\FreeDSx\Ldap\Middleware\RecordingMiddlewareHandler;
+
+final class RequestValidationMiddlewareTest extends TestCase
+{
+    private RequestValidationMiddleware $subject;
+
+    private RecordingMiddlewareHandler $next;
+
+    protected function setUp(): void
+    {
+        $this->subject = new RequestValidationMiddleware();
+        $this->next = new RecordingMiddlewareHandler(new CallLog());
+    }
+
+    public function test_a_message_id_of_zero_is_rejected(): void
+    {
+        $this->expectException(RequestValidationException::class);
+        $this->expectExceptionMessage('The message ID 0 cannot be used in a client request.');
+
+        $this->subject->process(
+            $this->contextFor(0),
+            $this->next,
+        );
+    }
+
+    public function test_a_reused_message_id_is_rejected(): void
+    {
+        $this->subject->process(
+            $this->contextFor(1),
+            $this->next,
+        );
+
+        $this->expectException(RequestValidationException::class);
+        $this->expectExceptionMessage('The message ID 1 is not valid.');
+
+        $this->subject->process(
+            $this->contextFor(1),
+            $this->next,
+        );
+    }
+
+    public function test_a_valid_message_id_is_delegated(): void
+    {
+        $this->subject->process(
+            $this->contextFor(1),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    private function contextFor(int $messageId): ServerRequestContext
+    {
+        return new ServerRequestContext(new LdapMessageRequest(
+            $messageId,
+            new ExtendedRequest(ExtendedRequest::OID_WHOAMI),
+        ));
+    }
+}

--- a/tests/unit/Server/ServerProtocolFactoryTest.php
+++ b/tests/unit/Server/ServerProtocolFactoryTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Server;
 
 use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
-use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\DnBindNameResolver;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
@@ -41,12 +40,9 @@ final class ServerProtocolFactoryTest extends TestCase
 
     private HandlerFactoryInterface&MockObject $mockHandlerFactory;
 
-    private ServerAuthorization&MockObject $mockServerAuthorization;
-
     protected function setUp(): void
     {
         $this->mockHandlerFactory = $this->createMock(HandlerFactoryInterface::class);
-        $this->mockServerAuthorization = $this->createMock(ServerAuthorization::class);
 
         $this->mockHandlerFactory
             ->method('makeBackend')
@@ -58,7 +54,6 @@ final class ServerProtocolFactoryTest extends TestCase
         $this->subject = new ServerProtocolFactory(
             $this->mockHandlerFactory,
             $options,
-            $this->mockServerAuthorization,
             $this->passwordPolicyEngine(),
             new ServerProtocolHandlerFactory($options),
             new PasswordModifyTargetResolver(
@@ -107,7 +102,6 @@ final class ServerProtocolFactoryTest extends TestCase
         $subject = new ServerProtocolFactory(
             $this->mockHandlerFactory,
             $options,
-            $this->mockServerAuthorization,
             $this->passwordPolicyEngine(),
             new ServerProtocolHandlerFactory($options),
             new PasswordModifyTargetResolver(
@@ -148,7 +142,6 @@ final class ServerProtocolFactoryTest extends TestCase
         $subject = new ServerProtocolFactory(
             $this->mockHandlerFactory,
             $options,
-            $this->mockServerAuthorization,
             $this->passwordPolicyEngine(),
             new ServerProtocolHandlerFactory($options),
             new PasswordModifyTargetResolver(


### PR DESCRIPTION
This mostly completes the move of the server logic into middleware where it makes sense. We still aren't sending responses back through the chain, but this makes all the logic way more isolated / ordered. It also makes some future work easier. I also discovered a bug in the swoole handling of authorization that went unnoticed :( That has also been fixed.