### PR TITLE
[1.0.0] Add a write timeout to the server.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=8.2",
     "freedsx/asn1": "dev-main#b57a38f",
-    "freedsx/socket": "dev-main#5738857",
+    "freedsx/socket": "dev-main#27a1c55",
     "freedsx/sasl": "dev-main#85e1ef9",
     "psr/log": "^3"
   },

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -144,6 +144,16 @@ Consider an idle client to timeout after this period of time (in seconds) and di
 **Default**: `600`
 
 ------------------
+#### setWriteTimeout
+
+Disconnect a client whose response send makes no progress for this many seconds (a reader that has stopped draining).
+Set to `0` to disable.
+
+**Note**: This applies to the PCNTL runner only.
+
+**Default**: `600`
+
+------------------
 #### setRequireAuthentication
 
 Whether authentication (bind) should be required before an operation is allowed.

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -29,6 +29,7 @@ use FreeDSx\Ldap\Server\Logging\ServerEvent;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
 use FreeDSx\Socket\Exception\ConnectionException;
+use FreeDSx\Socket\Exception\WriteTimeoutException;
 use Throwable;
 
 /**
@@ -65,6 +66,12 @@ readonly class ServerProtocolHandler
             # The message ID could not be used (zero or reused). Per RFC 4511 §4.1.1 the server cannot frame a
             # solicited response, so it sends a Notice of Disconnection and terminates the session.
             $this->sendNoticeOfDisconnect($e->getMessage());
+        } catch (WriteTimeoutException $e) {
+            # The client stopped reading mid-response; nothing further can be sent. Record it and close.
+            $this->eventLogger->record(
+                ServerEvent::WriteTimeout,
+                [EventContext::REASON_MESSAGE => $e->getMessage()],
+            );
         } catch (ConnectionException) {
             # Connection closure is recorded by the runner's lifecycle logging; no audit event for normal client disconnects.
         } catch (EncoderException|ProtocolException) {

--- a/src/FreeDSx/Ldap/Server/Logging/EventLogPolicy.php
+++ b/src/FreeDSx/Ldap/Server/Logging/EventLogPolicy.php
@@ -58,6 +58,7 @@ final readonly class EventLogPolicy
             ServerEvent::CriticalControlRejected,
             ServerEvent::SchemaViolation,
             ServerEvent::NoticeOfDisconnectSent,
+            ServerEvent::WriteTimeout,
             ServerEvent::PasswordPolicyAccountLocked,
             ServerEvent::PasswordPolicyAccountUnlocked,
             ServerEvent::PasswordPolicyExpired,

--- a/src/FreeDSx/Ldap/Server/Logging/ServerEvent.php
+++ b/src/FreeDSx/Ldap/Server/Logging/ServerEvent.php
@@ -44,6 +44,7 @@ enum ServerEvent: string
     case CriticalControlRejected        = 'control.critical.rejected';
     case SchemaViolation                = 'schema.violation';
     case NoticeOfDisconnectSent         = 'session.disconnect_notice';
+    case WriteTimeout                   = 'session.write_timeout';
     case PasswordPolicyAccountLocked    = 'password_policy.account_locked';
     case PasswordPolicyAccountUnlocked  = 'password_policy.account_unlocked';
     case PasswordPolicyExpired          = 'password_policy.expired';
@@ -64,6 +65,7 @@ enum ServerEvent: string
             self::CriticalControlRejected,
             self::SchemaViolation,
             self::NoticeOfDisconnectSent,
+            self::WriteTimeout,
             self::PasswordPolicyExpired,
             self::PasswordPolicyChangeRejected => LogLevel::NOTICE,
             default => LogLevel::INFO,

--- a/src/FreeDSx/Ldap/Server/SocketServerFactory.php
+++ b/src/FreeDSx/Ldap/Server/SocketServerFactory.php
@@ -39,9 +39,16 @@ class SocketServerFactory
             $this->removeExistingSocketIfNeeded($resource);
         }
 
+        // The write timeout uses a non-blocking stream_select loop, which causes performance issues on swoole.
+        // so no available there until a proper solution is designed.
+        $writeTimeout = $this->options->getUseSwooleRunner()
+            ? 0
+            : $this->options->getWriteTimeout();
+
         $socketServerOptions = (new SocketServerOptions())
             ->setTransport(Transport::from($this->options->getTransport()))
             ->setIdleTimeout($this->options->getIdleTimeout())
+            ->setWriteTimeout($writeTimeout)
             ->setUseSsl($this->options->isUseSsl())
             ->setSslCert($this->options->getSslCert())
             ->setSslCertKey($this->options->getSslCertKey())

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -102,6 +102,11 @@ final class ServerOptions
     private int $idleTimeout = 600;
 
     /**
+     * Disconnect a client whose response send makes no progress for this many seconds (a stalled reader).
+     */
+    private int $writeTimeout = 600;
+
+    /**
      * The largest incoming request PDU accepted, in bytes (5 MiB); 0 disables the limit.
      */
     private int $maxRequestSize = 5_242_880;
@@ -247,6 +252,18 @@ final class ServerOptions
     public function setIdleTimeout(int $idleTimeout): self
     {
         $this->idleTimeout = $idleTimeout;
+
+        return $this;
+    }
+
+    public function getWriteTimeout(): int
+    {
+        return $this->writeTimeout;
+    }
+
+    public function setWriteTimeout(int $writeTimeout): self
+    {
+        $this->writeTimeout = $writeTimeout;
 
         return $this;
     }

--- a/tests/unit/Protocol/ServerProtocolHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandlerTest.php
@@ -28,11 +28,13 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
 use FreeDSx\Socket\Exception\ConnectionException;
+use FreeDSx\Socket\Exception\WriteTimeoutException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -197,6 +199,32 @@ final class ServerProtocolHandlerTest extends TestCase
             ->handle();
     }
 
+    public function test_a_write_timeout_is_recorded_and_closes_without_a_notice_of_disconnect(): void
+    {
+        $recordingLogger = new RecordingLogger();
+        $this->queueReturns([
+            new LdapMessageRequest(1, new ModifyDnRequest('cn=foo,dc=bar', 'cn=bar', true)),
+        ]);
+
+        $this->mockQueue
+            ->expects(self::never())
+            ->method('sendMessage');
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('close');
+
+        $this->handlerWith(
+            new ThrowingMiddlewareHandler(new WriteTimeoutException('The write operation timed out after 600 seconds.')),
+            new EventLogger($recordingLogger, EventLogPolicy::default()),
+        )->handle();
+
+        $record = $this->findRecord($recordingLogger, 'session.write_timeout');
+        self::assertSame(
+            'The write operation timed out after 600 seconds.',
+            $record['context']['reason_message'],
+        );
+    }
+
     public function test_it_sends_a_notice_of_disconnect_and_closes_the_queue_on_shutdown(): void
     {
         $this->mockQueue
@@ -259,6 +287,33 @@ final class ServerProtocolHandlerTest extends TestCase
 
         $record = $this->findRecord($recordingLogger, 'session.disconnect_notice');
         self::assertNotEmpty($record['context']['exception_trace']);
+    }
+
+    public function test_a_write_timeout_is_logged_without_a_notice_of_disconnect(): void
+    {
+        $recordingLogger = new RecordingLogger();
+        $this->queueReturns([
+            new LdapMessageRequest(1, new ModifyDnRequest('cn=a,dc=bar', 'cn=b', true)),
+        ]);
+
+        $this->handlerWith(
+            new ThrowingMiddlewareHandler(new WriteTimeoutException('The write operation timed out after 600 seconds.')),
+            new EventLogger($recordingLogger, EventLogPolicy::default()),
+        )->handle();
+
+        $record = $this->findRecord($recordingLogger, 'session.write_timeout');
+        self::assertSame(
+            'The write operation timed out after 600 seconds.',
+            $record['context'][EventContext::REASON_MESSAGE],
+        );
+
+        foreach ($recordingLogger->records as $logged) {
+            self::assertNotSame(
+                'session.disconnect_notice',
+                $logged['message'],
+                'A stalled reader must not be sent a Notice of Disconnection.',
+            );
+        }
     }
 
     /**

--- a/tests/unit/Server/SocketServerFactoryTest.php
+++ b/tests/unit/Server/SocketServerFactoryTest.php
@@ -59,6 +59,37 @@ final class SocketServerFactoryTest extends TestCase
         $this->subject->makeAndBind();
     }
 
+    public function test_it_flows_the_write_timeout_to_the_socket_server_for_the_pcntl_runner(): void
+    {
+        $subject = new SocketServerFactory(
+            (new ServerOptions())
+                ->setPort(3391)
+                ->setWriteTimeout(45),
+            $this->mockLogger,
+        );
+
+        self::assertSame(
+            45,
+            $subject->makeAndBind()->getOptions()->getWriteTimeout(),
+        );
+    }
+
+    public function test_it_disables_the_write_timeout_for_the_swoole_runner(): void
+    {
+        $subject = new SocketServerFactory(
+            (new ServerOptions())
+                ->setPort(3392)
+                ->setWriteTimeout(45)
+                ->setUseSwooleRunner(true),
+            $this->mockLogger,
+        );
+
+        self::assertSame(
+            0,
+            $subject->makeAndBind()->getOptions()->getWriteTimeout(),
+        );
+    }
+
     public function test_it_should_make_a_unix_based_socket_server(): void
     {
         if (str_starts_with(strtoupper(PHP_OS), 'WIN')) {

--- a/tests/unit/ServerOptionsTest.php
+++ b/tests/unit/ServerOptionsTest.php
@@ -189,6 +189,24 @@ final class ServerOptionsTest extends TestCase
         );
     }
 
+    public function test_write_timeout_defaults_to_600(): void
+    {
+        self::assertSame(
+            600,
+            $this->subject->getWriteTimeout(),
+        );
+    }
+
+    public function test_it_can_set_write_timeout(): void
+    {
+        $this->subject->setWriteTimeout(0);
+
+        self::assertSame(
+            0,
+            $this->subject->getWriteTimeout(),
+        );
+    }
+
     public function test_require_authentication_defaults_to_true(): void
     {
         self::assertTrue($this->subject->isRequireAuthentication());


### PR DESCRIPTION
This adds a write timeout to the server. This protects against clients that start to read but stop / stall or just abandoned for whatever reason. Prevents us from keeping unneeded processes / resources open indefinitely.

Apparently I need a different strategy here for swoole because doing stream_select triggers a full coroutine event loop while we write (the changes on the socket side). Likely need some kind of interface + timeout enforcement strategy on the stream so swoole can use `Swoole\Timer` instead and coordinate it better. There's no issues with performance in PCNTL because the stream_select is cheap otherwise.