### PR TITLE
[1.0.0] Remove the ability to set custom backends.

### DIFF
--- a/docs/Server/Access-Control.md
+++ b/docs/Server/Access-Control.md
@@ -91,9 +91,8 @@ $server = new LdapServer(
                     ),
                 ),
         )
+        ->setStorage(new MyDirectoryStorage())
 );
-
-$server->useBackend(new MyDirectoryBackend());
 ```
 
 ### Rule Evaluation Order

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -16,7 +16,7 @@ LDAP Server Configuration
     * [ServerOptions:setAclRules](#setaclrules)
     * [ServerOptions:setAccessControl](#setaccesscontrol)
 * [Backend](#backend)
-    * [ServerOptions:setBackend](#setbackend)
+    * [ServerOptions:setStorage](#setstorage)
     * [ServerOptions:setFilterEvaluator](#setfilterevaluator)
     * [ServerOptions:setRootDseHandler](#setrootdsehandler)
     * [ServerOptions:setPasswordAuthenticator](#setpasswordauthenticator)
@@ -109,16 +109,13 @@ Specify a PSR-3 compatible logging instance to use. The server emits structured 
 (bind outcomes, authorization details, schema violations, etc.) through this logger. See
 [Server Logging](Logging.md) for the full event catalog and log properties.
 
-You can also set the logger after instantiating the server and before running it:
+You can also set the logger on your options instance before running the server:
 
 ```php
-use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\ServerOptions;
 
-$server = new LdapServer();
-
-// instantiate some logger class...
-
-$server->useLogger($logger);
+// with your current options instance
+$options->setLogger($logger);
 ```
 
 **Default**: `null`
@@ -252,35 +249,23 @@ The LDAP server works by being provided a backend that implements `LdapBackendIn
 optionally write operations). You can also plug in a custom filter evaluator or a custom RootDSE handler.
 
 ------------------
-#### setBackend
+#### setStorage
 
-This should be an object instance that implements `FreeDSx\Ldap\Server\Backend\LdapBackendInterface`. All directory
-operations (search, authenticate, and optionally write) are dispatched to this backend. Paging is handled automatically — no separate paging handler is needed.
-
-You can also use the fluent `useBackend()` method on `LdapServer` instead of setting it in `ServerOptions`:
+The storage backend is configured on `ServerOptions` via `setStorage()` (or `useInMemoryStorage()` for a
+transient in-memory directory). All directory operations (search, authenticate, and optionally write) are
+dispatched to it.
 
 ```php
 use FreeDSx\Ldap\LdapServer;
-use App\MyDirectoryBackend;
-
-$server = (new LdapServer())
-    ->useBackend(new MyDirectoryBackend());
-```
-
-Or via `ServerOptions`:
-
-```php
 use FreeDSx\Ldap\ServerOptions;
-use FreeDSx\Ldap\LdapServer;
-use App\MyDirectoryBackend;
 
-$server = new LdapServer(
-    (new ServerOptions)
-        ->setBackend(new MyDirectoryBackend())
-);
+$server = new LdapServer((new ServerOptions())->useInMemoryStorage());
 ```
 
-**Default**: `null` (falls back to an empty in-memory backend: searches return no entries, writes are rejected with `unwillingToPerform`)
+For a custom source, pass your own `EntryStorageInterface` implementation to `setStorage()`.
+
+**Note**: a non-proxy server started without a configured storage throws at startup rather than silently
+serving an empty directory.
 
 ------------------
 #### setFilterEvaluator
@@ -295,8 +280,7 @@ use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Ldap\LdapServer;
 use App\MyFilterEvaluator;
 
-$server = (new LdapServer())
-    ->useFilterEvaluator(new MyFilterEvaluator());
+$server = new LdapServer((new ServerOptions())->setFilterEvaluator(new MyFilterEvaluator()));
 ```
 
 **Default**: `FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluator`

--- a/docs/Server/General-Usage.md
+++ b/docs/Server/General-Usage.md
@@ -67,9 +67,7 @@ use FreeDSx\Ldap\ServerOptions;
 
 $passwordHash = '{SHA}' . base64_encode(sha1('secret', true));
 
-$server = new LdapServer();
-
-$server->useStorage(new InMemoryStorage([
+$options = (new ServerOptions())->setStorage(new InMemoryStorage([
     new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example')),
     new Entry(
         new Dn('cn=admin,dc=example,dc=com'),
@@ -78,6 +76,7 @@ $server->useStorage(new InMemoryStorage([
     ),
 ]));
 
+$server = new LdapServer($options);
 $server->run();
 ```
 
@@ -96,11 +95,11 @@ use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
 use FreeDSx\Ldap\ServerOptions;
 
-$server = new LdapServer(
-    (new ServerOptions())->setSaslMechanisms(ServerOptions::SASL_PLAIN),
-);
+$options = (new ServerOptions())
+    ->setSaslMechanisms(ServerOptions::SASL_PLAIN)
+    ->setStorage(JsonFileStorage::forPcntl('/var/lib/myapp/ldap.json'));
 
-$server->useStorage(JsonFileStorage::forPcntl('/var/lib/myapp/ldap.json'));
+$server = new LdapServer($options);
 $server->run();
 ```
 
@@ -152,15 +151,15 @@ class MyAuthenticator implements PasswordAuthenticatableInterface
     }
 }
 
-$server = new LdapServer(
-    (new ServerOptions())->setSaslMechanisms(
+$options = (new ServerOptions())
+    ->setSaslMechanisms(
         ServerOptions::SASL_PLAIN,
         ServerOptions::SASL_SCRAM_SHA_256,
-    ),
-);
+    )
+    ->setStorage(JsonFileStorage::forPcntl('/var/lib/myapp/ldap.json'))
+    ->setPasswordAuthenticator(new MyAuthenticator());
 
-$server->useStorage(JsonFileStorage::forPcntl('/var/lib/myapp/ldap.json'));
-$server->usePasswordAuthenticator(new MyAuthenticator());
+$server = new LdapServer($options);
 $server->run();
 ```
 
@@ -171,13 +170,15 @@ about the other.
 
 ## Running The Server
 
-In its simplest form you construct the server and call `run()`. Without a backend configured, the server accepts
-connections and returns empty results for searches; write operations are rejected with `unwillingToPerform`.
+In its simplest form you construct the server with storage and call `run()`. A non-proxy server started without
+storage throws at startup rather than silently serving an empty directory.
 
 ```php
 use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\ServerOptions;
 
-$server = (new LdapServer())->run();
+$server = new LdapServer((new ServerOptions())->useInMemoryStorage());
+$server->run();
 ```
 
 ## Reloading Configuration on SIGHUP
@@ -186,8 +187,8 @@ A running server can reload its configuration on a `SIGHUP` signal without dropp
 accepted after the reload use the updated configuration. Connections already in flight keep the configuration they
 started with. This works on both the PCNTL and Swoole runners.
 
-By default `SIGHUP` is a logged no-op. To opt in, register a reloader via `LdapServer::onReload()`. The reloader is
-invoked on each `SIGHUP` and returns the `ServerOptions` the server should adopt going forward:
+By default `SIGHUP` is a logged no-op. To opt in, register a reloader via `ServerOptions::setConfigReloader()`. The
+reloader is invoked on each `SIGHUP` and returns the `ServerOptions` the server should adopt going forward:
 
 ```php
 use FreeDSx\Ldap\Server\Configuration\ConfigReloaderInterface;
@@ -214,11 +215,13 @@ final class FileConfigReloader implements ConfigReloaderInterface
 
 ```php
 use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\ServerOptions;
 
-$server = (new LdapServer())
-    ->useStorage($storage)
-    ->onReload(new FileConfigReloader('/etc/myapp/ldap.json'));
+$options = (new ServerOptions())
+    ->setStorage($storage)
+    ->setConfigReloader(new FileConfigReloader('/etc/myapp/ldap.json'));
 
+$server = new LdapServer($options);
 $server->run();
 ```
 
@@ -295,19 +298,18 @@ and entry transformation. Your storage implementation handles only raw persisten
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 
-$server = (new LdapServer())->useStorage(new InMemoryStorage($entries));
+$server = new LdapServer((new ServerOptions())->setStorage(new InMemoryStorage($entries)));
 $server->run();
 ```
 
-For advanced cases where storage cannot model your source, implement a backend directly with `useBackend()`.
-This is a low-level path: you take on **all** LDAP semantics yourself (validation, error codes, scope and
-DN handling, operational attributes) with no help from `WritableStorageBackend`. Prefer `EntryStorageInterface`
-whenever possible.
+For a custom source that a bundled adapter cannot model, implement `EntryStorageInterface` yourself and pass
+it to `useStorage()`. `WritableStorageBackend` still handles LDAP semantics (validation, error codes, scope
+and DN handling, operational attributes) on top of your storage, so you only implement entry read/write.
 
 ```php
 use FreeDSx\Ldap\LdapServer;
 
-$server = (new LdapServer())->useBackend(new MyBackend());
+$server = new LdapServer((new ServerOptions())->setStorage(new MyEntryStorage()));
 $server->run();
 ```
 
@@ -344,10 +346,11 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\ServerOptions;
 
 $passwordHash = '{SHA}' . base64_encode(sha1('secret', true));
 
-$server = (new LdapServer())->useStorage(new InMemoryStorage([
+$options = (new ServerOptions())->setStorage(new InMemoryStorage([
     new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example')),
     new Entry(
         new Dn('cn=admin,dc=example,dc=com'),
@@ -355,6 +358,8 @@ $server = (new LdapServer())->useStorage(new InMemoryStorage([
         new Attribute('userPassword', $passwordHash),
     ),
 ]));
+
+$server = new LdapServer($options);
 $server->run();
 ```
 
@@ -368,13 +373,14 @@ Use the named constructor that matches your server runner:
 ```php
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
+use FreeDSx\Ldap\ServerOptions;
 
 // PCNTL runner — uses flock() to serialise writes across forked processes
-$server = (new LdapServer())->useStorage(JsonFileStorage::forPcntl('/var/lib/myapp/ldap.json'));
+$server = new LdapServer((new ServerOptions())->setStorage(JsonFileStorage::forPcntl('/var/lib/myapp/ldap.json')));
 $server->run();
 
 // Swoole runner — uses a coroutine Channel mutex and non-blocking file I/O
-$server = (new LdapServer())->useStorage(JsonFileStorage::forSwoole('/var/lib/myapp/ldap.json'));
+$server = new LdapServer((new ServerOptions())->setStorage(JsonFileStorage::forSwoole('/var/lib/myapp/ldap.json')));
 $server->run();
 ```
 
@@ -405,20 +411,21 @@ Use the named constructor that matches your server runner:
 ```php
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqliteStorage;
+use FreeDSx\Ldap\ServerOptions;
 
 // PCNTL runner — WAL journal mode, shared connection
-$server = (new LdapServer())->useStorage(SqliteStorage::forPcntl('/var/lib/myapp/ldap.sqlite'));
+$server = new LdapServer((new ServerOptions())->setStorage(SqliteStorage::forPcntl('/var/lib/myapp/ldap.sqlite')));
 $server->run();
 
 // Swoole runner — WAL journal mode, per-coroutine connection
-$server = (new LdapServer())->useStorage(SqliteStorage::forSwoole('/var/lib/myapp/ldap.sqlite'));
+$server = new LdapServer((new ServerOptions())->setStorage(SqliteStorage::forSwoole('/var/lib/myapp/ldap.sqlite')));
 $server->run();
 ```
 
 Use `:memory:` as the path to run a non-persistent, in-process SQLite database (useful for testing):
 
 ```php
-$server = (new LdapServer())->useStorage(SqliteStorage::forPcntl(':memory:'));
+$server = new LdapServer((new ServerOptions())->setStorage(SqliteStorage::forPcntl(':memory:')));
 ```
 
 #### MysqlStorage
@@ -430,17 +437,18 @@ Use the named constructor that matches your server runner:
 ```php
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\MysqlStorage;
+use FreeDSx\Ldap\ServerOptions;
 
 // PCNTL runner — shared connection across forked processes
-$server = (new LdapServer())->useStorage(
+$server = new LdapServer((new ServerOptions())->setStorage(
     MysqlStorage::forPcntl('mysql:host=localhost;dbname=ldap', 'user', 'secret')
-);
+));
 $server->run();
 
 // Swoole runner — per-coroutine connection
-$server = (new LdapServer())->useStorage(
+$server = new LdapServer((new ServerOptions())->setStorage(
     MysqlStorage::forSwoole('mysql:host=localhost;dbname=ldap', 'user', 'secret')
-);
+));
 $server->run();
 ```
 
@@ -526,13 +534,15 @@ pre-filtered results, you can replace the evaluator:
 
 ```php
 use FreeDSx\Ldap\LdapServer;
-use App\MyBackend;
+use FreeDSx\Ldap\ServerOptions;
+use App\MyEntryStorage;
 use App\MySqlFilterEvaluator;
 
-$server = (new LdapServer())
-    ->useBackend(new MyBackend())
-    ->useFilterEvaluator(new MySqlFilterEvaluator());
+$options = (new ServerOptions())
+    ->setStorage(new MyEntryStorage())
+    ->setFilterEvaluator(new MySqlFilterEvaluator());
 
+$server = new LdapServer($options);
 $server->run();
 ```
 
@@ -562,22 +572,24 @@ other source (database, remote URL, gzip stream, etc.). LDIF output uses the par
 
 ### Seeding Initial Entries
 
-`LdapServer::seed()` bulk-imports RFC 2849 LDIF content records into the storage configured via `useStorage()` in one
-atomic transaction, with schema validation and operational-attribute stamping (`createTimestamp`, `entryUUID`, etc.)
-applied. Use it to populate a persistent storage backend before `$server->run()`.
+`LdapServer::seed()` bulk-imports RFC 2849 LDIF content records into the storage configured via
+`ServerOptions::setStorage()` in one atomic transaction, with schema validation and operational-attribute stamping
+(`createTimestamp`, `entryUUID`, etc.) applied. Use it to populate a persistent storage backend before `$server->run()`.
 
 ```php
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Ldif\Loader\FileLdifLoader;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqliteStorage;
+use FreeDSx\Ldap\ServerOptions;
 
-$server = (new LdapServer())
-    ->useStorage(SqliteStorage::forPcntl('/var/lib/myapp/ldap.sqlite'))
-    ->seed(
-        new FileLdifLoader('/etc/myapp/initial-data.ldif'),
-        new Dn('cn=admin,dc=example,dc=com'),
-    );
+$server = new LdapServer(
+    (new ServerOptions())->setStorage(SqliteStorage::forPcntl('/var/lib/myapp/ldap.sqlite')),
+);
+$server->seed(
+    new FileLdifLoader('/etc/myapp/initial-data.ldif'),
+    new Dn('cn=admin,dc=example,dc=com'),
+);
 
 $server->run();
 ```
@@ -617,10 +629,10 @@ deleteoldrdn: 1
 ```php
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Ldif\Loader\FileLdifLoader;
+use FreeDSx\Ldap\ServerOptions;
 
-(new LdapServer())
-    ->useStorage($storage)
-    ->seed(new FileLdifLoader('/etc/myapp/initial-data.ldif'))
+$server = new LdapServer((new ServerOptions())->setStorage($storage));
+$server->seed(new FileLdifLoader('/etc/myapp/initial-data.ldif'))
     ->applyChanges(new FileLdifLoader('/etc/myapp/changes-today.ldif'))
     ->run();
 ```
@@ -639,10 +651,12 @@ entries exactly as they were.
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Ldif\Output\FileLdifOutput;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqliteStorage;
+use FreeDSx\Ldap\ServerOptions;
 
-(new LdapServer())
-    ->useStorage(SqliteStorage::forPcntl('/var/lib/myapp/ldap.sqlite'))
-    ->dump(new FileLdifOutput('/var/backups/ldap-snapshot.ldif'));
+$server = new LdapServer(
+    (new ServerOptions())->setStorage(SqliteStorage::forPcntl('/var/lib/myapp/ldap.sqlite')),
+);
+$server->dump(new FileLdifOutput('/var/backups/ldap-snapshot.ldif'));
 ```
 
 For in-memory use (logging, tests, piping over the network) use `StringLdifOutput`, which collects the chunks and is
@@ -766,6 +780,7 @@ use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\SaslIdentity;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
+use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Sasl\Mechanism\MechanismName;
 use SensitiveParameter;
 
@@ -788,7 +803,7 @@ class MyAuthenticator implements PasswordAuthenticatableInterface
     }
 }
 
-$server = (new LdapServer())->usePasswordAuthenticator(new MyAuthenticator());
+$server = new LdapServer((new ServerOptions())->setPasswordAuthenticator(new MyAuthenticator()));
 ```
 
 ## Handling the RootDSE
@@ -834,16 +849,19 @@ Register it with the server:
 
 ```php
 use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\ServerOptions;
+use App\MyEntryStorage;
 use App\MyRootDseHandler;
 
-$server = (new LdapServer())
-    ->useBackend(new MyBackend())
-    ->useRootDseHandler(new MyRootDseHandler());
+$options = (new ServerOptions())
+    ->setStorage(new MyEntryStorage())
+    ->setRootDseHandler(new MyRootDseHandler());
 
+$server = new LdapServer($options);
 $server->run();
 ```
 
-If your backend class also implements `RootDseHandlerInterface`, you do not need to call `useRootDseHandler()` — it will be used automatically.
+If your backend class also implements `RootDseHandlerInterface`, you do not need to set `setRootDseHandler()` — it will be used automatically.
 
 ## SASL Authentication
 

--- a/docs/Server/Logging.md
+++ b/docs/Server/Logging.md
@@ -19,22 +19,14 @@ Without a configured logger, the server runs silently.
 
 ## Wiring a Logger
 
-Any PSR-3 `LoggerInterface` works:
+Any PSR-3 `LoggerInterface` works — set it on `ServerOptions`:
 
 ```php
 use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\ServerOptions;
 use Psr\Log\LoggerInterface;
 
-$server = new LdapServer();
-$server->useLogger($logger);
-```
-
-Or via `ServerOptions`:
-
-```php
-use FreeDSx\Ldap\ServerOptions;
-
-$options = (new ServerOptions())->setLogger($logger);
+$server = new LdapServer((new ServerOptions())->setLogger($logger));
 ```
 
 ## Event Catalog

--- a/docs/Server/Schema.md
+++ b/docs/Server/Schema.md
@@ -19,10 +19,9 @@ schema in `Strict` mode.
 
 ```php
 use FreeDSx\Ldap\LdapServer;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\ServerOptions;
 
-$server = new LdapServer();
-$server->useStorage(new InMemoryStorage());
+$server = new LdapServer((new ServerOptions())->useInMemoryStorage());
 ```
 
 ## What Gets Validated
@@ -95,9 +94,10 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\ServerOptions;
 
 $server = new LdapServer(
-    (new ServerOptions())->setSchemaValidationMode(SchemaValidationMode::Lenient)
+    (new ServerOptions())
+        ->setSchemaValidationMode(SchemaValidationMode::Lenient)
+        ->setStorage(new InMemoryStorage())
 );
-$server->useStorage(new InMemoryStorage());
 ```
 
 Beyond the server-wide mode, an authorized client can relax validation for a *single* Add/Modify with the Relax Rules

--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -23,6 +23,14 @@ use FreeDSx\Ldap\Protocol\RootDseLoader;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Server\Clock\ClockInterface;
 use FreeDSx\Ldap\Server\Clock\SystemClock;
+use FreeDSx\Ldap\Schema\SchemaValidationMode;
+use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeRecorder;
+use FreeDSx\Ldap\Server\Backend\Storage\OperationalAttributeGenerator;
+use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use Psr\Log\NullLogger;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
 use FreeDSx\Ldap\Server\Metrics\File\FileSnapshotProvider;
 use FreeDSx\Ldap\Server\Metrics\File\FileSnapshotWriter;
@@ -183,6 +191,10 @@ class Container
         $this->registerFactory(
             className: HandlerFactoryInterface::class,
             factory: $this->makeHandlerFactory(...),
+        );
+        $this->registerFactory(
+            className: WritableStorageBackend::class,
+            factory: $this->makeBackend(...),
         );
         $this->registerFactory(
             className: ServerProtocolFactory::class,
@@ -429,7 +441,85 @@ class Container
 
     private function makeHandlerFactory(): HandlerFactory
     {
-        return new HandlerFactory($this->get(ServerOptions::class));
+        return new HandlerFactory(
+            $this->get(ServerOptions::class),
+            $this->backendOrFail(),
+        );
+    }
+
+    /**
+     * The configured backend; only reached on the non-proxy path, where LdapServer's startup check guarantees one.
+     */
+    private function backendOrFail(): WritableStorageBackend
+    {
+        return $this->backendOrNull()
+            ?? throw new RuntimeException('No storage is configured; set ServerOptions::setStorage().');
+    }
+
+    /**
+     * The configured backend, or null when no storage is set (the proxy path has none).
+     */
+    private function backendOrNull(): ?WritableStorageBackend
+    {
+        return $this->get(ServerOptions::class)->getStorage() !== null
+            ? $this->get(WritableStorageBackend::class)
+            : null;
+    }
+
+    /**
+     * Assemble the writable backend from the configured storage; only invoked when storage is set.
+     */
+    private function makeBackend(): WritableStorageBackend
+    {
+        $options = $this->get(ServerOptions::class);
+        $storage = $options->getStorage();
+
+        if ($storage === null) {
+            throw new RuntimeException('No storage is configured; set ServerOptions::setStorage().');
+        }
+
+        $schema = $options->getSchemaValidationMode() !== SchemaValidationMode::Off
+            ? $options->getSchema()
+            : null;
+
+        return new WritableStorageBackend(
+            storage: $storage,
+            limits: $options->makeSearchLimits(),
+            validator: $this->buildSchemaValidator(),
+            operationalAttrs: new OperationalAttributeGenerator($schema),
+            changeRecorder: $this->changeRecorderFor($storage),
+        );
+    }
+
+    private function buildSchemaValidator(): ?SchemaValidator
+    {
+        $options = $this->get(ServerOptions::class);
+        $mode = $options->getSchemaValidationMode();
+
+        if ($mode === SchemaValidationMode::Off) {
+            return null;
+        }
+
+        return new SchemaValidator(
+            $options->getSchema(),
+            $mode,
+        );
+    }
+
+    /**
+     * Configure the storage's journal and return a recorder when sync is enabled and the storage can journal.
+     */
+    private function changeRecorderFor(EntryStorageInterface $storage): ?ChangeRecorder
+    {
+        $options = $this->get(ServerOptions::class);
+
+        if (!$options->isSyncEnabled() || !$storage instanceof ChangeJournalingInterface) {
+            return null;
+        }
+
+        $storage->configureJournal($options->getChangeJournalConfig());
+
+        return new ChangeRecorder($options->getLogger() ?? new NullLogger());
     }
 
     private function makeServerRunner(): ServerRunnerInterface
@@ -456,6 +546,7 @@ class Container
             metricsRecorder: $metricsRecorder,
             snapshotPublisher: $this->makeSnapshotPublisher(),
             operationRollup: $this->makeOperationRollup(),
+            backend: $this->backendOrNull(),
         );
     }
 
@@ -500,6 +591,8 @@ class Container
         $proxyOptions = $this->has(ProxyOptions::class)
             ? $this->get(ProxyOptions::class)
             : null;
+        // Carry the backend across reloads so a SIGHUP does not drop the configured storage.
+        $backend = $this->backendOrNull();
 
         // Share the metrics state across reloads so SIGHUP does not reset the counters or detach cn=monitor. The rollup
         // coordinator is shared so a reloaded middleware streams to the same channel the (persistent) runner bound.
@@ -510,6 +603,7 @@ class Container
 
         return static function (ServerOptions $options) use (
             $proxyOptions,
+            $backend,
             $metricsRecorder,
             $metricsSnapshots,
             $inMemoryMetrics,
@@ -521,6 +615,10 @@ class Container
                 MetricsSnapshotProvider::class => $metricsSnapshots,
                 InMemoryMetricsRecorder::class => $inMemoryMetrics,
             ];
+
+            if ($backend !== null) {
+                $instances[WritableStorageBackend::class] = $backend;
+            }
 
             if ($proxyOptions !== null) {
                 $instances[ProxyOptions::class] = $proxyOptions;

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -23,32 +23,17 @@ use FreeDSx\Ldap\Ldif\LdifParser;
 use FreeDSx\Ldap\Ldif\Loader\LdifLoaderInterface;
 use FreeDSx\Ldap\Ldif\Output\LdifOutputInterface;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
-use FreeDSx\Ldap\Schema\SchemaValidationMode;
-use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\BackendAwareInterface;
 use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
-use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeRecorder;
-use FreeDSx\Ldap\Server\Backend\Storage\OperationalAttributeGenerator;
-use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
-use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
-use FreeDSx\Ldap\Server\Configuration\ConfigReloaderInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Export\DirectoryDumper;
 use FreeDSx\Ldap\Server\Backend\Storage\Export\DumpOptions;
 use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
-use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteRequestReplayer;
-use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
 use FreeDSx\Socket\Exception\ConnectionException;
 use Generator;
-use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 /**
  * The LDAP server.
@@ -105,30 +90,6 @@ class LdapServer
     }
 
     /**
-     * Specify an entry storage implementation to back the LDAP server.
-     *
-     * Schema validation is applied automatically. If you don't want it, set {@see SchemaValidationMode::Off} in your
-     * server options.
-     *
-     * Use {@see useBackend()} instead when implementing a fully custom backend (e.g. a proxy) that handles LDAP
-     * semantics itself.
-     */
-    public function useStorage(EntryStorageInterface $storage): self
-    {
-        $schema = $this->options->getSchemaValidationMode() !== SchemaValidationMode::Off
-            ? $this->options->getSchema()
-            : null;
-
-        return $this->useBackend(new WritableStorageBackend(
-            storage: $storage,
-            limits: $this->options->makeSearchLimits(),
-            validator: $this->buildSchemaValidator(),
-            operationalAttrs: new OperationalAttributeGenerator($schema),
-            changeRecorder: $this->changeRecorderFor($storage),
-        ));
-    }
-
-    /**
      * Bulk-loads LDIF content records into the storage configured via {@see useStorage()} as one atomic batch.
      *
      * Use {@see applyChanges()} instead to replay a changelog (modify/delete/rename) through the live write path.
@@ -143,10 +104,10 @@ class LdapServer
         LdifLoaderInterface $loader,
         Dn $creatorDn = new Dn(''),
     ): self {
-        $backend = $this->options->getBackend();
+        $backend = $this->backend();
 
-        if (!$backend instanceof WritableStorageBackend) {
-            throw new RuntimeException('seed() requires a storage backend configured via useStorage().');
+        if ($backend === null) {
+            throw new RuntimeException('seed() requires storage configured via ServerOptions::setStorage().');
         }
 
         (new LdapImporter(
@@ -170,10 +131,10 @@ class LdapServer
      */
     public function applyChanges(LdifLoaderInterface $loader): self
     {
-        $backend = $this->options->getBackend();
+        $backend = $this->backend();
 
         if ($backend === null) {
-            throw new RuntimeException('applyChanges() requires a backend configured via useStorage() or useBackend().');
+            throw new RuntimeException('applyChanges() requires storage configured via ServerOptions::setStorage().');
         }
 
         (new WriteRequestReplayer(
@@ -196,10 +157,10 @@ class LdapServer
         LdifOutputInterface $output,
         DumpOptions $options = new DumpOptions(),
     ): self {
-        $backend = $this->options->getBackend();
+        $backend = $this->backend();
 
-        if (!$backend instanceof WritableStorageBackend) {
-            throw new RuntimeException('dump() requires a storage backend configured via useStorage().');
+        if ($backend === null) {
+            throw new RuntimeException('dump() requires storage configured via ServerOptions::setStorage().');
         }
 
         $output->write((new DirectoryDumper(
@@ -207,100 +168,6 @@ class LdapServer
             $backend->namingContexts(),
             $this->options->getFilterEvaluator(),
         ))->dump($options));
-
-        return $this;
-    }
-
-    /**
-     * Specify a backend to use for incoming LDAP requests.
-     */
-    public function useBackend(WritableLdapBackendInterface $backend): self
-    {
-        $this->options->setBackend($backend);
-
-        return $this;
-    }
-
-    /**
-     * Set the identity resolver used to translate a name to an Entry for simple bind, SASL bind, and PasswordModify.
-     */
-    public function useIdentityResolver(BindNameResolverInterface $resolver): self
-    {
-        $this->options->setIdentityResolver($resolver);
-
-        return $this;
-    }
-
-    /**
-     * Override the password authenticator used for simple bind and SASL PLAIN.
-     */
-    public function usePasswordAuthenticator(PasswordAuthenticatableInterface $authenticator): self
-    {
-        $this->options->setPasswordAuthenticator($authenticator);
-
-        return $this;
-    }
-
-    /**
-     * Register a handler for one or more LDAP write operations.
-     */
-    public function useWriteHandler(WriteHandlerInterface $handler): self
-    {
-        $this->options->addWriteHandler($handler);
-
-        return $this;
-    }
-
-    /**
-     * Specify an instance of a RootDSE handler to use for RootDSE requests.
-     */
-    public function useRootDseHandler(RootDseHandlerInterface $rootDseHandler): self
-    {
-        $this->options->setRootDseHandler($rootDseHandler);
-
-        return $this;
-    }
-
-    /**
-     * Override the filter evaluator used by the server when applying LDAP filters
-     * to entries returned by the backend's search() generator.
-     */
-    public function useFilterEvaluator(FilterEvaluatorInterface $evaluator): self
-    {
-        $this->options->setFilterEvaluator($evaluator);
-
-        return $this;
-    }
-
-    /**
-     * Specify a logger to be used by the server process.
-     */
-    public function useLogger(LoggerInterface $logger): self
-    {
-        $this->options->setLogger($logger);
-
-        return $this;
-    }
-
-    /**
-     * Register a reloader that supplies fresh ServerOptions on a SIGHUP reload. New connections use the result.
-     */
-    public function onReload(ConfigReloaderInterface $configReloader): self
-    {
-        $this->options->setConfigReloader($configReloader);
-
-        return $this;
-    }
-
-    /**
-     * Configure the server to use the Swoole coroutine runner instead of the default PCNTL process runner.
-     *
-     * Requires the swoole PHP extension. The SwooleServerRunner handles each client connection in its own
-     * coroutine within a single process, making in-memory storage adapters safe to use concurrently.
-     */
-    public function useSwooleRunner(): self
-    {
-        $this->options->setUseSwooleRunner(true);
 
         return $this;
     }
@@ -324,23 +191,31 @@ class LdapServer
         );
     }
 
-    /**
-     * Configures the storage's journal and returns a recorder when sync is enabled and the storage can journal.
-     */
-    private function changeRecorderFor(EntryStorageInterface $storage): ?ChangeRecorder
-    {
-        if (!$this->options->isSyncEnabled() || !$storage instanceof ChangeJournalingInterface) {
-            return null;
-        }
-
-        $storage->configureJournal($this->options->getChangeJournalConfig());
-
-        return new ChangeRecorder($this->options->getLogger() ?? new NullLogger());
-    }
-
     private function init(): void
     {
+        $this->requireBackendUnlessProxy();
         $this->options->setAccessControl($this->resolveAccessControl());
+    }
+
+    private function requireBackendUnlessProxy(): void
+    {
+        if ($this->options->getStorage() !== null || $this->container->has(ProxyOptions::class)) {
+            return;
+        }
+
+        throw new RuntimeException(
+            'No storage is configured. Set ServerOptions::setStorage() (or useInMemoryStorage()) before running.',
+        );
+    }
+
+    /**
+     * The assembled storage backend from the container, or null when no storage is configured.
+     */
+    private function backend(): ?WritableStorageBackend
+    {
+        return $this->options->getStorage() === null
+            ? null
+            : $this->container->get(WritableStorageBackend::class);
     }
 
     private function resolveAccessControl(): AccessControlInterface
@@ -360,7 +235,7 @@ class LdapServer
 
     private function injectBackendIfNeeded(AccessControlInterface $acl): AccessControlInterface
     {
-        $backend = $this->options->getBackend();
+        $backend = $this->backend();
 
         if ($backend !== null && $acl instanceof BackendAwareInterface) {
             $acl->setBackend($backend);
@@ -385,19 +260,5 @@ class LdapServer
 
             yield $request->getEntry();
         }
-    }
-
-    private function buildSchemaValidator(): ?SchemaValidator
-    {
-        $mode = $this->options->getSchemaValidationMode();
-
-        if ($mode === SchemaValidationMode::Off) {
-            return null;
-        }
-
-        return new SchemaValidator(
-            $this->options->getSchema(),
-            $mode,
-        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/RequestHandler/HandlerFactory.php
+++ b/src/FreeDSx/Ldap/Server/RequestHandler/HandlerFactory.php
@@ -20,8 +20,7 @@ use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\DnBindNameResolver;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticator;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
@@ -35,14 +34,17 @@ use FreeDSx\Ldap\ServerOptions;
  */
 class HandlerFactory implements HandlerFactoryInterface
 {
-    public function __construct(private readonly ServerOptions $options) {}
+    public function __construct(
+        private readonly ServerOptions $options,
+        private readonly WritableLdapBackendInterface $backend,
+    ) {}
 
     /**
      * @inheritDoc
      */
     public function makeBackend(): LdapBackendInterface
     {
-        return $this->options->getBackend() ?? new WritableStorageBackend(new InMemoryStorage());
+        return $this->backend;
     }
 
     /**
@@ -55,9 +57,8 @@ class HandlerFactory implements HandlerFactoryInterface
             return $explicit;
         }
 
-        $backend = $this->options->getBackend();
-        if ($backend instanceof RootDseHandlerInterface) {
-            return $backend;
+        if ($this->backend instanceof RootDseHandlerInterface) {
+            return $this->backend;
         }
 
         return null;
@@ -102,11 +103,7 @@ class HandlerFactory implements HandlerFactoryInterface
     public function makeWriteDispatcher(WriteHandlerInterface ...$prepend): WriteOperationDispatcher
     {
         $handlers = $this->options->getWriteHandlers();
-
-        $backend = $this->options->getBackend();
-        if ($backend !== null) {
-            $handlers[] = $backend;
-        }
+        $handlers[] = $this->backend;
 
         return new WriteOperationDispatcher(
             ...$prepend,

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -17,6 +17,7 @@ use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Server\Backend\ResettableInterface;
+use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Metrics\File\SnapshotPublisher;
 use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
@@ -90,6 +91,7 @@ class PcntlServerRunner implements ServerRunnerInterface
         private readonly MetricsRecorderInterface $metricsRecorder = new NullMetricsRecorder(),
         private readonly ?SnapshotPublisher $snapshotPublisher = null,
         private readonly ?OperationRollupCoordinator $operationRollup = null,
+        private readonly ?WritableLdapBackendInterface $backend = null,
     ) {
         if (!extension_loaded('pcntl')) {
             throw new RuntimeException(
@@ -483,10 +485,9 @@ class PcntlServerRunner implements ServerRunnerInterface
 
         $context = ['pid' => $pid];
         $this->isMainProcess = false;
-        $backend = $this->options->getBackend();
 
-        if ($backend instanceof ResettableInterface) {
-            $backend->reset();
+        if ($this->backend instanceof ResettableInterface) {
+            $this->backend->reset();
         }
 
         $serverProtocolHandler = $this->serverProtocolFactory->make(

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap;
 
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Schema\PasswordPolicySchemaProvider;
 use FreeDSx\Ldap\Schema\Schema;
@@ -27,7 +28,8 @@ use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashScheme;
 use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\DefaultPasswordQualityChecker;
 use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\PasswordQualityCheckerInterface;
-use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluator;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
@@ -153,7 +155,7 @@ final class ServerOptions
 
     private ?string $dseVendorVersion = null;
 
-    private ?WritableLdapBackendInterface $backend = null;
+    private ?EntryStorageInterface $storage = null;
 
     private ?PasswordAuthenticatableInterface $passwordAuthenticator = null;
 
@@ -500,14 +502,26 @@ final class ServerOptions
         return $this;
     }
 
-    public function getBackend(): ?WritableLdapBackendInterface
+    public function getStorage(): ?EntryStorageInterface
     {
-        return $this->backend;
+        return $this->storage;
     }
 
-    public function setBackend(?WritableLdapBackendInterface $backend): self
+    public function setStorage(?EntryStorageInterface $storage): self
     {
-        $this->backend = $backend;
+        $this->storage = $storage;
+
+        return $this;
+    }
+
+    /**
+     * Back the server with a transient in-memory directory.
+     *
+     * @param Entry[] $entries
+     */
+    public function useInMemoryStorage(array $entries = []): self
+    {
+        $this->storage = new InMemoryStorage($entries);
 
         return $this;
     }
@@ -1041,7 +1055,7 @@ final class ServerOptions
     }
 
     /**
-     * @return array{ip: string, port: int, unix_socket: string, transport: string, idle_timeout: int, require_authentication: bool, allow_anonymous: bool, backend: ?WritableLdapBackendInterface, rootdse_handler: ?RootDseHandlerInterface, logger: ?LoggerInterface, use_ssl: bool, ssl_cert: ?string, ssl_cert_key: ?string, ssl_cert_passphrase: ?string, min_tls_version: string, ssl_ciphers: string, ssl_validate_cert: bool, ssl_allow_self_signed: ?bool, ssl_ca_cert: ?string, monitor_enabled: bool, monitor_snapshot_path: ?string, dse_alt_server: ?string, dse_vendor_name: string, dse_vendor_version: ?string, sasl_mechanisms: string[]}
+     * @return array{ip: string, port: int, unix_socket: string, transport: string, idle_timeout: int, require_authentication: bool, allow_anonymous: bool, rootdse_handler: ?RootDseHandlerInterface, logger: ?LoggerInterface, use_ssl: bool, ssl_cert: ?string, ssl_cert_key: ?string, ssl_cert_passphrase: ?string, min_tls_version: string, ssl_ciphers: string, ssl_validate_cert: bool, ssl_allow_self_signed: ?bool, ssl_ca_cert: ?string, monitor_enabled: bool, monitor_snapshot_path: ?string, dse_alt_server: ?string, dse_vendor_name: string, dse_vendor_version: ?string, sasl_mechanisms: string[]}
      */
     public function toArray(): array
     {
@@ -1053,7 +1067,6 @@ final class ServerOptions
             'idle_timeout' => $this->getIdleTimeout(),
             'require_authentication' => $this->isRequireAuthentication(),
             'allow_anonymous' => $this->isAllowAnonymous(),
-            'backend' => $this->getBackend(),
             'rootdse_handler' => $this->getRootDseHandler(),
             'logger' => $this->getLogger(),
             'use_ssl' => $this->isUseSsl(),

--- a/tests/integration/Ldif/LdapDumpServerTest.php
+++ b/tests/integration/Ldif/LdapDumpServerTest.php
@@ -15,6 +15,7 @@ namespace Tests\Integration\FreeDSx\Ldap\Ldif;
 
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Ldap\Ldif\LdifChanges;
 use FreeDSx\Ldap\Ldif\Loader\FileLdifLoader;
 use FreeDSx\Ldap\Ldif\Loader\StringLdifLoader;
@@ -109,8 +110,7 @@ final class LdapDumpServerTest extends ServerTestCase
     public function test_a_fresh_server_seeded_from_the_dump_reconstructs_the_directory(): void
     {
         $storage = new InMemoryStorage();
-        (new LdapServer())
-            ->useStorage($storage)
+        (new LdapServer((new ServerOptions())->setStorage($storage)))
             ->seed(new StringLdifLoader((string) file_get_contents(self::$dumpPath)));
 
         $alice = $storage->find(new Dn('cn=alice,dc=foo,dc=bar'));

--- a/tests/support/LdapAclCommand.php
+++ b/tests/support/LdapAclCommand.php
@@ -139,7 +139,7 @@ class LdapAclCommand extends Command
                 ),
         );
 
-        $server->useStorage(new InMemoryStorage($entries));
+        $server->getOptions()->setStorage(new InMemoryStorage($entries));
         $server->run();
 
         return Command::SUCCESS;

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -232,7 +232,7 @@ final class LdapBackendStorageCommand extends Command
         $server = new LdapServer($serverOptions);
 
         if ($storage === 'memory') {
-            $server->useStorage(new InMemoryStorage($entries));
+            $server->getOptions()->setStorage(new InMemoryStorage($entries));
         } elseif ($storage === 'json') {
             $filePath = sys_get_temp_dir() . '/ldap_test_backend_storage.json';
 
@@ -252,7 +252,7 @@ final class LdapBackendStorageCommand extends Command
                 $importer->importEntries($entries);
             }
 
-            $server->useStorage($adapter);
+            $server->getOptions()->setStorage($adapter);
         } elseif ($storage === 'sqlite') {
             $dbPath = sys_get_temp_dir() . '/ldap_test_backend_storage.sqlite';
 
@@ -274,7 +274,7 @@ final class LdapBackendStorageCommand extends Command
                 $importer->importEntries($entries);
             }
 
-            $server->useStorage($adapter);
+            $server->getOptions()->setStorage($adapter);
         } else {
             $dsn = getenv('MYSQL_DSN') ?: 'mysql:host=127.0.0.1;port=3306;dbname=freedsx';
             $user = getenv('MYSQL_USER') ?: 'root';
@@ -302,11 +302,11 @@ final class LdapBackendStorageCommand extends Command
                 $importer->importEntries($entries);
             }
 
-            $server->useStorage($adapter);
+            $server->getOptions()->setStorage($adapter);
         }
 
         if ($runner === 'swoole') {
-            $server->useSwooleRunner();
+            $server->getOptions()->setUseSwooleRunner(true);
         }
 
         $server->run();

--- a/tests/support/LdapPasswordPolicyCommand.php
+++ b/tests/support/LdapPasswordPolicyCommand.php
@@ -85,7 +85,7 @@ final class LdapPasswordPolicyCommand extends Command
                 ->setSaslMechanisms(ServerOptions::SASL_PLAIN)
                 ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL)),
         );
-        $server->useStorage(new InMemoryStorage($entries));
+        $server->getOptions()->setStorage(new InMemoryStorage($entries));
         $server->run();
 
         return Command::SUCCESS;

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -267,7 +267,7 @@ final class LdapServerCommand extends Command
             );
         }
 
-        $server->useStorage($storage);
+        $server->getOptions()->setStorage($storage);
 
         if ($seedFile !== '') {
             $server->seed(new FileLdifLoader($seedFile));

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -21,6 +21,7 @@ use FreeDSx\Ldap\Protocol\Factory\ClientProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\Queue\ClientQueueInstantiator;
 use FreeDSx\Ldap\Protocol\RootDseLoader;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
+use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
 use FreeDSx\Ldap\Server\Metrics\File\FileSnapshotProvider;
 use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
@@ -45,13 +46,21 @@ class ContainerTest extends TestCase
         parent::setUp();
 
         $client = new LdapClient();
-        $serverOptions = new ServerOptions();
+        $serverOptions = (new ServerOptions())->useInMemoryStorage();
 
         $this->subject = new Container([
             LdapClient::class => $client,
             ClientOptions::class => $client->getOptions(),
             ServerOptions::class => $serverOptions,
         ]);
+    }
+
+    public function test_it_assembles_the_backend_from_the_configured_storage(): void
+    {
+        self::assertInstanceOf(
+            WritableStorageBackend::class,
+            $this->subject->get(HandlerFactoryInterface::class)->makeBackend(),
+        );
     }
 
     /**
@@ -159,6 +168,8 @@ class ContainerTest extends TestCase
 
     private function containerFor(ServerOptions $options): Container
     {
-        return new Container([ServerOptions::class => $options]);
+        return new Container([
+            ServerOptions::class => $options->useInMemoryStorage(),
+        ]);
     }
 }

--- a/tests/unit/LdapServerTest.php
+++ b/tests/unit/LdapServerTest.php
@@ -19,20 +19,14 @@ use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Ldif\Loader\StringLdifLoader;
 use FreeDSx\Ldap\Ldif\Output\StringLdifOutput;
 use FreeDSx\Ldap\Search\Filters;
-use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Export\DumpOptions;
-use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
-use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
-use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\ProxyOptions;
-use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
 use FreeDSx\Ldap\ServerOptions;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 
 class LdapServerTest extends TestCase
 {
@@ -72,43 +66,15 @@ class LdapServerTest extends TestCase
             ->expects(self::once())
             ->method('run');
 
+        $this->options->useInMemoryStorage();
         $this->subject->run();
     }
 
-    public function test_it_should_use_the_backend_specified(): void
+    public function test_run_throws_when_no_storage_is_configured(): void
     {
-        $backend = $this->createMock(WritableLdapBackendInterface::class);
+        $this->expectException(RuntimeException::class);
 
-        $this->subject->useBackend($backend);
-
-        self::assertSame(
-            $backend,
-            $this->subject->getOptions()->getBackend(),
-        );
-    }
-
-    public function test_it_should_use_the_rootdse_handler_specified(): void
-    {
-        $rootDseHandler = $this->createMock(RootDseHandlerInterface::class);
-
-        $this->subject->useRootDseHandler($rootDseHandler);
-
-        self::assertSame(
-            $rootDseHandler,
-            $this->subject->getOptions()->getRootDseHandler(),
-        );
-    }
-
-    public function test_it_should_use_the_logger_specified(): void
-    {
-        $logger = $this->createMock(LoggerInterface::class);
-
-        $this->subject->useLogger($logger);
-
-        self::assertSame(
-            $logger,
-            $this->subject->getOptions()->getLogger(),
-        );
+        $this->subject->run();
     }
 
     public function test_it_should_get_the_default_options(): void
@@ -122,7 +88,6 @@ class LdapServerTest extends TestCase
                 'idle_timeout' => 600,
                 'require_authentication' => true,
                 'allow_anonymous' => false,
-                'backend' => null,
                 'rootdse_handler' => null,
                 'logger' => null,
                 'use_ssl' => false,
@@ -151,52 +116,10 @@ class LdapServerTest extends TestCase
 
         $this->options->setSaslMechanisms(ServerOptions::SASL_PLAIN);
 
+        $this->options->useInMemoryStorage();
         $this->subject->run();
 
         $this->expectNotToPerformAssertions();
-    }
-
-    public function test_it_should_use_the_password_authenticator_specified(): void
-    {
-        $authenticator = $this->createMock(PasswordAuthenticatableInterface::class);
-
-        $this->subject->usePasswordAuthenticator($authenticator);
-
-        self::assertSame(
-            $authenticator,
-            $this->subject->getOptions()->getPasswordAuthenticator(),
-        );
-    }
-
-    public function test_it_should_use_the_write_handler_specified(): void
-    {
-        $handler = $this->createMock(WriteHandlerInterface::class);
-
-        $this->subject->useWriteHandler($handler);
-
-        self::assertContains(
-            $handler,
-            $this->subject->getOptions()->getWriteHandlers(),
-        );
-    }
-
-    public function test_it_should_use_the_filter_evaluator_specified(): void
-    {
-        $evaluator = $this->createMock(FilterEvaluatorInterface::class);
-
-        $this->subject->useFilterEvaluator($evaluator);
-
-        self::assertSame(
-            $evaluator,
-            $this->subject->getOptions()->getFilterEvaluator(),
-        );
-    }
-
-    public function test_it_should_enable_swoole_runner(): void
-    {
-        $this->subject->useSwooleRunner();
-
-        self::assertTrue($this->subject->getOptions()->getUseSwooleRunner());
     }
 
     public function test_it_should_make_a_proxy_server(): void
@@ -216,7 +139,7 @@ class LdapServerTest extends TestCase
     public function test_it_should_seed_entries_into_the_configured_storage(): void
     {
         $storage = new InMemoryStorage();
-        $this->subject->useStorage($storage);
+        $this->options->setStorage($storage);
 
         $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
 
@@ -232,7 +155,7 @@ class LdapServerTest extends TestCase
     public function test_it_should_stamp_operational_attributes_on_seeded_entries(): void
     {
         $storage = new InMemoryStorage();
-        $this->subject->useStorage($storage);
+        $this->options->setStorage($storage);
 
         $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
 
@@ -256,7 +179,7 @@ class LdapServerTest extends TestCase
     public function test_it_should_record_the_creator_dn_when_seeding(): void
     {
         $storage = new InMemoryStorage();
-        $this->subject->useStorage($storage);
+        $this->options->setStorage($storage);
 
         $this->subject->seed(
             new StringLdifLoader(self::SEED_LDIF),
@@ -279,7 +202,7 @@ class LdapServerTest extends TestCase
     public function test_it_should_reject_seeding_when_the_ldif_contains_change_records(): void
     {
         $storage = new InMemoryStorage();
-        $this->subject->useStorage($storage);
+        $this->options->setStorage($storage);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('only accepts content records');
@@ -290,7 +213,7 @@ class LdapServerTest extends TestCase
     public function test_it_should_apply_modify_changes_against_the_seeded_storage(): void
     {
         $storage = new InMemoryStorage();
-        $this->subject->useStorage($storage);
+        $this->options->setStorage($storage);
         $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
 
         $this->subject->applyChanges(new StringLdifLoader(
@@ -306,7 +229,7 @@ class LdapServerTest extends TestCase
     public function test_it_should_apply_a_delete_change_against_the_seeded_storage(): void
     {
         $storage = new InMemoryStorage();
-        $this->subject->useStorage($storage);
+        $this->options->setStorage($storage);
         $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
 
         $this->subject->applyChanges(new StringLdifLoader(
@@ -319,7 +242,7 @@ class LdapServerTest extends TestCase
     public function test_it_should_throw_when_applying_changes_without_a_backend(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('requires a backend');
+        $this->expectExceptionMessage('requires storage configured');
 
         $this->subject->applyChanges(new StringLdifLoader("dn: cn=x,dc=x\nchangetype: delete\n"));
     }
@@ -327,7 +250,7 @@ class LdapServerTest extends TestCase
     public function test_it_should_throw_when_dumping_without_a_storage_backend(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('requires a storage backend');
+        $this->expectExceptionMessage('requires storage configured');
 
         $this->subject->dump(new StringLdifOutput());
     }
@@ -335,7 +258,7 @@ class LdapServerTest extends TestCase
     public function test_it_should_dump_seeded_entries_to_the_given_output(): void
     {
         $storage = new InMemoryStorage();
-        $this->subject->useStorage($storage);
+        $this->options->setStorage($storage);
         $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
 
         $output = new StringLdifOutput();
@@ -362,7 +285,7 @@ class LdapServerTest extends TestCase
     public function test_dump_seed_round_trip_preserves_entryUUID_and_create_timestamp(): void
     {
         $storage = new InMemoryStorage();
-        $this->subject->useStorage($storage);
+        $this->options->setStorage($storage);
         $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
 
         $originalFoo = $storage->find(new Dn('cn=foo,dc=example,dc=com'));
@@ -379,8 +302,7 @@ class LdapServerTest extends TestCase
         );
 
         $restoredStorage = new InMemoryStorage();
-        (new LdapServer())
-            ->useStorage($restoredStorage)
+        (new LdapServer((new ServerOptions())->setStorage($restoredStorage)))
             ->seed(new StringLdifLoader($output->getLdif()));
 
         $restoredFoo = $restoredStorage->find(new Dn('cn=foo,dc=example,dc=com'));
@@ -398,7 +320,7 @@ class LdapServerTest extends TestCase
     public function test_it_should_apply_the_dump_options_filter(): void
     {
         $storage = new InMemoryStorage();
-        $this->subject->useStorage($storage);
+        $this->options->setStorage($storage);
         $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
 
         $output = new StringLdifOutput();

--- a/tests/unit/Server/RequestHandler/HandlerFactoryTest.php
+++ b/tests/unit/Server/RequestHandler/HandlerFactoryTest.php
@@ -16,7 +16,6 @@ namespace Tests\Unit\FreeDSx\Ldap\Server\RequestHandler;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticator;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Server\RequestHandler\HandlerFactory;
 use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
 use FreeDSx\Ldap\ServerOptions;
@@ -25,47 +24,42 @@ use PHPUnit\Framework\TestCase;
 
 final class HandlerFactoryTest extends TestCase
 {
-    private HandlerFactory $subject;
-
-    public function test_it_should_return_an_in_memory_backend_when_none_is_configured(): void
-    {
-        $this->subject = new HandlerFactory(new ServerOptions());
-
-        self::assertInstanceOf(
-            WritableStorageBackend::class,
-            $this->subject->makeBackend(),
-        );
-    }
-
-    public function test_it_should_allow_a_backend_as_an_object(): void
+    public function test_it_returns_the_backend_it_was_built_with(): void
     {
         $backend = $this->createMock(WritableLdapBackendInterface::class);
-        $this->subject = new HandlerFactory((new ServerOptions())->setBackend($backend));
+        $subject = new HandlerFactory(
+            new ServerOptions(),
+            $backend,
+        );
 
         self::assertSame(
             $backend,
-            $this->subject->makeBackend(),
+            $subject->makeBackend(),
         );
     }
 
     public function test_it_should_allow_a_rootdse_handler_as_an_object(): void
     {
         $rootDseHandler = $this->createMock(RootDseHandlerInterface::class);
-        $this->subject = new HandlerFactory((new ServerOptions())->setRootDseHandler($rootDseHandler));
+        $subject = new HandlerFactory(
+            (new ServerOptions())->setRootDseHandler($rootDseHandler),
+            $this->backend(),
+        );
 
         self::assertSame(
             $rootDseHandler,
-            $this->subject->makeRootDseHandler(),
+            $subject->makeRootDseHandler(),
         );
     }
 
     public function test_it_should_allow_a_null_rootdse_handler(): void
     {
-        $this->subject = new HandlerFactory(
+        $subject = new HandlerFactory(
             (new ServerOptions())->setRootDseHandler(null),
+            $this->backend(),
         );
 
-        self::assertNull($this->subject->makeRootDseHandler());
+        self::assertNull($subject->makeRootDseHandler());
     }
 
     public function test_it_should_return_the_backend_as_rootdse_handler_if_it_implements_the_interface(): void
@@ -76,11 +70,14 @@ final class HandlerFactoryTest extends TestCase
             RootDseHandlerInterface::class,
         ]);
 
-        $this->subject = new HandlerFactory((new ServerOptions())->setBackend($backend));
+        $subject = new HandlerFactory(
+            new ServerOptions(),
+            $backend,
+        );
 
         self::assertSame(
             $backend,
-            $this->subject->makeRootDseHandler(),
+            $subject->makeRootDseHandler(),
         );
     }
 
@@ -93,20 +90,28 @@ final class HandlerFactoryTest extends TestCase
         ]);
         $explicit = $this->createMock(RootDseHandlerInterface::class);
 
-        $this->subject = new HandlerFactory(
-            (new ServerOptions())
-                ->setBackend($backend)
-                ->setRootDseHandler($explicit),
+        $subject = new HandlerFactory(
+            (new ServerOptions())->setRootDseHandler($explicit),
+            $backend,
         );
 
-        self::assertSame($explicit, $this->subject->makeRootDseHandler());
+        self::assertSame(
+            $explicit,
+            $subject->makeRootDseHandler(),
+        );
     }
 
     public function test_it_returns_default_password_authenticator_when_none_is_configured(): void
     {
-        $subject = new HandlerFactory(new ServerOptions());
+        $subject = new HandlerFactory(
+            new ServerOptions(),
+            $this->backend(),
+        );
 
-        self::assertInstanceOf(PasswordAuthenticator::class, $subject->makePasswordAuthenticator());
+        self::assertInstanceOf(
+            PasswordAuthenticator::class,
+            $subject->makePasswordAuthenticator(),
+        );
     }
 
     public function test_it_prefers_explicitly_configured_password_authenticator(): void
@@ -115,9 +120,13 @@ final class HandlerFactoryTest extends TestCase
 
         $subject = new HandlerFactory(
             (new ServerOptions())->setPasswordAuthenticator($authenticator),
+            $this->backend(),
         );
 
-        self::assertSame($authenticator, $subject->makePasswordAuthenticator());
+        self::assertSame(
+            $authenticator,
+            $subject->makePasswordAuthenticator(),
+        );
     }
 
     public function test_it_returns_backend_as_password_authenticator_if_it_implements_the_interface(): void
@@ -128,9 +137,15 @@ final class HandlerFactoryTest extends TestCase
             PasswordAuthenticatableInterface::class,
         ]);
 
-        $subject = new HandlerFactory((new ServerOptions())->setBackend($backend));
+        $subject = new HandlerFactory(
+            new ServerOptions(),
+            $backend,
+        );
 
-        self::assertSame($backend, $subject->makePasswordAuthenticator());
+        self::assertSame(
+            $backend,
+            $subject->makePasswordAuthenticator(),
+        );
     }
 
     public function test_explicit_password_authenticator_takes_precedence_over_backend(): void
@@ -144,11 +159,18 @@ final class HandlerFactoryTest extends TestCase
         ]);
 
         $subject = new HandlerFactory(
-            (new ServerOptions())
-                ->setBackend($backend)
-                ->setPasswordAuthenticator($authenticator),
+            (new ServerOptions())->setPasswordAuthenticator($authenticator),
+            $backend,
         );
 
-        self::assertSame($authenticator, $subject->makePasswordAuthenticator());
+        self::assertSame(
+            $authenticator,
+            $subject->makePasswordAuthenticator(),
+        );
+    }
+
+    private function backend(): WritableLdapBackendInterface
+    {
+        return $this->createMock(WritableLdapBackendInterface::class);
     }
 }

--- a/tests/unit/ServerOptionsTest.php
+++ b/tests/unit/ServerOptionsTest.php
@@ -24,7 +24,7 @@ use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Sasl\External\ExternalCredentialMapperInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
-use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluator;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
@@ -541,23 +541,6 @@ final class ServerOptionsTest extends TestCase
         );
     }
 
-    public function test_backend_is_null_by_default(): void
-    {
-        self::assertNull($this->subject->getBackend());
-    }
-
-    public function test_it_can_set_backend(): void
-    {
-        $backend = $this->createMock(WritableLdapBackendInterface::class);
-
-        $this->subject->setBackend($backend);
-
-        self::assertSame(
-            $backend,
-            $this->subject->getBackend(),
-        );
-    }
-
     public function test_password_authenticator_is_null_by_default(): void
     {
         self::assertNull($this->subject->getPasswordAuthenticator());
@@ -572,6 +555,33 @@ final class ServerOptionsTest extends TestCase
         self::assertSame(
             $authenticator,
             $this->subject->getPasswordAuthenticator(),
+        );
+    }
+
+    public function test_storage_is_null_by_default(): void
+    {
+        self::assertNull($this->subject->getStorage());
+    }
+
+    public function test_it_can_set_storage(): void
+    {
+        $storage = new InMemoryStorage();
+
+        $this->subject->setStorage($storage);
+
+        self::assertSame(
+            $storage,
+            $this->subject->getStorage(),
+        );
+    }
+
+    public function test_use_in_memory_storage_configures_an_in_memory_directory(): void
+    {
+        $this->subject->useInMemoryStorage();
+
+        self::assertInstanceOf(
+            InMemoryStorage::class,
+            $this->subject->getStorage(),
         );
     }
 


### PR DESCRIPTION
The custom backend for `WritableLdapBackendInterface` was meant as a replacement for the old custom LDAP server implementations that existed on the old main branch (now the maintenance branch). That was when the server was largely a protocol shell with very little LDAP logic and you had to implement a generic handler with your own logic for each LDAP operation.

The situation now is drastically different. The library has PDO / file based storage available. All LDAP server semantics are handled by the library. And anyone trying to implement their own custom backend would be in for a rough time. I really cannot think of a good reason for needing it with the storage solutions in place and all the other features available on the server. I have left the storage adapters interface open as the custom entry point. But the PDO / file implementations should really satisfy pretty much any use case.

I will also likely be dropping the RootDSE handler entry point. I may replace it with a decorator or something, just not the option to fully generate it without help from the library. Because the library advertises things based on config options / other LDAP details, and that really shouldn't be fully delegated out of the library (it's really just a user foot gun to do so). The original reason was so that people could advertise where the subschema entry lived. But that's now handled by the library too with how the schema is provided / configured.