### PR TITLE
[1.0.0] Better support cn=monitor updates via a child channel IPC

### DIFF
--- a/docs/Server/General-Usage.md
+++ b/docs/Server/General-Usage.md
@@ -35,6 +35,13 @@ General LDAP Server Usage
 The LdapServer class runs an LDAP server process that accepts client requests and sends back responses. It defaults to
 using a forking method (PCNTL) for handling client connections, which is only available on Linux.
 
+> **⚠️ PCNTL runner and the JIT**
+>
+> Under the PCNTL runner with high server load, PHP's JIT has been observed to cause instability in forked workers
+> (tracing JIT crashing, function JIT failing to serve). This appears related to current upstream JIT instability rather
+> than a FreeDSx issue. If you hit it, try running with `opcache.jit=off`. The single-process Swoole runner has not shown
+> this.
+
 The server has no built-in entry persistence. You provide a backend that implements the storage logic for your use
 case. Authentication is a separate, independently configurable concern. See [Providing a Backend](#providing-a-backend)
 and [Authentication](#authentication) for details.

--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -25,6 +25,8 @@ use FreeDSx\Ldap\Server\Clock\ClockInterface;
 use FreeDSx\Ldap\Server\Clock\SystemClock;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
 use FreeDSx\Ldap\Server\Metrics\File\FileSnapshotProvider;
+use FreeDSx\Ldap\Server\Metrics\File\FileSnapshotWriter;
+use FreeDSx\Ldap\Server\Metrics\File\SnapshotPublisher;
 use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
 use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
 use FreeDSx\Ldap\Server\Metrics\Recorder\InMemoryMetricsRecorder;
@@ -417,6 +419,7 @@ class Container
     {
         $options = $this->get(ServerOptions::class);
         $protocolFactoryProvider = $this->makeProtocolFactoryProvider();
+        $metricsRecorder = $this->get(MetricsRecorderInterface::class);
 
         if ($options->getUseSwooleRunner()) {
             return new SwooleServerRunner(
@@ -424,6 +427,7 @@ class Container
                 options: $options,
                 socketServerFactory: $this->get(SocketServerFactory::class),
                 protocolFactoryProvider: $protocolFactoryProvider,
+                metricsRecorder: $metricsRecorder,
             );
         }
 
@@ -432,6 +436,26 @@ class Container
             options: $options,
             socketServerFactory: $this->get(SocketServerFactory::class),
             protocolFactoryProvider: $protocolFactoryProvider,
+            metricsRecorder: $metricsRecorder,
+            snapshotPublisher: $this->makeSnapshotPublisher(),
+        );
+    }
+
+    /**
+     * The PCNTL parent publishes connection metrics to a file for forked children (serving cn=monitor) to read; built
+     * only when cn=monitor is enabled.
+     */
+    private function makeSnapshotPublisher(): ?SnapshotPublisher
+    {
+        $options = $this->get(ServerOptions::class);
+
+        if (!$options->isMonitorEnabled()) {
+            return null;
+        }
+
+        return new SnapshotPublisher(
+            $this->get(InMemoryMetricsRecorder::class),
+            new FileSnapshotWriter($this->monitorSnapshotPath($options)),
         );
     }
 

--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -32,6 +32,7 @@ use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
 use FreeDSx\Ldap\Server\Metrics\Recorder\InMemoryMetricsRecorder;
 use FreeDSx\Ldap\Server\Metrics\Recorder\MetricsRecorderChain;
 use FreeDSx\Ldap\Server\Metrics\Recorder\NullMetricsRecorder;
+use FreeDSx\Ldap\Server\Metrics\Rollup\OperationRollupCoordinator;
 use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\AllowUserChangeConstraint;
 use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\HistoryConstraint;
 use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\MinAgeConstraint;
@@ -438,7 +439,21 @@ class Container
             protocolFactoryProvider: $protocolFactoryProvider,
             metricsRecorder: $metricsRecorder,
             snapshotPublisher: $this->makeSnapshotPublisher(),
+            operationRollup: $this->makeOperationRollup(),
         );
+    }
+
+    /**
+     * The child-to-parent operation rollup for the forking runner, over the shared in-memory recorder; built only when
+     * cn=monitor is enabled.
+     */
+    private function makeOperationRollup(): ?OperationRollupCoordinator
+    {
+        if (!$this->get(ServerOptions::class)->isMonitorEnabled()) {
+            return null;
+        }
+
+        return new OperationRollupCoordinator($this->get(InMemoryMetricsRecorder::class));
     }
 
     /**

--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -233,6 +233,12 @@ class Container
             className: MetricsSnapshotProvider::class,
             factory: $this->makeMetricsSnapshotProvider(...),
         );
+        $this->registerFactory(
+            className: OperationRollupCoordinator::class,
+            factory: fn(): OperationRollupCoordinator => new OperationRollupCoordinator(
+                $this->get(InMemoryMetricsRecorder::class),
+            ),
+        );
     }
 
     /**
@@ -361,6 +367,7 @@ class Container
             policyComponentFactory: $this->get(PasswordPolicyComponentFactory::class),
             metricsRecorder: $this->get(MetricsRecorderInterface::class),
             metricsSnapshots: $this->get(MetricsSnapshotProvider::class),
+            operationRollup: $this->makeOperationRollup(),
         );
     }
 
@@ -453,7 +460,7 @@ class Container
             return null;
         }
 
-        return new OperationRollupCoordinator($this->get(InMemoryMetricsRecorder::class));
+        return $this->get(OperationRollupCoordinator::class);
     }
 
     /**
@@ -485,16 +492,19 @@ class Container
             ? $this->get(ProxyOptions::class)
             : null;
 
-        // Share the metrics state across reloads so SIGHUP does not reset the counters or detach cn=monitor.
+        // Share the metrics state across reloads so SIGHUP does not reset the counters or detach cn=monitor. The rollup
+        // coordinator is shared so a reloaded middleware streams to the same channel the (persistent) runner bound.
         $metricsRecorder = $this->get(MetricsRecorderInterface::class);
         $metricsSnapshots = $this->get(MetricsSnapshotProvider::class);
         $inMemoryMetrics = $this->get(InMemoryMetricsRecorder::class);
+        $operationRollup = $this->makeOperationRollup();
 
         return static function (ServerOptions $options) use (
             $proxyOptions,
             $metricsRecorder,
             $metricsSnapshots,
             $inMemoryMetrics,
+            $operationRollup,
         ): ServerProtocolFactoryInterface {
             $instances = [
                 ServerOptions::class => $options,
@@ -505,6 +515,10 @@ class Container
 
             if ($proxyOptions !== null) {
                 $instances[ProxyOptions::class] = $proxyOptions;
+            }
+
+            if ($operationRollup !== null) {
+                $instances[OperationRollupCoordinator::class] = $operationRollup;
             }
 
             return (new Container($instances))->get(ServerProtocolFactoryInterface::class);

--- a/src/FreeDSx/Ldap/Server/Metrics/File/SnapshotPublisher.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/File/SnapshotPublisher.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\File;
+
+use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
+
+/**
+ * Publishes the current metrics snapshot to a file so another process can read it (the PCNTL parent-to-child channel).
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class SnapshotPublisher
+{
+    public function __construct(
+        private MetricsSnapshotProvider $source,
+        private FileSnapshotWriter $writer,
+    ) {}
+
+    public function publish(): void
+    {
+        $this->writer->write($this->source->snapshot());
+    }
+
+    public function remove(): void
+    {
+        $this->writer->remove();
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/Recorder/InMemoryMetricsRecorder.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Recorder/InMemoryMetricsRecorder.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
 use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
 use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
 use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
+use FreeDSx\Ldap\Server\Metrics\Rollup\OperationRollupInterface;
 use FreeDSx\Ldap\Server\Metrics\Snapshot\ConnectionMetrics;
 use FreeDSx\Ldap\Server\Metrics\Snapshot\LifecycleMetrics;
 use FreeDSx\Ldap\Server\Metrics\Snapshot\MetricsSnapshot;
@@ -29,7 +30,7 @@ use function max;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final class InMemoryMetricsRecorder implements MetricsRecorderInterface, MetricsSnapshotProvider
+final class InMemoryMetricsRecorder implements MetricsRecorderInterface, MetricsSnapshotProvider, OperationRollupInterface
 {
     private int $startedAt = 0;
 
@@ -142,6 +143,47 @@ final class InMemoryMetricsRecorder implements MetricsRecorderInterface, Metrics
                 $this->resultCodeCounts,
             ),
         );
+    }
+
+    public function takeOperationDelta(): OperationMetrics
+    {
+        $delta = new OperationMetrics(
+            $this->operationCounts,
+            $this->operationErrors,
+            $this->operationDurationSeconds,
+            $this->resultCodeCounts,
+        );
+
+        $this->resetOperations();
+
+        return $delta;
+    }
+
+    public function resetOperations(): void
+    {
+        $this->operationCounts = [];
+        $this->operationErrors = [];
+        $this->operationDurationSeconds = [];
+        $this->resultCodeCounts = [];
+    }
+
+    public function mergeOperations(OperationMetrics $delta): void
+    {
+        foreach ($delta->counts as $operation => $count) {
+            $this->operationCounts[$operation] = max(0, ($this->operationCounts[$operation] ?? 0) + $count);
+        }
+
+        foreach ($delta->errors as $operation => $count) {
+            $this->operationErrors[$operation] = max(0, ($this->operationErrors[$operation] ?? 0) + $count);
+        }
+
+        foreach ($delta->durationSeconds as $operation => $seconds) {
+            $this->operationDurationSeconds[$operation] = ($this->operationDurationSeconds[$operation] ?? 0.0) + $seconds;
+        }
+
+        foreach ($delta->resultCodeCounts as $code => $count) {
+            $this->resultCodeCounts[$code] = max(0, ($this->resultCodeCounts[$code] ?? 0) + $count);
+        }
     }
 
     private function onOpened(): void

--- a/src/FreeDSx/Ldap/Server/Metrics/Rollup/OperationDeltaMessage.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Rollup/OperationDeltaMessage.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\Rollup;
+
+use FreeDSx\Ldap\Server\Metrics\Snapshot\OperationMetrics;
+use FreeDSx\Ldap\Server\Process\ChannelMessage;
+
+/**
+ * Carries a child process's operation-metrics delta to the parent over a ChildChannel.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class OperationDeltaMessage implements ChannelMessage
+{
+    public function __construct(private OperationMetrics $operations) {}
+
+    public function operations(): OperationMetrics
+    {
+        return $this->operations;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->operations->toArray();
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/Rollup/OperationDeltaMessageFactory.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Rollup/OperationDeltaMessageFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\Rollup;
+
+use FreeDSx\Ldap\Server\Metrics\Snapshot\OperationMetrics;
+use FreeDSx\Ldap\Server\Process\ChannelMessage;
+use FreeDSx\Ldap\Server\Process\ChannelMessageFactory;
+
+/**
+ * Rebuilds an OperationDeltaMessage from its wire form on the parent's end of a ChildChannel.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class OperationDeltaMessageFactory implements ChannelMessageFactory
+{
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    public function fromArray(array $data): ChannelMessage
+    {
+        return new OperationDeltaMessage(OperationMetrics::fromArray($data));
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/Rollup/OperationRollupCoordinator.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Rollup/OperationRollupCoordinator.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\Rollup;
+
+use FreeDSx\Ldap\Server\Process\ChannelMessageFactory;
+use FreeDSx\Ldap\Server\Process\ChildChannel;
+
+/**
+ * Moves child operation metrics to the parent over a ChildChannel.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class OperationRollupCoordinator
+{
+    public function __construct(
+        private OperationRollupInterface $recorder,
+        private ChannelMessageFactory $messageFactory = new OperationDeltaMessageFactory(),
+    ) {}
+
+    public function openChannel(): ChildChannel
+    {
+        return ChildChannel::create($this->messageFactory);
+    }
+
+    /**
+     * Clear the operations inherited from the parent so a fresh child reports only its own.
+     */
+    public function startChild(): void
+    {
+        $this->recorder->resetOperations();
+    }
+
+    /**
+     * Send this child's operation delta to the parent, then close the write end so the parent reads EOF.
+     */
+    public function reportChild(ChildChannel $channel): void
+    {
+        $channel->send(new OperationDeltaMessage($this->recorder->takeOperationDelta()));
+        $channel->closeWrite();
+    }
+
+    /**
+     * Fold any operation deltas a reaped child reported into the parent totals.
+     */
+    public function collect(ChildChannel $channel): void
+    {
+        foreach ($channel->receive() as $message) {
+            if ($message instanceof OperationDeltaMessage) {
+                $this->recorder->mergeOperations($message->operations());
+            }
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/Rollup/OperationRollupCoordinator.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Rollup/OperationRollupCoordinator.php
@@ -21,11 +21,13 @@ use FreeDSx\Ldap\Server\Process\ChildChannel;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final readonly class OperationRollupCoordinator
+final class OperationRollupCoordinator
 {
+    private ?ChildChannel $boundChannel = null;
+
     public function __construct(
-        private OperationRollupInterface $recorder,
-        private ChannelMessageFactory $messageFactory = new OperationDeltaMessageFactory(),
+        private readonly OperationRollupInterface $recorder,
+        private readonly ChannelMessageFactory $messageFactory = new OperationDeltaMessageFactory(),
     ) {}
 
     public function openChannel(): ChildChannel
@@ -34,24 +36,33 @@ final readonly class OperationRollupCoordinator
     }
 
     /**
-     * Clear the operations inherited from the parent so a fresh child reports only its own.
+     * In the child: clear operations inherited from the parent and bind the channel this child reports on.
      */
-    public function startChild(): void
+    public function enterChild(ChildChannel $channel): void
     {
         $this->recorder->resetOperations();
+        $this->boundChannel = $channel;
     }
 
     /**
-     * Send this child's operation delta to the parent, then close the write end so the parent reads EOF.
+     * In the child: report the operations recorded since the last flush.
      */
-    public function reportChild(ChildChannel $channel): void
+    public function flush(): void
     {
-        $channel->send(new OperationDeltaMessage($this->recorder->takeOperationDelta()));
-        $channel->closeWrite();
+        $this->boundChannel?->send(new OperationDeltaMessage($this->recorder->takeOperationDelta()));
     }
 
     /**
-     * Fold any operation deltas a reaped child reported into the parent totals.
+     * In the child: send a final flush, then close the write end so the parent reads EOF.
+     */
+    public function finish(): void
+    {
+        $this->flush();
+        $this->boundChannel?->closeWrite();
+    }
+
+    /**
+     * In the parent: fold any operation deltas available on a child's channel into the totals.
      */
     public function collect(ChildChannel $channel): void
     {

--- a/src/FreeDSx/Ldap/Server/Metrics/Rollup/OperationRollupInterface.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Rollup/OperationRollupInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\Rollup;
+
+use FreeDSx\Ldap\Server\Metrics\Snapshot\OperationMetrics;
+
+/**
+ * Moves operation metrics between a child and the parent's authoritative totals.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface OperationRollupInterface
+{
+    /**
+     * Return the operation metrics accumulated since the last call and reset them to zero.
+     */
+    public function takeOperationDelta(): OperationMetrics;
+
+    /**
+     * Clear the operation accumulators.
+     */
+    public function resetOperations(): void;
+
+    /**
+     * Fold an operation-metrics delta reported by a child process into the totals.
+     */
+    public function mergeOperations(OperationMetrics $delta): void;
+}

--- a/src/FreeDSx/Ldap/Server/Middleware/MetricsMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/MetricsMiddleware.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
 use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
+use FreeDSx\Ldap\Server\Metrics\Rollup\OperationRollupCoordinator;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
@@ -33,8 +34,13 @@ use function microtime;
  */
 final readonly class MetricsMiddleware implements MiddlewareInterface
 {
+    /**
+     * @param OperationRollupCoordinator|null $rollup Streams each op to the parent so cn=monitor stays fresh on
+     *                                                long-lived connections (null under Swoole and when monitor is off).
+     */
     public function __construct(
         private MetricsRecorderInterface $recorder,
+        private ?OperationRollupCoordinator $rollup = null,
     ) {}
 
     public function process(
@@ -79,5 +85,6 @@ final readonly class MetricsMiddleware implements MiddlewareInterface
             $durationSeconds,
             $resultCode,
         ));
+        $this->rollup?->flush();
     }
 }

--- a/src/FreeDSx/Ldap/Server/Process/ChannelMessage.php
+++ b/src/FreeDSx/Ldap/Server/Process/ChannelMessage.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Process;
+
+/**
+ * A message that can be sent between processes over a ChildChannel.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface ChannelMessage
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+}

--- a/src/FreeDSx/Ldap/Server/Process/ChannelMessageFactory.php
+++ b/src/FreeDSx/Ldap/Server/Process/ChannelMessageFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Process;
+
+/**
+ * Reconstructs a ChannelMessage from its wire form on the receiving end of a ChildChannel.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface ChannelMessageFactory
+{
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    public function fromArray(array $data): ChannelMessage;
+}

--- a/src/FreeDSx/Ldap/Server/Process/ChildChannel.php
+++ b/src/FreeDSx/Ldap/Server/Process/ChildChannel.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Process;
+
+use FreeDSx\Ldap\Exception\RuntimeException;
+
+use function explode;
+use function fclose;
+use function fread;
+use function fwrite;
+use function is_resource;
+use function json_decode;
+use function json_encode;
+use function stream_set_blocking;
+use function stream_socket_pair;
+use function strlen;
+use function strrpos;
+use function substr;
+
+/**
+ * A framed message channel between the parent and child process over a socket pair.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class ChildChannel
+{
+    private const FRAME_DELIMITER = "\n";
+
+    private const READ_CHUNK_SIZE = 8192;
+
+    /**
+     * @var resource
+     */
+    private $readEnd;
+
+    /**
+     * @var resource
+     */
+    private $writeEnd;
+
+    private string $readBuffer = '';
+
+    /**
+     * @param resource $readEnd
+     * @param resource $writeEnd
+     */
+    public function __construct(
+        $readEnd,
+        $writeEnd,
+        private readonly ChannelMessageFactory $messageFactory,
+    ) {
+        $this->readEnd = $readEnd;
+        $this->writeEnd = $writeEnd;
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    public static function create(ChannelMessageFactory $messageFactory): self
+    {
+        $pair = stream_socket_pair(
+            STREAM_PF_UNIX,
+            STREAM_SOCK_STREAM,
+            0,
+        );
+
+        if ($pair === false) {
+            throw new RuntimeException('Unable to create a child process channel.');
+        }
+
+        // The parent reads without blocking
+        // The write end stays blocking so the child's small frames flush whole.
+        stream_set_blocking(
+            $pair[0],
+            false,
+        );
+
+        return new self(
+            $pair[0],
+            $pair[1],
+            $messageFactory,
+        );
+    }
+
+    /**
+     * Keep the write end in the child; the read end belongs to the parent.
+     */
+    public function childKeepWrite(): void
+    {
+        if (is_resource($this->readEnd)) {
+            fclose($this->readEnd);
+        }
+    }
+
+    /**
+     * Keep the read end in the parent; the write end belongs to the child.
+     */
+    public function parentKeepRead(): void
+    {
+        if (is_resource($this->writeEnd)) {
+            fclose($this->writeEnd);
+        }
+    }
+
+    public function send(ChannelMessage $message): void
+    {
+        if (!is_resource($this->writeEnd)) {
+            return;
+        }
+
+        $encoded = json_encode($message->toArray());
+        if ($encoded === false) {
+            return;
+        }
+
+        $this->writeAll($encoded . self::FRAME_DELIMITER);
+    }
+
+    /**
+     * Non-blocking drain of any complete messages currently available.
+     *
+     * @return list<ChannelMessage>
+     */
+    public function receive(): array
+    {
+        $this->fillReadBuffer();
+
+        $boundary = strrpos(
+            $this->readBuffer,
+            self::FRAME_DELIMITER,
+        );
+        if ($boundary === false) {
+            return [];
+        }
+
+        $complete = substr(
+            $this->readBuffer,
+            0,
+            $boundary,
+        );
+        $this->readBuffer = substr(
+            $this->readBuffer,
+            $boundary + 1,
+        );
+
+        $messages = [];
+        foreach (explode(self::FRAME_DELIMITER, $complete) as $frame) {
+            if ($frame === '') {
+                continue;
+            }
+
+            $decoded = json_decode(
+                $frame,
+                associative: true,
+            );
+            if (!is_array($decoded)) {
+                continue;
+            }
+
+            $messages[] = $this->messageFactory->fromArray($decoded);
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Close the write end so the parent observes EOF after the final message.
+     */
+    public function closeWrite(): void
+    {
+        if (is_resource($this->writeEnd)) {
+            fclose($this->writeEnd);
+        }
+    }
+
+    public function close(): void
+    {
+        if (is_resource($this->readEnd)) {
+            fclose($this->readEnd);
+        }
+
+        if (is_resource($this->writeEnd)) {
+            fclose($this->writeEnd);
+        }
+    }
+
+    private function fillReadBuffer(): void
+    {
+        if (!is_resource($this->readEnd)) {
+            return;
+        }
+
+        while (true) {
+            $chunk = fread($this->readEnd, self::READ_CHUNK_SIZE);
+            if ($chunk === false || $chunk === '') {
+                break;
+            }
+
+            $this->readBuffer .= $chunk;
+        }
+    }
+
+    private function writeAll(string $payload): void
+    {
+        $length = strlen($payload);
+        $written = 0;
+
+        while ($written < $length) {
+            $result = fwrite(
+                $this->writeEnd,
+                substr($payload, $written),
+            );
+
+            if ($result === false || $result === 0) {
+                return;
+            }
+
+            $written += $result;
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Process/ChildProcess.php
+++ b/src/FreeDSx/Ldap/Server/Process/ChildProcess.php
@@ -11,23 +11,17 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap\Server;
+namespace FreeDSx\Ldap\Server\Process;
 
 use FreeDSx\Socket\Socket;
 
-class ChildProcess
+readonly class ChildProcess
 {
-    private int $pid;
-
-    private Socket $socket;
-
     public function __construct(
-        int $pid,
-        Socket $socket,
-    ) {
-        $this->pid = $pid;
-        $this->socket = $socket;
-    }
+        private int $pid,
+        private Socket $socket,
+        private ?ChildChannel $channel = null,
+    ) {}
 
     public function getPid(): int
     {
@@ -37,6 +31,11 @@ class ChildProcess
     public function getSocket(): Socket
     {
         return $this->socket;
+    }
+
+    public function getChannel(): ?ChildChannel
+    {
+        return $this->channel;
     }
 
     public function closeSocket(): void

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -45,6 +45,7 @@ use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
 use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
 use FreeDSx\Ldap\Server\Metrics\Recorder\InMemoryMetricsRecorder;
 use FreeDSx\Ldap\Server\Metrics\Recorder\NullMetricsRecorder;
+use FreeDSx\Ldap\Server\Metrics\Rollup\OperationRollupCoordinator;
 use FreeDSx\Ldap\Server\Middleware\AssertionMiddleware;
 use FreeDSx\Ldap\Server\Middleware\AuthorizationResolutionMiddleware;
 use FreeDSx\Ldap\Server\Middleware\MetricsMiddleware;
@@ -80,6 +81,7 @@ class ServerProtocolFactory implements ServerProtocolFactoryInterface
         private readonly PasswordPolicyComponentFactory $policyComponentFactory,
         private readonly MetricsRecorderInterface $metricsRecorder = new NullMetricsRecorder(),
         private readonly MetricsSnapshotProvider $metricsSnapshots = new InMemoryMetricsRecorder(),
+        private readonly ?OperationRollupCoordinator $operationRollup = null,
     ) {}
 
     protected function serverOptions(): ServerOptions
@@ -182,7 +184,10 @@ class ServerProtocolFactory implements ServerProtocolFactoryInterface
             requestPipeline: new MiddlewareChain(
                 [
                     // First, so it times and records every message (including binds) regardless of outcome.
-                    new MetricsMiddleware($this->metricsRecorder),
+                    new MetricsMiddleware(
+                        $this->metricsRecorder,
+                        $this->operationRollup,
+                    ),
                     // Order matters: AuthorizationResolutionMiddleware injects the token via withToken(), so
                     // every middleware after it may rely on tokenOrFail(). Keep token consumers below it.
                     new RequestValidationMiddleware(),

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -154,7 +154,12 @@ class PcntlServerRunner implements ServerRunnerInterface
                         ['child_pid' => $childProcess->getPid()],
                     ),
                 );
+
+                continue;
             }
+
+            // update cn=monitor with fresh stats.
+            $this->collectOperationDelta($childProcess);
         }
 
         $this->publishMetricsSnapshot();
@@ -166,9 +171,9 @@ class PcntlServerRunner implements ServerRunnerInterface
     }
 
     /**
-     * Fold a reaped child's final operation metrics into the parent totals, then close its channel.
+     * Fold the operation deltas available on a live child's channel into the parent totals.
      */
-    private function drainOperationDelta(ChildProcess $childProcess): void
+    private function collectOperationDelta(ChildProcess $childProcess): void
     {
         $channel = $childProcess->getChannel();
 
@@ -177,7 +182,15 @@ class PcntlServerRunner implements ServerRunnerInterface
         }
 
         $this->operationRollup->collect($channel);
-        $channel->close();
+    }
+
+    /**
+     * Fold a reaped child's final operation metrics into the parent totals, then close its channel.
+     */
+    private function drainOperationDelta(ChildProcess $childProcess): void
+    {
+        $this->collectOperationDelta($childProcess);
+        $childProcess->getChannel()?->close();
     }
 
     /**
@@ -412,7 +425,9 @@ class PcntlServerRunner implements ServerRunnerInterface
         $this->server->close(shutdown: false);
         $this->closeInheritedChannels();
         $channel?->childKeepWrite();
-        $this->operationRollup?->startChild();
+        if ($channel !== null) {
+            $this->operationRollup?->enterChild($channel);
+        }
 
         $context = ['pid' => $pid];
         $this->isMainProcess = false;
@@ -440,7 +455,7 @@ class PcntlServerRunner implements ServerRunnerInterface
         try {
             $serverProtocolHandler->handle();
         } finally {
-            $this->flushOperationDelta($channel);
+            $this->operationRollup?->finish();
         }
 
         $this->logInfo(
@@ -459,18 +474,6 @@ class PcntlServerRunner implements ServerRunnerInterface
         foreach ($this->childProcesses as $childProcess) {
             $childProcess->getChannel()?->close();
         }
-    }
-
-    /**
-     * Report this child's operation metrics to the parent, then close the write end so the parent reads EOF.
-     */
-    private function flushOperationDelta(?ChildChannel $channel): void
-    {
-        if ($channel === null || $this->operationRollup === null) {
-            return;
-        }
-
-        $this->operationRollup->reportChild($channel);
     }
 
     private function makeChildChannel(): ?ChildChannel

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -19,6 +19,10 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Server\ChildProcess;
 use FreeDSx\Ldap\Server\Backend\ResettableInterface;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
+use FreeDSx\Ldap\Server\Metrics\File\SnapshotPublisher;
+use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
+use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
+use FreeDSx\Ldap\Server\Metrics\Recorder\NullMetricsRecorder;
 use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
 use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Socket\Socket;
@@ -70,6 +74,8 @@ class PcntlServerRunner implements ServerRunnerInterface
         ServerOptions $options,
         private readonly SocketServerFactory $socketServerFactory,
         Closure $protocolFactoryProvider,
+        private readonly MetricsRecorderInterface $metricsRecorder = new NullMetricsRecorder(),
+        private readonly ?SnapshotPublisher $snapshotPublisher = null,
     ) {
         if (!extension_loaded('pcntl')) {
             throw new RuntimeException(
@@ -136,6 +142,7 @@ class PcntlServerRunner implements ServerRunnerInterface
                 $socket = $childProcess->getSocket();
                 $this->server->removeClient($socket);
                 $socket->close();
+                $this->metricsRecorder->connectionObserved(ConnectionObservation::Closed);
                 $this->logInfo(
                     'The child process has ended.',
                     array_merge(
@@ -145,6 +152,13 @@ class PcntlServerRunner implements ServerRunnerInterface
                 );
             }
         }
+
+        $this->publishMetricsSnapshot();
+    }
+
+    private function publishMetricsSnapshot(): void
+    {
+        $this->snapshotPublisher?->publish();
     }
 
     /**
@@ -155,6 +169,8 @@ class PcntlServerRunner implements ServerRunnerInterface
     {
         $this->installServerSignalHandlers();
         $this->logServerStarted($this->defaultContext);
+        $this->metricsRecorder->serverStarted(time());
+        $this->publishMetricsSnapshot();
         $this->options->getOnServerReady()?->__invoke();
 
         do {
@@ -179,6 +195,8 @@ class PcntlServerRunner implements ServerRunnerInterface
             $maxConnections = $this->options->getMaxConnections();
             if ($maxConnections > 0 && count($this->childProcesses) >= $maxConnections) {
                 $this->logConnectionLimitReached($this->defaultContext);
+                $this->metricsRecorder->connectionObserved(ConnectionObservation::Rejected);
+                $this->publishMetricsSnapshot();
 
                 $this->server->removeClient($socket);
                 $socket->close();
@@ -267,7 +285,9 @@ class PcntlServerRunner implements ServerRunnerInterface
         pcntl_signal(
             SIGHUP,
             function () {
+                $this->metricsRecorder->serverReloaded(time());
                 $this->reloadConfiguration($this->defaultContext);
+                $this->publishMetricsSnapshot();
             },
         );
     }
@@ -318,6 +338,7 @@ class PcntlServerRunner implements ServerRunnerInterface
         }
 
         $this->server->close();
+        $this->snapshotPublisher?->remove();
         $this->logShutdownCompleted($this->defaultContext);
     }
 
@@ -410,6 +431,7 @@ class PcntlServerRunner implements ServerRunnerInterface
             $pid,
             $socket,
         );
+        $this->metricsRecorder->connectionObserved(ConnectionObservation::Opened);
         $this->logClientConnected(
             array_merge(
                 ['child_pid' => $pid],

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -16,13 +16,15 @@ namespace FreeDSx\Ldap\Server\ServerRunner;
 use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
-use FreeDSx\Ldap\Server\ChildProcess;
 use FreeDSx\Ldap\Server\Backend\ResettableInterface;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Metrics\File\SnapshotPublisher;
 use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
 use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
 use FreeDSx\Ldap\Server\Metrics\Recorder\NullMetricsRecorder;
+use FreeDSx\Ldap\Server\Metrics\Rollup\OperationRollupCoordinator;
+use FreeDSx\Ldap\Server\Process\ChildChannel;
+use FreeDSx\Ldap\Server\Process\ChildProcess;
 use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
 use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Socket\Socket;
@@ -76,6 +78,7 @@ class PcntlServerRunner implements ServerRunnerInterface
         Closure $protocolFactoryProvider,
         private readonly MetricsRecorderInterface $metricsRecorder = new NullMetricsRecorder(),
         private readonly ?SnapshotPublisher $snapshotPublisher = null,
+        private readonly ?OperationRollupCoordinator $operationRollup = null,
     ) {
         if (!extension_loaded('pcntl')) {
             throw new RuntimeException(
@@ -139,6 +142,7 @@ class PcntlServerRunner implements ServerRunnerInterface
 
             if ($result === -1 || $result > 0) {
                 unset($this->childProcesses[$index]);
+                $this->drainOperationDelta($childProcess);
                 $socket = $childProcess->getSocket();
                 $this->server->removeClient($socket);
                 $socket->close();
@@ -159,6 +163,21 @@ class PcntlServerRunner implements ServerRunnerInterface
     private function publishMetricsSnapshot(): void
     {
         $this->snapshotPublisher?->publish();
+    }
+
+    /**
+     * Fold a reaped child's final operation metrics into the parent totals, then close its channel.
+     */
+    private function drainOperationDelta(ChildProcess $childProcess): void
+    {
+        $channel = $childProcess->getChannel();
+
+        if ($channel === null || $this->operationRollup === null) {
+            return;
+        }
+
+        $this->operationRollup->collect($channel);
+        $channel->close();
     }
 
     /**
@@ -204,9 +223,12 @@ class PcntlServerRunner implements ServerRunnerInterface
                 continue;
             }
 
+            $channel = $this->makeChildChannel();
+
             $pid = pcntl_fork();
             if ($pid == -1) {
                 // In parent process, but could not fork...
+                $channel?->close();
                 $this->logAndThrow(
                     'Unable to fork process.',
                     $this->defaultContext,
@@ -216,12 +238,14 @@ class PcntlServerRunner implements ServerRunnerInterface
                 $this->runChildProcessThenExit(
                     $socket,
                     posix_getpid(),
+                    $channel,
                 );
             } else {
                 // We are in the parent; the PID is the child process.
                 $this->runAfterChildStarted(
                     $pid,
                     $socket,
+                    $channel,
                 );
             }
             // Use the shutdown flag, not the socket state (not reliable after forking)
@@ -382,9 +406,13 @@ class PcntlServerRunner implements ServerRunnerInterface
     private function runChildProcessThenExit(
         Socket $socket,
         int $pid,
+        ?ChildChannel $channel,
     ): never {
         // Cleanup the child's inherited FD copy without shutting down the parent accept loop.
         $this->server->close(shutdown: false);
+        $this->closeInheritedChannels();
+        $channel?->childKeepWrite();
+        $this->operationRollup?->startChild();
 
         $context = ['pid' => $pid];
         $this->isMainProcess = false;
@@ -408,13 +436,62 @@ class PcntlServerRunner implements ServerRunnerInterface
             'Handling LDAP connection in new child process.',
             $context,
         );
-        $serverProtocolHandler->handle();
+
+        try {
+            $serverProtocolHandler->handle();
+        } finally {
+            $this->flushOperationDelta($channel);
+        }
+
         $this->logInfo(
             'The child process is ending.',
             $context,
         );
 
         exit(0);
+    }
+
+    /**
+     * Close the parent's channel read ends inherited by this fork so they do not leak in the child.
+     */
+    private function closeInheritedChannels(): void
+    {
+        foreach ($this->childProcesses as $childProcess) {
+            $childProcess->getChannel()?->close();
+        }
+    }
+
+    /**
+     * Report this child's operation metrics to the parent, then close the write end so the parent reads EOF.
+     */
+    private function flushOperationDelta(?ChildChannel $channel): void
+    {
+        if ($channel === null || $this->operationRollup === null) {
+            return;
+        }
+
+        $this->operationRollup->reportChild($channel);
+    }
+
+    private function makeChildChannel(): ?ChildChannel
+    {
+        if ($this->operationRollup === null) {
+            return null;
+        }
+
+        try {
+            return $this->operationRollup->openChannel();
+        } catch (RuntimeException $e) {
+            $this->logInfo(
+                'Unable to create a child metrics channel; continuing without operation rollup.',
+                array_merge(
+                    $this->defaultContext,
+                    ['error' => $e->getMessage()],
+                ),
+            );
+
+            return null;
+        }
     }
 
     /**
@@ -426,10 +503,13 @@ class PcntlServerRunner implements ServerRunnerInterface
     private function runAfterChildStarted(
         int $pid,
         Socket $socket,
+        ?ChildChannel $channel,
     ): void {
+        $channel?->parentKeepRead();
         $this->childProcesses[] = new ChildProcess(
             $pid,
             $socket,
+            $channel,
         );
         $this->metricsRecorder->connectionObserved(ConnectionObservation::Opened);
         $this->logClientConnected(

--- a/src/FreeDSx/Ldap/Server/ServerRunner/SwooleServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/SwooleServerRunner.php
@@ -16,6 +16,9 @@ namespace FreeDSx\Ldap\Server\ServerRunner;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
+use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
+use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
+use FreeDSx\Ldap\Server\Metrics\Recorder\NullMetricsRecorder;
 use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
 use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Ldap\ServerOptions;
@@ -79,6 +82,7 @@ class SwooleServerRunner implements ServerRunnerInterface
         ServerOptions $options,
         private readonly SocketServerFactory $socketServerFactory,
         Closure $protocolFactoryProvider,
+        private readonly MetricsRecorderInterface $metricsRecorder = new NullMetricsRecorder(),
     ) {
         if (!extension_loaded('swoole')) {
             throw new RuntimeException(
@@ -125,6 +129,7 @@ class SwooleServerRunner implements ServerRunnerInterface
 
     private function handleReloadSignal(int $signal): void
     {
+        $this->metricsRecorder->serverReloaded(time());
         $this->reloadConfiguration(['signal' => $signal]);
     }
 
@@ -175,6 +180,7 @@ class SwooleServerRunner implements ServerRunnerInterface
     private function acceptClients(): void
     {
         $this->logServerStarted();
+        $this->metricsRecorder->serverStarted(time());
         $this->options->getOnServerReady()?->__invoke();
 
         while (!$this->isShuttingDown) {
@@ -193,6 +199,7 @@ class SwooleServerRunner implements ServerRunnerInterface
             $maxConnections = $this->options->getMaxConnections();
             if ($maxConnections > 0 && count($this->activeSockets) >= $maxConnections) {
                 $this->logConnectionLimitReached(['max_connections' => $maxConnections]);
+                $this->metricsRecorder->connectionObserved(ConnectionObservation::Rejected);
                 $socket->close();
                 continue;
             }
@@ -201,12 +208,14 @@ class SwooleServerRunner implements ServerRunnerInterface
             Coroutine::create(function () use ($socket): void {
                 $socketId = spl_object_id($socket);
                 $this->activeSockets[$socketId] = $socket;
+                $this->metricsRecorder->connectionObserved(ConnectionObservation::Opened);
                 try {
                     $this->handleClient($socket, $socketId);
                 } finally {
                     $this->server->removeClient($socket);
                     unset($this->activeSockets[$socketId]);
                     unset($this->activeHandlers[$socketId]);
+                    $this->metricsRecorder->connectionObserved(ConnectionObservation::Closed);
                     $this->waitGroup->done();
                 }
             });

--- a/tests/performance/Config.php
+++ b/tests/performance/Config.php
@@ -86,6 +86,7 @@ final class Config
         public readonly string $writeBase = self::DEFAULT_WRITE_BASE,
         public readonly bool $jit = true,
         public readonly int $searchSubSizeLimit = self::DEFAULT_SEARCH_SUB_SIZE_LIMIT,
+        public readonly bool $monitor = false,
     ) {
         $this->assertEnum('backend', $backend, self::BACKENDS);
         $this->assertEnum('runner', $runner, self::RUNNERS);

--- a/tests/performance/Driver.php
+++ b/tests/performance/Driver.php
@@ -37,8 +37,13 @@ final class Driver
         private readonly Config $config,
     ) {}
 
-    public function run(OutputInterface $output): StatsSnapshot
-    {
+    /**
+     * @param (callable(): void)|null $afterRun Invoked once the run completes but before the server is torn down.
+     */
+    public function run(
+        OutputInterface $output,
+        ?callable $afterRun = null,
+    ): StatsSnapshot {
         $this->assertSwooleAvailable();
 
         if ($this->config->rngSeed !== null) {
@@ -67,10 +72,16 @@ final class Driver
         $progress->writeln($this->describeRunStart());
 
         try {
-            return $this->runCoroutinePool(
+            $snapshot = $this->runCoroutinePool(
                 $mix,
                 $stats,
             );
+            // While the server is still up, let the caller read cn=monitor for an apples-to-apples cross-check.
+            if ($afterRun !== null) {
+                $afterRun();
+            }
+
+            return $snapshot;
         } finally {
             $serverManager?->stop();
         }

--- a/tests/performance/LoadTestCommand.php
+++ b/tests/performance/LoadTestCommand.php
@@ -193,7 +193,13 @@ final class LoadTestCommand extends Command
                 'no-jit',
                 null,
                 InputOption::VALUE_NONE,
-                'Disable opcache + tracing JIT on the spawned FreeDSx server (default: enabled).',
+                'Disable opcache + tracing JIT on the spawned FreeDSx server (default: enabled for swoole, off for pcntl).',
+            )
+            ->addOption(
+                'monitor',
+                null,
+                InputOption::VALUE_NONE,
+                'Enable cn=monitor (and the PCNTL operation rollup) on the spawned server to measure its overhead.',
             )
             ->addOption(
                 'search-sub-size-limit',
@@ -293,8 +299,11 @@ final class LoadTestCommand extends Command
             bindPassword: $this->requireString($input, 'bind-password'),
             baseDn: $this->requireString($input, 'base-dn'),
             writeBase: $this->requireString($input, 'write-base'),
-            jit: !(bool) $input->getOption('no-jit'),
+            // The spawned server defaults JIT off for pcntl (tracing JIT can crash forked workers under load)
+            // Swoole keeps it. --no-jit forces it off either way.
+            jit: !(bool) $input->getOption('no-jit') && $runner !== 'pcntl',
             searchSubSizeLimit: $this->requireInt($input, 'search-sub-size-limit'),
+            monitor: (bool) $input->getOption('monitor'),
         );
     }
 

--- a/tests/performance/LoadTestCommand.php
+++ b/tests/performance/LoadTestCommand.php
@@ -13,6 +13,10 @@ declare(strict_types=1);
 
 namespace Tests\Performance\FreeDSx\Ldap;
 
+use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\Search\Filters;
 use InvalidArgumentException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -199,7 +203,7 @@ final class LoadTestCommand extends Command
                 'monitor',
                 null,
                 InputOption::VALUE_NONE,
-                'Enable cn=monitor (and the PCNTL operation rollup) on the spawned server to measure its overhead.',
+                'Enable cn=monitor on the spawned server and print its counters after the run for cross-checking.',
             )
             ->addOption(
                 'search-sub-size-limit',
@@ -227,8 +231,18 @@ final class LoadTestCommand extends Command
             return Command::INVALID;
         }
 
+        $monitorEntry = null;
+        $afterRun = $config->monitor
+            ? function () use ($config, &$monitorEntry, $errorOutput): void {
+                $monitorEntry = $this->readMonitorEntry($config, $errorOutput);
+            }
+        : null;
+
         try {
-            $snapshot = (new Driver($config))->run($output);
+            $snapshot = (new Driver($config))->run(
+                $output,
+                $afterRun,
+            );
         } catch (Throwable $e) {
             $errorOutput->writeln('<error>Load test failed: ' . $e->getMessage() . '</error>');
 
@@ -237,6 +251,13 @@ final class LoadTestCommand extends Command
 
         $mix = new WorkloadMix($config->mix);
         (new Report($config, $mix, $snapshot))->render($output);
+
+        if ($monitorEntry !== null) {
+            $this->renderMonitorEntry(
+                $output,
+                $monitorEntry,
+            );
+        }
 
         if ($thresholds->isEmpty()) {
             return Command::SUCCESS;
@@ -262,6 +283,84 @@ final class LoadTestCommand extends Command
         );
 
         return Command::FAILURE;
+    }
+
+    /**
+     * Read the cn=monitor entry from the still-running server for cross-checking against the load-test totals.
+     *
+     * @return array<string, list<string>>|null
+     */
+    private function readMonitorEntry(
+        Config $config,
+        OutputInterface $errorOutput,
+    ): ?array {
+        // Let the forking parent reap the just-closed worker connections and fold their final deltas first.
+        usleep(500_000);
+
+        try {
+            $client = new LdapClient(
+                (new ClientOptions())
+                    ->setServers([$config->host])
+                    ->setPort($config->port),
+            );
+            $client->bind(
+                $config->bindDn,
+                $config->bindPassword,
+            );
+            $entries = $client->search(
+                Operations::search(Filters::present('objectClass'))
+                    ->base('cn=monitor')
+                    ->useBaseScope(),
+            );
+            $client->unbind();
+        } catch (Throwable $e) {
+            $errorOutput->writeln('<comment>Could not read cn=monitor: ' . $e->getMessage() . '</comment>');
+
+            return null;
+        }
+
+        foreach ($entries as $entry) {
+            $values = [];
+            foreach ($entry->getAttributes() as $attribute) {
+                $values[$attribute->getName()] = array_values($attribute->getValues());
+            }
+
+            return $values;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, list<string>> $entry
+     */
+    private function renderMonitorEntry(
+        OutputInterface $output,
+        array $entry,
+    ): void {
+        $output->writeln('');
+        $output->writeln(
+            'cn=monitor (monotonic since start; includes warmup, per-connection binds/unbinds, and this query):',
+        );
+
+        $attributes = [
+            'connectionsTotal',
+            'connectionsActive',
+            'operationsCompleted',
+            'operationsFailed',
+            'operationsByType',
+        ];
+        foreach ($attributes as $name) {
+            if (!isset($entry[$name])) {
+                continue;
+            }
+
+            $output->writeln(sprintf(
+                '  %s: %s',
+                $name,
+                implode(', ', $entry[$name]),
+            ));
+        }
     }
 
     private function buildConfig(InputInterface $input): Config

--- a/tests/performance/Server/ServerManager.php
+++ b/tests/performance/Server/ServerManager.php
@@ -59,6 +59,10 @@ final class ServerManager
         $command[] = '--port=' . $this->config->port;
         $command[] = '--seed-entries=' . $this->config->seedEntries;
 
+        if ($this->config->monitor) {
+            $command[] = '--monitor';
+        }
+
         $this->process = new Process($command);
 
         $this->process->start();
@@ -89,8 +93,8 @@ final class ServerManager
     }
 
     /**
-     * Avoids Symfony Process::stop()'s SIGTERM/wait/SIGKILL dance, which segfaults under
-     * tracing JIT when stopping a pcntl-runner backend.
+     * Avoids Symfony Process::stop()'s SIGTERM/wait/SIGKILL dance, which has been observed to segfault a pcntl-runner
+     * backend under tracing JIT (the JIT instability is load-related; stopping is just where it tended to surface).
      */
     private function signalAndReap(int $pid): void
     {

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -90,6 +90,12 @@ final class LdapBackendStorageCommand extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Grant cn=user the Proxied Authorization control for identities under ou=people',
+            )
+            ->addOption(
+                'monitor',
+                null,
+                InputOption::VALUE_NONE,
+                'Enable the cn=monitor entry',
             );
     }
 
@@ -188,6 +194,7 @@ final class LdapBackendStorageCommand extends Command
             ->setTransport($transport)
             ->setSocketAcceptTimeout(0.1)
             ->setSchemaValidationMode($validationMode)
+            ->setMonitorEnabled((bool) $input->getOption('monitor'))
             ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL));
 
         if ($input->getOption('allow-relax')) {

--- a/tests/support/Server/Process/FakeChannelMessage.php
+++ b/tests/support/Server/Process/FakeChannelMessage.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\FreeDSx\Ldap\Server\Process;
+
+use FreeDSx\Ldap\Server\Process\ChannelMessage;
+
+final readonly class FakeChannelMessage implements ChannelMessage
+{
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function __construct(private array $payload) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->payload;
+    }
+}

--- a/tests/support/Server/Process/FakeChannelMessageFactory.php
+++ b/tests/support/Server/Process/FakeChannelMessageFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\FreeDSx\Ldap\Server\Process;
+
+use FreeDSx\Ldap\Server\Process\ChannelMessage;
+use FreeDSx\Ldap\Server\Process\ChannelMessageFactory;
+
+final class FakeChannelMessageFactory implements ChannelMessageFactory
+{
+    /**
+     * @param array<array-key, mixed> $data
+     */
+    public function fromArray(array $data): ChannelMessage
+    {
+        /** @var array<string, mixed> $data */
+        return new FakeChannelMessage($data);
+    }
+}

--- a/tests/unit/Server/Metrics/File/SnapshotPublisherTest.php
+++ b/tests/unit/Server/Metrics/File/SnapshotPublisherTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Metrics\File;
+
+use FreeDSx\Ldap\Server\Metrics\File\FileSnapshotProvider;
+use FreeDSx\Ldap\Server\Metrics\File\FileSnapshotWriter;
+use FreeDSx\Ldap\Server\Metrics\File\SnapshotPublisher;
+use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
+use FreeDSx\Ldap\Server\Metrics\Recorder\InMemoryMetricsRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class SnapshotPublisherTest extends TestCase
+{
+    private string $path;
+
+    private InMemoryMetricsRecorder $source;
+
+    private SnapshotPublisher $subject;
+
+    protected function setUp(): void
+    {
+        $this->path = sys_get_temp_dir() . '/freedsx_metrics_' . uniqid('', true) . '.json';
+        $this->source = new InMemoryMetricsRecorder();
+        $this->subject = new SnapshotPublisher(
+            $this->source,
+            new FileSnapshotWriter($this->path),
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->path . '*') ?: [] as $file) {
+            @unlink($file);
+        }
+    }
+
+    public function test_publish_writes_the_source_snapshot_to_the_file(): void
+    {
+        $this->source->serverStarted(1_000);
+        $this->source->connectionObserved(ConnectionObservation::Opened);
+        $this->source->connectionObserved(ConnectionObservation::Opened);
+
+        $this->subject->publish();
+
+        self::assertEquals(
+            $this->source->snapshot(),
+            (new FileSnapshotProvider($this->path))->snapshot(),
+        );
+    }
+
+    public function test_publish_overwrites_with_the_latest_snapshot(): void
+    {
+        $this->subject->publish();
+        $this->source->connectionObserved(ConnectionObservation::Opened);
+        $this->subject->publish();
+
+        self::assertSame(
+            1,
+            (new FileSnapshotProvider($this->path))->snapshot()->connections->active,
+        );
+    }
+
+    public function test_remove_deletes_the_published_file(): void
+    {
+        $this->subject->publish();
+        self::assertFileExists($this->path);
+
+        $this->subject->remove();
+
+        self::assertFileDoesNotExist($this->path);
+    }
+}

--- a/tests/unit/Server/Metrics/Recorder/InMemoryMetricsRecorderTest.php
+++ b/tests/unit/Server/Metrics/Recorder/InMemoryMetricsRecorderTest.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
 use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
 use FreeDSx\Ldap\Server\Metrics\Recorder\InMemoryMetricsRecorder;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\OperationMetrics;
 use PHPUnit\Framework\TestCase;
 
 final class InMemoryMetricsRecorderTest extends TestCase
@@ -115,6 +116,90 @@ final class InMemoryMetricsRecorderTest extends TestCase
         self::assertSame(
             1,
             $connections->idleTimeouts,
+        );
+    }
+
+    public function test_taking_the_operation_delta_returns_the_metrics_and_resets_them(): void
+    {
+        $this->subject->operationObserved(new OperationObservation(
+            OperationType::Search,
+            true,
+            0.5,
+            ResultCode::SUCCESS,
+        ));
+
+        $delta = $this->subject->takeOperationDelta();
+
+        self::assertSame(
+            ['search' => 1],
+            $delta->counts,
+        );
+        self::assertSame(
+            [ResultCode::SUCCESS => 1],
+            $delta->resultCodeCounts,
+        );
+        self::assertSame(
+            [],
+            $this->subject->takeOperationDelta()->counts,
+        );
+    }
+
+    public function test_resetting_operations_clears_the_accumulators_but_keeps_connections(): void
+    {
+        $this->subject->operationObserved(new OperationObservation(
+            OperationType::Search,
+            true,
+            0.5,
+            ResultCode::SUCCESS,
+        ));
+        $this->subject->connectionObserved(ConnectionObservation::Opened);
+
+        $this->subject->resetOperations();
+
+        $snapshot = $this->subject->snapshot();
+        self::assertSame(
+            [],
+            $snapshot->operations->counts,
+        );
+        self::assertSame(
+            1,
+            $snapshot->connections->active,
+        );
+    }
+
+    public function test_merging_an_operation_delta_sums_into_the_totals(): void
+    {
+        $this->subject->operationObserved(new OperationObservation(
+            OperationType::Search,
+            true,
+            0.5,
+            ResultCode::SUCCESS,
+        ));
+
+        $this->subject->mergeOperations(new OperationMetrics(
+            counts: ['search' => 2, 'bind' => 1],
+            errors: ['search' => 1],
+            durationSeconds: ['search' => 0.25],
+            resultCodeCounts: [ResultCode::SUCCESS => 2],
+        ));
+
+        $operations = $this->subject->snapshot()->operations;
+
+        self::assertSame(
+            ['search' => 3, 'bind' => 1],
+            $operations->counts,
+        );
+        self::assertSame(
+            ['search' => 1],
+            $operations->errors,
+        );
+        self::assertSame(
+            ['search' => 0.75],
+            $operations->durationSeconds,
+        );
+        self::assertSame(
+            [ResultCode::SUCCESS => 3],
+            $operations->resultCodeCounts,
         );
     }
 

--- a/tests/unit/Server/Metrics/Rollup/OperationDeltaMessageTest.php
+++ b/tests/unit/Server/Metrics/Rollup/OperationDeltaMessageTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Metrics\Rollup;
+
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\Metrics\Rollup\OperationDeltaMessage;
+use FreeDSx\Ldap\Server\Metrics\Rollup\OperationDeltaMessageFactory;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\OperationMetrics;
+use PHPUnit\Framework\TestCase;
+
+final class OperationDeltaMessageTest extends TestCase
+{
+    public function test_it_round_trips_operation_metrics_through_the_wire_form(): void
+    {
+        $operations = new OperationMetrics(
+            counts: ['search' => 4, 'bind' => 1],
+            errors: ['search' => 1],
+            durationSeconds: ['search' => 0.5],
+            resultCodeCounts: [ResultCode::SUCCESS => 4],
+        );
+
+        $message = new OperationDeltaMessage($operations);
+        $rebuilt = (new OperationDeltaMessageFactory())->fromArray($message->toArray());
+
+        self::assertInstanceOf(
+            OperationDeltaMessage::class,
+            $rebuilt,
+        );
+        self::assertSame(
+            $operations->counts,
+            $rebuilt->operations()->counts,
+        );
+        self::assertSame(
+            $operations->errors,
+            $rebuilt->operations()->errors,
+        );
+        self::assertSame(
+            $operations->durationSeconds,
+            $rebuilt->operations()->durationSeconds,
+        );
+        self::assertSame(
+            $operations->resultCodeCounts,
+            $rebuilt->operations()->resultCodeCounts,
+        );
+    }
+}

--- a/tests/unit/Server/Metrics/Rollup/OperationRollupCoordinatorTest.php
+++ b/tests/unit/Server/Metrics/Rollup/OperationRollupCoordinatorTest.php
@@ -32,6 +32,10 @@ final class OperationRollupCoordinatorTest extends TestCase
 
     protected function setUp(): void
     {
+        if (str_starts_with(strtoupper(PHP_OS), 'WIN')) {
+            self::markTestSkipped('The rollup uses a UNIX socket pair, unavailable on Windows; it is Linux/PCNTL-only.');
+        }
+
         $this->childRecorder = new InMemoryMetricsRecorder();
         $this->parentRecorder = new InMemoryMetricsRecorder();
         $this->child = new OperationRollupCoordinator($this->childRecorder);

--- a/tests/unit/Server/Metrics/Rollup/OperationRollupCoordinatorTest.php
+++ b/tests/unit/Server/Metrics/Rollup/OperationRollupCoordinatorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Metrics\Rollup;
+
+use FreeDSx\Ldap\Operation\OperationType;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
+use FreeDSx\Ldap\Server\Metrics\Recorder\InMemoryMetricsRecorder;
+use FreeDSx\Ldap\Server\Metrics\Rollup\OperationRollupCoordinator;
+use PHPUnit\Framework\TestCase;
+
+final class OperationRollupCoordinatorTest extends TestCase
+{
+    private InMemoryMetricsRecorder $childRecorder;
+
+    private InMemoryMetricsRecorder $parentRecorder;
+
+    private OperationRollupCoordinator $child;
+
+    private OperationRollupCoordinator $parent;
+
+    protected function setUp(): void
+    {
+        $this->childRecorder = new InMemoryMetricsRecorder();
+        $this->parentRecorder = new InMemoryMetricsRecorder();
+        $this->child = new OperationRollupCoordinator($this->childRecorder);
+        $this->parent = new OperationRollupCoordinator($this->parentRecorder);
+    }
+
+    public function test_a_child_delta_is_reported_and_collected_into_the_parent(): void
+    {
+        $channel = $this->child->openChannel();
+
+        $this->childRecorder->operationObserved(new OperationObservation(
+            OperationType::Search,
+            true,
+            0.5,
+            ResultCode::SUCCESS,
+        ));
+
+        $this->child->reportChild($channel);
+        $this->parent->collect($channel);
+
+        self::assertSame(
+            ['search' => 1],
+            $this->parentRecorder->snapshot()->operations->counts,
+        );
+    }
+
+    public function test_starting_a_child_clears_inherited_operations_before_it_reports(): void
+    {
+        $channel = $this->child->openChannel();
+
+        $this->childRecorder->operationObserved(new OperationObservation(
+            OperationType::Search,
+            true,
+            0.5,
+            ResultCode::SUCCESS,
+        ));
+        $this->child->startChild();
+        $this->child->reportChild($channel);
+        $this->parent->collect($channel);
+
+        self::assertSame(
+            [],
+            $this->parentRecorder->snapshot()->operations->counts,
+        );
+    }
+}

--- a/tests/unit/Server/Metrics/Rollup/OperationRollupCoordinatorTest.php
+++ b/tests/unit/Server/Metrics/Rollup/OperationRollupCoordinatorTest.php
@@ -38,9 +38,10 @@ final class OperationRollupCoordinatorTest extends TestCase
         $this->parent = new OperationRollupCoordinator($this->parentRecorder);
     }
 
-    public function test_a_child_delta_is_reported_and_collected_into_the_parent(): void
+    public function test_a_flushed_delta_is_collected_into_the_parent(): void
     {
         $channel = $this->child->openChannel();
+        $this->child->enterChild($channel);
 
         $this->childRecorder->operationObserved(new OperationObservation(
             OperationType::Search,
@@ -48,8 +49,7 @@ final class OperationRollupCoordinatorTest extends TestCase
             0.5,
             ResultCode::SUCCESS,
         ));
-
-        $this->child->reportChild($channel);
+        $this->child->flush();
         $this->parent->collect($channel);
 
         self::assertSame(
@@ -58,7 +58,29 @@ final class OperationRollupCoordinatorTest extends TestCase
         );
     }
 
-    public function test_starting_a_child_clears_inherited_operations_before_it_reports(): void
+    public function test_incremental_flushes_accumulate_in_the_parent(): void
+    {
+        $channel = $this->child->openChannel();
+        $this->child->enterChild($channel);
+
+        for ($i = 0; $i < 3; $i++) {
+            $this->childRecorder->operationObserved(new OperationObservation(
+                OperationType::Search,
+                true,
+                0.1,
+                ResultCode::SUCCESS,
+            ));
+            $this->child->flush();
+            $this->parent->collect($channel);
+        }
+
+        self::assertSame(
+            ['search' => 3],
+            $this->parentRecorder->snapshot()->operations->counts,
+        );
+    }
+
+    public function test_entering_a_child_clears_operations_inherited_from_the_parent(): void
     {
         $channel = $this->child->openChannel();
 
@@ -68,13 +90,37 @@ final class OperationRollupCoordinatorTest extends TestCase
             0.5,
             ResultCode::SUCCESS,
         ));
-        $this->child->startChild();
-        $this->child->reportChild($channel);
+        $this->child->enterChild($channel);
+        $this->child->flush();
         $this->parent->collect($channel);
 
         self::assertSame(
             [],
             $this->parentRecorder->snapshot()->operations->counts,
+        );
+    }
+
+    public function test_finishing_flushes_remaining_operations_and_signals_eof(): void
+    {
+        $channel = $this->child->openChannel();
+        $this->child->enterChild($channel);
+
+        $this->childRecorder->operationObserved(new OperationObservation(
+            OperationType::Bind,
+            true,
+            0.1,
+            ResultCode::SUCCESS,
+        ));
+        $this->child->finish();
+        $this->parent->collect($channel);
+
+        self::assertSame(
+            ['bind' => 1],
+            $this->parentRecorder->snapshot()->operations->counts,
+        );
+        self::assertSame(
+            [],
+            $channel->receive(),
         );
     }
 }

--- a/tests/unit/Server/Middleware/MetricsMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/MetricsMiddlewareTest.php
@@ -21,6 +21,7 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\Metrics\Recorder\InMemoryMetricsRecorder;
+use FreeDSx\Ldap\Server\Metrics\Rollup\OperationRollupCoordinator;
 use FreeDSx\Ldap\Server\Middleware\MetricsMiddleware;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
@@ -112,6 +113,30 @@ final class MetricsMiddlewareTest extends TestCase
         self::assertSame(
             [ResultCode::INSUFFICIENT_ACCESS_RIGHTS => 1],
             $operations->resultCodeCounts,
+        );
+    }
+
+    public function test_it_streams_each_recorded_operation_to_the_rollup_coordinator(): void
+    {
+        $coordinator = new OperationRollupCoordinator($this->recorder);
+        $channel = $coordinator->openChannel();
+        $coordinator->enterChild($channel);
+        $subject = new MetricsMiddleware(
+            $this->recorder,
+            $coordinator,
+        );
+
+        $subject->process(
+            $this->contextFor(new SearchRequest(Filters::present('objectClass'))),
+            new StubMiddlewareHandler(OperationOutcomeResult::succeeded()),
+        );
+
+        $parentRecorder = new InMemoryMetricsRecorder();
+        (new OperationRollupCoordinator($parentRecorder))->collect($channel);
+
+        self::assertSame(
+            ['search' => 1],
+            $parentRecorder->snapshot()->operations->counts,
         );
     }
 

--- a/tests/unit/Server/Middleware/MetricsMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/MetricsMiddlewareTest.php
@@ -118,6 +118,10 @@ final class MetricsMiddlewareTest extends TestCase
 
     public function test_it_streams_each_recorded_operation_to_the_rollup_coordinator(): void
     {
+        if (str_starts_with(strtoupper(PHP_OS), 'WIN')) {
+            self::markTestSkipped('The rollup uses a UNIX socket pair, unavailable on Windows; it is Linux/PCNTL-only.');
+        }
+
         $coordinator = new OperationRollupCoordinator($this->recorder);
         $channel = $coordinator->openChannel();
         $coordinator->enterChild($channel);

--- a/tests/unit/Server/Process/ChildChannelTest.php
+++ b/tests/unit/Server/Process/ChildChannelTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Process;
+
+use FreeDSx\Ldap\Server\Process\ChildChannel;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Server\Process\FakeChannelMessage;
+use Tests\Support\FreeDSx\Ldap\Server\Process\FakeChannelMessageFactory;
+
+final class ChildChannelTest extends TestCase
+{
+    private ChildChannel $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = ChildChannel::create(new FakeChannelMessageFactory());
+    }
+
+    public function test_a_sent_message_is_received_round_trip(): void
+    {
+        $this->subject->send(new FakeChannelMessage(['op' => 'search', 'n' => 2]));
+
+        $received = $this->subject->receive();
+
+        self::assertCount(
+            1,
+            $received,
+        );
+        self::assertSame(
+            ['op' => 'search', 'n' => 2],
+            $received[0]->toArray(),
+        );
+    }
+
+    public function test_multiple_messages_are_received_in_order(): void
+    {
+        $this->subject->send(new FakeChannelMessage(['seq' => 1]));
+        $this->subject->send(new FakeChannelMessage(['seq' => 2]));
+        $this->subject->send(new FakeChannelMessage(['seq' => 3]));
+
+        $received = $this->subject->receive();
+
+        self::assertSame(
+            [['seq' => 1], ['seq' => 2], ['seq' => 3]],
+            array_map(
+                static fn($message): array => $message->toArray(),
+                $received,
+            ),
+        );
+    }
+
+    public function test_receiving_with_nothing_sent_returns_empty(): void
+    {
+        self::assertSame(
+            [],
+            $this->subject->receive(),
+        );
+    }
+
+    public function test_the_read_buffer_persists_across_receive_calls(): void
+    {
+        $this->subject->send(new FakeChannelMessage(['seq' => 1]));
+        self::assertCount(
+            1,
+            $this->subject->receive(),
+        );
+
+        $this->subject->send(new FakeChannelMessage(['seq' => 2]));
+        $second = $this->subject->receive();
+
+        self::assertSame(
+            ['seq' => 2],
+            $second[0]->toArray(),
+        );
+    }
+
+    public function test_remaining_messages_are_drained_after_the_write_end_closes(): void
+    {
+        $this->subject->send(new FakeChannelMessage(['final' => true]));
+        $this->subject->closeWrite();
+
+        $received = $this->subject->receive();
+
+        self::assertSame(
+            ['final' => true],
+            $received[0]->toArray(),
+        );
+        self::assertSame(
+            [],
+            $this->subject->receive(),
+        );
+    }
+}

--- a/tests/unit/Server/Process/ChildChannelTest.php
+++ b/tests/unit/Server/Process/ChildChannelTest.php
@@ -24,6 +24,10 @@ final class ChildChannelTest extends TestCase
 
     protected function setUp(): void
     {
+        if (str_starts_with(strtoupper(PHP_OS), 'WIN')) {
+            self::markTestSkipped('UNIX socket pairs are unavailable on Windows; the channel is Linux/PCNTL-only.');
+        }
+
         $this->subject = ChildChannel::create(new FakeChannelMessageFactory());
     }
 

--- a/tests/unit/Server/Process/ChildProcessTest.php
+++ b/tests/unit/Server/Process/ChildProcessTest.php
@@ -68,6 +68,10 @@ final class ChildProcessTest extends TestCase
 
     public function test_it_should_get_the_channel_when_present(): void
     {
+        if (str_starts_with(strtoupper(PHP_OS), 'WIN')) {
+            self::markTestSkipped('UNIX socket pairs are unavailable on Windows; the channel is Linux/PCNTL-only.');
+        }
+
         $channel = ChildChannel::create(new FakeChannelMessageFactory());
 
         $subject = new ChildProcess(

--- a/tests/unit/Server/Process/ChildProcessTest.php
+++ b/tests/unit/Server/Process/ChildProcessTest.php
@@ -11,12 +11,14 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Unit\FreeDSx\Ldap\Server;
+namespace Tests\Unit\FreeDSx\Ldap\Server\Process;
 
-use FreeDSx\Ldap\Server\ChildProcess;
+use FreeDSx\Ldap\Server\Process\ChildChannel;
+use FreeDSx\Ldap\Server\Process\ChildProcess;
 use FreeDSx\Socket\Socket;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Server\Process\FakeChannelMessageFactory;
 
 final class ChildProcessTest extends TestCase
 {
@@ -57,5 +59,26 @@ final class ChildProcessTest extends TestCase
             ->method('close');
 
         $this->subject->closeSocket();
+    }
+
+    public function test_the_channel_is_null_by_default(): void
+    {
+        self::assertNull($this->subject->getChannel());
+    }
+
+    public function test_it_should_get_the_channel_when_present(): void
+    {
+        $channel = ChildChannel::create(new FakeChannelMessageFactory());
+
+        $subject = new ChildProcess(
+            9002,
+            $this->mockSocket,
+            $channel,
+        );
+
+        self::assertSame(
+            $channel,
+            $subject->getChannel(),
+        );
     }
 }


### PR DESCRIPTION
This keeps cn=monitor up to date under pcntl. Not needed under swooles coroutine model. I made the IPC channel generic in case other things need it later on.