### PR TITLE
[1.0.0] Add the file based journal implementation.

### DIFF
--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonFileStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonFileStorage.php
@@ -23,7 +23,17 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Support\ArrayEntryStorageTrait;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Support\JsonEntryBuffer;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingTrait;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\FileChangeJournal;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
+use FreeDSx\Ldap\Server\Logging\ExceptionLogging;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Throwable;
 
 /**
  * JSON-file storage; use forPcntl() / forSwoole() to pick a locking strategy. Reads are lock-free; writes go through atomic() which loads, mutates, and rewrites the file under lock.
@@ -34,9 +44,14 @@ use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final class JsonFileStorage implements EntryStorageInterface
+final class JsonFileStorage implements EntryStorageInterface, ChangeJournalingInterface
 {
     use ArrayEntryStorageTrait;
+    use ChangeJournalingTrait;
+
+    private const JOURNAL_SUFFIX = '.journal.jsonl';
+
+    private const SEQ_SUFFIX = '.journal.seq';
 
     /**
      * @var array<string, Entry>|null
@@ -48,25 +63,30 @@ final class JsonFileStorage implements EntryStorageInterface
     private function __construct(
         private readonly string $filePath,
         private readonly StorageLockInterface $lock,
+        private readonly LoggerInterface $logger = new NullLogger(),
     ) {}
 
     public static function forPcntl(
         string $filePath,
         ?StorageLockInterface $lock = null,
+        ?LoggerInterface $logger = null,
     ): self {
         return new self(
             $filePath,
             $lock ?? new FileLock($filePath),
+            $logger ?? new NullLogger(),
         );
     }
 
     public static function forSwoole(
         string $filePath,
         ?StorageLockInterface $lock = null,
+        ?LoggerInterface $logger = null,
     ): self {
         return new self(
             $filePath,
             $lock ?? new CoroutineLock($filePath),
+            $logger ?? new NullLogger(),
         );
     }
 
@@ -110,17 +130,23 @@ final class JsonFileStorage implements EntryStorageInterface
 
     public function atomic(callable $operation): void
     {
-        $this->withMutation(function (string $contents) use ($operation): string {
-            $data = $this->decodeContents($contents);
-            $buffer = new JsonEntryBuffer(
-                $data,
-                $this->arrayToEntry(...),
-                $this->entryToArray(...),
-            );
-            $operation($buffer);
+        $buffer = $this->newBuffer([]);
 
-            return $this->encodeContents($buffer->getData());
-        });
+        $this->withMutation(
+            function (string $contents) use ($operation, &$buffer): string {
+                $buffer = $this->newBuffer($this->decodeContents($contents));
+                $operation($buffer);
+
+                return $this->encodeContents($buffer->getData());
+            },
+            // Flush after the data is committed so a failed write records nothing; the shared lock is still held,
+            // so the journal append re-enters it rather than deadlocking.
+            function () use (&$buffer): void {
+                foreach ($buffer->getPendingChanges() as $change) {
+                    $this->flushChange($change);
+                }
+            },
+        );
     }
 
     public function namingContexts(): array
@@ -128,13 +154,45 @@ final class JsonFileStorage implements EntryStorageInterface
         return $this->namingContextsFromArray($this->read());
     }
 
+    protected function buildJournal(ChangeJournalConfig $config): ChangeJournalInterface
+    {
+        return new FileChangeJournal(
+            $this->lock,
+            $this->filePath . self::JOURNAL_SUFFIX,
+            $this->filePath . self::SEQ_SUFFIX,
+            $config->origin,
+        );
+    }
+
     /**
-     * @param callable(string): string $mutation
+     * Append a committed change to the journal, logging rather than raising a best-effort journal failure so an
+     * already-committed entry write is never reported as failed; sync reconciles the lost record via the present phase.
      */
-    private function withMutation(callable $mutation): void
+    private function flushChange(PendingChange $change): void
     {
         try {
-            $this->lock->withLock($mutation);
+            $this->appendChange($change);
+        } catch (Throwable $e) {
+            $this->logger->error(
+                'Failed to append a committed change to the file change journal.',
+                ExceptionLogging::makeLogContext($e),
+            );
+        }
+    }
+
+    /**
+     * @param callable(string): string $mutation
+     * @param ?callable(): void $afterCommit
+     */
+    private function withMutation(
+        callable $mutation,
+        ?callable $afterCommit = null,
+    ): void {
+        try {
+            $this->lock->withLock(
+                $mutation,
+                $afterCommit,
+            );
         } finally {
             $this->cache = null;
         }
@@ -255,6 +313,18 @@ final class JsonFileStorage implements EntryStorageInterface
         return new Entry(
             new Dn($dn),
             ...$attributes,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function newBuffer(array $data): JsonEntryBuffer
+    {
+        return new JsonEntryBuffer(
+            $data,
+            $this->arrayToEntry(...),
+            $this->entryToArray(...),
         );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/AtomicStorageLockTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/AtomicStorageLockTrait.php
@@ -25,20 +25,39 @@ trait AtomicStorageLockTrait
 {
     public function __construct(private readonly string $filePath) {}
 
-    final public function withLock(callable $mutation): void
+    final public function withLock(
+        callable $mutation,
+        ?callable $afterCommit = null,
+    ): void {
+        $this->withExclusive(function () use ($mutation, $afterCommit): void {
+            $newContents = $mutation($this->readCurrentContents());
+            $this->publishAtomically($newContents);
+
+            if ($afterCommit !== null) {
+                $afterCommit();
+            }
+        });
+    }
+
+    final public function withExclusive(callable $callback): void
     {
         $this->acquireLock();
 
         try {
-            $newContents = $mutation($this->readCurrentContents());
-            $this->publishAtomically($newContents);
+            $callback();
         } finally {
             $this->releaseLock();
         }
     }
 
+    /**
+     * Acquire the exclusive lock, or bump the re-entrancy depth when already held by this execution context.
+     */
     abstract private function acquireLock(): void;
 
+    /**
+     * Drop the re-entrancy depth, releasing the underlying lock only when the outermost holder exits.
+     */
     abstract private function releaseLock(): void;
 
     abstract private function readCurrentContents(): string;

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/CoroutineLock.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/CoroutineLock.php
@@ -26,6 +26,8 @@ final class CoroutineLock implements StorageLockInterface
 {
     use AtomicStorageLockTrait;
 
+    private const DEPTH_KEY = '__freedsx_storage_lock_depth';
+
     /**
      * @var Channel<mixed>|null
      */
@@ -33,16 +35,49 @@ final class CoroutineLock implements StorageLockInterface
 
     private function acquireLock(): void
     {
-        $this->getOrCreateMutex()->pop();
+        // Depth is tracked per coroutine, not per instance: coroutines share one lock.
+        $depth = $this->currentDepth();
+        if ($depth === 0) {
+            $this->getOrCreateMutex()->pop();
+        }
+
+        $this->setCurrentDepth($depth + 1);
     }
 
     private function releaseLock(): void
     {
-        if ($this->mutex === null) {
+        $depth = $this->currentDepth();
+        if ($depth === 0) {
             return;
         }
 
-        $this->mutex->push(true);
+        $this->setCurrentDepth($depth - 1);
+
+        if ($depth === 1) {
+            $this->mutex?->push(true);
+        }
+    }
+
+    private function currentDepth(): int
+    {
+        $context = Coroutine::getContext();
+        if ($context === null) {
+            return 0;
+        }
+
+        $depth = $context[self::DEPTH_KEY] ?? 0;
+
+        return is_int($depth) ? $depth : 0;
+    }
+
+    private function setCurrentDepth(int $depth): void
+    {
+        $context = Coroutine::getContext();
+        if ($context === null) {
+            return;
+        }
+
+        $context[self::DEPTH_KEY] = $depth;
     }
 
     private function readCurrentContents(): string

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/FileLock.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/FileLock.php
@@ -31,8 +31,20 @@ final class FileLock implements StorageLockInterface
      */
     private $lockHandle = null;
 
+    private int $depth = 0;
+
+    /**
+     * A process holds one instance, so a shared depth counter is per-context: re-entrant here, serialized
+     * across forked processes by the flock() below.
+     */
     private function acquireLock(): void
     {
+        if ($this->depth > 0) {
+            $this->depth++;
+
+            return;
+        }
+
         $handle = fopen(
             $this->filePath . self::LOCK_SUFFIX,
             'c',
@@ -49,11 +61,18 @@ final class FileLock implements StorageLockInterface
         }
 
         $this->lockHandle = $handle;
+        $this->depth = 1;
     }
 
     private function releaseLock(): void
     {
-        if ($this->lockHandle === null) {
+        if ($this->depth === 0) {
+            return;
+        }
+
+        $this->depth--;
+
+        if ($this->depth > 0 || $this->lockHandle === null) {
             return;
         }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/StorageLockInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Lock/StorageLockInterface.php
@@ -21,9 +21,21 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock;
 interface StorageLockInterface
 {
     /**
-     * Lock exclusively, hand the raw contents to $mutation, persist its return value, and release the lock.
+     * Lock exclusively, hand the raw contents to $mutation, persist its return value, run $afterCommit while
+     * still holding the lock, then release. $afterCommit sees the freshly committed data (e.g. journal flush).
      *
      * @param callable(string): string $mutation
+     * @param ?callable(): void $afterCommit
      */
-    public function withLock(callable $mutation): void;
+    public function withLock(
+        callable $mutation,
+        ?callable $afterCommit = null,
+    ): void;
+
+    /**
+     * Run $callback under the exclusive lock without any data read/publish.
+     *
+     * @param callable(): void $callback
+     */
+    public function withExclusive(callable $callback): void;
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/JsonEntryBuffer.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/JsonEntryBuffer.php
@@ -19,6 +19,8 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeAppenderInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 use Generator;
 
@@ -28,7 +30,7 @@ use Generator;
  * @internal
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final class JsonEntryBuffer implements EntryStorageInterface
+final class JsonEntryBuffer implements EntryStorageInterface, ChangeAppenderInterface
 {
     use DefaultHasChildrenTrait;
 
@@ -36,6 +38,11 @@ final class JsonEntryBuffer implements EntryStorageInterface
      * @var array<string, mixed>
      */
     private array $data;
+
+    /**
+     * @var list<PendingChange>
+     */
+    private array $pending = [];
 
     /**
      * @param array<string, mixed> $data
@@ -83,6 +90,21 @@ final class JsonEntryBuffer implements EntryStorageInterface
     public function atomic(callable $operation): void
     {
         $operation($this);
+    }
+
+    public function appendChange(PendingChange $change): void
+    {
+        $this->pending[] = $change;
+    }
+
+    /**
+     * Changes collected during this write cycle, for the storage to flush to the journal after it commits.
+     *
+     * @return list<PendingChange>
+     */
+    public function getPendingChanges(): array
+    {
+        return $this->pending;
     }
 
     public function namingContexts(): array

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Capture/ChangeAppenderInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Capture/ChangeAppenderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture;
+
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+
+/**
+ * Accepts a change within the active write boundary.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface ChangeAppenderInterface
+{
+    /**
+     * Append a change within the currently active write boundary.
+     */
+    public function appendChange(PendingChange $change): void;
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Capture/ChangeJournalingInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Capture/ChangeJournalingInterface.php
@@ -14,25 +14,19 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture;
 
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
 
 /**
- * Append a change within the active write boundary.
+ * A storage adapter that owns a configurable change journal.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-interface ChangeJournalingInterface
+interface ChangeJournalingInterface extends ChangeAppenderInterface
 {
     /**
      * Build the journal from central config using the storage's own atomic primitives; set-once at wiring time.
      */
     public function configureJournal(ChangeJournalConfig $config): void;
-
-    /**
-     * Append a change to the journal within the currently active write boundary.
-     */
-    public function appendChange(PendingChange $change): void;
 
     /**
      * The change journal, for reading recorded changes (e.g. the RFC 4533 sync provider).

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Capture/ChangeRecorder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Capture/ChangeRecorder.php
@@ -97,7 +97,7 @@ final readonly class ChangeRecorder
         ?Dn $previousDn = null,
         ?Entry $preImage = null,
     ): void {
-        if (!$storage instanceof ChangeJournalingInterface) {
+        if (!$storage instanceof ChangeAppenderInterface) {
             return;
         }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/FileChangeJournal.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/FileChangeJournal.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Journal;
+
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock\StorageLockInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeRecord;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Serializer\ChangeRecordRowMapper;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Serializer\JsonlRowSerializer;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Serializer\RowSerializerInterface;
+use FreeDSx\Ldap\Server\Clock\ClockInterface;
+use FreeDSx\Ldap\Server\Clock\SystemClock;
+use Generator;
+
+use function array_filter;
+use function array_slice;
+use function array_values;
+use function count;
+use function dirname;
+use function explode;
+use function fclose;
+use function fflush;
+use function file_get_contents;
+use function file_put_contents;
+use function fopen;
+use function fwrite;
+use function implode;
+use function is_file;
+use function is_numeric;
+use function rename;
+use function tempnam;
+use function trim;
+use function unlink;
+
+/**
+ * Change journal persisting records to an append-only line-per-record sidecar under the storage's file lock.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class FileChangeJournal implements ChangeJournalInterface
+{
+    public function __construct(
+        private StorageLockInterface $lock,
+        private string $journalPath,
+        private string $seqPath,
+        private ReplicaId $origin = new ReplicaId('local'),
+        private ClockInterface $clock = new SystemClock(),
+        private RowSerializerInterface $serializer = new JsonlRowSerializer(),
+        private ChangeRecordRowMapper $mapper = new ChangeRecordRowMapper(),
+    ) {}
+
+    public function append(PendingChange $change): ChangeRecord
+    {
+        $createdAt = $this->clock->now();
+        $seq = 0;
+
+        // Bump the counter before writing the line: a failed append leaves a seq gap, never a reused seq.
+        $this->lock->withExclusive(function () use ($change, $createdAt, &$seq): void {
+            $seq = $this->readSeq() + 1;
+            $this->writeSeq($seq);
+            $this->appendLine($this->serializer->encode($this->mapper->toRow(new ChangeRecord(
+                seq: $seq,
+                origin: $this->origin,
+                createdAt: $createdAt,
+                change: $change,
+            ))));
+        });
+
+        return new ChangeRecord(
+            seq: $seq,
+            origin: $this->origin,
+            createdAt: $createdAt,
+            change: $change,
+        );
+    }
+
+    public function read(int $afterSeq = 0): iterable
+    {
+        $lines = [];
+
+        $this->lock->withExclusive(function () use (&$lines): void {
+            $lines = $this->readLines();
+        });
+
+        return $this->streamRecords(
+            $lines,
+            $afterSeq,
+        );
+    }
+
+    public function latestSeq(): int
+    {
+        $seq = 0;
+
+        $this->lock->withExclusive(function () use (&$seq): void {
+            $seq = $this->readSeq();
+        });
+
+        return $seq;
+    }
+
+    public function retainsSince(int $afterSeq): bool
+    {
+        $minSeq = null;
+        $latest = 0;
+
+        $this->lock->withExclusive(function () use (&$minSeq, &$latest): void {
+            $minSeq = $this->readMinSeq();
+            $latest = $this->readSeq();
+        });
+
+        // Empty journal: only a consumer already at the high-water mark is retained.
+        if ($minSeq === null) {
+            return $afterSeq >= $latest;
+        }
+
+        return $afterSeq + 1 >= $minSeq;
+    }
+
+    public function prune(RetentionPolicy $policy): int
+    {
+        $removed = 0;
+
+        $this->lock->withExclusive(function () use ($policy, &$removed): void {
+            $lines = $this->readLines();
+            $kept = $this->applyPolicy(
+                $lines,
+                $policy,
+            );
+
+            if (count($kept) !== count($lines)) {
+                $this->rewriteLines($kept);
+            }
+
+            $removed = count($lines) - count($kept);
+        });
+
+        return $removed;
+    }
+
+    public function origin(): ReplicaId
+    {
+        return $this->origin;
+    }
+
+    private function decodeLine(string $line): ?ChangeRecord
+    {
+        $row = $this->serializer->decode($line);
+
+        return $row === null
+            ? null
+            : $this->mapper->fromRow($row);
+    }
+
+    /**
+     * @param list<string> $lines
+     *
+     * @return Generator<ChangeRecord>
+     */
+    private function streamRecords(
+        array $lines,
+        int $afterSeq,
+    ): Generator {
+        foreach ($lines as $line) {
+            $record = $this->decodeLine($line);
+
+            if ($record !== null && $record->seq > $afterSeq) {
+                yield $record;
+            }
+        }
+    }
+
+    /**
+     * @param list<string> $lines
+     *
+     * @return list<string>
+     */
+    private function applyPolicy(
+        array $lines,
+        RetentionPolicy $policy,
+    ): array {
+        if ($policy->maxRecords !== null && count($lines) > $policy->maxRecords) {
+            $lines = array_slice(
+                $lines,
+                count($lines) - $policy->maxRecords,
+            );
+        }
+
+        if ($policy->maxAgeSeconds !== null) {
+            $oldest = $this->clock->now()->getTimestamp() - $policy->maxAgeSeconds;
+            $lines = array_values(array_filter(
+                $lines,
+                function (string $line) use ($oldest): bool {
+                    $record = $this->decodeLine($line);
+
+                    // A torn line has no timestamp, so it is treated as oldest and reclaimed.
+                    return $record !== null && $record->createdAt->getTimestamp() >= $oldest;
+                },
+            ));
+        }
+
+        return $lines;
+    }
+
+    private function readSeq(): int
+    {
+        if (!is_file($this->seqPath)) {
+            return 0;
+        }
+
+        $raw = file_get_contents($this->seqPath);
+
+        if ($raw === false) {
+            throw new StorageIoException('Unable to read the change journal sequence counter.');
+        }
+
+        $raw = trim($raw);
+
+        return is_numeric($raw)
+            ? (int) $raw
+            : 0;
+    }
+
+    private function writeSeq(int $seq): void
+    {
+        $this->atomicWrite(
+            $this->seqPath,
+            (string) $seq,
+        );
+    }
+
+    private function readMinSeq(): ?int
+    {
+        foreach ($this->readLines() as $line) {
+            $record = $this->decodeLine($line);
+
+            if ($record !== null) {
+                return $record->seq;
+            }
+        }
+
+        return null;
+    }
+
+    private function appendLine(string $line): void
+    {
+        $handle = fopen($this->journalPath, 'a');
+
+        if ($handle === false) {
+            throw new StorageIoException('Unable to open the change journal for appending.');
+        }
+
+        try {
+            if (fwrite($handle, $line . "\n") === false) {
+                throw new StorageIoException('Unable to append to the change journal.');
+            }
+
+            fflush($handle);
+        } finally {
+            fclose($handle);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readLines(): array
+    {
+        if (!is_file($this->journalPath)) {
+            return [];
+        }
+
+        $raw = file_get_contents($this->journalPath);
+
+        if ($raw === false) {
+            throw new StorageIoException('Unable to read the change journal.');
+        }
+
+        $lines = [];
+        foreach (explode("\n", $raw) as $line) {
+            if ($line !== '') {
+                $lines[] = $line;
+            }
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @param list<string> $lines
+     */
+    private function rewriteLines(array $lines): void
+    {
+        $this->atomicWrite(
+            $this->journalPath,
+            $lines === [] ? '' : implode("\n", $lines) . "\n",
+        );
+    }
+
+    private function atomicWrite(
+        string $path,
+        string $contents,
+    ): void {
+        $tmpPath = tempnam(
+            dirname($path),
+            'ldap-journal-',
+        );
+
+        if ($tmpPath === false) {
+            throw new StorageIoException('Unable to stage a change journal update.');
+        }
+
+        if (file_put_contents($tmpPath, $contents) === false) {
+            @unlink($tmpPath);
+
+            throw new StorageIoException('Unable to stage a change journal update.');
+        }
+
+        if (!rename($tmpPath, $path)) {
+            @unlink($tmpPath);
+
+            throw new StorageIoException('Unable to publish a change journal update.');
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Serializer/ChangeRecordRowMapper.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Serializer/ChangeRecordRowMapper.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Journal\Serializer;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeRecord;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
+use FreeDSx\Ldap\Server\Clock\EpochMicroseconds;
+use Throwable;
+
+use function base64_decode;
+use function base64_encode;
+use function is_array;
+use function is_numeric;
+use function is_scalar;
+use function is_string;
+use function serialize;
+use function unserialize;
+
+/**
+ * Maps a ChangeRecord to a primitive, format-portable row and back; the one place field names live.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class ChangeRecordRowMapper
+{
+    /**
+     * @return array<string, int|string|null>
+     */
+    public function toRow(ChangeRecord $record): array
+    {
+        $change = $record->change;
+        $normDn = $change->dn->normalize();
+
+        return [
+            'seq' => $record->seq,
+            'origin' => (string) $record->origin,
+            'created_at' => EpochMicroseconds::fromDateTime($record->createdAt),
+            'change_type' => $change->changeType->value,
+            'dn' => $change->dn->toString(),
+            'lc_dn' => $normDn->toString(),
+            'lc_parent_dn' => $normDn->getParent()?->toString() ?? '',
+            'entry_uuid' => $change->entryUuid,
+            'authz_id' => $change->authzId->toString(),
+            'previous_dn' => $change->previousDn?->toString(),
+            'pre_image' => $this->encodePreImage($change->preImage),
+        ];
+    }
+
+    /**
+     * @param array<array-key, mixed> $row
+     */
+    public function fromRow(array $row): ?ChangeRecord
+    {
+        try {
+            $dn = new Dn($this->stringField($row, 'dn'));
+
+            return new ChangeRecord(
+                seq: $this->intField($row, 'seq'),
+                origin: new ReplicaId($this->stringField($row, 'origin')),
+                createdAt: EpochMicroseconds::toDateTime($this->intField($row, 'created_at')),
+                change: new PendingChange(
+                    changeType: ChangeType::from($this->stringField($row, 'change_type')),
+                    dn: $dn,
+                    entryUuid: $this->stringField($row, 'entry_uuid'),
+                    authzId: AuthzId::fromString($this->stringField($row, 'authz_id')),
+                    previousDn: is_string($row['previous_dn'] ?? null)
+                        ? new Dn($this->stringField($row, 'previous_dn'))
+                        : null,
+                    preImage: $this->decodePreImage($row['pre_image'] ?? null, $dn),
+                ),
+            );
+        } catch (Throwable) {
+            // A structurally valid row with bad field data is skipped rather than aborting the read.
+            return null;
+        }
+    }
+
+    private function encodePreImage(?Entry $preImage): ?string
+    {
+        if ($preImage === null) {
+            return null;
+        }
+
+        // base64 of a serialized attribute map keeps binary values portable across text formats in one field.
+        return base64_encode(serialize($preImage->toArray()));
+    }
+
+    private function decodePreImage(
+        mixed $encoded,
+        Dn $dn,
+    ): ?Entry {
+        if (!is_string($encoded)) {
+            return null;
+        }
+
+        $decoded = base64_decode($encoded, true);
+
+        if ($decoded === false) {
+            return null;
+        }
+
+        $attributes = unserialize(
+            $decoded,
+            ['allowed_classes' => false],
+        );
+
+        if (!is_array($attributes)) {
+            return null;
+        }
+
+        /** @var array<string, list<string>> $attributes */
+        return Entry::fromArray(
+            $dn->toString(),
+            $attributes,
+        );
+    }
+
+    /**
+     * @param array<array-key, mixed> $row
+     */
+    private function stringField(
+        array $row,
+        string $key,
+    ): string {
+        $value = $row[$key] ?? null;
+
+        return is_scalar($value)
+            ? (string) $value
+            : '';
+    }
+
+    /**
+     * @param array<array-key, mixed> $row
+     */
+    private function intField(
+        array $row,
+        string $key,
+    ): int {
+        $value = $row[$key] ?? null;
+
+        return is_numeric($value)
+            ? (int) $value
+            : 0;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Serializer/JsonlRowSerializer.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Serializer/JsonlRowSerializer.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Journal\Serializer;
+
+use function is_array;
+use function json_decode;
+use function json_encode;
+
+/**
+ * JSON-lines row format: one JSON object per line.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class JsonlRowSerializer implements RowSerializerInterface
+{
+    public function encode(array $row): string
+    {
+        return json_encode(
+            $row,
+            JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+        );
+    }
+
+    public function decode(string $line): ?array
+    {
+        $row = json_decode($line, true);
+
+        return is_array($row)
+            ? $row
+            : null;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Serializer/RowSerializerInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Serializer/RowSerializerInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Journal\Serializer;
+
+/**
+ * Encodes a primitive journal row to a single stored line and back.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface RowSerializerInterface
+{
+    /**
+     * Encode a row to a single line with no embedded newline.
+     *
+     * @param array<string, int|string|null> $row
+     */
+    public function encode(array $row): string;
+
+    /**
+     * Decode a stored line back to a row, or null when it is corrupt and should be skipped.
+     *
+     * @return array<array-key, mixed>|null
+     */
+    public function decode(string $line): ?array;
+}

--- a/tests/integration/Server/Backend/Storage/Journal/FileChangeJournalConcurrencyTest.php
+++ b/tests/integration/Server/Backend/Storage/Journal/FileChangeJournalConcurrencyTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Server\Backend\Storage\Journal;
+
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock\FileLock;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\FileChangeJournal;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
+use Tests\Support\FreeDSx\Ldap\Journal\JournalConcurrencyTestCase;
+
+final class FileChangeJournalConcurrencyTest extends JournalConcurrencyTestCase
+{
+    private string $base = '';
+
+    protected function tearDown(): void
+    {
+        // setUp() may skip (no pcntl) before $base is assigned, so there is nothing to clean.
+        if ($this->base === '') {
+            return;
+        }
+
+        foreach (['', '.journal.jsonl', '.journal.seq', '.lock'] as $suffix) {
+            $path = $this->base . $suffix;
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+    }
+
+    protected function prepareJournalStore(): void
+    {
+        $base = tempnam(sys_get_temp_dir(), 'file-journal-concurrency-');
+        self::assertIsString($base);
+        $this->base = $base;
+    }
+
+    protected function makeJournal(): ChangeJournalInterface
+    {
+        return new FileChangeJournal(
+            new FileLock($this->base),
+            $this->base . '.journal.jsonl',
+            $this->base . '.journal.seq',
+            new ReplicaId('node'),
+        );
+    }
+}

--- a/tests/integration/Server/Backend/Storage/Journal/PdoChangeJournalConcurrencyTest.php
+++ b/tests/integration/Server/Backend/Storage/Journal/PdoChangeJournalConcurrencyTest.php
@@ -13,47 +13,23 @@ declare(strict_types=1);
 
 namespace Tests\Integration\FreeDSx\Ldap\Server\Backend\Storage\Journal;
 
-use FreeDSx\Ldap\Entry\Dn;
-use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SqliteDialect;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoTransactor;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\SharedPdoConnectionProvider;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\PdoStorage;
-use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
-use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\PdoChangeJournal;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
 use PDO;
-use PHPUnit\Framework\TestCase;
-use Throwable;
+use Tests\Support\FreeDSx\Ldap\Journal\JournalConcurrencyTestCase;
 
-final class PdoChangeJournalConcurrencyTest extends TestCase
+final class PdoChangeJournalConcurrencyTest extends JournalConcurrencyTestCase
 {
-    private const WORKERS = 8;
-
-    private const WRITES_PER_WORKER = 25;
-
     private string $dbPath = '';
-
-    protected function setUp(): void
-    {
-        if (!function_exists('pcntl_fork')) {
-            $this->markTestSkipped('The journal concurrency proof requires the pcntl extension.');
-        }
-
-        $path = tempnam(sys_get_temp_dir(), 'journal-concurrency-');
-        self::assertIsString($path);
-        $this->dbPath = $path;
-
-        // Create the schema once, up front, then drop the connection before forking so no handle is inherited.
-        $pdo = $this->connect();
-        PdoStorage::initialize($pdo, new SqliteDialect());
-        unset($pdo);
-    }
 
     protected function tearDown(): void
     {
-        // setUp() may skip (Windows / no pcntl) before $dbPath is assigned, so there is nothing to clean.
+        // setUp() may skip (no pcntl) before $dbPath is assigned, so there is nothing to clean.
         if ($this->dbPath === '') {
             return;
         }
@@ -65,67 +41,19 @@ final class PdoChangeJournalConcurrencyTest extends TestCase
         }
     }
 
-    public function test_concurrent_forked_writers_allocate_a_gap_free_collision_free_seq_run(): void
+    protected function prepareJournalStore(): void
     {
-        $pids = [];
-        for ($worker = 0; $worker < self::WORKERS; $worker++) {
-            $pid = pcntl_fork();
-            self::assertNotSame(
-                -1,
-                $pid,
-                'pcntl_fork failed',
-            );
+        $path = tempnam(sys_get_temp_dir(), 'journal-concurrency-');
+        self::assertIsString($path);
+        $this->dbPath = $path;
 
-            if ($pid === 0) {
-                exit($this->runWorker());
-            }
-
-            $pids[] = $pid;
-        }
-
-        $failed = 0;
-        foreach ($pids as $pid) {
-            $status = 0;
-            pcntl_waitpid($pid, $status);
-            if (!is_int($status) || !pcntl_wifexited($status) || pcntl_wexitstatus($status) !== 0) {
-                $failed++;
-            }
-        }
-
-        self::assertSame(
-            0,
-            $failed,
-            'every forked writer committed its changes without error',
-        );
-        self::assertSame(
-            range(1, self::WORKERS * self::WRITES_PER_WORKER),
-            $this->readSeqs(),
-        );
+        // Create the schema once, up front, then drop the connection before forking so no handle is inherited.
+        $pdo = $this->connect();
+        PdoStorage::initialize($pdo, new SqliteDialect());
+        unset($pdo);
     }
 
-    /**
-     * Runs in a forked child on its own connection; returns the process exit code.
-     */
-    private function runWorker(): int
-    {
-        try {
-            $journal = $this->makeJournal();
-            for ($i = 0; $i < self::WRITES_PER_WORKER; $i++) {
-                $journal->append(new PendingChange(
-                    changeType: ChangeType::Add,
-                    dn: new Dn(sprintf('cn=%d-%d,dc=example,dc=com', getmypid(), $i)),
-                    entryUuid: '11111111-1111-4111-8111-111111111111',
-                    authzId: AuthzId::anonymous(),
-                ));
-            }
-
-            return 0;
-        } catch (Throwable) {
-            return 1;
-        }
-    }
-
-    private function makeJournal(): PdoChangeJournal
+    protected function makeJournal(): ChangeJournalInterface
     {
         $dialect = new SqliteDialect();
 
@@ -151,22 +79,5 @@ final class PdoChangeJournalConcurrencyTest extends TestCase
         $pdo->exec('PRAGMA busy_timeout=10000');
 
         return $pdo;
-    }
-
-    /**
-     * @return list<int>
-     */
-    private function readSeqs(): array
-    {
-        $stmt = $this->connect()
-            ->query('SELECT seq FROM ldap_change_journal ORDER BY seq ASC');
-        $rows = $stmt === false
-            ? []
-            : $stmt->fetchAll(PDO::FETCH_COLUMN);
-
-        return array_values(array_map(
-            static fn(mixed $value): int => is_numeric($value) ? (int) $value : 0,
-            $rows,
-        ));
     }
 }

--- a/tests/support/Journal/JournalConcurrencyTestCase.php
+++ b/tests/support/Journal/JournalConcurrencyTestCase.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Support\FreeDSx\Ldap\Journal;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeRecord;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+/**
+ * Test that a change journal allocates a gap-free, collision-free seq run under concurrent writers.
+ */
+abstract class JournalConcurrencyTestCase extends TestCase
+{
+    protected const WORKERS = 8;
+
+    protected const WRITES_PER_WORKER = 25;
+
+    protected function setUp(): void
+    {
+        if (!function_exists('pcntl_fork')) {
+            $this->markTestSkipped('The journal concurrency proof requires the pcntl extension.');
+        }
+
+        $this->prepareJournalStore();
+    }
+
+    public function test_concurrent_forked_writers_allocate_a_gap_free_collision_free_seq_run(): void
+    {
+        $pids = [];
+        for ($worker = 0; $worker < self::WORKERS; $worker++) {
+            $pid = pcntl_fork();
+            self::assertNotSame(
+                -1,
+                $pid,
+                'pcntl_fork failed',
+            );
+
+            if ($pid === 0) {
+                exit($this->runWorker());
+            }
+
+            $pids[] = $pid;
+        }
+
+        $failed = 0;
+        foreach ($pids as $pid) {
+            $status = 0;
+            pcntl_waitpid($pid, $status);
+            if (!is_int($status) || !pcntl_wifexited($status) || pcntl_wexitstatus($status) !== 0) {
+                $failed++;
+            }
+        }
+
+        self::assertSame(
+            0,
+            $failed,
+            'every forked writer committed its changes without error',
+        );
+        self::assertSame(
+            range(1, self::WORKERS * self::WRITES_PER_WORKER),
+            $this->readSeqs(),
+        );
+    }
+
+    /**
+     * Create the shared underlying store (schema, files) once before forking.
+     */
+    abstract protected function prepareJournalStore(): void;
+
+    /**
+     * A journal on its own connection/instance, sharing the prepared store across forks.
+     */
+    abstract protected function makeJournal(): ChangeJournalInterface;
+
+    /**
+     * Runs in a forked child on its own journal instance; returns the process exit code.
+     */
+    private function runWorker(): int
+    {
+        try {
+            $journal = $this->makeJournal();
+            for ($i = 0; $i < self::WRITES_PER_WORKER; $i++) {
+                $journal->append(new PendingChange(
+                    changeType: ChangeType::Add,
+                    dn: new Dn(sprintf('cn=%d-%d,dc=example,dc=com', getmypid(), $i)),
+                    entryUuid: '11111111-1111-4111-8111-111111111111',
+                    authzId: AuthzId::anonymous(),
+                ));
+            }
+
+            return 0;
+        } catch (Throwable) {
+            return 1;
+        }
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function readSeqs(): array
+    {
+        $seqs = array_map(
+            static fn(ChangeRecord $record): int => $record->seq,
+            iterator_to_array($this->makeJournal()->read()),
+        );
+        // sort() reindexes to a 0-based list; readers assert against range(1, N).
+        sort($seqs);
+
+        return $seqs;
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Adapter/JsonFileStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/JsonFileStorageTest.php
@@ -16,7 +16,15 @@ namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Adapter;
 use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeAppenderInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeRecorder;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Search\Filter\PresentFilter;
@@ -26,9 +34,14 @@ use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Tests\Support\FreeDSx\Ldap\Journal\JournalingStorageContractTests;
 
 final class JsonFileStorageTest extends TestCase
 {
+    use JournalingStorageContractTests;
+
     private WritableStorageBackend $subject;
 
     private JsonFileStorage $storage;
@@ -36,6 +49,11 @@ final class JsonFileStorageTest extends TestCase
     private string $tempFile;
 
     private Entry $alice;
+
+    /**
+     * @var list<string>
+     */
+    private array $tempFiles = [];
 
     protected function setUp(): void
     {
@@ -67,8 +85,10 @@ final class JsonFileStorageTest extends TestCase
 
     protected function tearDown(): void
     {
-        if (file_exists($this->tempFile)) {
-            unlink($this->tempFile);
+        $this->cleanupBase($this->tempFile);
+
+        foreach ($this->tempFiles as $base) {
+            $this->cleanupBase($base);
         }
     }
 
@@ -287,6 +307,127 @@ final class JsonFileStorageTest extends TestCase
             ['dc=example,dc=com', 'dc=other,dc=org'],
             $contexts,
         );
+    }
+
+    public function test_a_recorded_write_is_journaled_through_the_buffer(): void
+    {
+        $storage = JsonFileStorage::forPcntl($this->registerTemp());
+        $storage->configureJournal(new ChangeJournalConfig());
+        $backend = new WritableStorageBackend(
+            storage: $storage,
+            changeRecorder: new ChangeRecorder(),
+        );
+
+        $backend->add(
+            new AddCommand(new Entry(
+                new Dn('dc=example,dc=com'),
+                new Attribute('objectClass', 'dcObject'),
+                new Attribute('dc', 'example'),
+            )),
+            $this->systemContext(),
+        );
+
+        self::assertCount(
+            1,
+            iterator_to_array($storage->changeJournal()->read()),
+        );
+    }
+
+    public function test_a_failed_write_records_nothing_in_the_journal(): void
+    {
+        $storage = JsonFileStorage::forPcntl($this->registerTemp());
+        $storage->configureJournal(new ChangeJournalConfig());
+
+        try {
+            $storage->atomic(function (EntryStorageInterface $buffer): void {
+                // The recorder collects into the buffer; the storage only flushes it after the data commits.
+                if ($buffer instanceof ChangeAppenderInterface) {
+                    $buffer->appendChange(new PendingChange(
+                        changeType: ChangeType::Add,
+                        dn: new Dn('cn=a,dc=example,dc=com'),
+                        entryUuid: '11111111-1111-4111-8111-111111111111',
+                        authzId: AuthzId::anonymous(),
+                    ));
+                }
+
+                throw new RuntimeException('force rollback');
+            });
+        } catch (RuntimeException) {
+        }
+
+        self::assertCount(
+            0,
+            iterator_to_array($storage->changeJournal()->read()),
+        );
+        self::assertSame(
+            0,
+            $storage->changeJournal()->latestSeq(),
+        );
+    }
+
+    public function test_a_journal_write_failure_does_not_fail_a_committed_write(): void
+    {
+        $base = $this->registerTemp();
+        // A directory where the sidecar file must go makes the journal append fail while the entry write commits.
+        mkdir($base . '.journal.jsonl');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error');
+
+        $storage = JsonFileStorage::forPcntl(
+            $base,
+            null,
+            $logger,
+        );
+        $storage->configureJournal(new ChangeJournalConfig());
+        $backend = new WritableStorageBackend(
+            storage: $storage,
+            changeRecorder: new ChangeRecorder(),
+        );
+
+        // Swallow the E_WARNING fopen() raises on the directory sidecar; the thrown StorageIoException is the point.
+        set_error_handler(static fn(): bool => true);
+
+        try {
+            $backend->add(
+                new AddCommand(new Entry(
+                    new Dn('dc=example,dc=com'),
+                    new Attribute('objectClass', 'dcObject'),
+                    new Attribute('dc', 'example'),
+                )),
+                $this->systemContext(),
+            );
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertNotNull($backend->get(new Dn('dc=example,dc=com')));
+    }
+
+    protected function makeJournalingStorage(): ChangeJournalingInterface
+    {
+        return JsonFileStorage::forPcntl($this->registerTemp());
+    }
+
+    private function registerTemp(): string
+    {
+        $base = sys_get_temp_dir() . '/ldap_journal_' . uniqid('', true) . '.json';
+        $this->tempFiles[] = $base;
+
+        return $base;
+    }
+
+    private function cleanupBase(string $base): void
+    {
+        foreach (['', '.journal.jsonl', '.journal.seq', '.lock'] as $suffix) {
+            $path = $base . $suffix;
+            if (is_dir($path)) {
+                @rmdir($path);
+            } elseif (is_file($path)) {
+                @unlink($path);
+            }
+        }
     }
 
     private function context(): WriteContext

--- a/tests/unit/Server/Backend/Storage/Adapter/Lock/CoroutineLockTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Lock/CoroutineLockTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock;
+
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock\CoroutineLock;
+use PHPUnit\Framework\TestCase;
+use Swoole\Coroutine;
+use Swoole\Coroutine\Channel;
+
+final class CoroutineLockTest extends TestCase
+{
+    private string $tempFile = '';
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('swoole')) {
+            $this->markTestSkipped('The swoole extension is required for this test.');
+        }
+
+        $this->tempFile = sys_get_temp_dir() . '/ldap_test_corolock_' . uniqid() . '.dat';
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->tempFile === '') {
+            return;
+        }
+
+        foreach ([$this->tempFile, $this->tempFile . '.lock'] as $path) {
+            if (file_exists($path)) {
+                unlink($path);
+            }
+        }
+    }
+
+    public function test_with_exclusive_runs_the_callback(): void
+    {
+        $lock = new CoroutineLock($this->tempFile);
+        $ran = false;
+
+        Coroutine\run(function () use ($lock, &$ran): void {
+            $lock->withExclusive(function () use (&$ran): void {
+                $ran = true;
+            });
+        });
+
+        self::assertTrue($ran);
+    }
+
+    public function test_it_is_reentrant_within_a_single_coroutine(): void
+    {
+        $lock = new CoroutineLock($this->tempFile);
+        $ran = false;
+
+        Coroutine\run(function () use ($lock, &$ran): void {
+            $lock->withExclusive(function () use ($lock, &$ran): void {
+                // A nested acquire in the same coroutine must not deadlock on the Channel(1) mutex.
+                $lock->withExclusive(function () use (&$ran): void {
+                    $ran = true;
+                });
+            });
+        });
+
+        self::assertTrue($ran);
+    }
+
+    public function test_a_second_coroutine_cannot_enter_while_another_holds_the_lock(): void
+    {
+        // Directly targets the per-coroutine depth: a shared instance counter would let B see A's depth and
+        // skip the mutex, entering the critical section while A still holds it.
+        $lock = new CoroutineLock($this->tempFile);
+        $events = [];
+
+        Coroutine\run(function () use ($lock, &$events): void {
+            $aHolding = new Channel(1);
+            $done = new Channel(2);
+
+            Coroutine::create(function () use ($lock, $aHolding, $done, &$events): void {
+                $lock->withExclusive(function () use ($aHolding, &$events): void {
+                    $aHolding->push(true);
+                    Coroutine::sleep(0.03);
+                    $events[] = 'a-release';
+                });
+                $done->push(true);
+            });
+
+            Coroutine::create(function () use ($lock, $aHolding, $done, &$events): void {
+                $aHolding->pop();
+
+                $lock->withExclusive(function () use (&$events): void {
+                    $events[] = 'b-enter';
+                });
+                $done->push(true);
+            });
+
+            $done->pop();
+            $done->pop();
+        });
+
+        // B entered only after A released: no interleaving.
+        self::assertSame(
+            ['a-release', 'b-enter'],
+            $events,
+        );
+    }
+
+    public function test_reentry_in_one_coroutine_does_not_release_the_lock_for_another(): void
+    {
+        // A enters twice (re-entrant) then exits its inner scope; the lock must remain held for A, so B still
+        // cannot enter until A fully unwinds. A shared counter would drop to zero on the inner exit.
+        $lock = new CoroutineLock($this->tempFile);
+        $events = [];
+
+        Coroutine\run(function () use ($lock, &$events): void {
+            $aHolding = new Channel(1);
+            $done = new Channel(2);
+
+            Coroutine::create(function () use ($lock, $aHolding, $done, &$events): void {
+                $lock->withExclusive(function () use ($lock, $aHolding, &$events): void {
+                    $lock->withExclusive(function (): void {
+                        // inner re-entry
+                    });
+                    $aHolding->push(true);
+                    Coroutine::sleep(0.03);
+                    $events[] = 'a-release';
+                });
+                $done->push(true);
+            });
+
+            Coroutine::create(function () use ($lock, $aHolding, $done, &$events): void {
+                $aHolding->pop();
+
+                $lock->withExclusive(function () use (&$events): void {
+                    $events[] = 'b-enter';
+                });
+                $done->push(true);
+            });
+
+            $done->pop();
+            $done->pop();
+        });
+
+        self::assertSame(
+            ['a-release', 'b-enter'],
+            $events,
+        );
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Adapter/Lock/FileLockTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Lock/FileLockTest.php
@@ -28,7 +28,7 @@ final class FileLockTest extends TestCase
 
     protected function tearDown(): void
     {
-        foreach ([$this->tempFile, $this->tempFile . '.lock'] as $path) {
+        foreach ([$this->tempFile, $this->tempFile . '.lock', $this->tempFile . '.sidecar'] as $path) {
             if (file_exists($path)) {
                 unlink($path);
             }
@@ -151,6 +151,124 @@ final class FileLockTest extends TestCase
         self::assertSame(
             'original|recovered',
             file_get_contents($this->tempFile),
+        );
+    }
+
+    public function test_with_exclusive_runs_the_callback_under_the_lock(): void
+    {
+        $lock = new FileLock($this->tempFile);
+        $ran = false;
+
+        $lock->withExclusive(function () use (&$ran): void {
+            $ran = true;
+        });
+
+        self::assertTrue($ran);
+        self::assertFileExists($this->tempFile . '.lock');
+    }
+
+    public function test_with_exclusive_is_reentrant_and_does_not_deadlock(): void
+    {
+        $lock = new FileLock($this->tempFile);
+        $depth = 0;
+
+        // A nested acquire in the same process must not block on its own flock().
+        $lock->withExclusive(function () use ($lock, &$depth): void {
+            $lock->withExclusive(function () use (&$depth): void {
+                $depth = 2;
+            });
+        });
+
+        self::assertSame(
+            2,
+            $depth,
+        );
+    }
+
+    public function test_a_journal_style_append_runs_within_a_write_without_deadlocking(): void
+    {
+        $lock = new FileLock($this->tempFile);
+        $sidecar = $this->tempFile . '.sidecar';
+
+        $lock->withLock(
+            fn(string $_): string => 'entry-data',
+            // Mirrors the journal flush: a nested exclusive write while the data lock is still held.
+            function () use ($lock, $sidecar): void {
+                $lock->withExclusive(function () use ($sidecar): void {
+                    file_put_contents(
+                        $sidecar,
+                        'journal-record',
+                    );
+                });
+            },
+        );
+
+        self::assertSame(
+            'entry-data',
+            file_get_contents($this->tempFile),
+        );
+        self::assertSame(
+            'journal-record',
+            file_get_contents($sidecar),
+        );
+    }
+
+    public function test_after_commit_runs_after_the_data_is_published(): void
+    {
+        $lock = new FileLock($this->tempFile);
+        $seenDuringAfterCommit = null;
+
+        $lock->withLock(
+            fn(string $_): string => 'published',
+            function () use (&$seenDuringAfterCommit): void {
+                $seenDuringAfterCommit = file_get_contents($this->tempFile);
+            },
+        );
+
+        self::assertSame(
+            'published',
+            $seenDuringAfterCommit,
+        );
+    }
+
+    public function test_after_commit_is_skipped_when_the_mutation_throws(): void
+    {
+        $lock = new FileLock($this->tempFile);
+        $afterCommitRan = false;
+
+        try {
+            $lock->withLock(
+                function (string $_): string {
+                    throw new \RuntimeException('mutation failed');
+                },
+                function () use (&$afterCommitRan): void {
+                    $afterCommitRan = true;
+                },
+            );
+            self::fail('Expected exception was not thrown.');
+        } catch (\RuntimeException) {
+        }
+
+        self::assertFalse($afterCommitRan);
+    }
+
+    public function test_reentrant_use_balances_the_depth_counter(): void
+    {
+        $lock = new FileLock($this->tempFile);
+
+        $lock->withExclusive(function () use ($lock): void {
+            $lock->withLock(fn(string $_): string => 'data');
+        });
+
+        $depth = new \ReflectionProperty(
+            $lock,
+            'depth',
+        );
+
+        // Back to zero means the underlying flock was released exactly once, at the outermost exit.
+        self::assertSame(
+            0,
+            $depth->getValue($lock),
         );
     }
 }

--- a/tests/unit/Server/Backend/Storage/Journal/FileChangeJournalTest.php
+++ b/tests/unit/Server/Backend/Storage/Journal/FileChangeJournalTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Journal;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock\FileLock;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeRecord;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\FileChangeJournal;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
+
+final class FileChangeJournalTest extends TestCase
+{
+    private const UUID = '11111111-1111-4111-8111-111111111111';
+
+    private FileChangeJournal $subject;
+
+    private FrozenClock $clock;
+
+    private string $base;
+
+    protected function setUp(): void
+    {
+        $this->clock = FrozenClock::fromString('2025-05-15T12:00:00');
+        $base = tempnam(sys_get_temp_dir(), 'file-journal-');
+        self::assertIsString($base);
+        $this->base = $base;
+
+        $this->subject = new FileChangeJournal(
+            new FileLock($this->base),
+            $this->base . '.journal.jsonl',
+            $this->base . '.journal.seq',
+            new ReplicaId('node-a'),
+            $this->clock,
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (['', '.journal.jsonl', '.journal.seq', '.lock'] as $suffix) {
+            $path = $this->base . $suffix;
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+    }
+
+    public function test_it_allocates_strictly_increasing_seq_numbers(): void
+    {
+        $first = $this->subject->append($this->change('cn=a,dc=example,dc=com'));
+        $second = $this->subject->append($this->change('cn=b,dc=example,dc=com'));
+        $third = $this->subject->append($this->change('cn=c,dc=example,dc=com'));
+
+        self::assertSame(
+            1,
+            $first->seq,
+        );
+        self::assertSame(
+            2,
+            $second->seq,
+        );
+        self::assertSame(
+            3,
+            $third->seq,
+        );
+    }
+
+    public function test_latest_seq_is_zero_until_anything_is_appended(): void
+    {
+        self::assertSame(
+            0,
+            $this->subject->latestSeq(),
+        );
+
+        $this->subject->append($this->change('cn=a,dc=example,dc=com'));
+
+        self::assertSame(
+            1,
+            $this->subject->latestSeq(),
+        );
+    }
+
+    public function test_read_returns_only_records_after_the_given_seq(): void
+    {
+        $this->subject->append($this->change('cn=a,dc=example,dc=com'));
+        $this->subject->append($this->change('cn=b,dc=example,dc=com'));
+        $this->subject->append($this->change('cn=c,dc=example,dc=com'));
+
+        $seqs = array_map(
+            static fn(ChangeRecord $record): int => $record->seq,
+            iterator_to_array($this->subject->read(1)),
+        );
+
+        self::assertSame(
+            [2, 3],
+            $seqs,
+        );
+    }
+
+    public function test_it_round_trips_a_delete_record_with_a_pre_image(): void
+    {
+        $preImage = Entry::fromArray(
+            'cn=a,dc=example,dc=com',
+            ['cn' => ['a'], 'sn' => ['Doe']],
+        );
+        $this->subject->append(new PendingChange(
+            changeType: ChangeType::Delete,
+            dn: new Dn('cn=a,dc=example,dc=com'),
+            entryUuid: self::UUID,
+            authzId: AuthzId::fromDn(new Dn('cn=admin,dc=example,dc=com')),
+            preImage: $preImage,
+        ));
+
+        $records = iterator_to_array($this->subject->read());
+        self::assertCount(
+            1,
+            $records,
+        );
+        $record = $records[0];
+
+        self::assertSame(
+            ChangeType::Delete,
+            $record->change->changeType,
+        );
+        self::assertSame(
+            'cn=a,dc=example,dc=com',
+            $record->change->dn->toString(),
+        );
+        self::assertSame(
+            self::UUID,
+            $record->change->entryUuid,
+        );
+        self::assertSame(
+            'dn:cn=admin,dc=example,dc=com',
+            $record->change->authzId->toString(),
+        );
+        self::assertTrue($record->origin->equals(new ReplicaId('node-a')));
+        self::assertEquals(
+            $this->clock->now(),
+            $record->createdAt,
+        );
+        self::assertNotNull($record->change->preImage);
+        self::assertSame(
+            ['cn' => ['a'], 'sn' => ['Doe']],
+            $record->change->preImage->toArray(),
+        );
+    }
+
+    public function test_the_record_cap_keeps_only_the_newest_records(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->subject->append($this->change("cn={$i},dc=example,dc=com"));
+        }
+
+        $removed = $this->subject->prune(new RetentionPolicy(maxRecords: 2));
+
+        $seqs = array_map(
+            static fn(ChangeRecord $record): int => $record->seq,
+            iterator_to_array($this->subject->read()),
+        );
+        self::assertSame(
+            3,
+            $removed,
+        );
+        self::assertSame(
+            [4, 5],
+            $seqs,
+        );
+    }
+
+    public function test_the_age_window_drops_records_older_than_the_horizon(): void
+    {
+        $this->subject->append($this->change('cn=old,dc=example,dc=com'));
+        $this->clock->setTo($this->clock->now()->modify('+10 seconds'));
+        $this->subject->append($this->change('cn=new,dc=example,dc=com'));
+
+        $removed = $this->subject->prune(new RetentionPolicy(maxAgeSeconds: 5));
+
+        $dns = array_map(
+            static fn(ChangeRecord $record): string => $record->change->dn->toString(),
+            iterator_to_array($this->subject->read()),
+        );
+        self::assertSame(
+            1,
+            $removed,
+        );
+        self::assertSame(
+            ['cn=new,dc=example,dc=com'],
+            $dns,
+        );
+    }
+
+    public function test_the_seq_counter_survives_a_full_prune_and_keeps_climbing(): void
+    {
+        $this->subject->append($this->change('cn=a,dc=example,dc=com'));
+        $this->subject->append($this->change('cn=b,dc=example,dc=com'));
+        $this->subject->append($this->change('cn=c,dc=example,dc=com'));
+        $this->clock->setTo($this->clock->now()->modify('+10 seconds'));
+
+        // Age out every record: an empty journal file has no max seq, so latestSeq() can only come from the counter.
+        $removed = $this->subject->prune(new RetentionPolicy(maxAgeSeconds: 5));
+
+        self::assertSame(
+            3,
+            $removed,
+        );
+        self::assertSame(
+            3,
+            $this->subject->latestSeq(),
+        );
+        self::assertSame(
+            4,
+            $this->subject->append($this->change('cn=d,dc=example,dc=com'))->seq,
+        );
+    }
+
+    public function test_a_cookie_below_the_pruned_floor_has_lapsed(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->subject->append($this->change("cn={$i},dc=example,dc=com"));
+        }
+        $this->subject->prune(new RetentionPolicy(maxRecords: 2));
+
+        self::assertTrue($this->subject->retainsSince(3));
+        self::assertFalse($this->subject->retainsSince(2));
+    }
+
+    public function test_a_fully_pruned_journal_only_retains_a_caught_up_cookie(): void
+    {
+        $this->subject->append($this->change('cn=a,dc=example,dc=com'));
+        $this->subject->append($this->change('cn=b,dc=example,dc=com'));
+        $this->clock->setTo($this->clock->now()->modify('+10 seconds'));
+        $this->subject->prune(new RetentionPolicy(maxAgeSeconds: 5));
+
+        self::assertFalse($this->subject->retainsSince(1));
+        self::assertTrue($this->subject->retainsSince(2));
+    }
+
+    public function test_a_torn_trailing_line_is_skipped_on_read(): void
+    {
+        $this->subject->append($this->change('cn=a,dc=example,dc=com'));
+
+        // Simulate a crash mid-append that left a partial trailing line.
+        file_put_contents(
+            $this->base . '.journal.jsonl',
+            '{"seq":2,"origin":"node-a"',
+            FILE_APPEND,
+        );
+
+        $seqs = array_map(
+            static fn(ChangeRecord $record): int => $record->seq,
+            iterator_to_array($this->subject->read()),
+        );
+
+        self::assertSame(
+            [1],
+            $seqs,
+        );
+    }
+
+    private function change(string $dn): PendingChange
+    {
+        return new PendingChange(
+            changeType: ChangeType::Add,
+            dn: new Dn($dn),
+            entryUuid: self::UUID,
+            authzId: AuthzId::anonymous(),
+        );
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Journal/Serializer/ChangeRecordRowMapperTest.php
+++ b/tests/unit/Server/Backend/Storage/Journal/Serializer/ChangeRecordRowMapperTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Journal\Serializer;
+
+use DateTimeImmutable;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeRecord;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Serializer\ChangeRecordRowMapper;
+use PHPUnit\Framework\TestCase;
+
+final class ChangeRecordRowMapperTest extends TestCase
+{
+    private const UUID = '11111111-1111-4111-8111-111111111111';
+
+    private ChangeRecordRowMapper $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new ChangeRecordRowMapper();
+    }
+
+    public function test_to_row_derives_the_normalized_dn_fields(): void
+    {
+        $row = $this->subject->toRow($this->record(new PendingChange(
+            changeType: ChangeType::Add,
+            dn: new Dn('CN=Alice,DC=Example,DC=Com'),
+            entryUuid: self::UUID,
+            authzId: AuthzId::anonymous(),
+        )));
+
+        self::assertSame(
+            'CN=Alice,DC=Example,DC=Com',
+            $row['dn'],
+        );
+        self::assertSame(
+            'cn=alice,dc=example,dc=com',
+            $row['lc_dn'],
+        );
+        self::assertSame(
+            'dc=example,dc=com',
+            $row['lc_parent_dn'],
+        );
+    }
+
+    public function test_to_row_and_from_row_round_trip_a_delete_with_a_pre_image(): void
+    {
+        $preImage = Entry::fromArray(
+            'cn=a,dc=example,dc=com',
+            ['cn' => ['a'], 'sn' => ['Doe']],
+        );
+        $record = $this->record(new PendingChange(
+            changeType: ChangeType::Delete,
+            dn: new Dn('cn=a,dc=example,dc=com'),
+            entryUuid: self::UUID,
+            authzId: AuthzId::fromDn(new Dn('cn=admin,dc=example,dc=com')),
+            previousDn: new Dn('cn=old,dc=example,dc=com'),
+            preImage: $preImage,
+        ));
+
+        $decoded = $this->subject->fromRow($this->subject->toRow($record));
+
+        self::assertNotNull($decoded);
+        self::assertSame(
+            5,
+            $decoded->seq,
+        );
+        self::assertTrue($decoded->origin->equals(new ReplicaId('node-a')));
+        self::assertSame(
+            ChangeType::Delete,
+            $decoded->change->changeType,
+        );
+        self::assertSame(
+            'cn=a,dc=example,dc=com',
+            $decoded->change->dn->toString(),
+        );
+        self::assertSame(
+            'cn=old,dc=example,dc=com',
+            $decoded->change->previousDn?->toString(),
+        );
+        self::assertSame(
+            'dn:cn=admin,dc=example,dc=com',
+            $decoded->change->authzId->toString(),
+        );
+        self::assertNotNull($decoded->change->preImage);
+        self::assertSame(
+            ['cn' => ['a'], 'sn' => ['Doe']],
+            $decoded->change->preImage->toArray(),
+        );
+    }
+
+    public function test_from_row_returns_null_for_an_unknown_change_type(): void
+    {
+        $row = $this->subject->toRow($this->record(new PendingChange(
+            changeType: ChangeType::Add,
+            dn: new Dn('cn=a,dc=example,dc=com'),
+            entryUuid: self::UUID,
+            authzId: AuthzId::anonymous(),
+        )));
+        $row['change_type'] = 'not-a-real-type';
+
+        self::assertNull($this->subject->fromRow($row));
+    }
+
+    public function test_from_row_ignores_a_corrupt_pre_image(): void
+    {
+        $row = $this->subject->toRow($this->record(new PendingChange(
+            changeType: ChangeType::Delete,
+            dn: new Dn('cn=a,dc=example,dc=com'),
+            entryUuid: self::UUID,
+            authzId: AuthzId::anonymous(),
+            preImage: Entry::fromArray('cn=a,dc=example,dc=com', ['cn' => ['a']]),
+        )));
+        $row['pre_image'] = 'not-valid-base64-$$$';
+
+        $decoded = $this->subject->fromRow($row);
+
+        self::assertNotNull($decoded);
+        self::assertNull($decoded->change->preImage);
+    }
+
+    private function record(PendingChange $change): ChangeRecord
+    {
+        return new ChangeRecord(
+            seq: 5,
+            origin: new ReplicaId('node-a'),
+            createdAt: new DateTimeImmutable('2025-05-15T12:00:00+00:00'),
+            change: $change,
+        );
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Journal/Serializer/JsonlRowSerializerTest.php
+++ b/tests/unit/Server/Backend/Storage/Journal/Serializer/JsonlRowSerializerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Journal\Serializer;
+
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Serializer\JsonlRowSerializer;
+use PHPUnit\Framework\TestCase;
+
+final class JsonlRowSerializerTest extends TestCase
+{
+    private JsonlRowSerializer $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new JsonlRowSerializer();
+    }
+
+    public function test_encode_produces_a_single_line_with_no_embedded_newline(): void
+    {
+        $line = $this->subject->encode([
+            'seq' => 1,
+            'dn' => "cn=a\nb,dc=example,dc=com",
+            'pre_image' => null,
+        ]);
+
+        self::assertStringNotContainsString(
+            "\n",
+            $line,
+        );
+    }
+
+    public function test_encode_then_decode_round_trips_a_row(): void
+    {
+        $row = [
+            'seq' => 7,
+            'origin' => 'node-a',
+            'created_at' => 1_700_000_000_000_000,
+            'dn' => 'cn=a,dc=example,dc=com',
+            'previous_dn' => null,
+            'pre_image' => 'AAECAw==',
+        ];
+
+        self::assertSame(
+            $row,
+            $this->subject->decode($this->subject->encode($row)),
+        );
+    }
+
+    public function test_decode_returns_null_for_a_malformed_line(): void
+    {
+        self::assertNull($this->subject->decode('{not valid json'));
+    }
+
+    public function test_decode_returns_null_for_a_non_object_line(): void
+    {
+        self::assertNull($this->subject->decode('42'));
+    }
+}


### PR DESCRIPTION
This adds a file based journal implementation for the changelog / sync / replication work. This was more complicated than the PDO one since the journal is maintained in a separate file from the actual normal entry data (so the locking / atomicity needed special handling).

Still more followups needed for retention / more full integration tests / support for refresh and persist / etc.