### PR TITLE
[1.0.0] Make sync a privileged control.

### DIFF
--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
@@ -45,7 +45,7 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
 final readonly class OperationAuthorizationMiddleware implements MiddlewareInterface
 {
     /**
-     * @param list<string> $privilegedControls Control OIDs that require an explicit ControlRule grant before use on a write.
+     * @param list<string> $privilegedControls Control OIDs that require an explicit ControlRule grant before use.
      */
     public function __construct(
         private HandlerRouteResolverInterface $routeResolver,
@@ -67,6 +67,11 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
 
         if ($routeId === HandlerId::Search || $routeId === HandlerId::Paging) {
             $this->authorizeSearch(
+                $context->message,
+                $context->tokenOrFail(),
+            );
+        } elseif ($routeId === HandlerId::Sync) {
+            $this->authorizeSync(
                 $context->message,
                 $context->tokenOrFail(),
             );
@@ -113,6 +118,28 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
     }
 
     /**
+     * Gates a content-synchronization search on the privileged sync-request control, targeted at its base DN.
+     *
+     * @throws OperationException
+     */
+    private function authorizeSync(
+        LdapMessageRequest $message,
+        TokenInterface $token,
+    ): void {
+        $request = $message->getRequest();
+
+        if (!$request instanceof SearchRequest) {
+            return;
+        }
+
+        $this->authorizeControls(
+            $request->getBaseDn(),
+            $message->controls(),
+            $token,
+        );
+    }
+
+    /**
      * @throws OperationException
      */
     private function authorizeDispatch(
@@ -141,7 +168,7 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
         }
 
         $this->authorizeControls(
-            $request,
+            OperationTargetDn::of($request),
             $message->controls(),
             $token,
         );
@@ -241,17 +268,15 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
     }
 
     /**
-     * Authorizes any privileged control attached to a write before it is dispatched.
+     * Authorizes any privileged control attached to the request before it is dispatched.
      *
      * @throws OperationException
      */
     private function authorizeControls(
-        RequestInterface $request,
+        ?Dn $dn,
         ControlBag $controls,
         TokenInterface $token,
     ): void {
-        $dn = OperationTargetDn::of($request);
-
         if ($dn === null) {
             return;
         }

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -183,7 +183,10 @@ final class ServerOptions
     /**
      * @var list<string>
      */
-    private array $privilegedControls = [Control::OID_RELAX_RULES];
+    private array $privilegedControls = [
+        Control::OID_RELAX_RULES,
+        Control::OID_SYNC_REQUEST,
+    ];
 
     private ?PasswordPolicy $passwordPolicy = null;
 

--- a/tests/integration/Sync/SyncReplNativeTest.php
+++ b/tests/integration/Sync/SyncReplNativeTest.php
@@ -38,7 +38,10 @@ final class SyncReplNativeTest extends ServerTestCase
         static::initSharedServer(
             'ldap-server',
             'tcp',
-            ['--seed=' . self::SEED_LDIF],
+            [
+                '--seed=' . self::SEED_LDIF,
+                '--allow-sync',
+            ],
         );
     }
 

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -123,6 +123,12 @@ final class LdapServerCommand extends Command
                 'Grant the EXTERNAL cert identity (cn=extuser) the Proxied Authorization control over dc=foo,dc=bar',
             )
             ->addOption(
+                'allow-sync',
+                null,
+                InputOption::VALUE_NONE,
+                'Grant authenticated identities the (privileged) content-sync control over dc=foo,dc=bar',
+            )
+            ->addOption(
                 'seed',
                 null,
                 InputOption::VALUE_REQUIRED,
@@ -263,6 +269,18 @@ final class LdapServerCommand extends Command
                         Subject::dn('cn=extuser,dc=foo,dc=bar'),
                         Target::subtree('dc=foo,dc=bar'),
                         Control::OID_PROXY_AUTHORIZATION,
+                    )),
+            );
+        }
+
+        if ($input->getOption('allow-sync') === true) {
+            $options->setAclRules(
+                (new AclRules())
+                    ->withOperationRules(OperationRule::allow(Subject::authenticated()))
+                    ->withControlRules(ControlRule::allow(
+                        Subject::authenticated(),
+                        Target::subtree('dc=foo,dc=bar'),
+                        Control::OID_SYNC_REQUEST,
                     )),
             );
         }

--- a/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
@@ -312,6 +312,74 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
         self::assertNotNull($this->next->received);
     }
 
+    public function test_sync_route_authorizes_the_sync_control_against_the_base_dn(): void
+    {
+        $subject = new OperationAuthorizationMiddleware(
+            $this->resolver,
+            $this->accessControl,
+            [Control::OID_SYNC_REQUEST],
+        );
+        $this->routeResolvesTo(HandlerId::Sync);
+        $this->accessControl
+            ->expects(self::once())
+            ->method('authorizeControl')
+            ->with(
+                $this->token,
+                self::isInstanceOf(Dn::class),
+                Control::OID_SYNC_REQUEST,
+            );
+
+        $message = new LdapMessageRequest(
+            1,
+            (new SearchRequest(Filters::present('objectClass')))->base('dc=foo,dc=bar'),
+            new Control(Control::OID_SYNC_REQUEST, criticality: true),
+        );
+
+        $subject->process(
+            new ServerRequestContext($message, $this->token),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    public function test_sync_route_control_denial_blocks_dispatch(): void
+    {
+        $subject = new OperationAuthorizationMiddleware(
+            $this->resolver,
+            $this->accessControl,
+            [Control::OID_SYNC_REQUEST],
+        );
+        $this->routeResolvesTo(HandlerId::Sync);
+        $this->accessControl
+            ->method('authorizeControl')
+            ->willThrowException($this->denied());
+
+        $message = new LdapMessageRequest(
+            1,
+            (new SearchRequest(Filters::present('objectClass')))->base('dc=foo,dc=bar'),
+            new Control(Control::OID_SYNC_REQUEST, criticality: true),
+        );
+
+        try {
+            $subject->process(
+                new ServerRequestContext($message, $this->token),
+                $this->next,
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+                $e->getCode(),
+            );
+        }
+
+        self::assertNull(
+            $this->next->received,
+            'Dispatch must be blocked when the sync control is denied.',
+        );
+    }
+
     #[DataProvider('unauthorizedRoutes')]
     public function test_routes_without_operation_authorization_are_not_gated(HandlerId $routeId): void
     {

--- a/tests/unit/ServerOptionsTest.php
+++ b/tests/unit/ServerOptionsTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap;
 
+use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
@@ -50,6 +51,17 @@ final class ServerOptionsTest extends TestCase
     protected function setUp(): void
     {
         $this->subject = new ServerOptions();
+    }
+
+    public function test_privileged_controls_have_the_expected_defaults(): void
+    {
+        self::assertSame(
+            [
+                Control::OID_RELAX_RULES,
+                Control::OID_SYNC_REQUEST,
+            ],
+            $this->subject->getPrivilegedControls(),
+        );
     }
 
     public function test_sasl_mechanisms_are_empty_by_default(): void


### PR DESCRIPTION
Every other LDAP implementation treats it as a gated operation. I'm honestly a little uncertain why it needs to be. It's a search with a filter that's already ACL gated. However, it does keep things tied up and can mean a long running connection that's constantly doing a sync. And it's meant for operational things. So, I'm going to make it a privileged control by default. Allowing it is as easy as just gating it to all authenticated users or whatever you want to do via ACL.