### PR TITLE
[1.0.0]  Allow write timeout to work against all server runners.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=8.2",
     "freedsx/asn1": "dev-main#b57a38f",
-    "freedsx/socket": "dev-main#27a1c55",
+    "freedsx/socket": "dev-main#610bf80",
     "freedsx/sasl": "dev-main#85e1ef9",
     "psr/log": "^3"
   },

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -149,8 +149,6 @@ Consider an idle client to timeout after this period of time (in seconds) and di
 Disconnect a client whose response send makes no progress for this many seconds (a reader that has stopped draining).
 Set to `0` to disable.
 
-**Note**: This applies to the PCNTL runner only.
-
 **Default**: `600`
 
 ------------------

--- a/src/FreeDSx/Ldap/Server/SocketServerFactory.php
+++ b/src/FreeDSx/Ldap/Server/SocketServerFactory.php
@@ -17,6 +17,8 @@ use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\SocketServer;
 use FreeDSx\Socket\SocketServerOptions;
+use FreeDSx\Socket\Timeout\BlockingSelectEnforcer;
+use FreeDSx\Socket\Timeout\SwooleTimerEnforcer;
 use FreeDSx\Socket\Transport;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -39,16 +41,15 @@ class SocketServerFactory
             $this->removeExistingSocketIfNeeded($resource);
         }
 
-        // The write timeout uses a non-blocking stream_select loop, which causes performance issues on swoole.
-        // so no available there until a proper solution is designed.
-        $writeTimeout = $this->options->getUseSwooleRunner()
-            ? 0
-            : $this->options->getWriteTimeout();
+        $writeTimeoutEnforcer = $this->options->getUseSwooleRunner()
+            ? new SwooleTimerEnforcer()
+            : new BlockingSelectEnforcer();
 
         $socketServerOptions = (new SocketServerOptions())
             ->setTransport(Transport::from($this->options->getTransport()))
             ->setIdleTimeout($this->options->getIdleTimeout())
-            ->setWriteTimeout($writeTimeout)
+            ->setWriteTimeout($this->options->getWriteTimeout())
+            ->setWriteTimeoutEnforcer($writeTimeoutEnforcer)
             ->setUseSsl($this->options->isUseSsl())
             ->setSslCert($this->options->getSslCert())
             ->setSslCertKey($this->options->getSslCertKey())

--- a/tests/unit/Server/SocketServerFactoryTest.php
+++ b/tests/unit/Server/SocketServerFactoryTest.php
@@ -15,6 +15,8 @@ namespace Tests\Unit\FreeDSx\Ldap\Server;
 
 use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Socket\Timeout\BlockingSelectEnforcer;
+use FreeDSx\Socket\Timeout\SwooleTimerEnforcer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -59,7 +61,7 @@ final class SocketServerFactoryTest extends TestCase
         $this->subject->makeAndBind();
     }
 
-    public function test_it_flows_the_write_timeout_to_the_socket_server_for_the_pcntl_runner(): void
+    public function test_it_uses_the_blocking_select_enforcer_for_the_pcntl_runner(): void
     {
         $subject = new SocketServerFactory(
             (new ServerOptions())
@@ -68,13 +70,19 @@ final class SocketServerFactoryTest extends TestCase
             $this->mockLogger,
         );
 
+        $options = $subject->makeAndBind()->getOptions();
+
         self::assertSame(
             45,
-            $subject->makeAndBind()->getOptions()->getWriteTimeout(),
+            $options->getWriteTimeout(),
+        );
+        self::assertInstanceOf(
+            BlockingSelectEnforcer::class,
+            $options->getWriteTimeoutEnforcer(),
         );
     }
 
-    public function test_it_disables_the_write_timeout_for_the_swoole_runner(): void
+    public function test_it_uses_the_swoole_timer_enforcer_for_the_swoole_runner(): void
     {
         $subject = new SocketServerFactory(
             (new ServerOptions())
@@ -84,9 +92,15 @@ final class SocketServerFactoryTest extends TestCase
             $this->mockLogger,
         );
 
+        $options = $subject->makeAndBind()->getOptions();
+
         self::assertSame(
-            0,
-            $subject->makeAndBind()->getOptions()->getWriteTimeout(),
+            45,
+            $options->getWriteTimeout(),
+        );
+        self::assertInstanceOf(
+            SwooleTimerEnforcer::class,
+            $options->getWriteTimeoutEnforcer(),
         );
     }
 


### PR DESCRIPTION
Fixing it so it works for swoole or pcntl. Coroutines needed a different strategy in the socket library.