### PR TITLE
[1.0.0] Journal / Changelog Part 1. Add some base change journal classes / wiring.

### DIFF
--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
@@ -18,6 +18,10 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Support\ArrayEntryStorageTrait;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalingInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\InMemoryChangeJournal;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\PendingChange;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 
 /**
@@ -25,7 +29,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final class InMemoryStorage implements EntryStorageInterface
+final class InMemoryStorage implements EntryStorageInterface, ChangeJournalingInterface
 {
     use ArrayEntryStorageTrait;
 
@@ -34,11 +38,17 @@ final class InMemoryStorage implements EntryStorageInterface
      */
     private array $entries = [];
 
+    private readonly ChangeJournalInterface $journal;
+
     /**
      * @param Entry[] $entries pre-populated into the store
      */
-    public function __construct(array $entries = [])
-    {
+    public function __construct(
+        array $entries = [],
+        ?ChangeJournalInterface $journal = null,
+    ) {
+        $this->journal = $journal ?? new InMemoryChangeJournal();
+
         foreach ($entries as $entry) {
             $this->entries[$entry->getDn()->normalize()->toString()] = $entry;
         }
@@ -75,6 +85,11 @@ final class InMemoryStorage implements EntryStorageInterface
     public function atomic(callable $operation): void
     {
         $operation($this);
+    }
+
+    public function appendChange(PendingChange $change): void
+    {
+        $this->journal->append($change);
     }
 
     public function namingContexts(): array

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ChangeJournalInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ChangeJournalInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Journal;
+
+/**
+ * Append-only log of committed writes.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface ChangeJournalInterface
+{
+    /**
+     * Append a change, allocating the next monotonic seq, and return the stamped record.
+     */
+    public function append(PendingChange $change): ChangeRecord;
+
+    /**
+     * Records with seq greater than $afterSeq, in ascending seq order.
+     *
+     * @api
+     *
+     * @return iterable<ChangeRecord>
+     */
+    public function read(int $afterSeq = 0): iterable;
+
+    /**
+     * Highest allocated seq, or 0 when nothing has been appended.
+     *
+     * @api
+     */
+    public function latestSeq(): int;
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ChangeJournalingInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ChangeJournalingInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Journal;
+
+/**
+ * Append a change within the active write boundary.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface ChangeJournalingInterface
+{
+    /**
+     * Append a change to the journal within the currently active write boundary.
+     */
+    public function appendChange(PendingChange $change): void;
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ChangeRecord.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ChangeRecord.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Journal;
+
+use DateTimeImmutable;
+
+/**
+ * A PendingChange stamped by the journal.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ChangeRecord
+{
+    public function __construct(
+        public int $seq,
+        public ReplicaId $origin,
+        public DateTimeImmutable $createdAt,
+        public PendingChange $change,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ChangeRecorder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ChangeRecorder.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Journal;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Builds journal records for committed writes and appends them to journaling-capable storage.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ChangeRecorder
+{
+    public function __construct(
+        private LoggerInterface $logger = new NullLogger(),
+    ) {}
+
+    public function recordAdd(
+        EntryStorageInterface $storage,
+        Entry $entry,
+        WriteContext $context,
+    ): void {
+        $this->record(
+            $storage,
+            ChangeType::Add,
+            $entry,
+            $context,
+        );
+    }
+
+    public function recordModify(
+        EntryStorageInterface $storage,
+        Entry $entry,
+        WriteContext $context,
+    ): void {
+        $this->record(
+            $storage,
+            ChangeType::Modify,
+            $entry,
+            $context,
+        );
+    }
+
+    public function recordModRdn(
+        EntryStorageInterface $storage,
+        Entry $entry,
+        Dn $previousDn,
+        WriteContext $context,
+    ): void {
+        $this->record(
+            $storage,
+            ChangeType::ModRdn,
+            $entry,
+            $context,
+            previousDn: $previousDn,
+        );
+    }
+
+    public function recordDelete(
+        EntryStorageInterface $storage,
+        Entry $entry,
+        WriteContext $context,
+    ): void {
+        $this->record(
+            $storage,
+            ChangeType::Delete,
+            $entry,
+            $context,
+            preImage: $entry->makeCopy(),
+        );
+    }
+
+    private function record(
+        EntryStorageInterface $storage,
+        ChangeType $type,
+        Entry $entry,
+        WriteContext $context,
+        ?Dn $previousDn = null,
+        ?Entry $preImage = null,
+    ): void {
+        if (!$storage instanceof ChangeJournalingInterface) {
+            return;
+        }
+
+        $uuid = $entry->get(AttributeTypeOid::NAME_ENTRY_UUID)?->firstValue();
+
+        // entryUUID is stamped on every write.
+        // but account for bad data by skipping journal entries on potentially corrupt data (maybe a seed import).
+        if ($uuid === null || $uuid === '') {
+            $this->logger->warning(
+                'Skipping journal record for an entry missing a required attribute.',
+                [
+                    'changeType' => $type->value,
+                    'dn' => $entry->getDn()->toString(),
+                    'attribute' => AttributeTypeOid::NAME_ENTRY_UUID,
+                ],
+            );
+
+            return;
+        }
+
+        $storage->appendChange(new PendingChange(
+            changeType: $type,
+            dn: $entry->getDn(),
+            entryUuid: $uuid,
+            authzId: $context->getAuthzId(),
+            previousDn: $previousDn,
+            preImage: $preImage,
+        ));
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ChangeType.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ChangeType.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Journal;
+
+/**
+ * The kind of write a change-journal record captures.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+enum ChangeType: string
+{
+    case Add = 'add';
+    case Modify = 'modify';
+    case Delete = 'delete';
+    case ModRdn = 'modrdn';
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/InMemoryChangeJournal.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/InMemoryChangeJournal.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Journal;
+
+use FreeDSx\Ldap\Server\Clock\ClockInterface;
+use FreeDSx\Ldap\Server\Clock\SystemClock;
+
+/**
+ * Array-backed change journal. Used for in-process runners.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class InMemoryChangeJournal implements ChangeJournalInterface
+{
+    /**
+     * @var list<ChangeRecord>
+     */
+    private array $records = [];
+
+    private int $seq = 0;
+
+    public function __construct(
+        private readonly ReplicaId $origin = new ReplicaId('local'),
+        private readonly ClockInterface $clock = new SystemClock(),
+    ) {}
+
+    public function append(PendingChange $change): ChangeRecord
+    {
+        $record = new ChangeRecord(
+            seq: ++$this->seq,
+            origin: $this->origin,
+            createdAt: $this->clock->now(),
+            change: $change,
+        );
+        $this->records[] = $record;
+
+        return $record;
+    }
+
+    public function read(int $afterSeq = 0): iterable
+    {
+        foreach ($this->records as $record) {
+            if ($record->seq > $afterSeq) {
+                yield $record;
+            }
+        }
+    }
+
+    public function latestSeq(): int
+    {
+        return $this->seq;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/PendingChange.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/PendingChange.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Journal;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
+
+/**
+ * A change handed to the journal for appending; the journal assigns the seq, origin, and timestamp.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class PendingChange
+{
+    public function __construct(
+        public ChangeType $changeType,
+        public Dn $dn,
+        public string $entryUuid,
+        public AuthzId $authzId,
+        public ?Dn $previousDn = null,
+        public ?Entry $preImage = null,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ReplicaId.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ReplicaId.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Journal;
+
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+
+/**
+ * Identity of the replica that authored a change.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ReplicaId
+{
+    public function __construct(
+        private string $value,
+    ) {
+        if ($this->value === '') {
+            throw new InvalidArgumentException('A replica id cannot be empty.');
+        }
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    /**
+     * The default single-master identity.
+     */
+    public static function local(): self
+    {
+        return new self('local');
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->value === $other->value;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -24,6 +24,7 @@ use FreeDSx\Ldap\Exception\SchemaRuleException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Operation\WriteEntryOperationHandler;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeRecorder;
 use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\MoveCommand;
@@ -62,6 +63,7 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         private readonly ?SchemaValidator $validator = null,
         private readonly OperationalAttributeGenerator $operationalAttrs = new OperationalAttributeGenerator(),
         private readonly WriteEntryOperationHandler $entryHandler = new WriteEntryOperationHandler(),
+        private readonly ?ChangeRecorder $changeRecorder = null,
     ) {
         $this->searchStream = new SearchStreamBuilder(
             $this->storage,
@@ -273,6 +275,11 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
                 $context,
             );
             $storage->store($command->entry);
+            $this->changeRecorder?->recordAdd(
+                $storage,
+                $command->entry,
+                $context,
+            );
         });
     }
 
@@ -283,9 +290,12 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         DeleteCommand $command,
         WriteContext $context,
     ): void {
-        $this->writeAtomic(function (EntryStorageInterface $storage) use ($command): void {
+        $this->writeAtomic(function (EntryStorageInterface $storage) use ($command, $context): void {
             $dn = $command->dn->normalize();
-            $this->findOrFail($storage, $dn);
+            $entry = $this->findOrFail(
+                $storage,
+                $dn,
+            );
 
             if ($storage->hasChildren($dn)) {
                 throw new OperationException(
@@ -303,6 +313,11 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             );
 
             $storage->remove($dn);
+            $this->changeRecorder?->recordDelete(
+                $storage,
+                $entry,
+                $context,
+            );
         });
     }
 
@@ -334,9 +349,20 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         }
 
         foreach (array_chunk($dns, self::SUBTREE_DELETE_BATCH_SIZE) as $batch) {
-            $this->writeAtomic(static function (EntryStorageInterface $storage) use ($batch): void {
+            $this->writeAtomic(function (EntryStorageInterface $storage) use ($batch, $context): void {
                 foreach ($batch as $dn) {
+                    $entry = $this->changeRecorder !== null
+                        ? $storage->find($dn)
+                        : null;
                     $storage->remove($dn);
+
+                    if ($entry !== null) {
+                        $this->changeRecorder->recordDelete(
+                            $storage,
+                            $entry,
+                            $context,
+                        );
+                    }
                 }
             });
         }
@@ -363,6 +389,11 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
                 $context,
             );
             $storage->store($updated);
+            $this->changeRecorder?->recordModify(
+                $storage,
+                $updated,
+                $context,
+            );
         });
     }
 
@@ -404,6 +435,12 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             );
             $storage->remove($normOld);
             $storage->store($newEntry);
+            $this->changeRecorder?->recordModRdn(
+                $storage,
+                $newEntry,
+                $command->dn,
+                $context,
+            );
         });
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Write/WriteContext.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/WriteContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Write;
 
 use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -59,19 +60,17 @@ final readonly class WriteContext
         return $this->token->getUsername();
     }
 
-    public function isAnonymous(): bool
+    /**
+     * Effective authorization identity for this write.
+     */
+    public function getAuthzId(): AuthzId
     {
-        return $this->token->getUsername() === null;
+        return $this->token->getAuthzId();
     }
 
     public function isSystem(): bool
     {
         return $this->isSystem;
-    }
-
-    public function getLdapVersion(): int
-    {
-        return $this->token->getVersion();
     }
 
     public function getControls(): ControlBag

--- a/src/FreeDSx/Ldap/Server/Token/AnonToken.php
+++ b/src/FreeDSx/Ldap/Server/Token/AnonToken.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Token;
 
 use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Server\Utility\Uuid;
 
 /**
@@ -33,6 +34,8 @@ class AnonToken implements TokenInterface
 
     private readonly ?Dn $authorizingDn;
 
+    private readonly AuthzId $authzId;
+
     public function __construct(
         ?string $username = null,
         int $version = 3,
@@ -42,6 +45,7 @@ class AnonToken implements TokenInterface
         $this->username = $username;
         $this->version = $version;
         $this->authorizingDn = $authorizingDn;
+        $this->authzId = AuthzId::anonymous();
     }
 
     public function getId(): string
@@ -52,6 +56,11 @@ class AnonToken implements TokenInterface
     public function getUsername(): ?string
     {
         return $this->username;
+    }
+
+    public function getAuthzId(): AuthzId
+    {
+        return $this->authzId;
     }
 
     public function getVersion(): int

--- a/src/FreeDSx/Ldap/Server/Token/AuthenticatedTokenInterface.php
+++ b/src/FreeDSx/Ldap/Server/Token/AuthenticatedTokenInterface.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Token;
 
 use FreeDSx\Ldap\Entry\Dn;
-use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 
 /**
  * Implemented by tokens that represent a successfully authenticated identity with a resolved DN.
@@ -24,11 +23,6 @@ use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 interface AuthenticatedTokenInterface extends TokenInterface
 {
     public function getResolvedDn(): Dn;
-
-    /**
-     * The bound identity as an authorization identity: the resolved DN, or the username when it is not a DN.
-     */
-    public function getAuthzId(): AuthzId;
 
     /**
      * Whether the bound identity must change its password before any other operation is permitted (pwdReset).

--- a/src/FreeDSx/Ldap/Server/Token/SystemToken.php
+++ b/src/FreeDSx/Ldap/Server/Token/SystemToken.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Token;
 
 use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Server\Utility\Uuid;
 
 /**
@@ -27,9 +28,12 @@ final readonly class SystemToken implements TokenInterface
 
     private string $id;
 
+    private AuthzId $authzId;
+
     public function __construct(private int $version = 3)
     {
         $this->id = Uuid::v4();
+        $this->authzId = AuthzId::fromDn(new Dn(self::IDENTITY));
     }
 
     public function getId(): string
@@ -40,6 +44,11 @@ final readonly class SystemToken implements TokenInterface
     public function getUsername(): string
     {
         return self::IDENTITY;
+    }
+
+    public function getAuthzId(): AuthzId
+    {
+        return $this->authzId;
     }
 
     public function getVersion(): int

--- a/src/FreeDSx/Ldap/Server/Token/TokenInterface.php
+++ b/src/FreeDSx/Ldap/Server/Token/TokenInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Token;
 
 use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 
 /**
  * Represents a generic authentication token.
@@ -27,6 +28,11 @@ interface TokenInterface
     public function getId(): string;
 
     public function getUsername(): ?string;
+
+    /**
+     * The effective authorization identity.
+     */
+    public function getAuthzId(): AuthzId;
 
     public function getVersion(): int;
 

--- a/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
@@ -29,6 +29,11 @@ use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeRecord;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeRecorder;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeType;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\InMemoryChangeJournal;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\PendingChange;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\InvalidAttributeException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
@@ -1789,6 +1794,134 @@ final class WritableStorageBackendTest extends TestCase
         );
     }
 
+    public function test_add_is_journaled_when_a_recorder_is_set(): void
+    {
+        [$backend, $journal] = $this->journalingBackend();
+        $backend->add(
+            new AddCommand(new Entry(new Dn('cn=New,dc=example,dc=com'), new Attribute('cn', 'New'))),
+            $this->context(),
+        );
+
+        $records = iterator_to_array($journal->read());
+        self::assertCount(
+            1,
+            $records,
+        );
+        self::assertSame(
+            ChangeType::Add,
+            $records[0]->change->changeType,
+        );
+        self::assertNotSame(
+            '',
+            $records[0]->change->entryUuid,
+        );
+    }
+
+    public function test_modify_is_journaled(): void
+    {
+        [$backend, $journal] = $this->journalingBackend();
+        $this->seedJournaled($backend, 'cn=New,dc=example,dc=com');
+
+        $backend->update(
+            new UpdateCommand(
+                new Dn('cn=New,dc=example,dc=com'),
+                [new Change(Change::TYPE_ADD, 'mail', 'new@example.com')],
+            ),
+            $this->context(),
+        );
+
+        self::assertSame(
+            ChangeType::Modify,
+            $this->lastChange($journal)->changeType,
+        );
+    }
+
+    public function test_delete_is_journaled_with_a_pre_image(): void
+    {
+        [$backend, $journal] = $this->journalingBackend();
+        $this->seedJournaled($backend, 'cn=New,dc=example,dc=com');
+
+        $backend->delete(
+            new DeleteCommand(new Dn('cn=New,dc=example,dc=com')),
+            $this->context(),
+        );
+
+        $change = $this->lastChange($journal);
+        self::assertSame(
+            ChangeType::Delete,
+            $change->changeType,
+        );
+        self::assertNotNull($change->preImage);
+    }
+
+    public function test_modrdn_is_journaled_with_the_previous_dn(): void
+    {
+        [$backend, $journal] = $this->journalingBackend();
+        $this->seedJournaled($backend, 'cn=New,dc=example,dc=com');
+
+        $backend->move(
+            new MoveCommand(
+                new Dn('cn=New,dc=example,dc=com'),
+                Rdn::create('cn=Renamed'),
+                true,
+                null,
+            ),
+            $this->context(),
+        );
+
+        $change = $this->lastChange($journal);
+        self::assertSame(
+            ChangeType::ModRdn,
+            $change->changeType,
+        );
+        self::assertSame(
+            'cn=New,dc=example,dc=com',
+            $change->previousDn?->toString(),
+        );
+    }
+
+    public function test_subtree_delete_is_journaled_per_entry(): void
+    {
+        [$backend, $journal] = $this->journalingBackend();
+        $this->seedJournaled($backend, 'ou=people,dc=example,dc=com');
+        $this->seedJournaled($backend, 'cn=New,ou=people,dc=example,dc=com');
+
+        $backend->deleteSubtree(
+            new DeleteCommand(new Dn('ou=people,dc=example,dc=com')),
+            $this->context(),
+            static fn(): null => null,
+        );
+
+        $deletes = array_filter(
+            iterator_to_array($journal->read()),
+            static fn(ChangeRecord $record): bool => $record->change->changeType === ChangeType::Delete,
+        );
+        self::assertCount(
+            2,
+            $deletes,
+        );
+    }
+
+    public function test_nothing_is_journaled_without_a_recorder(): void
+    {
+        $journal = new InMemoryChangeJournal();
+        $storage = new InMemoryStorage(
+            [new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example'))],
+            $journal,
+        );
+        $backend = new WritableStorageBackend(storage: $storage);
+
+        $backend->add(
+            new AddCommand(new Entry(new Dn('cn=New,dc=example,dc=com'), new Attribute('cn', 'New'))),
+            $this->context(),
+        );
+
+        self::assertSame(
+            0,
+            $journal->latestSeq(),
+        );
+    }
+
     private function aliasEntry(): Entry
     {
         return new Entry(
@@ -1796,6 +1929,51 @@ final class WritableStorageBackendTest extends TestCase
             new Attribute('objectClass', 'alias'),
             new Attribute('aliasedObjectName', 'cn=Alice,dc=example,dc=com'),
         );
+    }
+
+    /**
+     * @return array{WritableStorageBackend, InMemoryChangeJournal}
+     */
+    private function journalingBackend(): array
+    {
+        $journal = new InMemoryChangeJournal();
+        // Seed the naming context directly so only the operations under test are journaled.
+        $storage = new InMemoryStorage(
+            [new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example'))],
+            $journal,
+        );
+        $backend = new WritableStorageBackend(
+            storage: $storage,
+            changeRecorder: new ChangeRecorder(),
+        );
+
+        return [$backend, $journal];
+    }
+
+    private function seedJournaled(
+        WritableStorageBackend $backend,
+        string $dn,
+    ): void {
+        $backend->add(
+            new AddCommand(new Entry(
+                new Dn($dn),
+                new Attribute('objectClass', 'person'),
+                new Attribute('cn', 'seed'),
+            )),
+            $this->context(),
+        );
+    }
+
+    private function lastChange(InMemoryChangeJournal $journal): PendingChange
+    {
+        $records = iterator_to_array($journal->read());
+        $last = end($records);
+        self::assertInstanceOf(
+            ChangeRecord::class,
+            $last,
+        );
+
+        return $last->change;
     }
 
     private function context(): WriteContext

--- a/tests/unit/Server/Backend/Storage/Journal/ChangeRecorderTest.php
+++ b/tests/unit/Server/Backend/Storage/Journal/ChangeRecorderTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Journal;
+
+use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeRecord;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeRecorder;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeType;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\InMemoryChangeJournal;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class ChangeRecorderTest extends TestCase
+{
+    private ChangeRecorder $subject;
+
+    private InMemoryChangeJournal $journal;
+
+    private InMemoryStorage $storage;
+
+    private WriteContext $context;
+
+    protected function setUp(): void
+    {
+        $this->subject = new ChangeRecorder();
+        $this->journal = new InMemoryChangeJournal();
+        $this->storage = new InMemoryStorage(
+            [],
+            $this->journal,
+        );
+        $this->context = new WriteContext(
+            BindToken::fromDn('cn=admin,dc=example,dc=com'),
+            new ControlBag(),
+        );
+    }
+
+    public function test_record_add_journals_an_add_with_the_acting_identity(): void
+    {
+        $this->subject->recordAdd(
+            $this->storage,
+            $this->entry('cn=a,dc=example,dc=com'),
+            $this->context,
+        );
+
+        $record = $this->onlyRecord();
+        self::assertSame(
+            ChangeType::Add,
+            $record->change->changeType,
+        );
+        self::assertSame(
+            'cn=a,dc=example,dc=com',
+            $record->change->dn->toString(),
+        );
+        self::assertSame(
+            'cn=admin,dc=example,dc=com',
+            $record->change->authzId->getValue(),
+        );
+    }
+
+    public function test_record_modify_journals_a_modify(): void
+    {
+        $this->subject->recordModify(
+            $this->storage,
+            $this->entry('cn=a,dc=example,dc=com'),
+            $this->context,
+        );
+
+        self::assertSame(
+            ChangeType::Modify,
+            $this->onlyRecord()->change->changeType,
+        );
+    }
+
+    public function test_record_modrdn_journals_the_previous_dn(): void
+    {
+        $this->subject->recordModRdn(
+            $this->storage,
+            $this->entry('cn=new,dc=example,dc=com'),
+            new Dn('cn=old,dc=example,dc=com'),
+            $this->context,
+        );
+
+        $record = $this->onlyRecord();
+        self::assertSame(
+            ChangeType::ModRdn,
+            $record->change->changeType,
+        );
+        self::assertSame(
+            'cn=old,dc=example,dc=com',
+            $record->change->previousDn?->toString(),
+        );
+    }
+
+    public function test_record_delete_captures_an_independent_pre_image(): void
+    {
+        $entry = $this->entry('cn=a,dc=example,dc=com');
+
+        $this->subject->recordDelete(
+            $this->storage,
+            $entry,
+            $this->context,
+        );
+
+        $preImage = $this->onlyRecord()->change->preImage;
+        self::assertNotNull($preImage);
+        self::assertNotSame(
+            $entry,
+            $preImage,
+        );
+        self::assertSame(
+            'a',
+            $preImage->get('cn')?->firstValue(),
+        );
+    }
+
+    public function test_it_skips_and_warns_when_the_entry_has_no_uuid(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning');
+        $recorder = new ChangeRecorder($logger);
+
+        $recorder->recordAdd(
+            $this->storage,
+            new Entry(
+                new Dn('cn=a,dc=example,dc=com'),
+                new Attribute('cn', 'a'),
+            ),
+            $this->context,
+        );
+
+        self::assertSame(
+            0,
+            $this->journal->latestSeq(),
+        );
+    }
+
+    public function test_it_is_a_no_op_for_non_journaling_storage(): void
+    {
+        $storage = $this->createMock(EntryStorageInterface::class);
+
+        $this->subject->recordAdd(
+            $storage,
+            $this->entry('cn=a,dc=example,dc=com'),
+            $this->context,
+        );
+
+        self::assertSame(
+            0,
+            $this->journal->latestSeq(),
+        );
+    }
+
+    private function entry(string $dn): Entry
+    {
+        return new Entry(
+            new Dn($dn),
+            new Attribute('cn', 'a'),
+            new Attribute(
+                AttributeTypeOid::NAME_ENTRY_UUID,
+                '11111111-1111-4111-8111-111111111111',
+            ),
+        );
+    }
+
+    private function onlyRecord(): ChangeRecord
+    {
+        $records = iterator_to_array($this->journal->read());
+
+        self::assertCount(
+            1,
+            $records,
+        );
+
+        return $records[0];
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Journal/InMemoryChangeJournalTest.php
+++ b/tests/unit/Server/Backend/Storage/Journal/InMemoryChangeJournalTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Journal;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeRecord;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeType;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\InMemoryChangeJournal;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
+
+final class InMemoryChangeJournalTest extends TestCase
+{
+    private InMemoryChangeJournal $subject;
+
+    private FrozenClock $clock;
+
+    protected function setUp(): void
+    {
+        $this->clock = FrozenClock::fromString('2025-05-15T12:00:00');
+        $this->subject = new InMemoryChangeJournal(
+            new ReplicaId('node-a'),
+            $this->clock,
+        );
+    }
+
+    public function test_it_allocates_strictly_increasing_seq_numbers(): void
+    {
+        $first = $this->subject->append($this->change('cn=a,dc=example,dc=com'));
+        $second = $this->subject->append($this->change('cn=b,dc=example,dc=com'));
+        $third = $this->subject->append($this->change('cn=c,dc=example,dc=com'));
+
+        self::assertSame(
+            1,
+            $first->seq,
+        );
+        self::assertSame(
+            2,
+            $second->seq,
+        );
+        self::assertSame(
+            3,
+            $third->seq,
+        );
+    }
+
+    public function test_latest_seq_is_zero_until_anything_is_appended(): void
+    {
+        self::assertSame(
+            0,
+            $this->subject->latestSeq(),
+        );
+
+        $this->subject->append($this->change('cn=a,dc=example,dc=com'));
+
+        self::assertSame(
+            1,
+            $this->subject->latestSeq(),
+        );
+    }
+
+    public function test_it_stamps_the_record_with_origin_clock_and_change(): void
+    {
+        $change = $this->change('cn=a,dc=example,dc=com');
+
+        $record = $this->subject->append($change);
+
+        self::assertSame(
+            $change,
+            $record->change,
+        );
+        self::assertTrue($record->origin->equals(new ReplicaId('node-a')));
+        self::assertEquals(
+            $this->clock->now(),
+            $record->createdAt,
+        );
+    }
+
+    public function test_read_returns_only_records_after_the_given_seq(): void
+    {
+        $this->subject->append($this->change('cn=a,dc=example,dc=com'));
+        $this->subject->append($this->change('cn=b,dc=example,dc=com'));
+        $this->subject->append($this->change('cn=c,dc=example,dc=com'));
+
+        $seqs = array_map(
+            static fn(ChangeRecord $record): int => $record->seq,
+            iterator_to_array($this->subject->read(1)),
+        );
+
+        self::assertSame(
+            [2, 3],
+            $seqs,
+        );
+    }
+
+    public function test_read_without_an_argument_returns_everything(): void
+    {
+        $this->subject->append($this->change('cn=a,dc=example,dc=com'));
+        $this->subject->append($this->change('cn=b,dc=example,dc=com'));
+
+        self::assertCount(
+            2,
+            iterator_to_array($this->subject->read()),
+        );
+    }
+
+    private function change(string $dn): PendingChange
+    {
+        return new PendingChange(
+            changeType: ChangeType::Add,
+            dn: new Dn($dn),
+            entryUuid: '11111111-1111-4111-8111-111111111111',
+            authzId: AuthzId::anonymous(),
+        );
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Journal/ReplicaIdTest.php
+++ b/tests/unit/Server/Backend/Storage/Journal/ReplicaIdTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Journal;
+
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
+use PHPUnit\Framework\TestCase;
+
+final class ReplicaIdTest extends TestCase
+{
+    public function test_it_rejects_an_empty_value(): void
+    {
+        self::expectException(InvalidArgumentException::class);
+
+        new ReplicaId('');
+    }
+
+    public function test_it_compares_by_value(): void
+    {
+        self::assertTrue((new ReplicaId('node-a'))->equals(new ReplicaId('node-a')));
+        self::assertFalse((new ReplicaId('node-a'))->equals(new ReplicaId('node-b')));
+    }
+
+    public function test_it_stringifies_to_its_value(): void
+    {
+        self::assertSame(
+            'node-a',
+            (string) new ReplicaId('node-a'),
+        );
+    }
+
+    public function test_local_is_the_default_single_master_identity(): void
+    {
+        self::assertSame(
+            'local',
+            (string) ReplicaId::local(),
+        );
+    }
+}

--- a/tests/unit/Server/Token/AnonTokenTest.php
+++ b/tests/unit/Server/Token/AnonTokenTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Server\Token;
 
+use FreeDSx\Ldap\Protocol\Authorization\AuthzIdType;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use PHPUnit\Framework\TestCase;
 
@@ -31,6 +32,11 @@ final class AnonTokenTest extends TestCase
             'foo',
             $this->subject->getUsername(),
         );
+    }
+
+    public function test_its_authz_id_is_anonymous_even_with_a_bind_name(): void
+    {
+        self::assertTrue($this->subject->getAuthzId()->isType(AuthzIdType::Anonymous));
     }
 
     public function test_it_should_get_the_version(): void

--- a/tests/unit/Server/Token/SystemTokenTest.php
+++ b/tests/unit/Server/Token/SystemTokenTest.php
@@ -32,6 +32,14 @@ final class SystemTokenTest extends TestCase
         );
     }
 
+    public function test_its_authz_id_is_the_system_identity(): void
+    {
+        self::assertSame(
+            'cn=system',
+            (new SystemToken())->getAuthzId()->getValue(),
+        );
+    }
+
     public function test_it_defaults_to_ldap_v3(): void
     {
         self::assertSame(


### PR DESCRIPTION
Part 1 of the journal / changelog system used for replication and detailed logging of changes. This starts to add some base classes. Splitting this into multiple PRs so I can merge this in a sane way.  But this will form what is needed for replication and changelog on the server side.