### PR TITLE
[1.0.0] Handle authzId in SASL bind for applicable mechs.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": ">=8.2",
     "freedsx/asn1": "dev-main#b57a38f",
     "freedsx/socket": "dev-main#df083d9",
-    "freedsx/sasl": "dev-main#b886acb",
+    "freedsx/sasl": "dev-main#ebf53ad",
     "psr/log": "^3"
   },
   "require-dev": {

--- a/src/FreeDSx/Ldap/Protocol/Authorization/AuthzIdResolver.php
+++ b/src/FreeDSx/Ldap/Protocol/Authorization/AuthzIdResolver.php
@@ -73,28 +73,25 @@ final readonly class AuthzIdResolver
         AuthenticatedTokenInterface $token,
         AuthzId $authzId,
     ): TokenInterface {
-        // a caller with no proxy grant cannot drive resolution.
+        if ($authzId->isType(AuthzIdType::Anonymous)) {
+            return $this->assumeAnonymous(
+                $token,
+                $authzId,
+            );
+        }
+
+        // Authorizing as the already-authenticated identity needs no proxy grant (RFC 4513 section 3.2).
+        if ($this->isAuthenticatedIdentity($authzId, $token)) {
+            return $token;
+        }
+
+        // Acting as any other identity is a proxy request and requires the grant (checked before resolving).
         if (!$this->accessControl->mayUseControl($token, Control::OID_PROXY_AUTHORIZATION)) {
             $this->deny(
                 $token,
                 $authzId->toString(),
             );
         }
-
-        if ($authzId->isType(AuthzIdType::Anonymous)) {
-            $this->authorize(
-                $token,
-                new Dn(''),
-                $authzId,
-            );
-
-            return new AnonToken(
-                null,
-                $token->getVersion(),
-                $token->getResolvedDn(),
-            );
-        }
-
         $entry = $this->resolve($authzId);
         if ($entry === null) {
             $this->deny(
@@ -141,6 +138,62 @@ final readonly class AuthzIdResolver
         );
 
         throw $exception;
+    }
+
+    /**
+     * Assume the anonymous identity (an empty authzId), which still requires the proxy-auth grant.
+     *
+     * @throws OperationException when the assumption is not permitted
+     */
+    private function assumeAnonymous(
+        AuthenticatedTokenInterface $token,
+        AuthzId $authzId,
+    ): TokenInterface {
+        if (!$this->accessControl->mayUseControl($token, Control::OID_PROXY_AUTHORIZATION)) {
+            $this->deny(
+                $token,
+                $authzId->toString(),
+            );
+        }
+        $this->authorize(
+            $token,
+            new Dn(''),
+            $authzId,
+        );
+
+        return new AnonToken(
+            null,
+            $token->getVersion(),
+            $token->getResolvedDn(),
+        );
+    }
+
+    /**
+     * Whether the authzId already names the authenticated identity, so no proxy assumption is involved.
+     */
+    private function isAuthenticatedIdentity(
+        AuthzId $authzId,
+        AuthenticatedTokenInterface $token,
+    ): bool {
+        if ($authzId->isType(AuthzIdType::Username)) {
+            return $authzId->getValue() === $token->getUsername();
+        }
+
+        return $authzId->isType(AuthzIdType::Dn)
+            && $this->isSameDn($authzId->getValue(), $token->getResolvedDn());
+    }
+
+    private function isSameDn(
+        string $candidate,
+        Dn $resolvedDn,
+    ): bool {
+        try {
+            $normalized = (new Dn($candidate))->normalize()->toString();
+        } catch (InvalidArgumentException|UnexpectedValueException) {
+            return false;
+        }
+
+        return $normalized === $resolvedDn->normalize()->toString();
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/ExternalMechanismOptionsBuilder.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/ExternalMechanismOptionsBuilder.php
@@ -14,16 +14,11 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder;
 
 use FreeDSx\Ldap\Entry\Dn;
-use FreeDSx\Ldap\Entry\Entry;
-use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
-use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Protocol\Authorization\AuthzIdResolver;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\Sasl\External\ExternalCredentialMapperInterface;
-use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
-use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Sasl\Options\ChallengeOptionsInterface;
@@ -40,8 +35,6 @@ final class ExternalMechanismOptionsBuilder implements MechanismOptionsBuilderIn
 
     private ?string $username = null;
 
-    private ?Dn $authorizingDn = null;
-
     public function __construct(
         private readonly ServerQueue $queue,
         private readonly ServerOptions $options,
@@ -54,7 +47,7 @@ final class ExternalMechanismOptionsBuilder implements MechanismOptionsBuilderIn
         MechanismName $mechanism,
     ): ChallengeOptionsInterface {
         return (new ExternalOptions())->setValidate(
-            fn(?string $authzId): bool => $this->validate($authzId),
+            fn(?string $authzId): bool => $this->validate(),
         );
     }
 
@@ -68,15 +61,13 @@ final class ExternalMechanismOptionsBuilder implements MechanismOptionsBuilderIn
         return $this->username;
     }
 
-    public function getAuthorizingDn(): ?Dn
-    {
-        return $this->authorizingDn;
-    }
-
     /**
-     * @throws OperationException when the channel is unsuitable for EXTERNAL or an assumed authzId is denied
+     * Validates the channel and resolves the certificate's authentication identity. A client-supplied
+     * authzId is honored later, uniformly, by the SASL exchange.
+     *
+     * @throws OperationException when the channel is unsuitable for EXTERNAL
      */
-    private function validate(?string $clientAuthzId): bool
+    private function validate(): bool
     {
         $this->assertSecureChannel();
 
@@ -98,55 +89,10 @@ final class ExternalMechanismOptionsBuilder implements MechanismOptionsBuilderIn
             return false;
         }
 
-        $token = $this->effectiveToken(
-            $authcEntry,
-            $clientAuthzId,
-        );
-        if ($token === null) {
-            return false;
-        }
-
-        $this->resolvedDn = $token->getResolvedDn();
-        $this->username = $token->getUsername();
-        $this->authorizingDn = $token->getAuthorizingDn();
+        $this->resolvedDn = $authcEntry->getDn();
+        $this->username = $authcEntry->getDn()->toString();
 
         return true;
-    }
-
-    /**
-     * The certificate identity, or the authzId it is authorized to assume.
-     *
-     * Returns null when the client authzId is malformed.
-     *
-     * @throws OperationException when the assumed authzId is denied
-     */
-    private function effectiveToken(
-        Entry $authcEntry,
-        ?string $clientAuthzId,
-    ): ?AuthenticatedTokenInterface {
-        $authcToken = BindToken::fromSasl(
-            $authcEntry->getDn()->toString(),
-            $authcEntry->getDn(),
-        );
-
-        if ($clientAuthzId === null || $clientAuthzId === '') {
-            return $authcToken;
-        }
-
-        try {
-            $authzId = AuthzId::fromString($clientAuthzId);
-        } catch (InvalidArgumentException) {
-            return null;
-        }
-
-        $assumed = $this->authzIdResolver->assume(
-            $authcToken,
-            $authzId,
-        );
-
-        return $assumed instanceof AuthenticatedTokenInterface
-            ? $assumed
-            : null;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/MechanismOptionsBuilderInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/MechanismOptionsBuilderInterface.php
@@ -41,9 +41,4 @@ interface MechanismOptionsBuilderInterface
      * The username the mechanism resolved directly, when it is not carried in the SASL credentials (else null).
      */
     public function getUsername(): ?string;
-
-    /**
-     * The authorizing identity's DN when an authorization identity was assumed for the bind (else null).
-     */
-    public function getAuthorizingDn(): ?Dn;
 }

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/RequireIdentityTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/RequireIdentityTrait.php
@@ -37,11 +37,6 @@ trait RequireIdentityTrait
         return null;
     }
 
-    public function getAuthorizingDn(): ?Dn
-    {
-        return null;
-    }
-
     /**
      * Validates the identity, stores its resolved DN, and returns it.
      *

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/SaslExchange.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/SaslExchange.php
@@ -14,17 +14,23 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\Bind\Sasl;
 
 use Closure;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
 use FreeDSx\Ldap\Operation\Response\BindResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzIdResolver;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\MechanismOptionsBuilderFactory;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\UsernameExtractor\SaslUsernameExtractorFactory;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
+use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Sasl\SaslContext;
 use Throwable;
@@ -40,6 +46,7 @@ final class SaslExchange
         private readonly ServerQueue $queue,
         private readonly ResponseFactory $responseFactory,
         private readonly MechanismOptionsBuilderFactory $optionsBuilderFactory,
+        private readonly AuthzIdResolver $authzIdResolver,
         private readonly SaslUsernameExtractorFactory $usernameExtractorFactory = new SaslUsernameExtractorFactory(),
     ) {}
 
@@ -66,6 +73,26 @@ final class SaslExchange
                 $input->getInitialCredentials(),
                 $message,
             );
+
+            $username = $optionsBuilder->getUsername() ?? $this->extractUsername(
+                $usernameCredentials,
+                $mechName,
+            );
+            $resolvedDn = $optionsBuilder->getResolvedDn();
+            // The authorizing identity is set only when an authzid is assumed, below.
+            $authorizingDn = null;
+
+            // A client-supplied authzid is honored uniformly here, after the mechanism authenticated.
+            $effective = $this->honorAuthzId(
+                $context,
+                $username,
+                $resolvedDn,
+            );
+            if ($effective !== null) {
+                $username = $effective->getUsername();
+                $resolvedDn = $effective->getResolvedDn();
+                $authorizingDn = $effective->getAuthorizingDn();
+            }
         } catch (OperationException $e) {
             // Once $message is a continuation, the outer ServerProtocolHandler holds a stale
             // initial-bind ID. Send the error here with the correct ID before re-throwing.
@@ -83,13 +110,68 @@ final class SaslExchange
         return new SaslExchangeResult(
             $context,
             $message,
-            $optionsBuilder->getUsername() ?? $this->extractUsername(
-                $usernameCredentials,
-                $mechName,
-            ),
-            $optionsBuilder->getResolvedDn(),
-            $optionsBuilder->getAuthorizingDn(),
+            $username,
+            $resolvedDn,
+            $authorizingDn,
         );
+    }
+
+    /**
+     * Resolves a client-supplied authzid (when the mechanism carried one) to the effective identity.
+     *
+     * Returns the token to bind as, or null when there is no authzid to honor.
+     *
+     * @throws OperationException when the assumption is denied
+     */
+    private function honorAuthzId(
+        SaslContext $context,
+        ?string $username,
+        ?Dn $resolvedDn,
+    ): ?AuthenticatedTokenInterface {
+        $rawAuthzId = $this->requestedAuthzId(
+            $context->getAuthzId(),
+            $username,
+        );
+        if ($rawAuthzId === null || $resolvedDn === null) {
+            return null;
+        }
+
+        $authcToken = BindToken::fromSasl(
+            $username ?? $resolvedDn->toString(),
+            $resolvedDn,
+        );
+        try {
+            $authzId = AuthzId::fromString($rawAuthzId);
+        } catch (InvalidArgumentException) {
+            $this->authzIdResolver->deny(
+                $authcToken,
+                $rawAuthzId,
+            );
+        }
+        $effective = $this->authzIdResolver->assume(
+            $authcToken,
+            $authzId,
+        );
+
+        return $effective instanceof AuthenticatedTokenInterface
+            ? $effective
+            : null;
+    }
+
+    /**
+     * The authzid to honor as a proxy request, or null when it is absent or names the authenticated identity itself.
+     *
+     * A client asking to act as its own authcId (the common case, e.g. PLAIN) needs no proxy authorization.
+     */
+    private function requestedAuthzId(
+        ?string $rawAuthzId,
+        ?string $authcId,
+    ): ?string {
+        if ($rawAuthzId === null || $rawAuthzId === '' || $rawAuthzId === $authcId) {
+            return null;
+        }
+
+        return $rawAuthzId;
     }
 
     private function extractUsername(

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSaslBindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSaslBindHandler.php
@@ -27,6 +27,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ClientQueue;
 use FreeDSx\Ldap\Protocol\Queue\MessageWrapper\SaslMessageWrapper;
 use FreeDSx\Ldap\Protocol\RootDseLoader;
+use FreeDSx\Sasl\Challenge\ChallengeInterface;
 use FreeDSx\Sasl\Exception\SaslException;
 use FreeDSx\Sasl\Mechanism\MechanismInterface;
 use FreeDSx\Sasl\Mechanism\MechanismName;
@@ -71,9 +72,18 @@ class ClientSaslBindHandler implements RequestHandlerInterface
         $detectDowngrade = ($request->getMechanism() === '');
         $mech = $this->selectSaslMech($request);
 
-        $this->queue->sendMessage($message);
+        # Compute the client's initial response. Client-first mechanisms (PLAIN, SCRAM, EXTERNAL)
+        # produce one to carry in the initial bind; server-first mechanisms produce null.
+        $challenge = $mech->challenge();
+        $context = $challenge->challenge(
+            null,
+            $request->getOptions(),
+        );
 
-        $response = $this->queue->getMessage($message->getMessageId());
+        $response = $this->sendInitialBind(
+            $request,
+            $context,
+        );
         $saslResponse = $response->getResponse();
         if (!$saslResponse instanceof BindResponse) {
             throw new ProtocolException(sprintf(
@@ -81,15 +91,24 @@ class ClientSaslBindHandler implements RequestHandlerInterface
                 get_class($saslResponse),
             ));
         }
-        if ($saslResponse->getResultCode() !== ResultCode::SASL_BIND_IN_PROGRESS) {
-            return $response;
+
+        if ($saslResponse->getResultCode() === ResultCode::SASL_BIND_IN_PROGRESS) {
+            $response = $this->processSaslChallenge(
+                $request,
+                $this->queue,
+                $saslResponse,
+                $mech,
+                $challenge,
+            );
+        } else {
+            # A client-first mechanism that completes in a single round (e.g. EXTERNAL): no challenge loop.
+            $this->activateSecurityLayer(
+                $context,
+                $saslResponse,
+                $mech,
+            );
         }
-        $response = $this->processSaslChallenge(
-            $request,
-            $this->queue,
-            $saslResponse,
-            $mech,
-        );
+
         if (
             $detectDowngrade
             && $response->getResponse() instanceof BindResponse
@@ -99,6 +118,27 @@ class ClientSaslBindHandler implements RequestHandlerInterface
         }
 
         return $response;
+    }
+
+    /**
+     * Sends the initial bind carrying the client's first response, then returns the server's reply.
+     */
+    private function sendInitialBind(
+        SaslBindRequest $request,
+        SaslContext $context,
+    ): LdapMessageResponse {
+        $message = $this->makeRequest(
+            $this->queue,
+            Operations::bindSasl(
+                $request->getOptions(),
+                MechanismName::from($request->getMechanism()),
+                $context->getResponse(),
+            )->setVersion($request->getVersion()),
+            $this->controls,
+        );
+        $this->queue->sendMessage($message);
+
+        return $this->queue->getMessage($message->getMessageId());
     }
 
     /**
@@ -133,13 +173,22 @@ class ClientSaslBindHandler implements RequestHandlerInterface
         ClientQueue $queue,
         BindResponse $saslResponse,
         MechanismInterface $mech,
+        ChallengeInterface $challenge,
     ): LdapMessageResponse {
-        $challenge = $mech->challenge();
-
         do {
-            $context = $challenge->challenge($saslResponse->getSaslCredentials(), $request->getOptions());
-            $saslBind = Operations::bindSasl($request->getOptions(), MechanismName::from($request->getMechanism()), $context->getResponse());
-            $response = $this->sendRequestGetResponse($saslBind, $queue);
+            $context = $challenge->challenge(
+                $saslResponse->getSaslCredentials(),
+                $request->getOptions(),
+            );
+            $saslBind = Operations::bindSasl(
+                $request->getOptions(),
+                MechanismName::from($request->getMechanism()),
+                $context->getResponse(),
+            );
+            $response = $this->sendRequestGetResponse(
+                $saslBind,
+                $queue,
+            );
             $saslResponse = $response->getResponse();
             if (!$saslResponse instanceof BindResponse) {
                 throw new BindException(sprintf(
@@ -150,14 +199,37 @@ class ClientSaslBindHandler implements RequestHandlerInterface
         } while (!$this->isChallengeComplete($context, $saslResponse));
 
         if (!$context->isComplete()) {
-            $context = $challenge->challenge($saslResponse->getSaslCredentials(), $request->getOptions());
+            $context = $challenge->challenge(
+                $saslResponse->getSaslCredentials(),
+                $request->getOptions(),
+            );
         }
 
-        if ($saslResponse->getResultCode() === ResultCode::SUCCESS && $context->hasSecurityLayer()) {
-            $queue->setMessageWrapper(new SaslMessageWrapper($mech->securityLayer(), $context));
-        }
+        $this->activateSecurityLayer(
+            $context,
+            $saslResponse,
+            $mech,
+        );
 
         return $response;
+    }
+
+    /**
+     * Installs the negotiated SASL security layer (integrity/privacy) once the bind has succeeded.
+     */
+    private function activateSecurityLayer(
+        SaslContext $context,
+        BindResponse $saslResponse,
+        MechanismInterface $mech,
+    ): void {
+        if ($saslResponse->getResultCode() !== ResultCode::SUCCESS || !$context->hasSecurityLayer()) {
+            return;
+        }
+
+        $this->queue->setMessageWrapper(new SaslMessageWrapper(
+            $mech->securityLayer(),
+            $context,
+        ));
     }
 
     private function sendRequestGetResponse(

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -160,6 +160,7 @@ class ServerProtocolFactory implements ServerProtocolFactoryInterface
                         $saslMechanisms,
                         $authzIdResolver,
                     ),
+                    $authzIdResolver,
                 ),
                 sasl: new Sasl(new SaslOptions(
                     supported: $this->parseKnownMechanisms($saslMechanisms),

--- a/tests/integration/Security/LdapExternalSaslProxyServerTest.php
+++ b/tests/integration/Security/LdapExternalSaslProxyServerTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Security;
+
+use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\Exception\BindException;
+use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Sasl\Mechanism\MechanismName;
+use FreeDSx\Sasl\Options\ExternalOptions;
+use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+use Throwable;
+
+use function strtolower;
+
+/**
+ * End-to-end SASL EXTERNAL proxied authorization: the cert identity cn=extuser is granted the control over dc=foo,dc=bar.
+ */
+final class LdapExternalSaslProxyServerTest extends ServerTestCase
+{
+    private const CLIENT_CERT = __DIR__ . '/../../resources/cert/test-cases/ext-client.crt';
+
+    private const CLIENT_KEY = __DIR__ . '/../../resources/cert/test-cases/ext-client.key';
+
+    /**
+     * @var LdapClient[]
+     */
+    private array $certificateClients = [];
+
+    public function setUp(): void
+    {
+        $this->setServerMode('ldap-server');
+
+        parent::setUp();
+
+        $this->createServerProcess(
+            'ssl',
+            [
+                '--external',
+                '--external-allow-proxy',
+            ],
+        );
+    }
+
+    public function tearDown(): void
+    {
+        foreach ($this->certificateClients as $client) {
+            try {
+                $client->unbind();
+            } catch (Throwable) {
+                // The connection may already be closed; ignore unbind failures.
+            }
+        }
+        $this->certificateClients = [];
+
+        parent::tearDown();
+    }
+
+    public function testItProxiesToAnotherIdentityWhenGranted(): void
+    {
+        $client = $this->clientWithCertificate();
+
+        $client->bindSasl(
+            (new ExternalOptions())->setAuthzId('dn:cn=user,dc=foo,dc=bar'),
+            MechanismName::EXTERNAL,
+        );
+
+        self::assertSame(
+            'dn:cn=user,dc=foo,dc=bar',
+            strtolower((string) $client->whoami()),
+        );
+    }
+
+    public function testItBindsAsSelfWhenTheAuthzIdNamesTheCertificateIdentity(): void
+    {
+        $client = $this->clientWithCertificate();
+
+        $client->bindSasl(
+            (new ExternalOptions())->setAuthzId('dn:cn=extuser,dc=foo,dc=bar'),
+            MechanismName::EXTERNAL,
+        );
+
+        self::assertSame(
+            'dn:cn=extuser,dc=foo,dc=bar',
+            strtolower((string) $client->whoami()),
+        );
+    }
+
+    public function testItDeniesProxyingToAnUnresolvableIdentity(): void
+    {
+        $client = $this->clientWithCertificate();
+
+        $this->expectException(BindException::class);
+
+        $client->bindSasl(
+            (new ExternalOptions())->setAuthzId('dn:cn=ghost,dc=foo,dc=bar'),
+            MechanismName::EXTERNAL,
+        );
+    }
+
+    private function clientWithCertificate(): LdapClient
+    {
+        $client = new LdapClient(
+            (new ClientOptions())
+                ->setServers(['127.0.0.1'])
+                ->setPort(10389)
+                ->setTransport('tcp')
+                ->setUseSsl(true)
+                ->setSslValidateCert(false)
+                ->setSslCert(self::CLIENT_CERT)
+                ->setSslCertKey(self::CLIENT_KEY),
+        );
+        $this->certificateClients[] = $client;
+
+        return $client;
+    }
+}

--- a/tests/integration/Security/LdapProxiedAuthorizationControlTest.php
+++ b/tests/integration/Security/LdapProxiedAuthorizationControlTest.php
@@ -113,11 +113,13 @@ final class LdapProxiedAuthorizationControlTest extends ServerTestCase
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::AUTHORIZATION_DENIED);
 
+        // dc=foo,dc=bar resolves but sits above ou=people, and is not the bound identity, so
+        // neither the grant nor the authorize-as-self path applies.
         $this->ldapClient()->search(
             Operations::search(Filters::present('objectClass'))
                 ->base('dc=foo,dc=bar')
                 ->useSubtreeScope(),
-            Controls::proxyAuthorization(AuthzId::fromString('dn:cn=user,dc=foo,dc=bar')),
+            Controls::proxyAuthorization(AuthzId::fromString('dn:dc=foo,dc=bar')),
         );
     }
 }

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -7,8 +7,13 @@ namespace Tests\Support\FreeDSx\Ldap;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Ldif\Loader\FileLdifLoader;
+use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Ldif\Output\FileLdifOutput;
+use FreeDSx\Ldap\Server\AccessControl\AclRules;
+use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
+use FreeDSx\Ldap\Server\AccessControl\Target\Target;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\Server\SearchLimit\SearchLimitRule;
 use FreeDSx\Ldap\Server\SearchLimit\SearchLimitRules;
@@ -110,6 +115,12 @@ final class LdapServerCommand extends Command
                 null,
                 InputOption::VALUE_NONE,
                 'Enable SASL EXTERNAL with client-certificate validation (implies TLS)',
+            )
+            ->addOption(
+                'external-allow-proxy',
+                null,
+                InputOption::VALUE_NONE,
+                'Grant the EXTERNAL cert identity (cn=extuser) the Proxied Authorization control over dc=foo,dc=bar',
             )
             ->addOption(
                 'seed',
@@ -241,6 +252,18 @@ final class LdapServerCommand extends Command
                 ->setSslValidateCert(true)
                 ->setSslCaCert(self::EXTERNAL_CA_CERT)
                 ->setSaslMechanisms(ServerOptions::SASL_EXTERNAL);
+        }
+
+        if ($external && $input->getOption('external-allow-proxy') === true) {
+            $options->setAclRules(
+                (new AclRules())
+                    ->withOperationRules(OperationRule::allow(Subject::authenticated()))
+                    ->withControlRules(ControlRule::allow(
+                        Subject::dn('cn=extuser,dc=foo,dc=bar'),
+                        Target::subtree('dc=foo,dc=bar'),
+                        Control::OID_PROXY_AUTHORIZATION,
+                    )),
+            );
         }
 
         $server->useStorage($storage);

--- a/tests/unit/Protocol/Authorization/AuthzIdResolverTest.php
+++ b/tests/unit/Protocol/Authorization/AuthzIdResolverTest.php
@@ -138,6 +138,47 @@ final class AuthzIdResolverTest extends TestCase
         );
     }
 
+    public function test_assume_returns_the_authenticated_token_when_the_authz_id_names_self_by_dn(): void
+    {
+        $this->accessControl
+            ->expects(self::never())
+            ->method('mayUseControl');
+        $this->accessControl
+            ->expects(self::never())
+            ->method('authorizeControl');
+
+        $token = $this->subject->assume(
+            $this->boundToken,
+            AuthzId::fromString('dn:' . self::ADMIN_DN),
+        );
+
+        self::assertSame(
+            $this->boundToken,
+            $token,
+        );
+    }
+
+    public function test_assume_returns_the_authenticated_token_when_the_authz_id_names_self_by_username(): void
+    {
+        $boundToken = BindToken::fromUsername('alice');
+        $this->accessControl
+            ->expects(self::never())
+            ->method('mayUseControl');
+        $this->accessControl
+            ->expects(self::never())
+            ->method('authorizeControl');
+
+        $token = $this->subject->assume(
+            $boundToken,
+            AuthzId::fromString('u:alice'),
+        );
+
+        self::assertSame(
+            $boundToken,
+            $token,
+        );
+    }
+
     public function test_assume_anonymous_returns_an_anonymous_token(): void
     {
         $this->accessControl

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/ExternalMechanismOptionsBuilderTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/ExternalMechanismOptionsBuilderTest.php
@@ -43,8 +43,6 @@ final class ExternalMechanismOptionsBuilderTest extends TestCase
 {
     private const CERT_DN = 'cn=client,dc=example,dc=com';
 
-    private const TARGET_DN = 'cn=service,dc=example,dc=com';
-
     private AccessControlInterface&MockObject $accessControl;
 
     private LdapBackendInterface&MockObject $backend;
@@ -123,7 +121,7 @@ final class ExternalMechanismOptionsBuilderTest extends TestCase
         self::assertFalse($validate(null));
     }
 
-    public function test_it_resolves_the_certificate_identity_when_no_authz_id_is_requested(): void
+    public function test_it_resolves_the_certificate_identity(): void
     {
         $this->backend
             ->method('get')
@@ -136,55 +134,12 @@ final class ExternalMechanismOptionsBuilderTest extends TestCase
             mapped: AuthzId::fromDn(new Dn(self::CERT_DN)),
         );
 
+        // The authzid (if any) is honored later by the SASL exchange, not here.
         self::assertTrue($this->validateClosure($builder)(null));
         self::assertSame(
             self::CERT_DN,
             $builder->getResolvedDn()?->toString(),
         );
-        self::assertNull($builder->getAuthorizingDn());
-    }
-
-    public function test_it_assumes_a_requested_authz_id_recording_the_authorizing_dn(): void
-    {
-        $this->accessControl
-            ->method('mayUseControl')
-            ->willReturn(true);
-        $this->backend
-            ->method('get')
-            ->willReturnCallback(fn(Dn $dn): Entry => new Entry($dn));
-
-        $builder = $this->builder(
-            encrypted: true,
-            validateCert: true,
-            certificate: $this->certificate(),
-            mapped: AuthzId::fromDn(new Dn(self::CERT_DN)),
-        );
-
-        self::assertTrue($this->validateClosure($builder)('dn:' . self::TARGET_DN));
-        self::assertSame(
-            self::TARGET_DN,
-            $builder->getResolvedDn()?->toString(),
-        );
-        self::assertSame(
-            self::CERT_DN,
-            $builder->getAuthorizingDn()?->toString(),
-        );
-    }
-
-    public function test_it_fails_on_a_malformed_authz_id(): void
-    {
-        $this->backend
-            ->method('get')
-            ->willReturn(new Entry(new Dn(self::CERT_DN)));
-
-        $builder = $this->builder(
-            encrypted: true,
-            validateCert: true,
-            certificate: $this->certificate(),
-            mapped: AuthzId::fromDn(new Dn(self::CERT_DN)),
-        );
-
-        self::assertFalse($this->validateClosure($builder)('not-an-authzid'));
     }
 
     private function builder(

--- a/tests/unit/Protocol/Bind/Sasl/SaslExchangeTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/SaslExchangeTest.php
@@ -17,13 +17,18 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
 use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzIdResolver;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\MechanismOptionsBuilderFactory;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\SaslExchange;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\SaslExchangeInput;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Sasl\Challenge\ChallengeInterface;
 use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Sasl\SaslContext;
@@ -56,6 +61,12 @@ final class SaslExchangeTest extends TestCase
             queue: $this->mockQueue,
             responseFactory: new ResponseFactory(),
             optionsBuilderFactory: new MechanismOptionsBuilderFactory($mockAuthenticator),
+            authzIdResolver: new AuthzIdResolver(
+                $this->createMock(AccessControlInterface::class),
+                $this->createMock(LdapBackendInterface::class),
+                $this->createMock(BindNameResolverInterface::class),
+                new EventLogger(null),
+            ),
         );
     }
 

--- a/tests/unit/Protocol/Bind/SaslBindTest.php
+++ b/tests/unit/Protocol/Bind/SaslBindTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Protocol\Bind;
 
 use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\ResponseAlreadySentException;
 use FreeDSx\Ldap\Exception\RuntimeException;
@@ -21,14 +22,19 @@ use FreeDSx\Ldap\Operation\Request\AnonBindRequest;
 use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
 use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzIdResolver;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\MechanismOptionsBuilderFactory;
 use FreeDSx\Ldap\Protocol\Bind\Sasl\SaslExchange;
 use FreeDSx\Ldap\Protocol\Bind\SaslBind;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\SaslIdentity;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Sasl\Mechanism\MechanismName;
@@ -54,6 +60,7 @@ final class SaslBindTest extends TestCase
                 $this->mockQueue,
                 new ResponseFactory(),
                 new MechanismOptionsBuilderFactory($this->mockAuthenticator),
+                $this->authzIdResolver(),
             ),
             mechanisms: [ServerOptions::SASL_PLAIN],
         );
@@ -111,8 +118,8 @@ final class SaslBindTest extends TestCase
 
     public function test_it_can_authenticate_with_plain(): void
     {
-        // PLAIN credential format: "authzid\x00authcid\x00passwd"
-        $credentials = "user\x00cn=user,dc=foo,dc=bar\x0012345";
+        // PLAIN credential format: "authzid\x00authcid\x00passwd"; the client sends authzid == authcid (bind as self).
+        $credentials = "cn=user,dc=foo,dc=bar\x00cn=user,dc=foo,dc=bar\x0012345";
         $identity = new SaslIdentity('12345', new Dn('cn=user,dc=foo,dc=bar'));
 
         $this->mockAuthenticator
@@ -138,6 +145,101 @@ final class SaslBindTest extends TestCase
             'cn=user,dc=foo,dc=bar',
             $token->getUsername(),
         );
+    }
+
+    public function test_it_honors_a_proxy_authz_id_when_the_grant_is_present(): void
+    {
+        // PLAIN authzid (dn:) distinct from the authenticated identity: a proxy request.
+        $credentials = "dn:cn=alice,dc=foo,dc=bar\x00cn=admin,dc=foo,dc=bar\x0012345";
+        $identity = new SaslIdentity('12345', new Dn('cn=admin,dc=foo,dc=bar'));
+
+        $this->mockAuthenticator
+            ->expects(self::once())
+            ->method('getSaslIdentity')
+            ->with('cn=admin,dc=foo,dc=bar', MechanismName::PLAIN)
+            ->willReturn($identity);
+
+        $accessControl = $this->createMock(AccessControlInterface::class);
+        $accessControl->method('mayUseControl')->willReturn(true);
+        $backend = $this->createMock(LdapBackendInterface::class);
+        $backend->method('get')->willReturn(new Entry(new Dn('cn=alice,dc=foo,dc=bar')));
+
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('sendMessage');
+
+        $token = $this->subjectWith($this->resolverWith(
+            $accessControl,
+            $backend,
+        ))->bind(new LdapMessageRequest(
+            1,
+            new SaslBindRequest('PLAIN', $credentials),
+        ));
+
+        self::assertInstanceOf(
+            BindToken::class,
+            $token,
+        );
+        self::assertSame(
+            'cn=alice,dc=foo,dc=bar',
+            $token->getResolvedDn()->toString(),
+        );
+        self::assertSame(
+            'cn=admin,dc=foo,dc=bar',
+            $token->getAuthorizingDn()?->toString(),
+        );
+    }
+
+    public function test_it_denies_a_proxy_authz_id_without_the_grant(): void
+    {
+        $credentials = "dn:cn=alice,dc=foo,dc=bar\x00cn=admin,dc=foo,dc=bar\x0012345";
+        $identity = new SaslIdentity('12345', new Dn('cn=admin,dc=foo,dc=bar'));
+
+        $this->mockAuthenticator
+            ->method('getSaslIdentity')
+            ->willReturn($identity);
+
+        $accessControl = $this->createMock(AccessControlInterface::class);
+        $accessControl->method('mayUseControl')->willReturn(false);
+
+        // The deny occurs after the exchange authenticated; the dispatcher sends the error, not us.
+        $this->mockQueue
+            ->expects(self::never())
+            ->method('sendMessage');
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::AUTHORIZATION_DENIED);
+
+        $this->subjectWith($this->resolverWith(
+            $accessControl,
+            $this->createMock(LdapBackendInterface::class),
+        ))->bind(new LdapMessageRequest(
+            1,
+            new SaslBindRequest('PLAIN', $credentials),
+        ));
+    }
+
+    public function test_it_denies_a_malformed_authz_id(): void
+    {
+        // 'bogus' is neither empty, a dn:, nor a u: form, and differs from the authcid.
+        $credentials = "bogus\x00cn=admin,dc=foo,dc=bar\x0012345";
+        $identity = new SaslIdentity('12345', new Dn('cn=admin,dc=foo,dc=bar'));
+
+        $this->mockAuthenticator
+            ->method('getSaslIdentity')
+            ->willReturn($identity);
+
+        $this->mockQueue
+            ->expects(self::never())
+            ->method('sendMessage');
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::AUTHORIZATION_DENIED);
+
+        $this->subject->bind(new LdapMessageRequest(
+            1,
+            new SaslBindRequest('PLAIN', $credentials),
+        ));
     }
 
     public function test_it_throws_invalid_credentials_when_plain_authentication_fails(): void
@@ -173,6 +275,7 @@ final class SaslBindTest extends TestCase
                 $this->mockQueue,
                 new ResponseFactory(),
                 new MechanismOptionsBuilderFactory($this->mockAuthenticator),
+                $this->authzIdResolver(),
             ),
             mechanisms: [ServerOptions::SASL_CRAM_MD5],
         );
@@ -233,6 +336,7 @@ final class SaslBindTest extends TestCase
                 $this->mockQueue,
                 new ResponseFactory(),
                 new MechanismOptionsBuilderFactory($this->mockAuthenticator),
+                $this->authzIdResolver(),
             ),
             mechanisms: [ServerOptions::SASL_CRAM_MD5],
         );
@@ -258,5 +362,39 @@ final class SaslBindTest extends TestCase
             1,
             new SaslBindRequest('CRAM-MD5'),
         ));
+    }
+
+    private function authzIdResolver(): AuthzIdResolver
+    {
+        return $this->resolverWith(
+            $this->createMock(AccessControlInterface::class),
+            $this->createMock(LdapBackendInterface::class),
+        );
+    }
+
+    private function resolverWith(
+        AccessControlInterface $accessControl,
+        LdapBackendInterface $backend,
+    ): AuthzIdResolver {
+        return new AuthzIdResolver(
+            $accessControl,
+            $backend,
+            $this->createMock(BindNameResolverInterface::class),
+            new EventLogger(null),
+        );
+    }
+
+    private function subjectWith(AuthzIdResolver $resolver): SaslBind
+    {
+        return new SaslBind(
+            queue: $this->mockQueue,
+            exchange: new SaslExchange(
+                $this->mockQueue,
+                new ResponseFactory(),
+                new MechanismOptionsBuilderFactory($this->mockAuthenticator),
+                $resolver,
+            ),
+            mechanisms: [ServerOptions::SASL_PLAIN],
+        );
     }
 }

--- a/tests/unit/Protocol/ClientProtocolHandler/ClientSaslBindHandlerTest.php
+++ b/tests/unit/Protocol/ClientProtocolHandler/ClientSaslBindHandlerTest.php
@@ -277,6 +277,47 @@ final class ClientSaslBindHandlerTest extends TestCase
         );
     }
 
+    public function test_it_sends_the_initial_response_and_completes_in_a_single_round(): void
+    {
+        // EXTERNAL: the client's first response is carried in the initial bind and the server
+        // completes immediately, so the challenge loop is never entered.
+        $saslBind = Operations::bindSasl(
+            null,
+            MechanismName::EXTERNAL,
+        );
+        $messageRequest = new LdapMessageRequest(1, $saslBind);
+
+        $this->mockQueue
+            ->expects(self::once())
+            ->method('getMessage')
+            ->willReturn($this->saslComplete);
+
+        $this->mockSasl
+            ->method('get')
+            ->with(MechanismName::EXTERNAL)
+            ->willReturn($this->mockMech);
+        $this->mockMech
+            ->method('getName')
+            ->willReturn(MechanismName::EXTERNAL);
+        $this->mockMech
+            ->method('challenge')
+            ->willReturn($this->mockChallenge);
+
+        $this->mockChallenge
+            ->expects(self::once())
+            ->method('challenge')
+            ->willReturn(
+                (new SaslContext())
+                    ->setResponse('dn:cn=proxy,dc=foo,dc=bar')
+                    ->setIsComplete(true),
+            );
+
+        self::assertSame(
+            $this->saslComplete,
+            $this->subject->handleRequest($messageRequest),
+        );
+    }
+
     private function withStandardRootDseResponse(): void
     {
         $this->mockRootDseLoader


### PR DESCRIPTION
Fixes proxy authorization in SASL for various mechs (plain, scram primarily). Needed to surface authzid in the sasl library and make some changes in this one. But now proxy auth works both in simple bind and across sasl.