### PR TITLE
[1.0.0] Refactor the AuthzId usage and remove the password from the token.

### DIFF
--- a/src/FreeDSx/Ldap/Control/ProxyAuthorizationControl.php
+++ b/src/FreeDSx/Ldap/Control/ProxyAuthorizationControl.php
@@ -15,7 +15,9 @@ namespace FreeDSx\Ldap\Control;
 
 use FreeDSx\Asn1\Type\AbstractType;
 use FreeDSx\Asn1\Type\SequenceType;
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Exception\ProtocolException;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 
 /**
  * Represents a proxied authorization control. RFC 4370.
@@ -26,10 +28,16 @@ use FreeDSx\Ldap\Exception\ProtocolException;
  */
 final class ProxyAuthorizationControl extends Control
 {
+    private string $rawAuthzId;
+
+    private ?AuthzId $authzId;
+
     public function __construct(
-        private string $authzId = '',
+        AuthzId $authzId,
         bool $criticality = true,
     ) {
+        $this->setAuthzId($authzId);
+
         parent::__construct(
             self::OID_PROXY_AUTHORIZATION,
             $criticality,
@@ -37,23 +45,34 @@ final class ProxyAuthorizationControl extends Control
     }
 
     /**
-     * The authorization identity to assume: an authzId ("dn:..." / "u:..."), or empty for anonymous.
+     * The authorization identity to assume; lazily parsed from the raw value when decoded from a request.
+     *
+     * @throws InvalidArgumentException when the raw wire value is not a valid authzId form (e.g. a malformed request)
      */
-    public function getAuthzId(): string
+    public function getAuthzId(): AuthzId
     {
-        return $this->authzId;
+        return $this->authzId ??= AuthzId::fromString($this->rawAuthzId);
     }
 
-    public function setAuthzId(string $authzId): self
+    /**
+     * The raw authzId wire value, which may be an invalid form when decoded from a request.
+     */
+    public function getRawAuthzId(): string
+    {
+        return $this->rawAuthzId;
+    }
+
+    public function setAuthzId(AuthzId $authzId): self
     {
         $this->authzId = $authzId;
+        $this->rawAuthzId = $authzId->toString();
 
         return $this;
     }
 
     public function toAsn1(): SequenceType
     {
-        $this->controlValue = $this->authzId;
+        $this->controlValue = $this->rawAuthzId;
 
         return parent::toAsn1();
     }
@@ -73,10 +92,23 @@ final class ProxyAuthorizationControl extends Control
         }
 
         [1 => $criticality, 2 => $authzId] = self::parseAsn1ControlValues($type);
+        $rawAuthzId = $authzId ?? '';
 
-        return new static(
-            $authzId ?? '',
-            $criticality,
-        );
+        try {
+            return new static(
+                AuthzId::fromString($rawAuthzId),
+                $criticality,
+            );
+        } catch (InvalidArgumentException) {
+            // Preserve a malformed value so it surfaces as an authorization denial rather than a decode failure.
+            $control = new static(
+                AuthzId::anonymous(),
+                $criticality,
+            );
+            $control->rawAuthzId = $rawAuthzId;
+            $control->authzId = null;
+
+            return $control;
+        }
     }
 }

--- a/src/FreeDSx/Ldap/Controls.php
+++ b/src/FreeDSx/Ldap/Controls.php
@@ -31,6 +31,7 @@ use FreeDSx\Ldap\Control\Sorting\SortKey;
 use FreeDSx\Ldap\Control\SubentriesControl;
 use FreeDSx\Ldap\Control\Sync\SyncRequestControl;
 use FreeDSx\Ldap\Control\Vlv\VlvControl;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Protocol\ProtocolElementInterface;
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
 use FreeDSx\Ldap\Search\Filter\GreaterThanOrEqualFilter;
@@ -184,9 +185,9 @@ class Controls
     }
 
     /**
-     * Create a Proxied Authorization control to run the operation as the given authzId ("dn:..." / "u:...", or empty for anonymous).
+     * Create a Proxied Authorization control to run the operation as the given authzId (use AuthzId::anonymous() for anonymous).
      */
-    public static function proxyAuthorization(string $authzId = ''): ProxyAuthorizationControl
+    public static function proxyAuthorization(AuthzId $authzId): ProxyAuthorizationControl
     {
         return new ProxyAuthorizationControl($authzId);
     }

--- a/src/FreeDSx/Ldap/Protocol/Authorization/AuthzId.php
+++ b/src/FreeDSx/Ldap/Protocol/Authorization/AuthzId.php
@@ -62,6 +62,11 @@ final readonly class AuthzId
         };
     }
 
+    public static function anonymous(): self
+    {
+        return new self(AuthzIdType::Anonymous);
+    }
+
     public static function fromDn(Dn $dn): self
     {
         return new self(

--- a/src/FreeDSx/Ldap/Protocol/Authorization/ProxiedAuthorizationResolver.php
+++ b/src/FreeDSx/Ldap/Protocol/Authorization/ProxiedAuthorizationResolver.php
@@ -89,21 +89,19 @@ final readonly class ProxiedAuthorizationResolver
             );
         }
 
-        $rawAuthzId = $control->getAuthzId();
-
         if (!$token instanceof AuthenticatedTokenInterface) {
             $this->authzIdResolver->deny(
                 $token,
-                $rawAuthzId,
+                $control->getRawAuthzId(),
             );
         }
 
         try {
-            $authzId = AuthzId::fromString($rawAuthzId);
+            $authzId = $control->getAuthzId();
         } catch (InvalidArgumentException) {
             $this->authzIdResolver->deny(
                 $token,
-                $rawAuthzId,
+                $control->getRawAuthzId(),
             );
         }
 

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
-use Exception;
 use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
@@ -46,14 +45,7 @@ class ServerWhoAmIHandler implements ServerProtocolHandlerInterface
         $userId = null;
 
         if ($token instanceof AuthenticatedTokenInterface) {
-            $resolvedDn = $token->getResolvedDn();
-
-            try {
-                $resolvedDn->toArray();
-                $userId = 'dn:' . $resolvedDn->toString();
-            } catch (Exception) {
-                $userId = 'u:' . $token->getUsername();
-            }
+            $userId = $token->getAuthzId()->toString();
         }
 
         $this->queue->sendMessage(new LdapMessageResponse(

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticator.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Server\Backend\Auth;
 
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
@@ -58,9 +59,9 @@ final class PasswordAuthenticator implements PasswordAuthenticatableInterface
         foreach ($attr->getValues() as $stored) {
             if ($this->hashService->verify($password, $stored)) {
                 return new BindToken(
-                    $name,
+                    AuthzId::fromDn($entry->getDn()),
                     $password,
-                    $entry->getDn(),
+                    $name,
                 );
             }
         }

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticator.php
@@ -60,7 +60,6 @@ final class PasswordAuthenticator implements PasswordAuthenticatableInterface
             if ($this->hashService->verify($password, $stored)) {
                 return new BindToken(
                     AuthzId::fromDn($entry->getDn()),
-                    $password,
                     $name,
                 );
             }

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyAuthenticator.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyAuthenticator.php
@@ -56,10 +56,7 @@ final readonly class ProxyAuthenticator implements PasswordAuthenticatableInterf
             );
         }
 
-        return BindToken::fromDn(
-            $name,
-            $password,
-        );
+        return BindToken::fromDn($name);
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Token/AnonToken.php
+++ b/src/FreeDSx/Ldap/Server/Token/AnonToken.php
@@ -54,11 +54,6 @@ class AnonToken implements TokenInterface
         return $this->username;
     }
 
-    public function getPassword(): ?string
-    {
-        return null;
-    }
-
     public function getVersion(): int
     {
         return $this->version;

--- a/src/FreeDSx/Ldap/Server/Token/AuthenticatedTokenInterface.php
+++ b/src/FreeDSx/Ldap/Server/Token/AuthenticatedTokenInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Token;
 
 use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 
 /**
  * Implemented by tokens that represent a successfully authenticated identity with a resolved DN.
@@ -23,6 +24,11 @@ use FreeDSx\Ldap\Entry\Dn;
 interface AuthenticatedTokenInterface extends TokenInterface
 {
     public function getResolvedDn(): Dn;
+
+    /**
+     * The bound identity as an authorization identity: the resolved DN, or the username when it is not a DN.
+     */
+    public function getAuthzId(): AuthzId;
 
     /**
      * Whether the bound identity must change its password before any other operation is permitted (pwdReset).

--- a/src/FreeDSx/Ldap/Server/Token/BindToken.php
+++ b/src/FreeDSx/Ldap/Server/Token/BindToken.php
@@ -16,7 +16,6 @@ namespace FreeDSx\Ldap\Server\Token;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Server\Utility\Uuid;
-use SensitiveParameter;
 
 /**
  * Represents a bound and authorized identity, identified by its authorization identity (authzId).
@@ -33,8 +32,6 @@ class BindToken implements AuthenticatedTokenInterface
 
     private string $authcId;
 
-    private string $password;
-
     private int $version;
 
     private bool $mustChangePassword = false;
@@ -47,8 +44,6 @@ class BindToken implements AuthenticatedTokenInterface
      */
     public function __construct(
         private readonly AuthzId $authzId,
-        #[SensitiveParameter]
-        string $password = '',
         ?string $authcId = null,
         int $version = 3,
         ?Dn $authorizingDn = null,
@@ -56,21 +51,17 @@ class BindToken implements AuthenticatedTokenInterface
         $this->id = Uuid::v4();
         $this->resolvedDn = new Dn($authzId->getValue());
         $this->authcId = $authcId ?? $authzId->getValue();
-        $this->password = $password;
         $this->version = $version;
         $this->authorizingDn = $authorizingDn;
     }
 
     public static function fromDn(
         string $dn,
-        #[SensitiveParameter]
-        string $password,
         int $version = 3,
         ?Dn $authorizingDn = null,
     ): self {
         return new self(
             AuthzId::fromDn(new Dn($dn)),
-            $password,
             $dn,
             $version,
             $authorizingDn,
@@ -78,7 +69,7 @@ class BindToken implements AuthenticatedTokenInterface
     }
 
     /**
-     * Creates a token for a SASL-authenticated identity; no plaintext password is carried.
+     * Creates a token for a SASL-authenticated identity.
      */
     public static function fromSasl(
         string $username,
@@ -88,7 +79,6 @@ class BindToken implements AuthenticatedTokenInterface
     ): self {
         return new self(
             AuthzId::fromDn($resolvedDn),
-            '',
             $username,
             $version,
             $authorizingDn,
@@ -105,7 +95,6 @@ class BindToken implements AuthenticatedTokenInterface
     ): self {
         return new self(
             AuthzId::fromUsername($username),
-            '',
             $username,
             $version,
             $authorizingDn,
@@ -125,11 +114,6 @@ class BindToken implements AuthenticatedTokenInterface
     public function getUsername(): ?string
     {
         return $this->authcId;
-    }
-
-    public function getPassword(): ?string
-    {
-        return $this->password;
     }
 
     public function getResolvedDn(): Dn

--- a/src/FreeDSx/Ldap/Server/Token/BindToken.php
+++ b/src/FreeDSx/Ldap/Server/Token/BindToken.php
@@ -14,11 +14,12 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Token;
 
 use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Server\Utility\Uuid;
 use SensitiveParameter;
 
 /**
- * Represents a username/password token that is bound and authorized.
+ * Represents a bound and authorized identity, identified by its authorization identity (authzId).
  *
  * @api
  *
@@ -28,9 +29,9 @@ class BindToken implements AuthenticatedTokenInterface
 {
     private string $id;
 
-    private string $username;
-
     private readonly Dn $resolvedDn;
+
+    private string $authcId;
 
     private string $password;
 
@@ -40,17 +41,21 @@ class BindToken implements AuthenticatedTokenInterface
 
     private readonly ?Dn $authorizingDn;
 
+    /**
+     * @param AuthzId $authzId the resolved authorization identity (its DN, or the username when it is not a DN)
+     * @param string|null $authcId the authentication identity as presented, for auditing; defaults to the authzId value
+     */
     public function __construct(
-        string $username,
+        private readonly AuthzId $authzId,
         #[SensitiveParameter]
-        string $password,
-        Dn $resolvedDn,
+        string $password = '',
+        ?string $authcId = null,
         int $version = 3,
         ?Dn $authorizingDn = null,
     ) {
         $this->id = Uuid::v4();
-        $this->username = $username;
-        $this->resolvedDn = $resolvedDn;
+        $this->resolvedDn = new Dn($authzId->getValue());
+        $this->authcId = $authcId ?? $authzId->getValue();
         $this->password = $password;
         $this->version = $version;
         $this->authorizingDn = $authorizingDn;
@@ -64,9 +69,9 @@ class BindToken implements AuthenticatedTokenInterface
         ?Dn $authorizingDn = null,
     ): self {
         return new self(
-            $dn,
+            AuthzId::fromDn(new Dn($dn)),
             $password,
-            new Dn($dn),
+            $dn,
             $version,
             $authorizingDn,
         );
@@ -82,9 +87,26 @@ class BindToken implements AuthenticatedTokenInterface
         ?Dn $authorizingDn = null,
     ): self {
         return new self(
-            $username,
+            AuthzId::fromDn($resolvedDn),
             '',
-            $resolvedDn,
+            $username,
+            $version,
+            $authorizingDn,
+        );
+    }
+
+    /**
+     * Creates a token for an identity that resolved to a bare username rather than a DN.
+     */
+    public static function fromUsername(
+        string $username,
+        int $version = 3,
+        ?Dn $authorizingDn = null,
+    ): self {
+        return new self(
+            AuthzId::fromUsername($username),
+            '',
+            $username,
             $version,
             $authorizingDn,
         );
@@ -95,9 +117,14 @@ class BindToken implements AuthenticatedTokenInterface
         return $this->id;
     }
 
+    public function getAuthzId(): AuthzId
+    {
+        return $this->authzId;
+    }
+
     public function getUsername(): ?string
     {
-        return $this->username;
+        return $this->authcId;
     }
 
     public function getPassword(): ?string

--- a/src/FreeDSx/Ldap/Server/Token/SystemToken.php
+++ b/src/FreeDSx/Ldap/Server/Token/SystemToken.php
@@ -42,11 +42,6 @@ final readonly class SystemToken implements TokenInterface
         return self::IDENTITY;
     }
 
-    public function getPassword(): ?string
-    {
-        return null;
-    }
-
     public function getVersion(): int
     {
         return $this->version;

--- a/src/FreeDSx/Ldap/Server/Token/TokenInterface.php
+++ b/src/FreeDSx/Ldap/Server/Token/TokenInterface.php
@@ -28,8 +28,6 @@ interface TokenInterface
 
     public function getUsername(): ?string;
 
-    public function getPassword(): ?string;
-
     public function getVersion(): int;
 
     /**

--- a/tests/integration/Security/LdapProxiedAuthorizationControlTest.php
+++ b/tests/integration/Security/LdapProxiedAuthorizationControlTest.php
@@ -15,6 +15,7 @@ namespace Tests\Integration\FreeDSx\Ldap\Security;
 
 use FreeDSx\Ldap\Controls;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operations;
@@ -62,7 +63,7 @@ final class LdapProxiedAuthorizationControlTest extends ServerTestCase
 
         $response = $this->ldapClient()->send(
             Operations::whoami(),
-            Controls::proxyAuthorization('dn:' . self::PROXIED_DN),
+            Controls::proxyAuthorization(AuthzId::fromString('dn:' . self::PROXIED_DN)),
         );
 
         self::assertNotNull($response);
@@ -95,7 +96,7 @@ final class LdapProxiedAuthorizationControlTest extends ServerTestCase
             Operations::search(Filters::equal('cn', 'alice'))
                 ->base('dc=foo,dc=bar')
                 ->useSubtreeScope(),
-            Controls::proxyAuthorization('dn:' . self::PROXIED_DN),
+            Controls::proxyAuthorization(AuthzId::fromString('dn:' . self::PROXIED_DN)),
         );
 
         self::assertCount(1, $entries);
@@ -116,7 +117,7 @@ final class LdapProxiedAuthorizationControlTest extends ServerTestCase
             Operations::search(Filters::present('objectClass'))
                 ->base('dc=foo,dc=bar')
                 ->useSubtreeScope(),
-            Controls::proxyAuthorization('dn:cn=user,dc=foo,dc=bar'),
+            Controls::proxyAuthorization(AuthzId::fromString('dn:cn=user,dc=foo,dc=bar')),
         );
     }
 }

--- a/tests/integration/Security/PasswordPolicyChangeEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyChangeEnforcementTest.php
@@ -353,17 +353,13 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
 
     private function selfToken(): BindToken
     {
-        return BindToken::fromDn(
-            self::USER_DN,
-            self::OLD_PASSWORD,
-        );
+        return BindToken::fromDn(self::USER_DN);
     }
 
     private function adminToken(): BindToken
     {
         return BindToken::fromDn(
             'cn=admin,dc=foo,dc=bar',
-            'admin-pass',
         );
     }
 

--- a/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
@@ -366,7 +366,6 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
     {
         return BindToken::fromDn(
             self::USER_DN,
-            'original-pass',
         );
     }
 

--- a/tests/unit/Control/ProxyAuthorizationControlTest.php
+++ b/tests/unit/Control/ProxyAuthorizationControlTest.php
@@ -7,23 +7,33 @@ namespace Tests\Unit\FreeDSx\Ldap\Control;
 use FreeDSx\Asn1\Asn1;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\ProxyAuthorizationControl;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzIdType;
 use PHPUnit\Framework\TestCase;
 
 final class ProxyAuthorizationControlTest extends TestCase
 {
     public function test_it_defaults_to_an_empty_anonymous_authz_id(): void
     {
-        self::assertSame(
-            '',
-            (new ProxyAuthorizationControl())->getAuthzId(),
-        );
+        $control = new ProxyAuthorizationControl(AuthzId::anonymous());
+
+        self::assertSame('', $control->getRawAuthzId());
+        self::assertTrue($control->getAuthzId()->isType(AuthzIdType::Anonymous));
     }
 
     public function test_it_exposes_the_authz_id(): void
     {
+        $control = new ProxyAuthorizationControl(AuthzId::fromDn(new Dn('cn=foo,dc=example,dc=com')));
+
         self::assertSame(
             'dn:cn=foo,dc=example,dc=com',
-            (new ProxyAuthorizationControl('dn:cn=foo,dc=example,dc=com'))->getAuthzId(),
+            $control->getRawAuthzId(),
+        );
+        self::assertSame(
+            'dn:cn=foo,dc=example,dc=com',
+            $control->getAuthzId()->toString(),
         );
     }
 
@@ -31,13 +41,13 @@ final class ProxyAuthorizationControlTest extends TestCase
     {
         self::assertSame(
             Control::OID_PROXY_AUTHORIZATION,
-            (new ProxyAuthorizationControl())->getTypeOid(),
+            (new ProxyAuthorizationControl(AuthzId::anonymous()))->getTypeOid(),
         );
     }
 
     public function test_it_is_critical_by_default(): void
     {
-        self::assertTrue((new ProxyAuthorizationControl('u:bob'))->getCriticality());
+        self::assertTrue((new ProxyAuthorizationControl(AuthzId::fromUsername('bob')))->getCriticality());
     }
 
     public function test_it_preserves_a_non_critical_flag_from_asn1(): void
@@ -59,7 +69,7 @@ final class ProxyAuthorizationControlTest extends TestCase
                 Asn1::boolean(true),
                 Asn1::octetString('dn:cn=foo,dc=example,dc=com'),
             ),
-            (new ProxyAuthorizationControl('dn:cn=foo,dc=example,dc=com'))->toAsn1(),
+            (new ProxyAuthorizationControl(AuthzId::fromDn(new Dn('cn=foo,dc=example,dc=com'))))->toAsn1(),
         );
     }
 
@@ -71,7 +81,7 @@ final class ProxyAuthorizationControlTest extends TestCase
                 Asn1::boolean(true),
                 Asn1::octetString(''),
             ),
-            (new ProxyAuthorizationControl())->toAsn1(),
+            (new ProxyAuthorizationControl(AuthzId::anonymous()))->toAsn1(),
         );
     }
 
@@ -85,7 +95,11 @@ final class ProxyAuthorizationControlTest extends TestCase
 
         self::assertSame(
             'u:bob',
-            $control->getAuthzId(),
+            $control->getRawAuthzId(),
+        );
+        self::assertSame(
+            'u:bob',
+            $control->getAuthzId()->toString(),
         );
         self::assertTrue($control->getCriticality());
         self::assertSame(
@@ -104,7 +118,25 @@ final class ProxyAuthorizationControlTest extends TestCase
 
         self::assertSame(
             '',
-            $control->getAuthzId(),
+            $control->getRawAuthzId(),
         );
+    }
+
+    public function test_it_defers_a_malformed_authz_id_until_it_is_read(): void
+    {
+        $control = ProxyAuthorizationControl::fromAsn1(Asn1::sequence(
+            Asn1::octetString(Control::OID_PROXY_AUTHORIZATION),
+            Asn1::boolean(true),
+            Asn1::octetString('mail:bob@example.com'),
+        ));
+
+        self::assertSame(
+            'mail:bob@example.com',
+            $control->getRawAuthzId(),
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $control->getAuthzId();
     }
 }

--- a/tests/unit/Protocol/AuthenticatorTest.php
+++ b/tests/unit/Protocol/AuthenticatorTest.php
@@ -72,7 +72,6 @@ final class AuthenticatorTest extends TestCase
 
         $token = BindToken::fromDn(
             'foo',
-            'bar',
         );
 
         $this->authOne

--- a/tests/unit/Protocol/Authorization/AuthzIdResolverTest.php
+++ b/tests/unit/Protocol/Authorization/AuthzIdResolverTest.php
@@ -61,10 +61,9 @@ final class AuthzIdResolverTest extends TestCase
                 EventLogPolicy::all(),
             ),
         );
-        $this->boundToken = new BindToken(
+        $this->boundToken = BindToken::fromDn(
             self::ADMIN_DN,
             'secret',
-            new Dn(self::ADMIN_DN),
         );
     }
 

--- a/tests/unit/Protocol/Authorization/AuthzIdResolverTest.php
+++ b/tests/unit/Protocol/Authorization/AuthzIdResolverTest.php
@@ -63,7 +63,6 @@ final class AuthzIdResolverTest extends TestCase
         );
         $this->boundToken = BindToken::fromDn(
             self::ADMIN_DN,
-            'secret',
         );
     }
 

--- a/tests/unit/Protocol/Authorization/DispatchAuthorizationTest.php
+++ b/tests/unit/Protocol/Authorization/DispatchAuthorizationTest.php
@@ -24,7 +24,6 @@ final class DispatchAuthorizationTest extends TestCase
     {
         $token = BindToken::fromDn(
             'cn=alice,dc=example,dc=com',
-            'secret',
         );
 
         $authorization = DispatchAuthorization::proceed($token);

--- a/tests/unit/Protocol/Authorization/DispatchAuthorizationTest.php
+++ b/tests/unit/Protocol/Authorization/DispatchAuthorizationTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Protocol\Authorization;
 
-use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\Authorization\DispatchAuthorization;
 use FreeDSx\Ldap\Server\Token\BindToken;
@@ -23,10 +22,9 @@ final class DispatchAuthorizationTest extends TestCase
 {
     public function test_proceed_carries_the_effective_token(): void
     {
-        $token = new BindToken(
+        $token = BindToken::fromDn(
             'cn=alice,dc=example,dc=com',
             'secret',
-            new Dn('cn=alice,dc=example,dc=com'),
         );
 
         $authorization = DispatchAuthorization::proceed($token);

--- a/tests/unit/Protocol/Authorization/DispatchAuthorizerTest.php
+++ b/tests/unit/Protocol/Authorization/DispatchAuthorizerTest.php
@@ -200,7 +200,6 @@ final class DispatchAuthorizerTest extends TestCase
     {
         return BindToken::fromDn(
             self::BOUND_DN,
-            'secret',
         );
     }
 

--- a/tests/unit/Protocol/Authorization/DispatchAuthorizerTest.php
+++ b/tests/unit/Protocol/Authorization/DispatchAuthorizerTest.php
@@ -15,12 +15,12 @@ namespace Tests\Unit\FreeDSx\Ldap\Protocol\Authorization;
 
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\ProxyAuthorizationControl;
-use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Protocol\Authorization\DispatchAuthorizer;
 use FreeDSx\Ldap\Protocol\Authorization\AuthzIdResolver;
 use FreeDSx\Ldap\Protocol\Authorization\ProxiedAuthorizationResolver;
@@ -156,7 +156,7 @@ final class DispatchAuthorizerTest extends TestCase
             ->willReturn(new Entry(self::PROXIED_DN));
 
         $authorization = $this->subject->authorize($this->message(
-            new ProxyAuthorizationControl('dn:' . self::PROXIED_DN),
+            new ProxyAuthorizationControl(AuthzId::fromString('dn:' . self::PROXIED_DN)),
         ));
 
         $effective = $authorization->token();
@@ -192,16 +192,15 @@ final class DispatchAuthorizerTest extends TestCase
         $this->expectExceptionCode(ResultCode::AUTHORIZATION_DENIED);
 
         $this->subject->authorize($this->message(
-            new ProxyAuthorizationControl('dn:' . self::PROXIED_DN),
+            new ProxyAuthorizationControl(AuthzId::fromString('dn:' . self::PROXIED_DN)),
         ));
     }
 
     private function boundToken(): BindToken
     {
-        return new BindToken(
+        return BindToken::fromDn(
             self::BOUND_DN,
             'secret',
-            new Dn(self::BOUND_DN),
         );
     }
 

--- a/tests/unit/Protocol/Authorization/ProxiedAuthorizationResolverTest.php
+++ b/tests/unit/Protocol/Authorization/ProxiedAuthorizationResolverTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Protocol\Authorization;
 
+use FreeDSx\Asn1\Asn1;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Control\ProxyAuthorizationControl;
-use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -24,6 +24,7 @@ use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Protocol\Authorization\AuthzIdResolver;
 use FreeDSx\Ldap\Protocol\Authorization\ProxiedAuthorizationResolver;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
@@ -75,10 +76,9 @@ final class ProxiedAuthorizationResolverTest extends TestCase
                 ),
             ),
         );
-        $this->boundToken = new BindToken(
+        $this->boundToken = BindToken::fromDn(
             self::ADMIN_DN,
             'secret',
-            new Dn(self::ADMIN_DN),
         );
     }
 
@@ -105,7 +105,7 @@ final class ProxiedAuthorizationResolverTest extends TestCase
 
         $result = $this->subject->resolve(
             $this->eligibleRequest(),
-            new ControlBag(new ProxyAuthorizationControl('dn:' . self::PROXIED_DN)),
+            new ControlBag(new ProxyAuthorizationControl(AuthzId::fromString('dn:' . self::PROXIED_DN))),
             $this->boundToken,
         );
 
@@ -132,7 +132,7 @@ final class ProxiedAuthorizationResolverTest extends TestCase
 
         $result = $this->subject->resolve(
             $this->eligibleRequest(),
-            new ControlBag(new ProxyAuthorizationControl('u:alice')),
+            new ControlBag(new ProxyAuthorizationControl(AuthzId::fromString('u:alice'))),
             $this->boundToken,
         );
 
@@ -152,7 +152,7 @@ final class ProxiedAuthorizationResolverTest extends TestCase
 
         $result = $this->subject->resolve(
             $this->eligibleRequest(),
-            new ControlBag(new ProxyAuthorizationControl('')),
+            new ControlBag(new ProxyAuthorizationControl(AuthzId::anonymous())),
             $this->boundToken,
         );
 
@@ -179,7 +179,7 @@ final class ProxiedAuthorizationResolverTest extends TestCase
             ->method('resolve');
 
         $this->assertDeniesWith(
-            new ProxyAuthorizationControl('dn:' . self::PROXIED_DN),
+            new ProxyAuthorizationControl(AuthzId::fromString('dn:' . self::PROXIED_DN)),
             'dn:' . self::PROXIED_DN,
         );
     }
@@ -198,7 +198,7 @@ final class ProxiedAuthorizationResolverTest extends TestCase
             ));
 
         $this->assertDeniesWith(
-            new ProxyAuthorizationControl('dn:' . self::PROXIED_DN),
+            new ProxyAuthorizationControl(AuthzId::fromString('dn:' . self::PROXIED_DN)),
             'dn:' . self::PROXIED_DN,
         );
     }
@@ -211,7 +211,7 @@ final class ProxiedAuthorizationResolverTest extends TestCase
             ->willReturn(null);
 
         $this->assertDeniesWith(
-            new ProxyAuthorizationControl('dn:' . self::PROXIED_DN),
+            new ProxyAuthorizationControl(AuthzId::fromString('dn:' . self::PROXIED_DN)),
             'dn:' . self::PROXIED_DN,
         );
     }
@@ -224,7 +224,7 @@ final class ProxiedAuthorizationResolverTest extends TestCase
             ->willThrowException(new InvalidArgumentException('The DN value is not valid.'));
 
         $this->assertDeniesWith(
-            new ProxyAuthorizationControl('dn:not a dn'),
+            new ProxyAuthorizationControl(AuthzId::fromString('dn:not a dn')),
             'dn:not a dn',
         );
     }
@@ -233,8 +233,13 @@ final class ProxiedAuthorizationResolverTest extends TestCase
     {
         $this->grantProxyCapability();
 
+        // A malformed authzId form can only originate from the wire, so build it via fromAsn1.
         $this->assertDeniesWith(
-            new ProxyAuthorizationControl('mail:alice@example.com'),
+            ProxyAuthorizationControl::fromAsn1(Asn1::sequence(
+                Asn1::octetString(Control::OID_PROXY_AUTHORIZATION),
+                Asn1::boolean(true),
+                Asn1::octetString('mail:alice@example.com'),
+            )),
             'mail:alice@example.com',
         );
     }
@@ -244,7 +249,7 @@ final class ProxiedAuthorizationResolverTest extends TestCase
         try {
             $this->subject->resolve(
                 $this->eligibleRequest(),
-                new ControlBag(new ProxyAuthorizationControl('dn:' . self::PROXIED_DN)),
+                new ControlBag(new ProxyAuthorizationControl(AuthzId::fromString('dn:' . self::PROXIED_DN))),
                 new AnonToken(),
             );
             self::fail('Expected an OperationException.');
@@ -264,7 +269,7 @@ final class ProxiedAuthorizationResolverTest extends TestCase
         try {
             $this->subject->resolve(
                 new ExtendedRequest($extendedOid),
-                new ControlBag(new ProxyAuthorizationControl('dn:' . self::PROXIED_DN)),
+                new ControlBag(new ProxyAuthorizationControl(AuthzId::fromString('dn:' . self::PROXIED_DN))),
                 $this->boundToken,
             );
             self::fail('Expected an OperationException.');
@@ -298,7 +303,7 @@ final class ProxiedAuthorizationResolverTest extends TestCase
             $this->subject->resolve(
                 $this->eligibleRequest(),
                 new ControlBag(new ProxyAuthorizationControl(
-                    'dn:' . self::PROXIED_DN,
+                    AuthzId::fromString('dn:' . self::PROXIED_DN),
                     false,
                 )),
                 $this->boundToken,
@@ -323,8 +328,8 @@ final class ProxiedAuthorizationResolverTest extends TestCase
             $this->subject->resolve(
                 $this->eligibleRequest(),
                 new ControlBag(
-                    new ProxyAuthorizationControl('dn:' . self::PROXIED_DN),
-                    new ProxyAuthorizationControl('u:alice'),
+                    new ProxyAuthorizationControl(AuthzId::fromString('dn:' . self::PROXIED_DN)),
+                    new ProxyAuthorizationControl(AuthzId::fromString('u:alice')),
                 ),
                 $this->boundToken,
             );

--- a/tests/unit/Protocol/Authorization/ProxiedAuthorizationResolverTest.php
+++ b/tests/unit/Protocol/Authorization/ProxiedAuthorizationResolverTest.php
@@ -78,7 +78,6 @@ final class ProxiedAuthorizationResolverTest extends TestCase
         );
         $this->boundToken = BindToken::fromDn(
             self::ADMIN_DN,
-            'secret',
         );
     }
 

--- a/tests/unit/Protocol/Bind/SimpleBindTest.php
+++ b/tests/unit/Protocol/Bind/SimpleBindTest.php
@@ -50,9 +50,8 @@ final class SimpleBindTest extends TestCase
 
     public function test_it_should_return_a_token_on_success(): void
     {
-        $expectedToken = new BindToken(
+        $expectedToken = BindToken::fromSasl(
             'foo@bar',
-            'bar',
             new Dn('cn=foo,dc=bar'),
         );
 

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordModifyHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordModifyHandlerTest.php
@@ -69,7 +69,6 @@ final class ServerPasswordModifyHandlerTest extends TestCase
         );
         $this->userToken = BindToken::fromDn(
             'cn=user,dc=foo,dc=bar',
-            '12345',
         );
 
         $this->subject = new ServerPasswordModifyHandler(

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerTest.php
@@ -81,9 +81,8 @@ final class ServerWhoAmIHandlerTest extends TestCase
 
         $this->subject->handleRequest(
             $request,
-            new BindToken(
+            BindToken::fromSasl(
                 'uid=alice',
-                '12345',
                 new Dn('cn=Alice,dc=example,dc=com'),
             ),
         );
@@ -103,9 +102,8 @@ final class ServerWhoAmIHandlerTest extends TestCase
 
         $this->subject->handleRequest(
             $request,
-            BindToken::fromDn(
+            BindToken::fromUsername(
                 'foo@bar.local',
-                '12345',
             ),
         );
     }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerTest.php
@@ -55,7 +55,6 @@ final class ServerWhoAmIHandlerTest extends TestCase
             $request,
             BindToken::fromDn(
                 'cn=foo,dc=foo,dc=bar',
-                '12345',
             ),
         );
     }

--- a/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
+++ b/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
@@ -47,7 +47,6 @@ final class RuleBasedAccessControlTest extends TestCase
         $this->dn = new Dn('dc=foo,dc=bar');
         $this->bindToken = BindToken::fromDn(
             'cn=admin,dc=foo,dc=bar',
-            'secret',
         );
     }
 

--- a/tests/unit/Server/AccessControl/SimpleAccessControlTest.php
+++ b/tests/unit/Server/AccessControl/SimpleAccessControlTest.php
@@ -115,7 +115,6 @@ final class SimpleAccessControlTest extends TestCase
             OperationType::Search,
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $this->dn,
         );
@@ -129,7 +128,6 @@ final class SimpleAccessControlTest extends TestCase
             OperationType::Add,
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $this->dn,
         );
@@ -142,7 +140,6 @@ final class SimpleAccessControlTest extends TestCase
         $result = $this->subject->filterEntry(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $entry,
         );
@@ -175,7 +172,6 @@ final class SimpleAccessControlTest extends TestCase
         $this->subject->authorizeAttribute(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $this->dn,
             'userPassword',

--- a/tests/unit/Server/AccessControl/Subject/AnonymousSubjectMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Subject/AnonymousSubjectMatcherTest.php
@@ -44,7 +44,6 @@ final class AnonymousSubjectMatcherTest extends TestCase
         self::assertFalse($this->subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $this->dn,
         ));

--- a/tests/unit/Server/AccessControl/Subject/AuthenticatedSubjectMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Subject/AuthenticatedSubjectMatcherTest.php
@@ -37,7 +37,6 @@ final class AuthenticatedSubjectMatcherTest extends TestCase
         self::assertTrue($this->subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $this->dn,
         ));

--- a/tests/unit/Server/AccessControl/Subject/CallbackSubjectMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Subject/CallbackSubjectMatcherTest.php
@@ -31,7 +31,6 @@ final class CallbackSubjectMatcherTest extends TestCase
         self::assertTrue($subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             new Dn('dc=foo,dc=bar'),
         ));
@@ -46,7 +45,6 @@ final class CallbackSubjectMatcherTest extends TestCase
         self::assertFalse($subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             new Dn('dc=foo,dc=bar'),
         ));
@@ -59,7 +57,6 @@ final class CallbackSubjectMatcherTest extends TestCase
 
         $token = BindToken::fromDn(
             'cn=admin,dc=foo,dc=bar',
-            'secret',
         );
         $dn = new Dn('dc=foo,dc=bar');
 
@@ -96,7 +93,6 @@ final class CallbackSubjectMatcherTest extends TestCase
         self::assertFalse($subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             new Dn('dc=foo,dc=bar'),
         ));

--- a/tests/unit/Server/AccessControl/Subject/DnSubjectMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Subject/DnSubjectMatcherTest.php
@@ -35,7 +35,6 @@ final class DnSubjectMatcherTest extends TestCase
         self::assertTrue($subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $this->targetDn,
         ));
@@ -48,7 +47,6 @@ final class DnSubjectMatcherTest extends TestCase
         self::assertTrue($subject->matches(
             BindToken::fromDn(
                 'CN=Admin,DC=foo,DC=bar',
-                'secret',
             ),
             $this->targetDn,
         ));
@@ -61,7 +59,6 @@ final class DnSubjectMatcherTest extends TestCase
         self::assertFalse($subject->matches(
             BindToken::fromDn(
                 'cn=other,dc=foo,dc=bar',
-                'secret',
             ),
             $this->targetDn,
         ));

--- a/tests/unit/Server/AccessControl/Subject/DnSubtreeSubjectMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Subject/DnSubtreeSubjectMatcherTest.php
@@ -35,7 +35,6 @@ final class DnSubtreeSubjectMatcherTest extends TestCase
         self::assertTrue($subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $this->targetDn,
         ));
@@ -48,7 +47,6 @@ final class DnSubtreeSubjectMatcherTest extends TestCase
         self::assertFalse($subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=other,dc=bar',
-                'secret',
             ),
             $this->targetDn,
         ));
@@ -81,7 +79,6 @@ final class DnSubtreeSubjectMatcherTest extends TestCase
         self::assertFalse($subject->matches(
             BindToken::fromDn(
                 'jdoe',
-                'secret',
             ),
             $this->targetDn,
         ));

--- a/tests/unit/Server/AccessControl/Subject/GroupSubjectMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Subject/GroupSubjectMatcherTest.php
@@ -51,7 +51,6 @@ final class GroupSubjectMatcherTest extends TestCase
         self::assertTrue($subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $this->targetDn,
         ));
@@ -74,7 +73,6 @@ final class GroupSubjectMatcherTest extends TestCase
         self::assertTrue($subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $this->targetDn,
         ));
@@ -97,7 +95,6 @@ final class GroupSubjectMatcherTest extends TestCase
         self::assertFalse($subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $this->targetDn,
         ));
@@ -115,7 +112,6 @@ final class GroupSubjectMatcherTest extends TestCase
         self::assertFalse($subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $this->targetDn,
         ));
@@ -128,7 +124,6 @@ final class GroupSubjectMatcherTest extends TestCase
         self::assertFalse($subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $this->targetDn,
         ));
@@ -184,7 +179,6 @@ final class GroupSubjectMatcherTest extends TestCase
         self::assertTrue($subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $this->targetDn,
         ));
@@ -207,7 +201,6 @@ final class GroupSubjectMatcherTest extends TestCase
 
         $token = BindToken::fromDn(
             'cn=admin,dc=foo,dc=bar',
-            'secret',
         );
 
         $subject->matches(
@@ -257,14 +250,12 @@ final class GroupSubjectMatcherTest extends TestCase
         $subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $this->targetDn,
         );
         $subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $this->targetDn,
         );
@@ -291,7 +282,6 @@ final class GroupSubjectMatcherTest extends TestCase
 
         $token = BindToken::fromDn(
             'cn=admin,dc=foo,dc=bar',
-            'secret',
         );
 
         $subject->matches($token, $this->targetDn);
@@ -316,7 +306,6 @@ final class GroupSubjectMatcherTest extends TestCase
         self::assertTrue($subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'secret',
             ),
             $this->targetDn,
         ));
@@ -339,7 +328,6 @@ final class GroupSubjectMatcherTest extends TestCase
         self::assertFalse($subject->matches(
             BindToken::fromDn(
                 'cn=admin, dc=foo, dc=bar',
-                'secret',
             ),
             $this->targetDn,
         ));
@@ -364,9 +352,9 @@ final class GroupSubjectMatcherTest extends TestCase
         );
         $subject->setBackend($this->mockBackend);
 
-        $token1 = BindToken::fromDn('cn=admin,dc=foo,dc=bar', 'secret');
-        $token2 = BindToken::fromDn('cn=admin,dc=foo,dc=bar', 'secret');
-        $token3 = BindToken::fromDn('cn=admin,dc=foo,dc=bar', 'secret');
+        $token1 = BindToken::fromDn('cn=admin,dc=foo,dc=bar');
+        $token2 = BindToken::fromDn('cn=admin,dc=foo,dc=bar');
+        $token3 = BindToken::fromDn('cn=admin,dc=foo,dc=bar');
 
         $subject->matches($token1, $this->targetDn);
         $subject->matches($token2, $this->targetDn);

--- a/tests/unit/Server/AccessControl/Subject/SelfSubjectMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Subject/SelfSubjectMatcherTest.php
@@ -33,7 +33,6 @@ final class SelfSubjectMatcherTest extends TestCase
         self::assertTrue($this->subject->matches(
             BindToken::fromDn(
                 'cn=foo,dc=bar',
-                'secret',
             ),
             new Dn('cn=foo,dc=bar'),
         ));
@@ -44,7 +43,6 @@ final class SelfSubjectMatcherTest extends TestCase
         self::assertTrue($this->subject->matches(
             BindToken::fromDn(
                 'CN=Foo,DC=bar',
-                'secret',
             ),
             new Dn('cn=foo,dc=bar'),
         ));
@@ -55,7 +53,6 @@ final class SelfSubjectMatcherTest extends TestCase
         self::assertFalse($this->subject->matches(
             BindToken::fromDn(
                 'cn=admin,dc=bar',
-                'secret',
             ),
             new Dn('cn=foo,dc=bar'),
         ));

--- a/tests/unit/Server/Backend/Auth/PasswordPolicyAwareAuthenticatorTest.php
+++ b/tests/unit/Server/Backend/Auth/PasswordPolicyAwareAuthenticatorTest.php
@@ -227,7 +227,6 @@ final class PasswordPolicyAwareAuthenticatorTest extends TestCase
     {
         $token = BindToken::fromDn(
             self::DN,
-            'secret',
         );
         $this->inner
             ->method('authenticate')

--- a/tests/unit/Server/Backend/Storage/OperationalAttributeGeneratorTest.php
+++ b/tests/unit/Server/Backend/Storage/OperationalAttributeGeneratorTest.php
@@ -438,10 +438,7 @@ final class OperationalAttributeGeneratorTest extends TestCase
     private function boundContext(string $dn): WriteContext
     {
         return new WriteContext(
-            BindToken::fromDn(
-                $dn,
-                '',
-            ),
+            BindToken::fromDn($dn),
             new ControlBag(),
         );
     }

--- a/tests/unit/Server/Backend/Write/PasswordPolicyWriteHandlerTest.php
+++ b/tests/unit/Server/Backend/Write/PasswordPolicyWriteHandlerTest.php
@@ -348,7 +348,6 @@ final class PasswordPolicyWriteHandlerTest extends TestCase
         return new WriteContext(
             BindToken::fromDn(
                 self::USER_DN,
-                'original-pass',
             ),
             new ControlBag(),
         );

--- a/tests/unit/Server/Logging/EventLoggerTest.php
+++ b/tests/unit/Server/Logging/EventLoggerTest.php
@@ -93,10 +93,9 @@ final class EventLoggerTest extends TestCase
 
     public function test_record_includes_authorized_by_for_a_proxied_subject(): void
     {
-        $token = new BindToken(
+        $token = BindToken::fromDn(
             'cn=alice,dc=example,dc=com',
             '',
-            new Dn('cn=alice,dc=example,dc=com'),
             3,
             new Dn('cn=admin,dc=example,dc=com'),
         );
@@ -131,10 +130,9 @@ final class EventLoggerTest extends TestCase
 
     public function test_record_omits_authorized_by_for_a_non_proxied_subject(): void
     {
-        $token = new BindToken(
+        $token = BindToken::fromDn(
             'cn=alice,dc=example,dc=com',
             'secret',
-            new Dn('cn=alice,dc=example,dc=com'),
         );
 
         $this->mockLogger

--- a/tests/unit/Server/Logging/EventLoggerTest.php
+++ b/tests/unit/Server/Logging/EventLoggerTest.php
@@ -95,7 +95,6 @@ final class EventLoggerTest extends TestCase
     {
         $token = BindToken::fromDn(
             'cn=alice,dc=example,dc=com',
-            '',
             3,
             new Dn('cn=admin,dc=example,dc=com'),
         );
@@ -132,7 +131,6 @@ final class EventLoggerTest extends TestCase
     {
         $token = BindToken::fromDn(
             'cn=alice,dc=example,dc=com',
-            'secret',
         );
 
         $this->mockLogger

--- a/tests/unit/Server/Logging/OperationAuditorTest.php
+++ b/tests/unit/Server/Logging/OperationAuditorTest.php
@@ -63,10 +63,9 @@ final class OperationAuditorTest extends TestCase
             $this->recordingLogger,
             EventLogPolicy::all(),
         ));
-        $this->token = new BindToken(
+        $this->token = BindToken::fromDn(
             self::ACTOR_DN,
             'secret',
-            new Dn(self::ACTOR_DN),
         );
     }
 

--- a/tests/unit/Server/Logging/OperationAuditorTest.php
+++ b/tests/unit/Server/Logging/OperationAuditorTest.php
@@ -65,7 +65,6 @@ final class OperationAuditorTest extends TestCase
         ));
         $this->token = BindToken::fromDn(
             self::ACTOR_DN,
-            'secret',
         );
     }
 

--- a/tests/unit/Server/Middleware/AuthorizationResolutionMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/AuthorizationResolutionMiddlewareTest.php
@@ -64,7 +64,7 @@ final class AuthorizationResolutionMiddlewareTest extends TestCase
 
     public function test_a_request_requiring_a_password_change_is_rejected_and_stashes_the_control(): void
     {
-        $token = BindToken::fromDn('cn=user,dc=foo,dc=bar', 'secret');
+        $token = BindToken::fromDn('cn=user,dc=foo,dc=bar');
         $token->markMustChangePassword();
         $this->authorization->setToken($token);
 
@@ -90,7 +90,7 @@ final class AuthorizationResolutionMiddlewareTest extends TestCase
 
     public function test_an_authorized_request_is_delegated_with_the_resolved_token(): void
     {
-        $token = BindToken::fromDn('cn=user,dc=foo,dc=bar', 'secret');
+        $token = BindToken::fromDn('cn=user,dc=foo,dc=bar');
         $this->authorization->setToken($token);
 
         $this->subject()->process(

--- a/tests/unit/Server/Middleware/BindMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/BindMiddlewareTest.php
@@ -66,7 +66,7 @@ final class BindMiddlewareTest extends TestCase
 
     public function test_a_successful_bind_stores_the_token_and_short_circuits(): void
     {
-        $token = BindToken::fromDn('cn=user,dc=foo,dc=bar', 'secret');
+        $token = BindToken::fromDn('cn=user,dc=foo,dc=bar');
         $this->authenticator
             ->method('bind')
             ->willReturn($token);
@@ -119,7 +119,7 @@ final class BindMiddlewareTest extends TestCase
 
     public function test_a_failed_rebind_resets_an_authenticated_session_to_anonymous(): void
     {
-        $this->authorization->setToken(BindToken::fromDn('cn=admin,dc=foo,dc=bar', 'secret'));
+        $this->authorization->setToken(BindToken::fromDn('cn=admin,dc=foo,dc=bar'));
         $this->authenticator
             ->method('bind')
             ->willThrowException(new OperationException(

--- a/tests/unit/Server/Middleware/OperationAuditMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationAuditMiddlewareTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Server\Middleware;
 
-use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\SchemaRuleException;
@@ -55,10 +54,9 @@ final class OperationAuditMiddlewareTest extends TestCase
         )));
         $this->context = new ServerRequestContext(
             new LdapMessageRequest(1, new AddRequest(Entry::create('cn=foo,dc=bar'))),
-            new BindToken(
+            BindToken::fromDn(
                 'cn=alice,dc=bar',
                 'secret',
-                new Dn('cn=alice,dc=bar'),
             ),
         );
     }
@@ -206,10 +204,9 @@ final class OperationAuditMiddlewareTest extends TestCase
     {
         return new ServerRequestContext(
             new LdapMessageRequest(1, $request),
-            new BindToken(
+            BindToken::fromDn(
                 'cn=alice,dc=bar',
                 'secret',
-                new Dn('cn=alice,dc=bar'),
             ),
         );
     }

--- a/tests/unit/Server/Middleware/OperationAuditMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationAuditMiddlewareTest.php
@@ -56,7 +56,6 @@ final class OperationAuditMiddlewareTest extends TestCase
             new LdapMessageRequest(1, new AddRequest(Entry::create('cn=foo,dc=bar'))),
             BindToken::fromDn(
                 'cn=alice,dc=bar',
-                'secret',
             ),
         );
     }
@@ -206,7 +205,6 @@ final class OperationAuditMiddlewareTest extends TestCase
             new LdapMessageRequest(1, $request),
             BindToken::fromDn(
                 'cn=alice,dc=bar',
-                'secret',
             ),
         );
     }

--- a/tests/unit/Server/Middleware/Pipeline/ServerRequestContextTest.php
+++ b/tests/unit/Server/Middleware/Pipeline/ServerRequestContextTest.php
@@ -46,7 +46,7 @@ final class ServerRequestContextTest extends TestCase
 
     public function test_with_token_returns_a_new_context_carrying_the_token(): void
     {
-        $token = BindToken::fromDn('cn=user,dc=foo,dc=bar', 'secret');
+        $token = BindToken::fromDn('cn=user,dc=foo,dc=bar');
 
         $withToken = $this->subject->withToken($token);
 

--- a/tests/unit/Server/PasswordModify/PasswordModifyServiceTest.php
+++ b/tests/unit/Server/PasswordModify/PasswordModifyServiceTest.php
@@ -67,7 +67,6 @@ final class PasswordModifyServiceTest extends TestCase
         );
         $this->userToken = BindToken::fromDn(
             self::USER_DN,
-            '12345',
         );
 
         $this->subject = new PasswordModifyService(
@@ -124,7 +123,6 @@ final class PasswordModifyServiceTest extends TestCase
             ),
             BindToken::fromDn(
                 'cn=admin,dc=foo,dc=bar',
-                'adminpass',
             ),
             new ControlBag(),
         );
@@ -277,7 +275,6 @@ final class PasswordModifyServiceTest extends TestCase
 
         $token = BindToken::fromDn(
             'cn=other,dc=foo,dc=bar',
-            'secret',
         );
         $token->markMustChangePassword();
 
@@ -313,7 +310,6 @@ final class PasswordModifyServiceTest extends TestCase
 
         $token = BindToken::fromDn(
             self::USER_DN,
-            '12345',
         );
         $token->markMustChangePassword();
 

--- a/tests/unit/Server/PasswordPolicy/PasswordResetGateTest.php
+++ b/tests/unit/Server/PasswordPolicy/PasswordResetGateTest.php
@@ -145,7 +145,6 @@ final class PasswordResetGateTest extends TestCase
     {
         return BindToken::fromDn(
             self::USER_DN,
-            'secret',
         );
     }
 }

--- a/tests/unit/Server/SearchLimit/SearchLimitResolverTest.php
+++ b/tests/unit/Server/SearchLimit/SearchLimitResolverTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Server\SearchLimit;
 
-use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\SearchLimit\SearchLimitResolver;
 use FreeDSx\Ldap\Server\SearchLimit\SearchLimitRule;
@@ -96,10 +95,9 @@ final class SearchLimitResolverTest extends TestCase
 
     private function authenticatedToken(): BindToken
     {
-        return new BindToken(
+        return BindToken::fromDn(
             'cn=user,dc=foo,dc=bar',
             '12345',
-            new Dn('cn=user,dc=foo,dc=bar'),
         );
     }
 }

--- a/tests/unit/Server/SearchLimit/SearchLimitResolverTest.php
+++ b/tests/unit/Server/SearchLimit/SearchLimitResolverTest.php
@@ -97,7 +97,6 @@ final class SearchLimitResolverTest extends TestCase
     {
         return BindToken::fromDn(
             'cn=user,dc=foo,dc=bar',
-            '12345',
         );
     }
 }

--- a/tests/unit/Server/Token/AnonTokenTest.php
+++ b/tests/unit/Server/Token/AnonTokenTest.php
@@ -33,12 +33,6 @@ final class AnonTokenTest extends TestCase
         );
     }
 
-    public function test_it_should_get_a_null_password(): void
-    {
-        self::assertNull($this->subject->getPassword());
-        ;
-    }
-
     public function test_it_should_get_the_version(): void
     {
         self::assertSame(

--- a/tests/unit/Server/Token/BindTokenTest.php
+++ b/tests/unit/Server/Token/BindTokenTest.php
@@ -24,7 +24,6 @@ final class BindTokenTest extends TestCase
     {
         $this->subject = BindToken::fromDn(
             'foo',
-            'bar',
         );
     }
 
@@ -33,14 +32,6 @@ final class BindTokenTest extends TestCase
         self::assertSame(
             'foo',
             $this->subject->getUsername(),
-        );
-    }
-
-    public function test_it_should_get_the_password(): void
-    {
-        self::assertSame(
-            'bar',
-            $this->subject->getPassword(),
         );
     }
 
@@ -64,7 +55,6 @@ final class BindTokenTest extends TestCase
     {
         $other = BindToken::fromDn(
             'foo',
-            'bar',
         );
 
         self::assertNotSame(
@@ -77,7 +67,6 @@ final class BindTokenTest extends TestCase
     {
         $token = BindToken::fromDn(
             'cn=foo,dc=bar',
-            'secret',
         );
 
         self::assertSame(

--- a/tests/unit/Server/Token/SystemTokenTest.php
+++ b/tests/unit/Server/Token/SystemTokenTest.php
@@ -32,11 +32,6 @@ final class SystemTokenTest extends TestCase
         );
     }
 
-    public function test_it_carries_no_password(): void
-    {
-        self::assertNull((new SystemToken())->getPassword());
-    }
-
     public function test_it_defaults_to_ldap_v3(): void
     {
         self::assertSame(


### PR DESCRIPTION
Two refactors going on here that touch a lot of files:

1. Use AuthzID in the spots that are relevant so we aren't passing raw strings around.
2. Remove the password from the token. It was previously used in the old proxy server setup. But it's no longer needed and should not be stored on the token.