### PR TITLE
[1.0.0] Add the metrics middleware. Return the result code through middleware.

### DIFF
--- a/src/FreeDSx/Ldap/Operation/OperationType.php
+++ b/src/FreeDSx/Ldap/Operation/OperationType.php
@@ -11,15 +11,19 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap\Server\AccessControl;
+namespace FreeDSx\Ldap\Operation;
 
+use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
+use FreeDSx\Ldap\Operation\Request\BindRequest;
 use FreeDSx\Ldap\Operation\Request\CompareRequest;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyRequest;
+use FreeDSx\Ldap\Operation\Request\PasswordModifyRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\Request\UnbindRequest;
 
 enum OperationType: string
 {
@@ -30,7 +34,14 @@ enum OperationType: string
     case ModifyDn = 'modify_dn';
     case Compare = 'compare';
     case PasswordModify = 'password_modify';
+    case Bind = 'bind';
+    case Unbind = 'unbind';
+    case Abandon = 'abandon';
+    case Extended = 'extended';
 
+    /**
+     * The access-controlled operation a request targets, or null for requests that are not authorized by target DN.
+     */
     public static function fromRequest(RequestInterface $request): ?self
     {
         return match (true) {
@@ -41,6 +52,20 @@ enum OperationType: string
             $request instanceof CompareRequest => self::Compare,
             $request instanceof SearchRequest => self::Search,
             default => null,
+        };
+    }
+
+    /**
+     * The operation type for any request, including the non-access-controlled ones (bind, unbind, abandon, extended).
+     */
+    public static function classify(RequestInterface $request): self
+    {
+        return self::fromRequest($request) ?? match (true) {
+            $request instanceof BindRequest => self::Bind,
+            $request instanceof PasswordModifyRequest => self::PasswordModify,
+            $request instanceof UnbindRequest => self::Unbind,
+            $request instanceof AbandonRequest => self::Abandon,
+            default => self::Extended,
         };
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerCancelHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerCancelHandler.php
@@ -46,6 +46,6 @@ readonly class ServerCancelHandler implements ServerProtocolHandlerInterface
             new ExtendedResponse(new LdapResult(ResultCode::NO_SUCH_OPERATION)),
         ));
 
-        return OperationOutcomeResult::failed();
+        return OperationOutcomeResult::failed(ResultCode::NO_SUCH_OPERATION);
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -25,7 +25,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
 use FreeDSx\Ldap\Server\Backend\Write\SchemaViolations;

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
@@ -79,7 +79,7 @@ class ServerStartTlsHandler implements ServerProtocolHandlerInterface
                 message: $message,
             );
 
-            return OperationOutcomeResult::failed();
+            return OperationOutcomeResult::failed(ResultCode::UNAVAILABLE);
         }
         # If we are already encrypted, then consider this an operations error...
         if ($this->queue->isEncrypted()) {
@@ -96,7 +96,7 @@ class ServerStartTlsHandler implements ServerProtocolHandlerInterface
                 message: $message,
             );
 
-            return OperationOutcomeResult::failed();
+            return OperationOutcomeResult::failed(ResultCode::OPERATIONS_ERROR);
         }
 
         $this->queue->sendMessage(new LdapMessageResponse($message->getMessageId(), new ExtendedResponse(

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnsupportedExtendedHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnsupportedExtendedHandler.php
@@ -65,6 +65,6 @@ final readonly class ServerUnsupportedExtendedHandler implements ServerProtocolH
             ),
         ));
 
-        return OperationOutcomeResult::failed();
+        return OperationOutcomeResult::failed(ResultCode::PROTOCOL_ERROR);
     }
 }

--- a/src/FreeDSx/Ldap/Server/AccessControl/AccessControlInterface.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/AccessControlInterface.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Server\AccessControl;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**

--- a/src/FreeDSx/Ldap/Server/AccessControl/Rule/OperationRule.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Rule/OperationRule.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\AccessControl\Rule;
 
-use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\AccessControl\Subject\SubjectMatcherInterface;
 use FreeDSx\Ldap\Server\AccessControl\Target\AnyTargetMatcher;
 use FreeDSx\Ldap\Server\AccessControl\Target\TargetMatcherInterface;

--- a/src/FreeDSx/Ldap/Server/AccessControl/RuleBasedAccessControl.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/RuleBasedAccessControl.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Server\AccessControl;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;

--- a/src/FreeDSx/Ldap/Server/AccessControl/SimpleAccessControl.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/SimpleAccessControl.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Server\AccessControl;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use FreeDSx\Ldap\Server\Token\TokenInterface;

--- a/src/FreeDSx/Ldap/Server/Logging/OperationAuditor.php
+++ b/src/FreeDSx/Ldap/Server/Logging/OperationAuditor.php
@@ -21,7 +21,7 @@ use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Server\AccessControl\OperationTargetDn;
-use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\Backend\Write\SchemaViolations;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 

--- a/src/FreeDSx/Ldap/Server/Logging/ServerEvent.php
+++ b/src/FreeDSx/Ldap/Server/Logging/ServerEvent.php
@@ -15,7 +15,7 @@ namespace FreeDSx\Ldap\Server\Logging;
 
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
-use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Operation\OperationType;
 use Psr\Log\LogLevel;
 
 /**

--- a/src/FreeDSx/Ldap/Server/Metrics/Observation/OperationObservation.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Observation/OperationObservation.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Metrics\Observation;
 
+use FreeDSx\Ldap\Operation\OperationType;
+
 /**
  * A single observed operation, with its low-cardinality metric dimensions.
  *
@@ -21,11 +23,10 @@ namespace FreeDSx\Ldap\Server\Metrics\Observation;
 final readonly class OperationObservation
 {
     /**
-     * @param string $operation The operation label (matches the audit log's operation values).
      * @param int $resultCode The LDAP result code the operation produced.
      */
     public function __construct(
-        public string $operation,
+        public OperationType $operation,
         public bool $succeeded,
         public float $durationSeconds,
         public int $resultCode,

--- a/src/FreeDSx/Ldap/Server/Metrics/Recorder/InMemoryMetricsRecorder.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Recorder/InMemoryMetricsRecorder.php
@@ -87,7 +87,7 @@ final class InMemoryMetricsRecorder implements MetricsRecorderInterface, Metrics
 
     public function operationObserved(OperationObservation $observation): void
     {
-        $operation = $observation->operation;
+        $operation = $observation->operation->value;
         $this->operationCounts[$operation] = ($this->operationCounts[$operation] ?? 0) + 1;
         $this->operationDurationSeconds[$operation] = ($this->operationDurationSeconds[$operation] ?? 0.0)
             + $observation->durationSeconds;

--- a/src/FreeDSx/Ldap/Server/Middleware/MetricsMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/MetricsMiddleware.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\OperationType;
+use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
+use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationOutcome;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+
+use function microtime;
+
+/**
+ * Times each message and records its operation outcome to the metrics recorder.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class MetricsMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private MetricsRecorderInterface $recorder,
+    ) {}
+
+    public function process(
+        ServerRequestContext $context,
+        MiddlewareHandlerInterface $next,
+    ): OperationResult {
+        $operation = OperationType::classify($context->message->getRequest());
+        $startedAt = microtime(true);
+
+        try {
+            $result = $next->handle($context);
+        } catch (OperationException $e) {
+            $this->record(
+                $operation,
+                false,
+                microtime(true) - $startedAt,
+                $e->getCode(),
+            );
+
+            throw $e;
+        }
+
+        $this->record(
+            $operation,
+            $result->outcome() === OperationOutcome::Succeeded,
+            microtime(true) - $startedAt,
+            $result->resultCode(),
+        );
+
+        return $result;
+    }
+
+    private function record(
+        OperationType $operation,
+        bool $succeeded,
+        float $durationSeconds,
+        int $resultCode,
+    ): void {
+        $this->recorder->operationObserved(new OperationObservation(
+            $operation,
+            $succeeded,
+            $durationSeconds,
+            $resultCode,
+        ));
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
@@ -27,7 +27,7 @@ use FreeDSx\Ldap\Protocol\Factory\HandlerRouteResolverInterface;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\OperationTargetDn;
-use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationErrorMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationErrorMiddleware.php
@@ -65,7 +65,7 @@ final readonly class OperationErrorMiddleware implements MiddlewareInterface
                 ),
             ));
 
-            return OperationOutcomeResult::failed();
+            return OperationOutcomeResult::failed($e->getCode());
         }
     }
 }

--- a/src/FreeDSx/Ldap/Server/Operation/CompareOperationResult.php
+++ b/src/FreeDSx/Ldap/Server/Operation/CompareOperationResult.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Operation;
 
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Server\Logging\OperationAuditor;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -43,6 +44,13 @@ final readonly class CompareOperationResult implements AuditableResult
     public function outcome(): OperationOutcome
     {
         return OperationOutcome::Succeeded;
+    }
+
+    public function resultCode(): int
+    {
+        return $this->match
+            ? ResultCode::COMPARE_TRUE
+            : ResultCode::COMPARE_FALSE;
     }
 
     public function record(

--- a/src/FreeDSx/Ldap/Server/Operation/OperationOutcomeResult.php
+++ b/src/FreeDSx/Ldap/Server/Operation/OperationOutcomeResult.php
@@ -13,28 +13,44 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Operation;
 
+use FreeDSx\Ldap\Operation\ResultCode;
+
 /**
- * A result conveying only its outcome, with no further detail to carry.
+ * A result conveying only its outcome and result code, with no further detail to carry.
  *
  * @internal
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 final readonly class OperationOutcomeResult implements OperationResult
 {
-    private function __construct(private OperationOutcome $outcome) {}
+    private function __construct(
+        private OperationOutcome $outcome,
+        private int $resultCode,
+    ) {}
 
     public static function succeeded(): self
     {
-        return new self(OperationOutcome::Succeeded);
+        return new self(
+            OperationOutcome::Succeeded,
+            ResultCode::SUCCESS,
+        );
     }
 
-    public static function failed(): self
+    public static function failed(int $resultCode = ResultCode::OPERATIONS_ERROR): self
     {
-        return new self(OperationOutcome::Failed);
+        return new self(
+            OperationOutcome::Failed,
+            $resultCode,
+        );
     }
 
     public function outcome(): OperationOutcome
     {
         return $this->outcome;
+    }
+
+    public function resultCode(): int
+    {
+        return $this->resultCode;
     }
 }

--- a/src/FreeDSx/Ldap/Server/Operation/OperationResult.php
+++ b/src/FreeDSx/Ldap/Server/Operation/OperationResult.php
@@ -22,4 +22,9 @@ namespace FreeDSx\Ldap\Server\Operation;
 interface OperationResult
 {
     public function outcome(): OperationOutcome;
+
+    /**
+     * The LDAP result code the operation produced (e.g. for metrics).
+     */
+    public function resultCode(): int;
 }

--- a/src/FreeDSx/Ldap/Server/Operation/PasswordModifyOperationResult.php
+++ b/src/FreeDSx/Ldap/Server/Operation/PasswordModifyOperationResult.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Server\Operation;
 
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Server\Logging\OperationAuditor;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -60,6 +61,11 @@ final readonly class PasswordModifyOperationResult implements AuditableResult
         return $this->failure === null
             ? OperationOutcome::Succeeded
             : OperationOutcome::Failed;
+    }
+
+    public function resultCode(): int
+    {
+        return $this->failure?->getCode() ?? ResultCode::SUCCESS;
     }
 
     public function record(

--- a/src/FreeDSx/Ldap/Server/Operation/SearchOperationResult.php
+++ b/src/FreeDSx/Ldap/Server/Operation/SearchOperationResult.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Operation;
 
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Server\Logging\OperationAuditor;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -57,6 +58,11 @@ final readonly class SearchOperationResult implements AuditableResult
         return $this->failure === null
             ? OperationOutcome::Succeeded
             : OperationOutcome::Failed;
+    }
+
+    public function resultCode(): int
+    {
+        return $this->failure?->getCode() ?? ResultCode::SUCCESS;
     }
 
     public function record(

--- a/src/FreeDSx/Ldap/Server/Operation/WriteOperationResult.php
+++ b/src/FreeDSx/Ldap/Server/Operation/WriteOperationResult.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Operation;
 
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Server\Backend\Write\SchemaViolations;
 use FreeDSx\Ldap\Server\Logging\OperationAuditor;
@@ -60,6 +61,11 @@ final readonly class WriteOperationResult implements AuditableResult
         return $this->failure === null
             ? OperationOutcome::Succeeded
             : OperationOutcome::Failed;
+    }
+
+    public function resultCode(): int
+    {
+        return $this->failure?->getCode() ?? ResultCode::SUCCESS;
     }
 
     public function record(

--- a/src/FreeDSx/Ldap/Server/PasswordModify/PasswordModifyService.php
+++ b/src/FreeDSx/Ldap/Server/PasswordModify/PasswordModifyService.php
@@ -22,7 +22,7 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\PasswordModifyRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyRequestForwarder.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyRequestForwarder.php
@@ -80,7 +80,7 @@ final readonly class ProxyRequestForwarder implements MiddlewareHandlerInterface
                 $e->getMatchedDn(),
             ));
 
-            return OperationOutcomeResult::failed();
+            return OperationOutcomeResult::failed($e->getCode());
         }
 
         if ($request instanceof SearchRequest) {

--- a/tests/support/LdapAclCommand.php
+++ b/tests/support/LdapAclCommand.php
@@ -9,7 +9,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Server\AccessControl\AclRules;
-use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;

--- a/tests/unit/Server/AccessControl/Rule/OperationRuleTest.php
+++ b/tests/unit/Server/AccessControl/Rule/OperationRuleTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl\Rule;
 
-use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;
 use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\AnySubjectMatcher;

--- a/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
+++ b/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
@@ -19,7 +19,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\AccessControl\AclRules;
-use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;

--- a/tests/unit/Server/AccessControl/SimpleAccessControlTest.php
+++ b/tests/unit/Server/AccessControl/SimpleAccessControlTest.php
@@ -17,7 +17,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
-use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\AccessControl\SimpleAccessControl;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use FreeDSx\Ldap\Server\Token\BindToken;

--- a/tests/unit/Server/Metrics/Recorder/InMemoryMetricsRecorderTest.php
+++ b/tests/unit/Server/Metrics/Recorder/InMemoryMetricsRecorderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Server\Metrics\Recorder;
 
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
 use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
@@ -31,13 +32,13 @@ final class InMemoryMetricsRecorderTest extends TestCase
     public function test_it_records_operations_with_counts_errors_and_durations(): void
     {
         $this->subject->operationObserved(new OperationObservation(
-            'search',
+            OperationType::Search,
             true,
             0.5,
             ResultCode::SUCCESS,
         ));
         $this->subject->operationObserved(new OperationObservation(
-            'search',
+            OperationType::Search,
             false,
             0.25,
             ResultCode::NO_SUCH_OBJECT,

--- a/tests/unit/Server/Metrics/Recorder/MetricsRecorderChainTest.php
+++ b/tests/unit/Server/Metrics/Recorder/MetricsRecorderChainTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Server\Metrics\Recorder;
 
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
 use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
@@ -43,7 +44,7 @@ final class MetricsRecorderChainTest extends TestCase
         $this->subject->serverStarted(1_000);
         $this->subject->connectionObserved(ConnectionObservation::Opened);
         $this->subject->operationObserved(new OperationObservation(
-            'bind',
+            OperationType::Bind,
             true,
             0.1,
             ResultCode::SUCCESS,

--- a/tests/unit/Server/Metrics/Recorder/NullMetricsRecorderTest.php
+++ b/tests/unit/Server/Metrics/Recorder/NullMetricsRecorderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Server\Metrics\Recorder;
 
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
 use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
@@ -30,7 +31,7 @@ final class NullMetricsRecorderTest extends TestCase
         $subject->serverReloaded(2_000);
         $subject->connectionObserved(ConnectionObservation::Opened);
         $subject->operationObserved(new OperationObservation(
-            'search',
+            OperationType::Search,
             true,
             0.1,
             ResultCode::SUCCESS,

--- a/tests/unit/Server/Middleware/MetricsMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/MetricsMiddlewareTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\Metrics\Recorder\InMemoryMetricsRecorder;
+use FreeDSx\Ldap\Server\Middleware\MetricsMiddleware;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Middleware\StubMiddlewareHandler;
+use Tests\Support\FreeDSx\Ldap\Middleware\ThrowingMiddlewareHandler;
+
+final class MetricsMiddlewareTest extends TestCase
+{
+    private InMemoryMetricsRecorder $recorder;
+
+    private MetricsMiddleware $subject;
+
+    protected function setUp(): void
+    {
+        $this->recorder = new InMemoryMetricsRecorder();
+        $this->subject = new MetricsMiddleware($this->recorder);
+    }
+
+    public function test_it_records_a_successful_operation(): void
+    {
+        $this->subject->process(
+            $this->contextFor(new SearchRequest(Filters::present('objectClass'))),
+            new StubMiddlewareHandler(OperationOutcomeResult::succeeded()),
+        );
+
+        $operations = $this->recorder->snapshot()->operations;
+
+        self::assertSame(
+            ['search' => 1],
+            $operations->counts,
+        );
+        self::assertSame(
+            [],
+            $operations->errors,
+        );
+        self::assertSame(
+            [ResultCode::SUCCESS => 1],
+            $operations->resultCodeCounts,
+        );
+    }
+
+    public function test_it_records_a_returned_failure_with_its_result_code(): void
+    {
+        $this->subject->process(
+            $this->contextFor(new SearchRequest(Filters::present('objectClass'))),
+            new StubMiddlewareHandler(OperationOutcomeResult::failed(ResultCode::NO_SUCH_OBJECT)),
+        );
+
+        $operations = $this->recorder->snapshot()->operations;
+
+        self::assertSame(
+            ['search' => 1],
+            $operations->errors,
+        );
+        self::assertSame(
+            [ResultCode::NO_SUCH_OBJECT => 1],
+            $operations->resultCodeCounts,
+        );
+    }
+
+    public function test_a_thrown_operation_exception_is_recorded_and_rethrown(): void
+    {
+        $caught = null;
+
+        try {
+            $this->subject->process(
+                $this->contextFor(new SimpleBindRequest('cn=user,dc=foo,dc=bar', 'secret')),
+                new ThrowingMiddlewareHandler(new OperationException(
+                    'Denied.',
+                    ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+                )),
+            );
+        } catch (OperationException $e) {
+            $caught = $e;
+        }
+
+        self::assertInstanceOf(
+            OperationException::class,
+            $caught,
+        );
+
+        $operations = $this->recorder->snapshot()->operations;
+
+        self::assertSame(
+            ['bind' => 1],
+            $operations->errors,
+        );
+        self::assertSame(
+            [ResultCode::INSUFFICIENT_ACCESS_RIGHTS => 1],
+            $operations->resultCodeCounts,
+        );
+    }
+
+    private function contextFor(RequestInterface $request): ServerRequestContext
+    {
+        return new ServerRequestContext(new LdapMessageRequest(
+            1,
+            $request,
+        ));
+    }
+}

--- a/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
@@ -29,7 +29,7 @@ use FreeDSx\Ldap\Protocol\Factory\HandlerRouteResolverInterface;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\AccessControl\OperationType;
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\Middleware\OperationAuthorizationMiddleware;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
 use FreeDSx\Ldap\Server\Token\TokenInterface;


### PR DESCRIPTION
This does 2 things:

1. Adds the metrics middleware that times and triggers the recording.
2. Returns the relevant result code through the operation outcome that returns through the middleware.

This still does not wire it in yet. Still just getting things in place.