### PR TITLE
[1.0.0] Add the server sync handler / cookie. Replication / Sync / Changelog Part 4.

### DIFF
--- a/src/FreeDSx/Ldap/Protocol/Factory/HandlerId.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/HandlerId.php
@@ -31,6 +31,7 @@ enum HandlerId: string
     case Subschema = 'subschema';
     case Monitor = 'monitor';
     case Paging = 'paging';
+    case Sync = 'sync';
     case Search = 'search';
     case Unbind = 'unbind';
     case Dispatch = 'dispatch';

--- a/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
@@ -19,6 +19,10 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerProtocolHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeStream;
+use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
@@ -71,6 +75,7 @@ final readonly class ProtocolHandlerProvider implements ProtocolHandlerProviderI
             HandlerId::Subschema => $this->getSubschemaHandler(),
             HandlerId::Monitor => $this->getMonitorHandler(),
             HandlerId::Paging => $this->getPagingHandler($searchLimits),
+            HandlerId::Sync => $this->getSyncHandler($searchLimits),
             HandlerId::Search => $this->getSearchHandler($searchLimits),
             HandlerId::Unbind => new ServerProtocolHandler\ServerUnbindHandler($this->queue),
             HandlerId::Dispatch => $this->getDispatchHandler(),
@@ -133,6 +138,35 @@ final readonly class ProtocolHandlerProvider implements ProtocolHandlerProviderI
         );
     }
 
+    private function getSyncHandler(?SearchLimits $searchLimits): ServerProtocolHandler\ServerSyncHandler
+    {
+        $backend = $this->handlerFactory->makeBackend();
+
+        return new ServerProtocolHandler\ServerSyncHandler(
+            queue: $this->queue,
+            backend: $backend,
+            filterEvaluator: $this->options->getFilterEvaluator(),
+            accessControl: $this->options->getAccessControl(),
+            limits: $searchLimits ?? $this->options->makeSearchLimits(),
+            changeStream: $this->changeStreamFor($backend),
+        );
+    }
+
+    private function changeStreamFor(LdapBackendInterface $backend): ?ChangeStream
+    {
+        if (!$backend instanceof WritableStorageBackend) {
+            return null;
+        }
+
+        $storage = $backend->getStorage();
+
+        if (!$storage instanceof ChangeJournalingInterface) {
+            return null;
+        }
+
+        return new ChangeStream($storage->changeJournal());
+    }
+
     private function getDispatchHandler(): ServerProtocolHandler\ServerDispatchHandler
     {
         $policyWriteHandler = $this->policyComponentFactory->makeWriteHandler(
@@ -153,11 +187,14 @@ final readonly class ProtocolHandlerProvider implements ProtocolHandlerProviderI
 
     private function getRootDseHandler(): ServerProtocolHandler\ServerRootDseHandler
     {
+        $backend = $this->handlerFactory->makeBackend();
+
         return new ServerProtocolHandler\ServerRootDseHandler(
             options: $this->options,
             queue: $this->queue,
-            backend: $this->handlerFactory->makeBackend(),
+            backend: $backend,
             rootDseHandler: $this->handlerFactory->makeRootDseHandler(),
+            supportsSync: $this->changeStreamFor($backend) !== null,
         );
     }
 

--- a/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
@@ -46,6 +46,7 @@ readonly class ServerProtocolHandlerFactory implements HandlerRouteResolverInter
             $this->isRootDseSearch($request) => HandlerId::RootDse,
             $this->isSubschemaSearch($request) => HandlerId::Subschema,
             $this->isMonitorSearch($request) => HandlerId::Monitor,
+            $this->isSyncSearch($request, $controls) => HandlerId::Sync,
             $this->isPagingSearch($request, $controls) => HandlerId::Paging,
             $request instanceof SearchRequest => HandlerId::Search,
             $request instanceof UnbindRequest => HandlerId::Unbind,
@@ -90,5 +91,13 @@ readonly class ServerProtocolHandlerFactory implements HandlerRouteResolverInter
     ): bool {
         return $request instanceof SearchRequest
             && $controls->has(Control::OID_PAGING);
+    }
+
+    private function isSyncSearch(
+        RequestInterface $request,
+        ControlBag $controls,
+    ): bool {
+        return $request instanceof SearchRequest
+            && $controls->has(Control::OID_SYNC_REQUEST);
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
@@ -57,6 +57,7 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
         private readonly ServerQueue $queue,
         private readonly LdapBackendInterface $backend,
         private readonly ?RootDseHandlerInterface $rootDseHandler = null,
+        private readonly bool $supportsSync = false,
     ) {}
 
     /**
@@ -95,6 +96,12 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
             'supportedLDAPVersion' => ['3'],
             'vendorName' => $this->options->getDseVendorName(),
         ]);
+        if ($this->supportsSync) {
+            $entry->add(
+                'supportedControl',
+                Control::OID_SYNC_REQUEST,
+            );
+        }
         if ($this->options->getSslCert()) {
             $entry->add(
                 'supportedExtension',

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSyncHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSyncHandler.php
@@ -1,0 +1,365 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\Sync\SyncDoneControl;
+use FreeDSx\Ldap\Control\Sync\SyncRequestControl;
+use FreeDSx\Ldap\Control\Sync\SyncStateControl;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\Response\SearchResultDone;
+use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeScope;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeStream;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+use FreeDSx\Ldap\Server\Operation\SearchOperationResult;
+use FreeDSx\Ldap\Server\SearchLimits;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\Server\Utility\Uuid;
+use FreeDSx\Ldap\Sync\Provider\Exception\MalformedSyncCookieException;
+use FreeDSx\Ldap\Sync\Provider\SyncCookie;
+use Generator;
+
+/**
+ * Serves RFC 4533 content-synchronization (refreshOnly) from the change journal.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class ServerSyncHandler implements ServerProtocolHandlerInterface
+{
+    use ServerSearchTrait;
+
+    public function __construct(
+        private readonly ServerQueue $queue,
+        private readonly LdapBackendInterface $backend,
+        private readonly FilterEvaluatorInterface $filterEvaluator,
+        private readonly AccessControlInterface $accessControl,
+        private readonly SearchLimits $limits = new SearchLimits(),
+        private readonly ?ChangeStream $changeStream = null,
+    ) {}
+
+    /**
+     * @throws OperationException
+     */
+    public function handleRequest(
+        LdapMessageRequest $message,
+        TokenInterface $token,
+    ): OperationResult {
+        $request = $this->getSearchRequestFromMessage($message);
+        $control = $this->syncRequestControl($message);
+        $stream = $this->changeStream;
+
+        if ($stream === null) {
+            throw new OperationException(
+                'Content synchronization is not supported.',
+                ResultCode::UNWILLING_TO_PERFORM,
+            );
+        }
+
+        if ($control->getMode() !== SyncRequestControl::MODE_REFRESH_ONLY) {
+            throw new OperationException(
+                'Only refreshOnly content synchronization is supported.',
+                ResultCode::UNWILLING_TO_PERFORM,
+            );
+        }
+
+        $baseDn = $this->assertBaseDnProvided($request);
+        $latestSeq = $stream->latestSeq();
+        $sinceSeq = $this->resolveSince($control, $stream, $latestSeq);
+        $state = new SearchResultState();
+
+        $entries = $sinceSeq === null
+            ? $this->fullRefreshEntries($message, $request, $token, $state)
+            : $this->incrementalEntries($message, $request, $token, $stream, $sinceSeq, $state);
+
+        // refreshDeletes: a delete phase (true) only for an incremental sync that sent explicit
+        // deletes; a full refresh is a present phase (false) the consumer reconciles by absence.
+        $doneControl = new SyncDoneControl(
+            (new SyncCookie($stream->origin(), $latestSeq))->encode(),
+            $sinceSeq !== null,
+        );
+        $this->queue->sendMessages($this->withSyncDone(
+            $entries,
+            $message->getMessageId(),
+            $baseDn,
+            $doneControl,
+        ));
+
+        return SearchOperationResult::success(
+            $message,
+            $state->entriesReturned,
+        );
+    }
+
+    /**
+     * @param Generator<LdapMessageResponse> $entries
+     * @return Generator<LdapMessageResponse>
+     */
+    private function withSyncDone(
+        Generator $entries,
+        int $messageId,
+        Dn $baseDn,
+        SyncDoneControl $doneControl,
+    ): Generator {
+        yield from $entries;
+
+        yield new LdapMessageResponse(
+            $messageId,
+            new SearchResultDone(
+                ResultCode::SUCCESS,
+                $baseDn->toString(),
+            ),
+            $doneControl,
+        );
+    }
+
+    /**
+     * Empty/unknown cookie: every in-scope live entry as an add.
+     *
+     * @return Generator<LdapMessageResponse>
+     */
+    private function fullRefreshEntries(
+        LdapMessageRequest $message,
+        SearchRequest $request,
+        TokenInterface $token,
+        SearchResultState $state,
+    ): Generator {
+        $result = $this->backend->search(
+            $request,
+            $this->controlsForBackend($message),
+            $this->limits,
+        );
+
+        foreach ($result->entries as $entry) {
+            $visible = $this->accessControl->filterEntry(
+                $token,
+                $entry,
+            );
+
+            if ($visible === null) {
+                continue;
+            }
+
+            yield from $this->emit(
+                $this->addResponse($message->getMessageId(), $visible),
+                $state,
+            );
+        }
+    }
+
+    /**
+     * Valid cookie: the net effect per entry since its seq, as adds and deletes.
+     *
+     * @return Generator<LdapMessageResponse>
+     */
+    private function incrementalEntries(
+        LdapMessageRequest $message,
+        SearchRequest $request,
+        TokenInterface $token,
+        ChangeStream $stream,
+        int $sinceSeq,
+        SearchResultState $state,
+    ): Generator {
+        $netByUuid = [];
+
+        foreach ($stream->since($sinceSeq, $this->scopeFor($request)) as $record) {
+            $netByUuid[$record->change->entryUuid] = $record->change;
+        }
+
+        foreach ($netByUuid as $change) {
+            $response = $change->changeType === ChangeType::Delete
+                ? $this->deleteResponse($message->getMessageId(), $request, $token, $change)
+                : $this->changedEntryResponse($message->getMessageId(), $request, $token, $change);
+
+            yield from $this->emit($response, $state);
+        }
+    }
+
+    private function addResponse(
+        int $messageId,
+        Entry $entry,
+    ): ?LdapMessageResponse {
+        $uuid = $entry->get(AttributeTypeOid::NAME_ENTRY_UUID)?->firstValue();
+
+        if ($uuid === null || $uuid === '') {
+            return null;
+        }
+
+        return new LdapMessageResponse(
+            $messageId,
+            new SearchResultEntry($entry),
+            new SyncStateControl(
+                SyncStateControl::STATE_ADD,
+                Uuid::toBinary($uuid),
+            ),
+        );
+    }
+
+    /**
+     * The delete is announced only if the consumer could have seen the entry, checked against its
+     * pre-image, so a gone entry never leaks a DN/UUID the read-side ACL would have hidden.
+     */
+    private function deleteResponse(
+        int $messageId,
+        SearchRequest $request,
+        TokenInterface $token,
+        PendingChange $change,
+    ): ?LdapMessageResponse {
+        if (!$this->wasVisible($request, $token, $change->preImage)) {
+            return null;
+        }
+
+        return new LdapMessageResponse(
+            $messageId,
+            new SearchResultEntry(new Entry($change->dn)),
+            new SyncStateControl(
+                SyncStateControl::STATE_DELETE,
+                Uuid::toBinary($change->entryUuid),
+            ),
+        );
+    }
+
+    private function changedEntryResponse(
+        int $messageId,
+        SearchRequest $request,
+        TokenInterface $token,
+        PendingChange $change,
+    ): ?LdapMessageResponse {
+        $entry = $this->backend->get($change->dn);
+
+        if ($entry === null) {
+            return null;
+        }
+
+        $visible = $this->accessControl->filterEntry(
+            $token,
+            $entry,
+        );
+
+        if ($visible === null) {
+            return null;
+        }
+
+        if (!$this->filterEvaluator->evaluate($visible, $request->getFilter())) {
+            return null;
+        }
+
+        return $this->addResponse(
+            $messageId,
+            $visible,
+        );
+    }
+
+    /**
+     * Whether the entry, as it was before deletion, was readable by and matched the consumer's view.
+     */
+    private function wasVisible(
+        SearchRequest $request,
+        TokenInterface $token,
+        ?Entry $preImage,
+    ): bool {
+        if ($preImage === null) {
+            return false;
+        }
+
+        $visible = $this->accessControl->filterEntry(
+            $token,
+            $preImage,
+        );
+
+        return $visible !== null
+            && $this->filterEvaluator->evaluate($visible, $request->getFilter());
+    }
+
+    /**
+     * @return Generator<LdapMessageResponse>
+     */
+    private function emit(
+        ?LdapMessageResponse $response,
+        SearchResultState $state,
+    ): Generator {
+        if ($response === null) {
+            return;
+        }
+
+        $state->entriesReturned++;
+
+        yield $response;
+    }
+
+    private function resolveSince(
+        SyncRequestControl $control,
+        ChangeStream $stream,
+        int $latestSeq,
+    ): ?int {
+        $cookie = $control->getCookie();
+
+        if ($cookie === null || $cookie === '' || $control->getReloadHint()) {
+            return null;
+        }
+
+        try {
+            $decoded = SyncCookie::decode($cookie);
+        } catch (MalformedSyncCookieException) {
+            return null;
+        }
+
+        if (!$decoded->origin->equals($stream->origin()) || $decoded->seq > $latestSeq) {
+            return null;
+        }
+
+        return $decoded->seq;
+    }
+
+    private function scopeFor(SearchRequest $request): ChangeScope
+    {
+        $baseDn = $request->getBaseDn() ?? new Dn('');
+
+        return match ($request->getScope()) {
+            SearchRequest::SCOPE_BASE_OBJECT => ChangeScope::baseObject($baseDn),
+            SearchRequest::SCOPE_SINGLE_LEVEL => ChangeScope::oneLevel($baseDn),
+            default => ChangeScope::wholeSubtree($baseDn),
+        };
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function syncRequestControl(LdapMessageRequest $message): SyncRequestControl
+    {
+        $control = $message->controls()->get(Control::OID_SYNC_REQUEST);
+
+        if (!$control instanceof SyncRequestControl) {
+            throw new OperationException(
+                'The sync request control was expected, but not received.',
+                ResultCode::PROTOCOL_ERROR,
+            );
+        }
+
+        return $control;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
@@ -92,6 +92,11 @@ final class InMemoryStorage implements EntryStorageInterface, ChangeJournalingIn
         $this->journal->append($change);
     }
 
+    public function changeJournal(): ChangeJournalInterface
+    {
+        return $this->journal;
+    }
+
     public function namingContexts(): array
     {
         return $this->namingContextsFromArray($this->entries);

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Audit/AuditingChangeJournal.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Audit/AuditingChangeJournal.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Journal\Audit;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeRecord;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
 use FreeDSx\Ldap\Server\Logging\ExceptionLogging;
 use Psr\Log\LoggerInterface;
@@ -68,5 +69,10 @@ final class AuditingChangeJournal implements ChangeJournalInterface
     public function prune(RetentionPolicy $policy): int
     {
         return $this->journal->prune($policy);
+    }
+
+    public function origin(): ReplicaId
+    {
+        return $this->journal->origin();
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Audit/JsonLinesAuditSink.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Audit/JsonLinesAuditSink.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Journal\Audit;
 
-use DateTimeInterface;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeRecord;
 
@@ -37,35 +36,20 @@ final readonly class JsonLinesAuditSink implements AuditSinkInterface
 
     public function write(ChangeRecord $record): void
     {
+        $data = $record->toArray();
+
+        // Redact at the export boundary: overwrite the full pre-image with a redacted projection.
+        if ($record->change->preImage !== null) {
+            $data['pre_image'] = $this->redaction->apply($record->change->preImage);
+        }
+
         $line = json_encode(
-            $this->toArray($record),
+            $data,
             JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
         ) . "\n";
 
         if (file_put_contents($this->path, $line, FILE_APPEND | LOCK_EX) === false) {
             throw new RuntimeException('Failed to write a record to the audit sink.');
         }
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function toArray(ChangeRecord $record): array
-    {
-        $change = $record->change;
-
-        return [
-            'seq' => $record->seq,
-            'origin' => (string) $record->origin,
-            'created_at' => $record->createdAt->format(DateTimeInterface::ATOM),
-            'change_type' => $change->changeType->value,
-            'dn' => $change->dn->toString(),
-            'entry_uuid' => $change->entryUuid,
-            'authz_id' => $change->authzId->toString(),
-            'previous_dn' => $change->previousDn?->toString(),
-            'pre_image' => $change->preImage !== null
-                ? $this->redaction->apply($change->preImage)
-                : null,
-        ];
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Capture/ChangeJournalingInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Capture/ChangeJournalingInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture;
 
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
 
 /**
  * Append a change within the active write boundary.
@@ -26,4 +27,9 @@ interface ChangeJournalingInterface
      * Append a change to the journal within the currently active write boundary.
      */
     public function appendChange(PendingChange $change): void;
+
+    /**
+     * The change journal, for reading recorded changes (e.g. the RFC 4533 sync provider).
+     */
+    public function changeJournal(): ChangeJournalInterface;
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Change/ChangeRecord.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Change/ChangeRecord.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Journal\Change;
 
 use DateTimeImmutable;
+use DateTimeInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
 
 /**
@@ -29,4 +30,17 @@ final readonly class ChangeRecord
         public DateTimeImmutable $createdAt,
         public PendingChange $change,
     ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'seq' => $this->seq,
+            'origin' => (string) $this->origin,
+            'created_at' => $this->createdAt->format(DateTimeInterface::ATOM),
+            ...$this->change->toArray(),
+        ];
+    }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Change/PendingChange.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Change/PendingChange.php
@@ -32,4 +32,19 @@ final readonly class PendingChange
         public ?Dn $previousDn = null,
         public ?Entry $preImage = null,
     ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'change_type' => $this->changeType->value,
+            'dn' => $this->dn->toString(),
+            'entry_uuid' => $this->entryUuid,
+            'authz_id' => $this->authzId->toString(),
+            'previous_dn' => $this->previousDn?->toString(),
+            'pre_image' => $this->preImage?->toArray(),
+        ];
+    }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ChangeJournalInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ChangeJournalInterface.php
@@ -50,4 +50,11 @@ interface ChangeJournalInterface
      * @api
      */
     public function prune(RetentionPolicy $policy): int;
+
+    /**
+     * The replica that authored this journal's records; the origin a sync cookie is stamped with.
+     *
+     * @api
+     */
+    public function origin(): ReplicaId;
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/InMemoryChangeJournal.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/InMemoryChangeJournal.php
@@ -64,6 +64,11 @@ final class InMemoryChangeJournal implements ChangeJournalInterface
         return $this->seq;
     }
 
+    public function origin(): ReplicaId
+    {
+        return $this->origin;
+    }
+
     public function prune(RetentionPolicy $policy): int
     {
         $before = count($this->records);

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Read/ChangeStream.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Read/ChangeStream.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Journal\Read;
 
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeRecord;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
 
 /**
  * Read-only view over the journal: the seam the audit sink and RFC 4533 provider consume.
@@ -53,5 +54,15 @@ final readonly class ChangeStream
     public function latestSeq(): int
     {
         return $this->journal->latestSeq();
+    }
+
+    /**
+     * The origin replica a sync cookie should be stamped with.
+     *
+     * @api
+     */
+    public function origin(): ReplicaId
+    {
+        return $this->journal->origin();
     }
 }

--- a/src/FreeDSx/Ldap/Server/Middleware/ServerControlRegistry.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/ServerControlRegistry.php
@@ -82,6 +82,9 @@ final class ServerControlRegistry
                 Control::OID_POST_READ,
                 Control::OID_SUBTREE_DELETE,
             ],
+            HandlerId::Sync => [
+                Control::OID_SYNC_REQUEST,
+            ],
             default => [],
         };
     }

--- a/src/FreeDSx/Ldap/Server/Utility/Uuid.php
+++ b/src/FreeDSx/Ldap/Server/Utility/Uuid.php
@@ -13,11 +13,16 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Utility;
 
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+
 use function bin2hex;
 use function chr;
+use function hex2bin;
 use function ord;
 use function random_bytes;
+use function str_replace;
 use function str_split;
+use function strlen;
 use function vsprintf;
 
 /**
@@ -47,5 +52,21 @@ final class Uuid
                 4,
             ),
         );
+    }
+
+    /**
+     * The 16-byte binary form of a dashed UUID string, as RFC 4533 sync controls carry it.
+     *
+     * @throws InvalidArgumentException when the value is not a UUID
+     */
+    public static function toBinary(string $uuid): string
+    {
+        $binary = hex2bin(str_replace('-', '', $uuid));
+
+        if ($binary === false || strlen($binary) !== 16) {
+            throw new InvalidArgumentException(sprintf('"%s" is not a valid UUID.', $uuid));
+        }
+
+        return $binary;
     }
 }

--- a/src/FreeDSx/Ldap/Sync/Provider/Exception/MalformedSyncCookieException.php
+++ b/src/FreeDSx/Ldap/Sync/Provider/Exception/MalformedSyncCookieException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Sync\Provider\Exception;
+
+use FreeDSx\Ldap\Exception\RuntimeException;
+
+/**
+ * Thrown when a presented sync cookie cannot be decoded.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class MalformedSyncCookieException extends RuntimeException {}

--- a/src/FreeDSx/Ldap/Sync/Provider/SyncCookie.php
+++ b/src/FreeDSx/Ldap/Sync/Provider/SyncCookie.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Sync\Provider;
+
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
+use FreeDSx\Ldap\Sync\Provider\Exception\MalformedSyncCookieException;
+use JsonException;
+
+/**
+ * Opaque, versioned RFC 4533 sync cookie carrying the origin replica and its seq high-water mark.
+ *
+ * @api
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class SyncCookie
+{
+    /**
+     * Encoding version; bumped if the blob grows (e.g. a per-origin vector for multi-master).
+     */
+    private const VERSION = 1;
+
+    public function __construct(
+        public ReplicaId $origin,
+        public int $seq,
+    ) {
+        if ($this->seq < 0) {
+            throw new InvalidArgumentException('A sync cookie seq cannot be negative.');
+        }
+    }
+
+    public function encode(): string
+    {
+        return base64_encode(json_encode(
+            [
+                'v' => self::VERSION,
+                'origin' => (string) $this->origin,
+                'seq' => $this->seq,
+            ],
+            JSON_THROW_ON_ERROR,
+        ));
+    }
+
+    /**
+     * @throws MalformedSyncCookieException
+     */
+    public static function decode(string $cookie): self
+    {
+        $json = base64_decode($cookie, true);
+
+        if ($json === false) {
+            throw new MalformedSyncCookieException('The sync cookie is not valid base64.');
+        }
+
+        try {
+            $data = json_decode(
+                $json,
+                true,
+                flags: JSON_THROW_ON_ERROR,
+            );
+        } catch (JsonException $e) {
+            throw new MalformedSyncCookieException(
+                'The sync cookie is not valid JSON.',
+                previous: $e,
+            );
+        }
+
+        if (!is_array($data) || ($data['v'] ?? null) !== self::VERSION) {
+            throw new MalformedSyncCookieException('The sync cookie has an unsupported version.');
+        }
+
+        $origin = $data['origin'] ?? null;
+        $seq = $data['seq'] ?? null;
+
+        if (!is_string($origin) || $origin === '' || !is_int($seq) || $seq < 0) {
+            throw new MalformedSyncCookieException('The sync cookie is missing a valid origin or seq.');
+        }
+
+        return new self(
+            new ReplicaId($origin),
+            $seq,
+        );
+    }
+}

--- a/tests/integration/LdapServerTest.php
+++ b/tests/integration/LdapServerTest.php
@@ -194,6 +194,7 @@ final class LdapServerTest extends ServerTestCase
                     '1.3.6.1.1.13.1',
                     '1.3.6.1.1.13.2',
                     '1.2.840.113556.1.4.805',
+                    '1.3.6.1.4.1.4203.1.9.1.1',
                 ],
                 'supportedExtension' => [
                     '1.3.6.1.4.1.4203.1.11.3',

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerRootDseHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerRootDseHandlerTest.php
@@ -133,6 +133,40 @@ final class ServerRootDseHandlerTest extends TestCase
         );
     }
 
+    public function test_it_advertises_the_sync_control_when_sync_is_enabled(): void
+    {
+        $this->subject = new ServerRootDseHandler(
+            $this->options,
+            $this->mockQueue,
+            $this->mockBackend,
+            null,
+            true,
+        );
+
+        $search = new LdapMessageRequest(
+            1,
+            (new SearchRequest(Filters::present('objectClass')))->base('')->useBaseScope(),
+        );
+
+        $this->mockQueue
+            ->expects($this->once())
+            ->method('sendMessage')
+            ->with(
+                self::callback(function (LdapMessageResponse $response) {
+                    /** @var SearchResultEntry $result */
+                    $result = $response->getResponse();
+
+                    return $result->getEntry()->get('supportedControl')?->has(Control::OID_SYNC_REQUEST) === true;
+                }),
+                self::anything(),
+            );
+
+        $this->subject->handleRequest(
+            $search,
+            $this->mockToken,
+        );
+    }
+
     public function test_it_should_send_a_request_to_the_dispatcher_if_it_implements_a_rootdse_aware_interface(): void
     {
         $this->options->setDseVendorName('Foo');

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSyncHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSyncHandlerTest.php
@@ -1,0 +1,499 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\Sync\SyncDoneControl;
+use FreeDSx\Ldap\Control\Sync\SyncRequestControl;
+use FreeDSx\Ldap\Control\Sync\SyncStateControl;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\Response\SearchResultDone;
+use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerSyncHandler;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
+use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\InMemoryChangeJournal;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeStream;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
+use FreeDSx\Ldap\Server\Operation\OperationOutcome;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\Sync\Provider\SyncCookie;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class ServerSyncHandlerTest extends TestCase
+{
+    private const ORIGIN = 'test-origin';
+
+    private const UUID_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+    private const UUID_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+    private ServerQueue&MockObject $queue;
+
+    private LdapBackendInterface&MockObject $backend;
+
+    private FilterEvaluatorInterface&MockObject $filterEvaluator;
+
+    private AccessControlInterface&MockObject $accessControl;
+
+    private TokenInterface&MockObject $token;
+
+    private InMemoryChangeJournal $journal;
+
+    private ServerSyncHandler $subject;
+
+    /**
+     * @var list<LdapMessageResponse>
+     */
+    private array $sent = [];
+
+    /**
+     * @var list<string> DNs the ACL hides from the consumer
+     */
+    private array $hiddenDns = [];
+
+    private bool $filterMatches = true;
+
+    /**
+     * @var array<string, Entry> live entries returned by backend::get(), keyed by DN
+     */
+    private array $liveEntries = [];
+
+    /**
+     * @var list<Entry> entries returned by backend::search() for a full refresh
+     */
+    private array $searchEntries = [];
+
+    protected function setUp(): void
+    {
+        $this->queue = $this->createMock(ServerQueue::class);
+        $this->backend = $this->createMock(LdapBackendInterface::class);
+        $this->filterEvaluator = $this->createMock(FilterEvaluatorInterface::class);
+        $this->accessControl = $this->createMock(AccessControlInterface::class);
+        $this->token = $this->createMock(TokenInterface::class);
+        $this->journal = new InMemoryChangeJournal(new ReplicaId(self::ORIGIN));
+
+        $this->accessControl
+            ->method('filterEntry')
+            ->willReturnCallback(fn(TokenInterface $token, Entry $entry): ?Entry => in_array(
+                $entry->getDn()->toString(),
+                $this->hiddenDns,
+                true,
+            ) ? null : $entry);
+        $this->filterEvaluator
+            ->method('evaluate')
+            ->willReturnCallback(fn(): bool => $this->filterMatches);
+        $this->backend
+            ->method('search')
+            ->willReturnCallback(fn(): EntryStream => new EntryStream($this->stream(...$this->searchEntries)));
+        $this->backend
+            ->method('get')
+            ->willReturnCallback(fn(Dn $dn): ?Entry => $this->liveEntries[$dn->toString()] ?? null);
+        $this->queue
+            ->method('sendMessages')
+            ->willReturnCallback(function (iterable $messages): ServerQueue {
+                foreach ($messages as $message) {
+                    if (!$message instanceof LdapMessageResponse) {
+                        continue;
+                    }
+
+                    $this->sent[] = $message;
+                }
+
+                return $this->queue;
+            });
+
+        $this->subject = new ServerSyncHandler(
+            queue: $this->queue,
+            backend: $this->backend,
+            filterEvaluator: $this->filterEvaluator,
+            accessControl: $this->accessControl,
+            changeStream: new ChangeStream($this->journal),
+        );
+    }
+
+    public function test_an_empty_cookie_streams_all_live_entries_as_add(): void
+    {
+        $this->append(ChangeType::Add, 'cn=a,dc=example,dc=com', self::UUID_A);
+        $this->searchEntries = [
+            $this->entry('cn=a,dc=example,dc=com', self::UUID_A),
+            $this->entry('cn=b,dc=example,dc=com', self::UUID_B),
+        ];
+
+        $result = $this->handle(null);
+
+        self::assertSame(
+            OperationOutcome::Succeeded,
+            $result->outcome(),
+        );
+        self::assertSame(
+            [
+                [SyncStateControl::STATE_ADD, self::UUID_A],
+                [SyncStateControl::STATE_ADD, self::UUID_B],
+            ],
+            $this->states(),
+        );
+        self::assertSame(
+            1,
+            $this->doneCookie()->seq,
+        );
+    }
+
+    public function test_the_done_cookie_carries_the_origin(): void
+    {
+        $this->handle(null);
+
+        self::assertTrue($this->doneCookie()->origin->equals(new ReplicaId(self::ORIGIN)));
+    }
+
+    public function test_a_full_refresh_is_a_present_phase(): void
+    {
+        $this->handle(null);
+
+        self::assertFalse($this->doneControl()->getRefreshDeletes());
+    }
+
+    public function test_an_incremental_sync_is_a_delete_phase(): void
+    {
+        $this->append(ChangeType::Modify, 'cn=a,dc=example,dc=com', self::UUID_A);
+        $this->liveEntries['cn=a,dc=example,dc=com'] = $this->entry('cn=a,dc=example,dc=com', self::UUID_A);
+
+        $this->handle($this->cookieAt(0));
+
+        self::assertTrue($this->doneControl()->getRefreshDeletes());
+    }
+
+    public function test_an_acl_hidden_entry_is_omitted_from_a_full_refresh(): void
+    {
+        $this->searchEntries = [
+            $this->entry('cn=a,dc=example,dc=com', self::UUID_A),
+            $this->entry('cn=b,dc=example,dc=com', self::UUID_B),
+        ];
+        $this->hiddenDns = ['cn=b,dc=example,dc=com'];
+
+        $this->handle(null);
+
+        self::assertSame(
+            [[SyncStateControl::STATE_ADD, self::UUID_A]],
+            $this->states(),
+        );
+    }
+
+    public function test_an_entry_without_a_uuid_is_skipped(): void
+    {
+        $this->searchEntries = [Entry::create('cn=a,dc=example,dc=com', ['cn' => 'a'])];
+
+        $this->handle(null);
+
+        self::assertSame(
+            [],
+            $this->states(),
+        );
+    }
+
+    #[DataProvider('fullRefreshTriggers')]
+    public function test_an_unusable_cookie_falls_back_to_a_full_refresh(string $cookie, bool $reloadHint): void
+    {
+        // A journal record that would surface under an incremental sync, so its absence proves a full refresh.
+        $this->append(ChangeType::Modify, 'cn=b,dc=example,dc=com', self::UUID_B);
+        $this->searchEntries = [$this->entry('cn=a,dc=example,dc=com', self::UUID_A)];
+
+        $this->handle($cookie, reloadHint: $reloadHint);
+
+        self::assertSame(
+            [[SyncStateControl::STATE_ADD, self::UUID_A]],
+            $this->states(),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, bool}>
+     */
+    public static function fullRefreshTriggers(): iterable
+    {
+        yield 'malformed cookie' => ['@@not a cookie@@', false];
+        yield 'cookie from another origin' => [(new SyncCookie(new ReplicaId('other'), 0))->encode(), false];
+        yield 'reload hint set' => [(new SyncCookie(new ReplicaId(self::ORIGIN), 0))->encode(), true];
+    }
+
+    public function test_a_valid_cookie_streams_the_delta_as_adds_and_deletes(): void
+    {
+        $this->append(ChangeType::Modify, 'cn=a,dc=example,dc=com', self::UUID_A);
+        $this->append(
+            ChangeType::Delete,
+            'cn=b,dc=example,dc=com',
+            self::UUID_B,
+            $this->entry('cn=b,dc=example,dc=com', self::UUID_B),
+        );
+        $this->liveEntries['cn=a,dc=example,dc=com'] = $this->entry('cn=a,dc=example,dc=com', self::UUID_A);
+
+        $this->handle($this->cookieAt(0));
+
+        self::assertSame(
+            [
+                [SyncStateControl::STATE_ADD, self::UUID_A],
+                [SyncStateControl::STATE_DELETE, self::UUID_B],
+            ],
+            $this->states(),
+        );
+        self::assertSame(
+            2,
+            $this->doneCookie()->seq,
+        );
+    }
+
+    public function test_repeated_changes_to_one_entry_collapse_to_the_net_effect(): void
+    {
+        $this->append(ChangeType::Add, 'cn=a,dc=example,dc=com', self::UUID_A);
+        $this->append(
+            ChangeType::Delete,
+            'cn=a,dc=example,dc=com',
+            self::UUID_A,
+            $this->entry('cn=a,dc=example,dc=com', self::UUID_A),
+        );
+
+        $this->handle($this->cookieAt(0));
+
+        self::assertSame(
+            [[SyncStateControl::STATE_DELETE, self::UUID_A]],
+            $this->states(),
+        );
+    }
+
+    public function test_a_changed_entry_that_no_longer_matches_the_filter_is_skipped(): void
+    {
+        $this->append(ChangeType::Modify, 'cn=a,dc=example,dc=com', self::UUID_A);
+        $this->liveEntries['cn=a,dc=example,dc=com'] = $this->entry('cn=a,dc=example,dc=com', self::UUID_A);
+        $this->filterMatches = false;
+
+        $this->handle($this->cookieAt(0));
+
+        self::assertSame(
+            [],
+            $this->states(),
+        );
+    }
+
+    public function test_a_changed_entry_gone_since_the_change_is_skipped(): void
+    {
+        $this->append(ChangeType::Modify, 'cn=a,dc=example,dc=com', self::UUID_A);
+        // No live entry registered: backend::get() returns null.
+
+        $this->handle($this->cookieAt(0));
+
+        self::assertSame(
+            [],
+            $this->states(),
+        );
+    }
+
+    public function test_a_delete_is_not_announced_when_the_consumer_could_not_see_the_entry(): void
+    {
+        $this->append(
+            ChangeType::Delete,
+            'cn=secret,dc=example,dc=com',
+            self::UUID_B,
+            $this->entry('cn=secret,dc=example,dc=com', self::UUID_B),
+        );
+        $this->hiddenDns = ['cn=secret,dc=example,dc=com'];
+
+        $this->handle($this->cookieAt(0));
+
+        self::assertSame(
+            [],
+            $this->states(),
+        );
+    }
+
+    public function test_a_delete_without_a_pre_image_is_not_announced(): void
+    {
+        $this->append(ChangeType::Delete, 'cn=b,dc=example,dc=com', self::UUID_B);
+
+        $this->handle($this->cookieAt(0));
+
+        self::assertSame(
+            [],
+            $this->states(),
+        );
+    }
+
+    public function test_refresh_and_persist_is_declined(): void
+    {
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
+
+        $this->handle(null, mode: SyncRequestControl::MODE_REFRESH_AND_PERSIST);
+    }
+
+    public function test_sync_is_declined_when_no_change_stream_is_available(): void
+    {
+        $handler = new ServerSyncHandler(
+            queue: $this->queue,
+            backend: $this->backend,
+            filterEvaluator: $this->filterEvaluator,
+            accessControl: $this->accessControl,
+        );
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
+
+        $handler->handleRequest(
+            $this->syncMessage(null),
+            $this->token,
+        );
+    }
+
+    private function handle(
+        ?string $cookie,
+        int $mode = SyncRequestControl::MODE_REFRESH_ONLY,
+        bool $reloadHint = false,
+    ): OperationResult {
+        return $this->subject->handleRequest(
+            $this->syncMessage($cookie, $mode, $reloadHint),
+            $this->token,
+        );
+    }
+
+    private function syncMessage(
+        ?string $cookie,
+        int $mode = SyncRequestControl::MODE_REFRESH_ONLY,
+        bool $reloadHint = false,
+    ): LdapMessageRequest {
+        $request = (new SearchRequest(Filters::present('objectClass')))
+            ->base('dc=example,dc=com')
+            ->useSubtreeScope();
+
+        return new LdapMessageRequest(
+            1,
+            $request,
+            new SyncRequestControl($mode, $cookie, $reloadHint),
+        );
+    }
+
+    private function cookieAt(int $seq): string
+    {
+        return (new SyncCookie(new ReplicaId(self::ORIGIN), $seq))->encode();
+    }
+
+    private function append(
+        ChangeType $type,
+        string $dn,
+        string $uuid,
+        ?Entry $preImage = null,
+    ): void {
+        $this->journal->append(new PendingChange(
+            changeType: $type,
+            dn: new Dn($dn),
+            entryUuid: $uuid,
+            authzId: AuthzId::anonymous(),
+            preImage: $preImage,
+        ));
+    }
+
+    private function entry(
+        string $dn,
+        string $uuid,
+    ): Entry {
+        return Entry::create(
+            $dn,
+            [
+                'cn' => 'x',
+                'entryUUID' => $uuid,
+            ],
+        );
+    }
+
+    /**
+     * @return Generator<Entry>
+     */
+    private function stream(Entry ...$entries): Generator
+    {
+        yield from $entries;
+    }
+
+    /**
+     * The (state, dashed-uuid) of every emitted SearchResultEntry, in order.
+     *
+     * @return list<array{int, string}>
+     */
+    private function states(): array
+    {
+        $states = [];
+
+        foreach ($this->sent as $message) {
+            if (!$message->getResponse() instanceof SearchResultEntry) {
+                continue;
+            }
+
+            $control = $message->controls()->get(Control::OID_SYNC_STATE);
+            self::assertInstanceOf(
+                SyncStateControl::class,
+                $control,
+            );
+            $states[] = [$control->getState(), $control->decodedUuid()];
+        }
+
+        return $states;
+    }
+
+    private function lastSent(): LdapMessageResponse
+    {
+        $last = end($this->sent);
+        self::assertInstanceOf(
+            LdapMessageResponse::class,
+            $last,
+        );
+
+        return $last;
+    }
+
+    private function doneControl(): SyncDoneControl
+    {
+        $last = $this->lastSent();
+        self::assertInstanceOf(
+            SearchResultDone::class,
+            $last->getResponse(),
+        );
+
+        $control = $last->controls()->get(Control::OID_SYNC_DONE);
+        self::assertInstanceOf(
+            SyncDoneControl::class,
+            $control,
+        );
+
+        return $control;
+    }
+
+    private function doneCookie(): SyncCookie
+    {
+        return SyncCookie::decode((string) $this->doneControl()->getCookie());
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Journal/Change/ChangeRecordTest.php
+++ b/tests/unit/Server/Backend/Storage/Journal/Change/ChangeRecordTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Journal\Change;
+
+use DateTimeImmutable;
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeRecord;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
+use PHPUnit\Framework\TestCase;
+
+final class ChangeRecordTest extends TestCase
+{
+    public function test_to_array_is_the_full_canonical_shape(): void
+    {
+        $record = new ChangeRecord(
+            seq: 3,
+            origin: new ReplicaId('node-a'),
+            createdAt: new DateTimeImmutable('2025-05-15T12:00:00+00:00'),
+            change: new PendingChange(
+                changeType: ChangeType::ModRdn,
+                dn: new Dn('cn=b,dc=example,dc=com'),
+                entryUuid: '11111111-1111-4111-8111-111111111111',
+                authzId: AuthzId::fromDn(new Dn('cn=admin,dc=example,dc=com')),
+                previousDn: new Dn('cn=a,dc=example,dc=com'),
+                preImage: new Entry(
+                    new Dn('cn=b,dc=example,dc=com'),
+                    new Attribute('cn', 'b'),
+                    new Attribute('userPassword', 'secret'),
+                ),
+            ),
+        );
+
+        self::assertSame(
+            [
+                'seq' => 3,
+                'origin' => 'node-a',
+                'created_at' => '2025-05-15T12:00:00+00:00',
+                'change_type' => 'modrdn',
+                'dn' => 'cn=b,dc=example,dc=com',
+                'entry_uuid' => '11111111-1111-4111-8111-111111111111',
+                'authz_id' => 'dn:cn=admin,dc=example,dc=com',
+                'previous_dn' => 'cn=a,dc=example,dc=com',
+                'pre_image' => [
+                    'cn' => ['b'],
+                    'userPassword' => ['secret'],
+                ],
+            ],
+            $record->toArray(),
+        );
+    }
+}

--- a/tests/unit/Sync/Provider/SyncCookieTest.php
+++ b/tests/unit/Sync/Provider/SyncCookieTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Sync\Provider;
+
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
+use FreeDSx\Ldap\Sync\Provider\Exception\MalformedSyncCookieException;
+use FreeDSx\Ldap\Sync\Provider\SyncCookie;
+use PHPUnit\Framework\TestCase;
+
+final class SyncCookieTest extends TestCase
+{
+    public function test_encode_decode_preserves_the_origin_and_seq(): void
+    {
+        $decoded = SyncCookie::decode(
+            (new SyncCookie(new ReplicaId('node-a'), 42))->encode(),
+        );
+
+        self::assertTrue($decoded->origin->equals(new ReplicaId('node-a')));
+        self::assertSame(
+            42,
+            $decoded->seq,
+        );
+    }
+
+    public function test_a_zero_seq_round_trips(): void
+    {
+        $decoded = SyncCookie::decode(
+            (new SyncCookie(new ReplicaId('node-a'), 0))->encode(),
+        );
+
+        self::assertSame(
+            0,
+            $decoded->seq,
+        );
+    }
+
+    public function test_it_rejects_a_negative_seq(): void
+    {
+        self::expectException(InvalidArgumentException::class);
+
+        new SyncCookie(
+            new ReplicaId('node-a'),
+            -1,
+        );
+    }
+
+    public function test_decode_rejects_invalid_base64(): void
+    {
+        self::expectException(MalformedSyncCookieException::class);
+
+        SyncCookie::decode('@@not base64@@');
+    }
+
+    public function test_decode_rejects_an_unsupported_version(): void
+    {
+        $future = base64_encode((string) json_encode([
+            'v' => 99,
+            'origin' => 'node-a',
+            'seq' => 1,
+        ]));
+
+        self::expectException(MalformedSyncCookieException::class);
+
+        SyncCookie::decode($future);
+    }
+}


### PR DESCRIPTION
This adds the actual server sync handler logic. It only handles refreshOnly right now. Working on this has surfaced some other things that I also need to fix in some follow-up PRs (and some completely unrelated things for tagging attribute options).