### PR TITLE
[1.0.0] Add the core metrics files.

### DIFF
--- a/src/FreeDSx/Ldap/Server/Metrics/File/FileSnapshotProvider.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/File/FileSnapshotProvider.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\File;
+
+use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\MetricsSnapshot;
+
+use function file_get_contents;
+use function is_array;
+use function json_decode;
+
+/**
+ * Reads a metrics snapshot another process published to a file.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class FileSnapshotProvider implements MetricsSnapshotProvider
+{
+    public function __construct(private string $path) {}
+
+    /**
+     * Returns an empty snapshot when the file is missing or unreadable, so cn=monitor still serves what it can.
+     */
+    public function snapshot(): MetricsSnapshot
+    {
+        $contents = @file_get_contents($this->path);
+
+        if ($contents === false) {
+            return new MetricsSnapshot();
+        }
+
+        $data = json_decode(
+            $contents,
+            true,
+        );
+
+        if (!is_array($data)) {
+            return new MetricsSnapshot();
+        }
+
+        return MetricsSnapshot::fromArray($data);
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/File/FileSnapshotWriter.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/File/FileSnapshotWriter.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\File;
+
+use FreeDSx\Ldap\Server\Metrics\Snapshot\MetricsSnapshot;
+
+use function file_put_contents;
+use function getmypid;
+use function json_encode;
+use function rename;
+use function unlink;
+
+/**
+ * Publishes a metrics snapshot to a file for another process to read.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class FileSnapshotWriter
+{
+    public function __construct(private string $path) {}
+
+    public function write(MetricsSnapshot $snapshot): void
+    {
+        $json = json_encode($snapshot->toArray());
+
+        if ($json === false) {
+            return;
+        }
+
+        $temporaryPath = $this->path . '.' . getmypid() . '.tmp';
+
+        if (@file_put_contents($temporaryPath, $json) === false) {
+            return;
+        }
+
+        @rename(
+            $temporaryPath,
+            $this->path,
+        );
+    }
+
+    public function remove(): void
+    {
+        @unlink($this->path);
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/MetricsRecorderInterface.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/MetricsRecorderInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics;
+
+use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
+use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
+
+/**
+ * Sink that server components push metric observations to.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface MetricsRecorderInterface
+{
+    public function operationObserved(OperationObservation $observation): void;
+
+    public function connectionObserved(ConnectionObservation $observation): void;
+
+    /**
+     * @param int $startedAt The server start time as a Unix timestamp.
+     */
+    public function serverStarted(int $startedAt): void;
+
+    /**
+     * @param int $reloadedAt The configuration reload time as a Unix timestamp.
+     */
+    public function serverReloaded(int $reloadedAt): void;
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/MetricsSnapshotProvider.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/MetricsSnapshotProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics;
+
+use FreeDSx\Ldap\Server\Metrics\Snapshot\MetricsSnapshot;
+
+/**
+ * Supplies a point-in-time metrics snapshot, e.g. for the cn=monitor entry.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface MetricsSnapshotProvider
+{
+    public function snapshot(): MetricsSnapshot;
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/Observation/ConnectionObservation.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Observation/ConnectionObservation.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\Observation;
+
+/**
+ * A connection lifecycle event reported to a metrics recorder.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+enum ConnectionObservation: string
+{
+    case Opened = 'opened';
+
+    case Closed = 'closed';
+
+    case Rejected = 'rejected';
+
+    case WriteTimeout = 'write_timeout';
+
+    case IdleTimeout = 'idle_timeout';
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/Observation/OperationObservation.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Observation/OperationObservation.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\Observation;
+
+/**
+ * A single observed operation, with its low-cardinality metric dimensions.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class OperationObservation
+{
+    /**
+     * @param string $operation The operation label (matches the audit log's operation values).
+     * @param int $resultCode The LDAP result code the operation produced.
+     */
+    public function __construct(
+        public string $operation,
+        public bool $succeeded,
+        public float $durationSeconds,
+        public int $resultCode,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/Recorder/InMemoryMetricsRecorder.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Recorder/InMemoryMetricsRecorder.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\Recorder;
+
+use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
+use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
+use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
+use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\ConnectionMetrics;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\LifecycleMetrics;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\MetricsSnapshot;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\OperationMetrics;
+
+use function max;
+
+/**
+ * Accumulates metrics in process memory and serves them as a snapshot.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class InMemoryMetricsRecorder implements MetricsRecorderInterface, MetricsSnapshotProvider
+{
+    private int $startedAt = 0;
+
+    private int $lastReloadAt = 0;
+
+    /**
+     * @var int<0, max>
+     */
+    private int $reloadCount = 0;
+
+    /**
+     * @var int<0, max>
+     */
+    private int $activeConnections = 0;
+
+    /**
+     * @var int<0, max>
+     */
+    private int $totalConnections = 0;
+
+    /**
+     * @var int<0, max>
+     */
+    private int $rejectedConnections = 0;
+
+    /**
+     * @var int<0, max>
+     */
+    private int $writeTimeouts = 0;
+
+    /**
+     * @var int<0, max>
+     */
+    private int $idleTimeouts = 0;
+
+    /**
+     * @var array<string, int<0, max>>
+     */
+    private array $operationCounts = [];
+
+    /**
+     * @var array<string, int<0, max>>
+     */
+    private array $operationErrors = [];
+
+    /**
+     * @var array<string, float>
+     */
+    private array $operationDurationSeconds = [];
+
+    /**
+     * @var array<int, int<0, max>>
+     */
+    private array $resultCodeCounts = [];
+
+    public function operationObserved(OperationObservation $observation): void
+    {
+        $operation = $observation->operation;
+        $this->operationCounts[$operation] = ($this->operationCounts[$operation] ?? 0) + 1;
+        $this->operationDurationSeconds[$operation] = ($this->operationDurationSeconds[$operation] ?? 0.0)
+            + $observation->durationSeconds;
+        $this->resultCodeCounts[$observation->resultCode] = ($this->resultCodeCounts[$observation->resultCode] ?? 0) + 1;
+
+        if (!$observation->succeeded) {
+            $this->operationErrors[$operation] = ($this->operationErrors[$operation] ?? 0) + 1;
+        }
+    }
+
+    public function connectionObserved(ConnectionObservation $observation): void
+    {
+        match ($observation) {
+            ConnectionObservation::Opened => $this->onOpened(),
+            ConnectionObservation::Closed => $this->activeConnections = max(0, $this->activeConnections - 1),
+            ConnectionObservation::Rejected => $this->rejectedConnections++,
+            ConnectionObservation::WriteTimeout => $this->writeTimeouts++,
+            ConnectionObservation::IdleTimeout => $this->idleTimeouts++,
+        };
+    }
+
+    public function serverStarted(int $startedAt): void
+    {
+        $this->startedAt = $startedAt;
+    }
+
+    public function serverReloaded(int $reloadedAt): void
+    {
+        $this->lastReloadAt = $reloadedAt;
+        $this->reloadCount++;
+    }
+
+    public function snapshot(): MetricsSnapshot
+    {
+        return new MetricsSnapshot(
+            new LifecycleMetrics(
+                $this->startedAt,
+                $this->lastReloadAt,
+                $this->reloadCount,
+            ),
+            new ConnectionMetrics(
+                $this->activeConnections,
+                $this->totalConnections,
+                $this->rejectedConnections,
+                $this->writeTimeouts,
+                $this->idleTimeouts,
+            ),
+            new OperationMetrics(
+                $this->operationCounts,
+                $this->operationErrors,
+                $this->operationDurationSeconds,
+                $this->resultCodeCounts,
+            ),
+        );
+    }
+
+    private function onOpened(): void
+    {
+        $this->activeConnections++;
+        $this->totalConnections++;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/Recorder/MetricsRecorderChain.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Recorder/MetricsRecorderChain.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\Recorder;
+
+use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
+use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
+use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
+
+use function array_values;
+
+/**
+ * Fans every observation out to several recorders, e.g. an in-memory recorder for cn=monitor and a push exporter.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class MetricsRecorderChain implements MetricsRecorderInterface
+{
+    /**
+     * @var list<MetricsRecorderInterface>
+     */
+    private array $recorders;
+
+    public function __construct(MetricsRecorderInterface ...$recorders)
+    {
+        $this->recorders = array_values($recorders);
+    }
+
+    public function operationObserved(OperationObservation $observation): void
+    {
+        foreach ($this->recorders as $recorder) {
+            $recorder->operationObserved($observation);
+        }
+    }
+
+    public function connectionObserved(ConnectionObservation $observation): void
+    {
+        foreach ($this->recorders as $recorder) {
+            $recorder->connectionObserved($observation);
+        }
+    }
+
+    public function serverStarted(int $startedAt): void
+    {
+        foreach ($this->recorders as $recorder) {
+            $recorder->serverStarted($startedAt);
+        }
+    }
+
+    public function serverReloaded(int $reloadedAt): void
+    {
+        foreach ($this->recorders as $recorder) {
+            $recorder->serverReloaded($reloadedAt);
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/Recorder/NullMetricsRecorder.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Recorder/NullMetricsRecorder.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\Recorder;
+
+use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
+use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
+use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
+
+/**
+ * The default recorder; discards every observation for zero overhead when metrics are unconfigured.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class NullMetricsRecorder implements MetricsRecorderInterface
+{
+    public function operationObserved(OperationObservation $observation): void {}
+
+    public function connectionObserved(ConnectionObservation $observation): void {}
+
+    public function serverStarted(int $startedAt): void {}
+
+    public function serverReloaded(int $reloadedAt): void {}
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/Snapshot/ConnectionMetrics.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Snapshot/ConnectionMetrics.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\Snapshot;
+
+/**
+ * Connection metrics: the live gauge plus cumulative lifecycle counters.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ConnectionMetrics
+{
+    public function __construct(
+        public int $active = 0,
+        public int $total = 0,
+        public int $rejected = 0,
+        public int $writeTimeouts = 0,
+        public int $idleTimeouts = 0,
+    ) {}
+
+    /**
+     * @return array<string, int>
+     */
+    public function toArray(): array
+    {
+        return [
+            'active' => $this->active,
+            'total' => $this->total,
+            'rejected' => $this->rejected,
+            'write_timeouts' => $this->writeTimeouts,
+            'idle_timeouts' => $this->idleTimeouts,
+        ];
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            active: SnapshotValue::toInt($data['active'] ?? null),
+            total: SnapshotValue::toInt($data['total'] ?? null),
+            rejected: SnapshotValue::toInt($data['rejected'] ?? null),
+            writeTimeouts: SnapshotValue::toInt($data['write_timeouts'] ?? null),
+            idleTimeouts: SnapshotValue::toInt($data['idle_timeouts'] ?? null),
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/Snapshot/LifecycleMetrics.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Snapshot/LifecycleMetrics.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\Snapshot;
+
+/**
+ * Server lifecycle metrics: start time and configuration reloads.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class LifecycleMetrics
+{
+    /**
+     * @param int $startedAt Server start time (Unix timestamp), or 0 when unknown.
+     * @param int $lastReloadAt Last config reload (Unix timestamp), or 0 when never reloaded.
+     */
+    public function __construct(
+        public int $startedAt = 0,
+        public int $lastReloadAt = 0,
+        public int $reloadCount = 0,
+    ) {}
+
+    /**
+     * @return array<string, int>
+     */
+    public function toArray(): array
+    {
+        return [
+            'started_at' => $this->startedAt,
+            'last_reload_at' => $this->lastReloadAt,
+            'reload_count' => $this->reloadCount,
+        ];
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            startedAt: SnapshotValue::toInt($data['started_at'] ?? null),
+            lastReloadAt: SnapshotValue::toInt($data['last_reload_at'] ?? null),
+            reloadCount: SnapshotValue::toInt($data['reload_count'] ?? null),
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/Snapshot/MetricsSnapshot.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Snapshot/MetricsSnapshot.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\Snapshot;
+
+/**
+ * An immutable point-in-time view of the collected server metrics, grouped by area.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class MetricsSnapshot
+{
+    public function __construct(
+        public LifecycleMetrics $lifecycle = new LifecycleMetrics(),
+        public ConnectionMetrics $connections = new ConnectionMetrics(),
+        public OperationMetrics $operations = new OperationMetrics(),
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'lifecycle' => $this->lifecycle->toArray(),
+            'connections' => $this->connections->toArray(),
+            'operations' => $this->operations->toArray(),
+        ];
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            lifecycle: LifecycleMetrics::fromArray(self::section(
+                $data,
+                'lifecycle',
+            )),
+            connections: ConnectionMetrics::fromArray(self::section(
+                $data,
+                'connections',
+            )),
+            operations: OperationMetrics::fromArray(self::section(
+                $data,
+                'operations',
+            )),
+        );
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     * @return array<array-key, mixed>
+     */
+    private static function section(
+        array $data,
+        string $key,
+    ): array {
+        $section = $data[$key] ?? [];
+
+        return is_array($section)
+            ? $section
+            : [];
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/Snapshot/OperationMetrics.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Snapshot/OperationMetrics.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\Snapshot;
+
+use function array_sum;
+
+/**
+ * Operation metrics: counts, failures, and latency by operation, plus a result-code breakdown.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class OperationMetrics
+{
+    /**
+     * @param array<string, int> $counts Operation label to total count.
+     * @param array<string, int> $errors Operation label to failed count.
+     * @param array<string, float> $durationSeconds Operation label to summed duration.
+     * @param array<int, int> $resultCodeCounts LDAP result code to count.
+     */
+    public function __construct(
+        public array $counts = [],
+        public array $errors = [],
+        public array $durationSeconds = [],
+        public array $resultCodeCounts = [],
+    ) {}
+
+    public function total(): int
+    {
+        return array_sum($this->counts);
+    }
+
+    public function totalErrors(): int
+    {
+        return array_sum($this->errors);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'counts' => $this->counts,
+            'errors' => $this->errors,
+            'duration_seconds' => $this->durationSeconds,
+            'result_code_counts' => $this->resultCodeCounts,
+        ];
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            counts: SnapshotValue::toIntMap($data['counts'] ?? null),
+            errors: SnapshotValue::toIntMap($data['errors'] ?? null),
+            durationSeconds: SnapshotValue::toFloatMap($data['duration_seconds'] ?? null),
+            resultCodeCounts: SnapshotValue::toIntKeyedIntMap($data['result_code_counts'] ?? null),
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/Snapshot/SnapshotValue.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Snapshot/SnapshotValue.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\Snapshot;
+
+use function is_array;
+use function is_numeric;
+
+/**
+ * Coerces values decoded from an untyped snapshot array into the metric scalar types.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class SnapshotValue
+{
+    public static function toInt(mixed $value): int
+    {
+        return is_numeric($value)
+            ? (int) $value
+            : 0;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public static function toIntMap(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($value as $key => $count) {
+            $result[(string) $key] = self::toInt($count);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<string, float>
+     */
+    public static function toFloatMap(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($value as $key => $duration) {
+            $result[(string) $key] = is_numeric($duration)
+                ? (float) $duration
+                : 0.0;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public static function toIntKeyedIntMap(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($value as $key => $count) {
+            $result[(int) $key] = self::toInt($count);
+        }
+
+        return $result;
+    }
+}

--- a/tests/unit/Server/Metrics/File/FileSnapshotProviderTest.php
+++ b/tests/unit/Server/Metrics/File/FileSnapshotProviderTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Metrics\File;
+
+use FreeDSx\Ldap\Server\Metrics\File\FileSnapshotProvider;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\ConnectionMetrics;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\LifecycleMetrics;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\MetricsSnapshot;
+use PHPUnit\Framework\TestCase;
+
+final class FileSnapshotProviderTest extends TestCase
+{
+    private string $path;
+
+    private FileSnapshotProvider $subject;
+
+    protected function setUp(): void
+    {
+        $this->path = sys_get_temp_dir() . '/freedsx_metrics_' . uniqid('', true) . '.json';
+        $this->subject = new FileSnapshotProvider($this->path);
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->path)) {
+            @unlink($this->path);
+        }
+    }
+
+    public function test_it_reads_the_snapshot_published_to_the_file(): void
+    {
+        $snapshot = new MetricsSnapshot(
+            new LifecycleMetrics(1_000, 0, 0),
+            new ConnectionMetrics(3, 9, 1),
+        );
+        file_put_contents(
+            $this->path,
+            (string) json_encode($snapshot->toArray()),
+        );
+
+        self::assertEquals(
+            $snapshot,
+            $this->subject->snapshot(),
+        );
+    }
+
+    public function test_a_missing_file_degrades_to_an_empty_snapshot(): void
+    {
+        self::assertEquals(
+            new MetricsSnapshot(),
+            $this->subject->snapshot(),
+        );
+    }
+
+    public function test_malformed_json_degrades_to_an_empty_snapshot(): void
+    {
+        file_put_contents(
+            $this->path,
+            '{not valid json',
+        );
+
+        self::assertEquals(
+            new MetricsSnapshot(),
+            $this->subject->snapshot(),
+        );
+    }
+
+    public function test_non_object_json_degrades_to_an_empty_snapshot(): void
+    {
+        file_put_contents(
+            $this->path,
+            '"a string"',
+        );
+
+        self::assertEquals(
+            new MetricsSnapshot(),
+            $this->subject->snapshot(),
+        );
+    }
+}

--- a/tests/unit/Server/Metrics/File/FileSnapshotWriterTest.php
+++ b/tests/unit/Server/Metrics/File/FileSnapshotWriterTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Metrics\File;
+
+use FreeDSx\Ldap\Server\Metrics\File\FileSnapshotWriter;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\ConnectionMetrics;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\LifecycleMetrics;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\MetricsSnapshot;
+use PHPUnit\Framework\TestCase;
+
+final class FileSnapshotWriterTest extends TestCase
+{
+    private string $path;
+
+    private FileSnapshotWriter $subject;
+
+    protected function setUp(): void
+    {
+        $this->path = sys_get_temp_dir() . '/freedsx_metrics_' . uniqid('', true) . '.json';
+        $this->subject = new FileSnapshotWriter($this->path);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->path . '*') ?: [] as $file) {
+            @unlink($file);
+        }
+    }
+
+    public function test_it_writes_the_snapshot_as_decodable_json(): void
+    {
+        $snapshot = new MetricsSnapshot(
+            new LifecycleMetrics(1_000, 0, 0),
+            new ConnectionMetrics(3, 9, 1),
+        );
+
+        $this->subject->write($snapshot);
+
+        self::assertSame(
+            $snapshot->toArray(),
+            json_decode(
+                (string) file_get_contents($this->path),
+                true,
+            ),
+        );
+    }
+
+    public function test_writing_again_overwrites_the_previous_snapshot(): void
+    {
+        $this->subject->write(new MetricsSnapshot(new LifecycleMetrics(1_000)));
+        $this->subject->write(new MetricsSnapshot(new LifecycleMetrics(2_000)));
+
+        self::assertSame(
+            (new MetricsSnapshot(new LifecycleMetrics(2_000)))->toArray(),
+            json_decode(
+                (string) file_get_contents($this->path),
+                true,
+            ),
+        );
+    }
+
+    public function test_it_does_not_leave_a_temporary_file_behind(): void
+    {
+        $this->subject->write(new MetricsSnapshot());
+
+        self::assertSame(
+            [],
+            glob($this->path . '.*.tmp') ?: [],
+        );
+    }
+
+    public function test_remove_deletes_the_snapshot_file(): void
+    {
+        $this->subject->write(new MetricsSnapshot());
+        self::assertFileExists($this->path);
+
+        $this->subject->remove();
+
+        self::assertFileDoesNotExist($this->path);
+    }
+}

--- a/tests/unit/Server/Metrics/Recorder/InMemoryMetricsRecorderTest.php
+++ b/tests/unit/Server/Metrics/Recorder/InMemoryMetricsRecorderTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Metrics\Recorder;
+
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
+use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
+use FreeDSx\Ldap\Server\Metrics\Recorder\InMemoryMetricsRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class InMemoryMetricsRecorderTest extends TestCase
+{
+    private InMemoryMetricsRecorder $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new InMemoryMetricsRecorder();
+    }
+
+    public function test_it_records_operations_with_counts_errors_and_durations(): void
+    {
+        $this->subject->operationObserved(new OperationObservation(
+            'search',
+            true,
+            0.5,
+            ResultCode::SUCCESS,
+        ));
+        $this->subject->operationObserved(new OperationObservation(
+            'search',
+            false,
+            0.25,
+            ResultCode::NO_SUCH_OBJECT,
+        ));
+
+        $operations = $this->subject->snapshot()->operations;
+
+        self::assertSame(
+            ['search' => 2],
+            $operations->counts,
+        );
+        self::assertSame(
+            ['search' => 1],
+            $operations->errors,
+        );
+        self::assertSame(
+            ['search' => 0.75],
+            $operations->durationSeconds,
+        );
+        self::assertSame(
+            [
+                ResultCode::SUCCESS => 1,
+                ResultCode::NO_SUCH_OBJECT => 1,
+            ],
+            $operations->resultCodeCounts,
+        );
+    }
+
+    public function test_the_active_connection_gauge_rises_on_open_and_falls_on_close(): void
+    {
+        $this->subject->connectionObserved(ConnectionObservation::Opened);
+        $this->subject->connectionObserved(ConnectionObservation::Opened);
+        $this->subject->connectionObserved(ConnectionObservation::Closed);
+
+        $connections = $this->subject->snapshot()->connections;
+
+        self::assertSame(
+            1,
+            $connections->active,
+        );
+        self::assertSame(
+            2,
+            $connections->total,
+        );
+    }
+
+    public function test_closing_more_than_were_opened_floors_the_gauge_at_zero(): void
+    {
+        $this->subject->connectionObserved(ConnectionObservation::Closed);
+
+        self::assertSame(
+            0,
+            $this->subject->snapshot()->connections->active,
+        );
+    }
+
+    public function test_it_counts_rejected_and_timed_out_connections(): void
+    {
+        $this->subject->connectionObserved(ConnectionObservation::Rejected);
+        $this->subject->connectionObserved(ConnectionObservation::WriteTimeout);
+        $this->subject->connectionObserved(ConnectionObservation::WriteTimeout);
+        $this->subject->connectionObserved(ConnectionObservation::IdleTimeout);
+
+        $connections = $this->subject->snapshot()->connections;
+
+        self::assertSame(
+            1,
+            $connections->rejected,
+        );
+        self::assertSame(
+            2,
+            $connections->writeTimeouts,
+        );
+        self::assertSame(
+            1,
+            $connections->idleTimeouts,
+        );
+    }
+
+    public function test_it_records_the_start_time_and_counts_reloads(): void
+    {
+        $this->subject->serverStarted(1_000);
+        $this->subject->serverReloaded(2_000);
+        $this->subject->serverReloaded(3_000);
+
+        $lifecycle = $this->subject->snapshot()->lifecycle;
+
+        self::assertSame(
+            1_000,
+            $lifecycle->startedAt,
+        );
+        self::assertSame(
+            3_000,
+            $lifecycle->lastReloadAt,
+        );
+        self::assertSame(
+            2,
+            $lifecycle->reloadCount,
+        );
+    }
+}

--- a/tests/unit/Server/Metrics/Recorder/MetricsRecorderChainTest.php
+++ b/tests/unit/Server/Metrics/Recorder/MetricsRecorderChainTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Metrics\Recorder;
+
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
+use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
+use FreeDSx\Ldap\Server\Metrics\Recorder\InMemoryMetricsRecorder;
+use FreeDSx\Ldap\Server\Metrics\Recorder\MetricsRecorderChain;
+use PHPUnit\Framework\TestCase;
+
+final class MetricsRecorderChainTest extends TestCase
+{
+    private InMemoryMetricsRecorder $first;
+
+    private InMemoryMetricsRecorder $second;
+
+    private MetricsRecorderChain $subject;
+
+    protected function setUp(): void
+    {
+        $this->first = new InMemoryMetricsRecorder();
+        $this->second = new InMemoryMetricsRecorder();
+        $this->subject = new MetricsRecorderChain(
+            $this->first,
+            $this->second,
+        );
+    }
+
+    public function test_it_fans_every_observation_out_to_each_recorder(): void
+    {
+        $this->subject->serverStarted(1_000);
+        $this->subject->connectionObserved(ConnectionObservation::Opened);
+        $this->subject->operationObserved(new OperationObservation(
+            'bind',
+            true,
+            0.1,
+            ResultCode::SUCCESS,
+        ));
+
+        foreach ([$this->first, $this->second] as $recorder) {
+            $snapshot = $recorder->snapshot();
+            self::assertSame(
+                1_000,
+                $snapshot->lifecycle->startedAt,
+            );
+            self::assertSame(
+                1,
+                $snapshot->connections->active,
+            );
+            self::assertSame(
+                ['bind' => 1],
+                $snapshot->operations->counts,
+            );
+        }
+    }
+}

--- a/tests/unit/Server/Metrics/Recorder/NullMetricsRecorderTest.php
+++ b/tests/unit/Server/Metrics/Recorder/NullMetricsRecorderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Metrics\Recorder;
+
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
+use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
+use FreeDSx\Ldap\Server\Metrics\Recorder\NullMetricsRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class NullMetricsRecorderTest extends TestCase
+{
+    public function test_every_observation_is_a_harmless_no_op(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $subject = new NullMetricsRecorder();
+        $subject->serverStarted(1_000);
+        $subject->serverReloaded(2_000);
+        $subject->connectionObserved(ConnectionObservation::Opened);
+        $subject->operationObserved(new OperationObservation(
+            'search',
+            true,
+            0.1,
+            ResultCode::SUCCESS,
+        ));
+    }
+}

--- a/tests/unit/Server/Metrics/Snapshot/MetricsSnapshotTest.php
+++ b/tests/unit/Server/Metrics/Snapshot/MetricsSnapshotTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Metrics\Snapshot;
+
+use FreeDSx\Ldap\Server\Metrics\Snapshot\ConnectionMetrics;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\LifecycleMetrics;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\MetricsSnapshot;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\OperationMetrics;
+use PHPUnit\Framework\TestCase;
+
+final class MetricsSnapshotTest extends TestCase
+{
+    private MetricsSnapshot $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new MetricsSnapshot(
+            new LifecycleMetrics(
+                1_000,
+                2_000,
+                3,
+            ),
+            new ConnectionMetrics(
+                4,
+                10,
+                2,
+                1,
+                0,
+            ),
+            new OperationMetrics(
+                ['search' => 7],
+                ['search' => 1],
+                ['search' => 3.5],
+                [0 => 6, 32 => 1],
+            ),
+        );
+    }
+
+    public function test_it_round_trips_through_an_array_via_json(): void
+    {
+        $json = json_encode($this->subject->toArray());
+        self::assertIsString($json);
+
+        $restored = MetricsSnapshot::fromArray((array) json_decode(
+            $json,
+            true,
+        ));
+
+        self::assertEquals(
+            $this->subject,
+            $restored,
+        );
+    }
+
+    public function test_operation_totals_sum_across_operations(): void
+    {
+        self::assertSame(
+            7,
+            $this->subject->operations->total(),
+        );
+        self::assertSame(
+            1,
+            $this->subject->operations->totalErrors(),
+        );
+    }
+
+    public function test_from_array_yields_an_empty_snapshot_for_missing_sections(): void
+    {
+        self::assertEquals(
+            new MetricsSnapshot(),
+            MetricsSnapshot::fromArray([]),
+        );
+    }
+}

--- a/tests/unit/Server/Metrics/Snapshot/SnapshotValueTest.php
+++ b/tests/unit/Server/Metrics/Snapshot/SnapshotValueTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Metrics\Snapshot;
+
+use FreeDSx\Ldap\Server\Metrics\Snapshot\SnapshotValue;
+use PHPUnit\Framework\TestCase;
+
+final class SnapshotValueTest extends TestCase
+{
+    public function test_to_int_coerces_numeric_values_and_defaults_others_to_zero(): void
+    {
+        self::assertSame(
+            5,
+            SnapshotValue::toInt(5),
+        );
+        self::assertSame(
+            5,
+            SnapshotValue::toInt('5'),
+        );
+        self::assertSame(
+            5,
+            SnapshotValue::toInt(5.9),
+        );
+        self::assertSame(
+            0,
+            SnapshotValue::toInt('not-a-number'),
+        );
+        self::assertSame(
+            0,
+            SnapshotValue::toInt(null),
+        );
+        self::assertSame(
+            0,
+            SnapshotValue::toInt(['array']),
+        );
+    }
+
+    public function test_to_int_map_coerces_values_and_defaults_corrupt_entries_to_zero(): void
+    {
+        self::assertSame(
+            ['search' => 3, 'bind' => 0],
+            SnapshotValue::toIntMap([
+                'search' => '3',
+                'bind' => 'corrupt',
+            ]),
+        );
+    }
+
+    public function test_to_float_map_coerces_values(): void
+    {
+        self::assertSame(
+            ['search' => 1.5, 'bind' => 0.0],
+            SnapshotValue::toFloatMap([
+                'search' => '1.5',
+                'bind' => null,
+            ]),
+        );
+    }
+
+    public function test_to_int_keyed_int_map_casts_keys_to_int(): void
+    {
+        self::assertSame(
+            [0 => 6, 32 => 1],
+            SnapshotValue::toIntKeyedIntMap([
+                '0' => '6',
+                '32' => 1,
+            ]),
+        );
+    }
+
+    public function test_non_array_values_yield_an_empty_map(): void
+    {
+        self::assertSame(
+            [],
+            SnapshotValue::toIntMap('nope'),
+        );
+        self::assertSame(
+            [],
+            SnapshotValue::toFloatMap(null),
+        );
+        self::assertSame(
+            [],
+            SnapshotValue::toIntKeyedIntMap(42),
+        );
+    }
+}


### PR DESCRIPTION
This starts to add the core metrics files. These will be used as a way to pipe metrics out to something like prometheus and also serve a virtual `cn=monitor` entry like some other LDAP server systems.