### PR TITLE
[1.0.0] Add the base classes for refreshAndPersist support in both runners.

### DIFF
--- a/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
@@ -21,9 +21,11 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerProtocolHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeStream;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\Clock\BlockingSleeper;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
@@ -35,6 +37,7 @@ use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
 use FreeDSx\Ldap\Server\RequestHistory;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\Sync\Provider\SyncPersistStreamer;
 use FreeDSx\Ldap\Sync\Provider\SyncResultProjector;
 
 /**
@@ -142,21 +145,53 @@ final readonly class ProtocolHandlerProvider implements ProtocolHandlerProviderI
     private function getSyncHandler(?SearchLimits $searchLimits): ServerProtocolHandler\ServerSyncHandler
     {
         $backend = $this->handlerFactory->makeBackend();
+        $journal = $this->syncJournalFor($backend);
+        $projector = new SyncResultProjector(
+            accessControl: $this->options->getAccessControl(),
+            filterEvaluator: $this->options->getFilterEvaluator(),
+            eventLogger: $this->eventLogger,
+        );
+
+        $stream = null;
+        $streamer = null;
+        $persistSupported = false;
+
+        if ($journal !== null) {
+            $stream = new ChangeStream($journal);
+            $streamer = new SyncPersistStreamer(
+                queue: $this->queue,
+                backend: $backend,
+                projector: $projector,
+                stream: $stream,
+                sleeper: new BlockingSleeper(),
+            );
+            // Persist can only deliver writes made on other connections: a single process (Swoole)
+            // shares them in memory, otherwise the journal itself must be cross-process.
+            $persistSupported = $this->options->getUseSwooleRunner()
+                || $journal->sharesAcrossProcesses();
+        }
 
         return new ServerProtocolHandler\ServerSyncHandler(
             queue: $this->queue,
             backend: $backend,
-            projector: new SyncResultProjector(
-                accessControl: $this->options->getAccessControl(),
-                filterEvaluator: $this->options->getFilterEvaluator(),
-                eventLogger: $this->eventLogger,
-            ),
+            projector: $projector,
             limits: $searchLimits ?? $this->options->makeSearchLimits(),
-            changeStream: $this->changeStreamFor($backend),
+            changeStream: $stream,
+            persistStreamer: $streamer,
+            persistSupported: $persistSupported,
         );
     }
 
     private function changeStreamFor(LdapBackendInterface $backend): ?ChangeStream
+    {
+        $journal = $this->syncJournalFor($backend);
+
+        return $journal !== null
+            ? new ChangeStream($journal)
+            : null;
+    }
+
+    private function syncJournalFor(LdapBackendInterface $backend): ?ChangeJournalInterface
     {
         if (!$this->options->isSyncEnabled() || !$backend instanceof WritableStorageBackend) {
             return null;
@@ -168,7 +203,7 @@ final readonly class ProtocolHandlerProvider implements ProtocolHandlerProviderI
             return null;
         }
 
-        return new ChangeStream($storage->changeJournal());
+        return $storage->changeJournal();
     }
 
     private function getDispatchHandler(): ServerProtocolHandler\ServerDispatchHandler

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSyncHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSyncHandler.php
@@ -20,14 +20,14 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
+use FreeDSx\Ldap\Operation\Response\SyncInfo\SyncRefreshDelete;
+use FreeDSx\Ldap\Operation\Response\SyncInfo\SyncRefreshPresent;
+use FreeDSx\Ldap\Operation\Response\SyncInfoMessage;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
-use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
-use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeScope;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeStream;
 use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Operation\SearchOperationResult;
@@ -35,12 +35,13 @@ use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\Sync\Provider\Exception\MalformedSyncCookieException;
 use FreeDSx\Ldap\Sync\Provider\SyncCookie;
+use FreeDSx\Ldap\Sync\Provider\SyncPersistStreamer;
 use FreeDSx\Ldap\Sync\Provider\SyncResult;
 use FreeDSx\Ldap\Sync\Provider\SyncResultProjector;
 use Generator;
 
 /**
- * Serves RFC 4533 content-synchronization (refreshOnly) from the change journal.
+ * Serves RFC 4533 content-synchronization (refreshOnly and refreshAndPersist) from the change journal.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -54,6 +55,8 @@ final class ServerSyncHandler implements ServerProtocolHandlerInterface
         private readonly SyncResultProjector $projector,
         private readonly SearchLimits $limits = new SearchLimits(),
         private readonly ?ChangeStream $changeStream = null,
+        private readonly ?SyncPersistStreamer $persistStreamer = null,
+        private readonly bool $persistSupported = false,
     ) {}
 
     /**
@@ -66,20 +69,17 @@ final class ServerSyncHandler implements ServerProtocolHandlerInterface
         $request = $this->getSearchRequestFromMessage($message);
         $control = $this->syncRequestControl($message);
         $stream = $this->changeStream;
+        $streamer = $this->persistStreamer;
 
-        if ($stream === null) {
+        if ($stream === null || $streamer === null) {
             throw new OperationException(
                 'Content synchronization is not supported.',
                 ResultCode::UNWILLING_TO_PERFORM,
             );
         }
 
-        if ($control->getMode() !== SyncRequestControl::MODE_REFRESH_ONLY) {
-            throw new OperationException(
-                'Only refreshOnly content synchronization is supported.',
-                ResultCode::UNWILLING_TO_PERFORM,
-            );
-        }
+        $mode = $control->getMode();
+        $this->assertModeSupported($mode);
 
         $baseDn = $this->assertBaseDnProvided($request);
         $latestSeq = $stream->latestSeq();
@@ -88,25 +88,60 @@ final class ServerSyncHandler implements ServerProtocolHandlerInterface
 
         $entries = $sinceSeq === null
             ? $this->fullRefreshEntries($message, $request, $token, $state)
-            : $this->incrementalEntries($message, $request, $token, $stream, $sinceSeq, $state);
+            : $this->incrementalEntries($message, $request, $token, $streamer, $sinceSeq, $state);
 
-        // refreshDeletes: a delete phase (true) only for an incremental sync that sent explicit
-        // deletes; a full refresh is a present phase (false) the consumer reconciles by absence.
-        $doneControl = new SyncDoneControl(
-            (new SyncCookie($stream->origin(), $latestSeq))->encode(),
-            $sinceSeq !== null,
-        );
-        $this->queue->sendMessages($this->withSyncDone(
-            $entries,
-            $message->getMessageId(),
-            $baseDn,
-            $doneControl,
-        ));
+        $cookie = (new SyncCookie($stream->origin(), $latestSeq))->encode();
+
+        if ($mode === SyncRequestControl::MODE_REFRESH_AND_PERSIST) {
+            $this->queue->sendMessages($this->withRefreshDone(
+                $entries,
+                $message->getMessageId(),
+                $sinceSeq === null
+                    ? new SyncRefreshPresent(true, $cookie)
+                    : new SyncRefreshDelete(true, $cookie),
+            ));
+            $streamer->persist(
+                $latestSeq,
+                $request,
+                $token,
+                $message->getMessageId(),
+                $baseDn,
+            );
+        } else {
+            // refreshDeletes: a delete phase (true) only for an incremental sync that sent explicit
+            // deletes; a full refresh is a present phase (false) the consumer reconciles by absence.
+            $this->queue->sendMessages($this->withSyncDone(
+                $entries,
+                $message->getMessageId(),
+                $baseDn,
+                new SyncDoneControl($cookie, $sinceSeq !== null),
+            ));
+        }
 
         return SearchOperationResult::success(
             $message,
             $state->entriesReturned,
         );
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function assertModeSupported(int $mode): void
+    {
+        if ($mode !== SyncRequestControl::MODE_REFRESH_ONLY && $mode !== SyncRequestControl::MODE_REFRESH_AND_PERSIST) {
+            throw new OperationException(
+                'The requested content synchronization mode is not supported.',
+                ResultCode::UNWILLING_TO_PERFORM,
+            );
+        }
+
+        if ($mode === SyncRequestControl::MODE_REFRESH_AND_PERSIST && !$this->persistSupported) {
+            throw new OperationException(
+                'The refreshAndPersist synchronization mode is not supported by this server.',
+                ResultCode::UNWILLING_TO_PERFORM,
+            );
+        }
     }
 
     /**
@@ -128,6 +163,25 @@ final class ServerSyncHandler implements ServerProtocolHandlerInterface
                 $baseDn->toString(),
             ),
             $doneControl,
+        );
+    }
+
+    /**
+     * refreshAndPersist ends its refresh phase with a SyncInfo boundary instead of a SearchResultDone.
+     *
+     * @param Generator<LdapMessageResponse> $entries
+     * @return Generator<LdapMessageResponse>
+     */
+    private function withRefreshDone(
+        Generator $entries,
+        int $messageId,
+        SyncInfoMessage $boundary,
+    ): Generator {
+        yield from $entries;
+
+        yield new LdapMessageResponse(
+            $messageId,
+            $boundary,
         );
     }
 
@@ -168,47 +222,16 @@ final class ServerSyncHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         SearchRequest $request,
         TokenInterface $token,
-        ChangeStream $stream,
+        SyncPersistStreamer $streamer,
         int $sinceSeq,
         SearchResultState $state,
     ): Generator {
-        $netByUuid = [];
-
-        foreach ($stream->since($sinceSeq, $this->scopeFor($request)) as $record) {
-            $netByUuid[$record->change->entryUuid] = $record->change;
-        }
-
-        foreach ($netByUuid as $change) {
-            $result = $change->changeType === ChangeType::Delete
-                ? $this->projector->projectDeleted($change, $request, $token)
-                : $this->changedResult($request, $token, $change);
-
+        foreach ($streamer->projectSince($sinceSeq, $request, $token) as $result) {
             yield from $this->emit(
                 $this->toResponse($message->getMessageId(), $result),
                 $state,
             );
         }
-    }
-
-    /**
-     * Re-reads the live entry for a non-delete change; null when it is gone or no longer matches.
-     */
-    private function changedResult(
-        SearchRequest $request,
-        TokenInterface $token,
-        PendingChange $change,
-    ): ?SyncResult {
-        $entry = $this->backend->get($change->dn);
-
-        if ($entry === null) {
-            return null;
-        }
-
-        return $this->projector->projectFetched(
-            $entry,
-            $request,
-            $token,
-        );
     }
 
     private function toResponse(
@@ -270,17 +293,6 @@ final class ServerSyncHandler implements ServerProtocolHandlerInterface
         }
 
         return $decoded->seq;
-    }
-
-    private function scopeFor(SearchRequest $request): ChangeScope
-    {
-        $baseDn = $request->getBaseDn() ?? new Dn('');
-
-        return match ($request->getScope()) {
-            SearchRequest::SCOPE_BASE_OBJECT => ChangeScope::baseObject($baseDn),
-            SearchRequest::SCOPE_SINGLE_LEVEL => ChangeScope::oneLevel($baseDn),
-            default => ChangeScope::wholeSubtree($baseDn),
-        };
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Audit/AuditingChangeJournal.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/Audit/AuditingChangeJournal.php
@@ -80,4 +80,9 @@ final class AuditingChangeJournal implements ChangeJournalInterface
     {
         return $this->journal->origin();
     }
+
+    public function sharesAcrossProcesses(): bool
+    {
+        return $this->journal->sharesAcrossProcesses();
+    }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ChangeJournalInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ChangeJournalInterface.php
@@ -65,4 +65,11 @@ interface ChangeJournalInterface
      * @api
      */
     public function origin(): ReplicaId;
+
+    /**
+     * Whether appends are observable from a separate OS process.
+     *
+     * @api
+     */
+    public function sharesAcrossProcesses(): bool;
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/FileChangeJournal.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/FileChangeJournal.php
@@ -155,6 +155,11 @@ final readonly class FileChangeJournal implements ChangeJournalInterface
         return $this->origin;
     }
 
+    public function sharesAcrossProcesses(): bool
+    {
+        return true;
+    }
+
     private function decodeLine(string $line): ?ChangeRecord
     {
         $row = $this->serializer->decode($line);

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/InMemoryChangeJournal.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/InMemoryChangeJournal.php
@@ -80,6 +80,11 @@ final class InMemoryChangeJournal implements ChangeJournalInterface
         return $this->origin;
     }
 
+    public function sharesAcrossProcesses(): bool
+    {
+        return false;
+    }
+
     public function prune(RetentionPolicy $policy): int
     {
         $before = count($this->records);

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/PdoChangeJournal.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/PdoChangeJournal.php
@@ -131,6 +131,11 @@ final readonly class PdoChangeJournal implements ChangeJournalInterface
         return $this->origin;
     }
 
+    public function sharesAcrossProcesses(): bool
+    {
+        return true;
+    }
+
     private function pruneToRecordCap(int $maxRecords): int
     {
         $pdo = $this->transactor->pdo();

--- a/src/FreeDSx/Ldap/Server/Clock/BlockingSleeper.php
+++ b/src/FreeDSx/Ldap/Server/Clock/BlockingSleeper.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Clock;
+
+use function usleep;
+
+/**
+ * Blocking sleeper.
+ *
+ * PCNTL runs per-process, so it's fine. Yields under coroutines like Swoole (via the SWOOLE_HOOK_SLEEP runtime hook).
+ */
+final class BlockingSleeper implements Sleeper
+{
+    public function sleep(float $seconds): void
+    {
+        if ($seconds <= 0.0) {
+            return;
+        }
+
+        usleep((int) ($seconds * 1_000_000));
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Clock/Sleeper.php
+++ b/src/FreeDSx/Ldap/Server/Clock/Sleeper.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Clock;
+
+/**
+ * Pauses execution for a duration, cooperating with the runner.
+ */
+interface Sleeper
+{
+    public function sleep(float $seconds): void;
+}

--- a/src/FreeDSx/Ldap/Sync/Provider/SyncPersistStreamer.php
+++ b/src/FreeDSx/Ldap/Sync/Provider/SyncPersistStreamer.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Sync\Provider;
+
+use FreeDSx\Ldap\Control\Sync\SyncDoneControl;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Operation\LdapResult;
+use FreeDSx\Ldap\Operation\Request\CancelRequest;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
+use FreeDSx\Ldap\Operation\Response\SearchResultDone;
+use FreeDSx\Ldap\Operation\Response\SyncInfo\SyncNewCookie;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeScope;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeStream;
+use FreeDSx\Ldap\Server\Clock\Sleeper;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+
+/**
+ * Tails the change journal for a refreshAndPersist consumer, pushing changes until it cancels or disconnects.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class SyncPersistStreamer
+{
+    /**
+     * Seconds between journal polls; also bounds change-delivery latency and dead-peer detection.
+     */
+    public const DEFAULT_POLL_INTERVAL = 1.0;
+
+    public function __construct(
+        private ServerQueue $queue,
+        private LdapBackendInterface $backend,
+        private SyncResultProjector $projector,
+        private ChangeStream $stream,
+        private Sleeper $sleeper,
+        private float $pollInterval = self::DEFAULT_POLL_INTERVAL,
+    ) {}
+
+    /**
+     * The net effect of journal changes since a sequence, as sync results (adds and deletes).
+     *
+     * @return iterable<SyncResult>
+     */
+    public function projectSince(
+        int $sinceSeq,
+        SearchRequest $request,
+        TokenInterface $token,
+    ): iterable {
+        $scope = $this->scopeFor($request);
+        $netByUuid = [];
+
+        foreach ($this->stream->since($sinceSeq, $scope) as $record) {
+            $netByUuid[$record->change->entryUuid] = $record->change;
+        }
+
+        foreach ($netByUuid as $change) {
+            $result = $change->changeType === ChangeType::Delete
+                ? $this->projector->projectDeleted($change, $request, $token)
+                : $this->fetchAndProject($change, $request, $token);
+
+            if ($result !== null) {
+                yield $result;
+            }
+        }
+    }
+
+    /**
+     * Runs the persist phase: pushes each change as it lands, advancing the cookie, until cancel or disconnect.
+     */
+    public function persist(
+        int $startSeq,
+        SearchRequest $request,
+        TokenInterface $token,
+        int $messageId,
+        Dn $baseDn,
+    ): void {
+        $lastSeq = $startSeq;
+        $origin = $this->stream->origin();
+
+        while (true) {
+            $latestSeq = $this->stream->latestSeq();
+
+            // A trim past the consumer's position would silently drop changes: force a full re-sync instead.
+            if ($latestSeq > $lastSeq && !$this->stream->retainsSince($lastSeq)) {
+                $this->sendRefreshRequired($messageId, $baseDn, $origin, $latestSeq);
+
+                return;
+            }
+
+            if ($latestSeq > $lastSeq) {
+                $this->pushChanges($lastSeq, $request, $token, $messageId);
+                $lastSeq = $latestSeq;
+            }
+
+            // Advances the client cookie, and doubles as a keepalive that surfaces a dead peer on the next poll.
+            $this->queue->sendMessage(new LdapMessageResponse(
+                $messageId,
+                new SyncNewCookie((new SyncCookie($origin, $lastSeq))->encode()),
+            ));
+
+            $signal = $this->queue->peekForCancelSignal($messageId);
+
+            if ($signal !== null) {
+                $this->sendTerminal($signal, $messageId, $baseDn, $origin, $lastSeq);
+
+                return;
+            }
+
+            $this->sleeper->sleep($this->pollInterval);
+        }
+    }
+
+    private function pushChanges(
+        int $sinceSeq,
+        SearchRequest $request,
+        TokenInterface $token,
+        int $messageId,
+    ): void {
+        foreach ($this->projectSince($sinceSeq, $request, $token) as $result) {
+            $this->queue->sendMessage(new LdapMessageResponse(
+                $messageId,
+                $result->entry,
+                $result->control,
+            ));
+        }
+    }
+
+    private function fetchAndProject(
+        PendingChange $change,
+        SearchRequest $request,
+        TokenInterface $token,
+    ): ?SyncResult {
+        $entry = $this->backend->get($change->dn);
+
+        if ($entry === null) {
+            return null;
+        }
+
+        return $this->projector->projectFetched(
+            $entry,
+            $request,
+            $token,
+        );
+    }
+
+    private function scopeFor(SearchRequest $request): ChangeScope
+    {
+        $baseDn = $request->getBaseDn() ?? new Dn('');
+
+        return match ($request->getScope()) {
+            SearchRequest::SCOPE_BASE_OBJECT => ChangeScope::baseObject($baseDn),
+            SearchRequest::SCOPE_SINGLE_LEVEL => ChangeScope::oneLevel($baseDn),
+            default => ChangeScope::wholeSubtree($baseDn),
+        };
+    }
+
+    private function sendTerminal(
+        LdapMessageRequest $signal,
+        int $messageId,
+        Dn $baseDn,
+        ReplicaId $origin,
+        int $lastSeq,
+    ): void {
+        // Abandon carries no response (RFC 4511 §4.11); only a Cancel gets an acknowledged close.
+        if (!($signal->getRequest() instanceof CancelRequest)) {
+            return;
+        }
+
+        $this->queue->sendMessage(
+            new LdapMessageResponse(
+                $messageId,
+                new SearchResultDone(
+                    ResultCode::CANCELED,
+                    $baseDn->toString(),
+                ),
+                new SyncDoneControl(
+                    (new SyncCookie($origin, $lastSeq))->encode(),
+                    true,
+                ),
+            ),
+            new LdapMessageResponse(
+                $signal->getMessageId(),
+                new ExtendedResponse(new LdapResult(ResultCode::SUCCESS)),
+            ),
+        );
+    }
+
+    private function sendRefreshRequired(
+        int $messageId,
+        Dn $baseDn,
+        ReplicaId $origin,
+        int $latestSeq,
+    ): void {
+        $this->queue->sendMessage(new LdapMessageResponse(
+            $messageId,
+            new SearchResultDone(
+                ResultCode::SYNCHRONIZATION_REFRESH_REQUIRED,
+                $baseDn->toString(),
+            ),
+            new SyncDoneControl(
+                (new SyncCookie($origin, $latestSeq))->encode(),
+                true,
+            ),
+        ));
+    }
+}

--- a/tests/support/Server/Clock/CallbackSleeper.php
+++ b/tests/support/Server/Clock/CallbackSleeper.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Support\FreeDSx\Ldap\Server\Clock;
+
+use Closure;
+use FreeDSx\Ldap\Server\Clock\Sleeper;
+use RuntimeException;
+
+/**
+ * Test sleeper that runs an optional callback each tick and caps iterations so a runaway loop fails fast.
+ */
+final class CallbackSleeper implements Sleeper
+{
+    private int $ticks = 0;
+
+    public function __construct(
+        private readonly ?Closure $onSleep = null,
+        private readonly int $maxTicks = 20,
+    ) {}
+
+    public function sleep(float $seconds): void
+    {
+        if (++$this->ticks > $this->maxTicks) {
+            throw new RuntimeException('The loop did not terminate within the expected number of iterations.');
+        }
+
+        if ($this->onSleep !== null) {
+            ($this->onSleep)();
+        }
+    }
+}

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSyncHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSyncHandlerTest.php
@@ -20,9 +20,11 @@ use FreeDSx\Ldap\Control\Sync\SyncStateControl;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\CancelRequest;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
+use FreeDSx\Ldap\Operation\Response\SyncInfo\SyncRefreshPresent;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
@@ -43,7 +45,9 @@ use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
 use FreeDSx\Ldap\Server\Operation\OperationOutcome;
 use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\Server\Clock\BlockingSleeper;
 use FreeDSx\Ldap\Sync\Provider\SyncCookie;
+use FreeDSx\Ldap\Sync\Provider\SyncPersistStreamer;
 use FreeDSx\Ldap\Sync\Provider\SyncResultProjector;
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -70,7 +74,18 @@ final class ServerSyncHandlerTest extends TestCase
 
     private InMemoryChangeJournal $journal;
 
+    private ChangeStream $changeStream;
+
+    private SyncResultProjector $syncProjector;
+
+    private SyncPersistStreamer $persistStreamer;
+
     private ServerSyncHandler $subject;
+
+    /**
+     * @var list<?LdapMessageRequest> cancel/abandon signals the persist loop peeks, in order
+     */
+    private array $cancelSignals = [];
 
     /**
      * @var list<LdapMessageResponse>
@@ -132,15 +147,38 @@ final class ServerSyncHandlerTest extends TestCase
 
                 return $this->queue;
             });
+        $this->queue
+            ->method('sendMessage')
+            ->willReturnCallback(function (LdapMessageResponse ...$responses): ServerQueue {
+                foreach ($responses as $response) {
+                    $this->sent[] = $response;
+                }
+
+                return $this->queue;
+            });
+        $this->queue
+            ->method('peekForCancelSignal')
+            ->willReturnCallback(fn(): ?LdapMessageRequest => array_shift($this->cancelSignals));
+
+        $this->changeStream = new ChangeStream($this->journal);
+        $this->syncProjector = new SyncResultProjector(
+            accessControl: $this->accessControl,
+            filterEvaluator: $this->filterEvaluator,
+        );
+        $this->persistStreamer = new SyncPersistStreamer(
+            queue: $this->queue,
+            backend: $this->backend,
+            projector: $this->syncProjector,
+            stream: $this->changeStream,
+            sleeper: new BlockingSleeper(),
+        );
 
         $this->subject = new ServerSyncHandler(
             queue: $this->queue,
             backend: $this->backend,
-            projector: new SyncResultProjector(
-                accessControl: $this->accessControl,
-                filterEvaluator: $this->filterEvaluator,
-            ),
-            changeStream: new ChangeStream($this->journal),
+            projector: $this->syncProjector,
+            changeStream: $this->changeStream,
+            persistStreamer: $this->persistStreamer,
         );
     }
 
@@ -407,12 +445,39 @@ final class ServerSyncHandlerTest extends TestCase
         self::assertTrue($this->doneControl()->getRefreshDeletes());
     }
 
-    public function test_refresh_and_persist_is_declined(): void
+    public function test_refresh_and_persist_is_declined_when_persist_is_unsupported(): void
     {
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
 
         $this->handle(null, mode: SyncRequestControl::MODE_REFRESH_AND_PERSIST);
+    }
+
+    public function test_refresh_and_persist_full_refresh_ends_the_refresh_phase_with_a_present_boundary(): void
+    {
+        $this->searchEntries = [$this->entry('cn=a,dc=example,dc=com', self::UUID_A)];
+        // A pending cancel terminates the persist loop after the boundary is emitted.
+        $this->cancelSignals = [new LdapMessageRequest(9, new CancelRequest(1))];
+
+        $this->persistHandler()->handleRequest(
+            $this->syncMessage(null, SyncRequestControl::MODE_REFRESH_AND_PERSIST),
+            $this->token,
+        );
+
+        $boundary = null;
+        foreach ($this->sent as $message) {
+            if ($message->getResponse() instanceof SyncRefreshPresent) {
+                $boundary = $message->getResponse();
+
+                break;
+            }
+        }
+
+        self::assertInstanceOf(
+            SyncRefreshPresent::class,
+            $boundary,
+        );
+        self::assertTrue($boundary->getRefreshDone());
     }
 
     public function test_sync_is_declined_when_no_change_stream_is_available(): void
@@ -432,6 +497,18 @@ final class ServerSyncHandlerTest extends TestCase
         $handler->handleRequest(
             $this->syncMessage(null),
             $this->token,
+        );
+    }
+
+    private function persistHandler(): ServerSyncHandler
+    {
+        return new ServerSyncHandler(
+            queue: $this->queue,
+            backend: $this->backend,
+            projector: $this->syncProjector,
+            changeStream: $this->changeStream,
+            persistStreamer: $this->persistStreamer,
+            persistSupported: true,
         );
     }
 

--- a/tests/unit/Sync/Provider/SyncPersistStreamerTest.php
+++ b/tests/unit/Sync/Provider/SyncPersistStreamerTest.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Sync\Provider;
+
+use Closure;
+use FreeDSx\Ldap\Control\Sync\SyncDoneControl;
+use FreeDSx\Ldap\Control\Sync\SyncStateControl;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Operation\Request\AbandonRequest;
+use FreeDSx\Ldap\Operation\Request\CancelRequest;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\Response\SearchResultDone;
+use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
+use FreeDSx\Ldap\Operation\Response\SyncInfo\SyncNewCookie;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\InMemoryChangeJournal;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeStream;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+use FreeDSx\Ldap\Sync\Provider\SyncPersistStreamer;
+use FreeDSx\Ldap\Sync\Provider\SyncResultProjector;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Server\Clock\CallbackSleeper;
+
+final class SyncPersistStreamerTest extends TestCase
+{
+    private const ORIGIN = 'test-origin';
+
+    private const ENTRY_DN = 'cn=new,dc=example,dc=com';
+
+    private const ENTRY_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+    private ServerQueue&MockObject $queue;
+
+    private LdapBackendInterface&MockObject $backend;
+
+    private TokenInterface&MockObject $token;
+
+    private InMemoryChangeJournal $journal;
+
+    private SyncPersistStreamer $subject;
+
+    /**
+     * @var list<LdapMessageResponse>
+     */
+    private array $sent = [];
+
+    /**
+     * @var list<?LdapMessageRequest>
+     */
+    private array $cancelSignals = [];
+
+    /**
+     * @var array<string, Entry>
+     */
+    private array $liveEntries = [];
+
+    private Closure $onSleep;
+
+    protected function setUp(): void
+    {
+        $this->onSleep = static function (): void {};
+        $this->journal = new InMemoryChangeJournal(new ReplicaId(self::ORIGIN));
+        $this->token = $this->createMock(TokenInterface::class);
+
+        $this->queue = $this->createMock(ServerQueue::class);
+        $this->queue
+            ->method('sendMessage')
+            ->willReturnCallback(function (LdapMessageResponse ...$responses): ServerQueue {
+                foreach ($responses as $response) {
+                    $this->sent[] = $response;
+                }
+
+                return $this->queue;
+            });
+        $this->queue
+            ->method('peekForCancelSignal')
+            ->willReturnCallback(fn(): ?LdapMessageRequest => array_shift($this->cancelSignals));
+
+        $this->backend = $this->createMock(LdapBackendInterface::class);
+        $this->backend
+            ->method('get')
+            ->willReturnCallback(fn(Dn $dn): ?Entry => $this->liveEntries[$dn->toString()] ?? null);
+
+        $accessControl = $this->createMock(AccessControlInterface::class);
+        $accessControl
+            ->method('filterEntry')
+            ->willReturnArgument(1);
+        $filterEvaluator = $this->createMock(FilterEvaluatorInterface::class);
+        $filterEvaluator
+            ->method('evaluate')
+            ->willReturn(true);
+
+        $this->subject = new SyncPersistStreamer(
+            queue: $this->queue,
+            backend: $this->backend,
+            projector: new SyncResultProjector(
+                accessControl: $accessControl,
+                filterEvaluator: $filterEvaluator,
+            ),
+            stream: new ChangeStream($this->journal),
+            sleeper: new CallbackSleeper(fn() => ($this->onSleep)()),
+            pollInterval: 0.0,
+        );
+    }
+
+    public function test_a_cancel_closes_the_stream_with_a_canceled_result_and_acknowledges_the_cancel(): void
+    {
+        $this->cancelSignals = [new LdapMessageRequest(9, new CancelRequest(5))];
+
+        $this->persist();
+
+        $done = $this->firstSent(fn(LdapMessageResponse $m): bool => $m->getResponse() instanceof SearchResultDone);
+        self::assertNotNull($done);
+        $response = $done->getResponse();
+        self::assertInstanceOf(SearchResultDone::class, $response);
+        self::assertSame(
+            ResultCode::CANCELED,
+            $response->getResultCode(),
+        );
+        self::assertSame(
+            5,
+            $done->getMessageId(),
+        );
+        self::assertNotNull($done->controls()->getByClass(SyncDoneControl::class));
+
+        $ack = $this->firstSent(fn(LdapMessageResponse $m): bool => $m->getMessageId() === 9);
+        self::assertNotNull($ack);
+    }
+
+    public function test_an_abandon_closes_the_stream_without_any_response(): void
+    {
+        $this->cancelSignals = [new LdapMessageRequest(9, new AbandonRequest(5))];
+
+        $this->persist();
+
+        self::assertNull(
+            $this->firstSent(fn(LdapMessageResponse $m): bool => $m->getResponse() instanceof SearchResultDone),
+            'An abandon must not produce a SearchResultDone.',
+        );
+        self::assertNotNull(
+            $this->firstSent(fn(LdapMessageResponse $m): bool => $m->getResponse() instanceof SyncNewCookie),
+        );
+    }
+
+    public function test_a_change_that_lands_during_the_loop_is_pushed_as_an_add(): void
+    {
+        $this->liveEntries[self::ENTRY_DN] = $this->entry();
+        $this->onSleep = function (): void {
+            $this->append(ChangeType::Add);
+            $this->cancelSignals[] = new LdapMessageRequest(9, new CancelRequest(5));
+        };
+
+        $this->persist();
+
+        $entry = $this->firstSent(fn(LdapMessageResponse $m): bool => $m->getResponse() instanceof SearchResultEntry);
+        self::assertNotNull($entry);
+        $response = $entry->getResponse();
+        self::assertInstanceOf(SearchResultEntry::class, $response);
+        self::assertSame(
+            self::ENTRY_DN,
+            $response->getEntry()->getDn()->toString(),
+        );
+        $state = $entry->controls()->getByClass(SyncStateControl::class);
+        self::assertNotNull($state);
+        self::assertSame(
+            SyncStateControl::STATE_ADD,
+            $state->getState(),
+        );
+    }
+
+    public function test_a_trim_past_the_consumer_position_ends_with_refresh_required(): void
+    {
+        $journal = $this->createMock(ChangeJournalInterface::class);
+        $journal
+            ->method('latestSeq')
+            ->willReturn(5);
+        $journal
+            ->method('retainsSince')
+            ->willReturn(false);
+        $journal
+            ->method('origin')
+            ->willReturn(new ReplicaId(self::ORIGIN));
+
+        $subject = new SyncPersistStreamer(
+            queue: $this->queue,
+            backend: $this->backend,
+            projector: new SyncResultProjector(
+                accessControl: $this->createMock(AccessControlInterface::class),
+                filterEvaluator: $this->createMock(FilterEvaluatorInterface::class),
+            ),
+            stream: new ChangeStream($journal),
+            sleeper: new CallbackSleeper(),
+            pollInterval: 0.0,
+        );
+
+        $subject->persist(
+            0,
+            $this->request(),
+            $this->token,
+            5,
+            new Dn('dc=example,dc=com'),
+        );
+
+        $done = $this->firstSent(fn(LdapMessageResponse $m): bool => $m->getResponse() instanceof SearchResultDone);
+        self::assertNotNull($done);
+        $response = $done->getResponse();
+        self::assertInstanceOf(SearchResultDone::class, $response);
+        self::assertSame(
+            ResultCode::SYNCHRONIZATION_REFRESH_REQUIRED,
+            $response->getResultCode(),
+        );
+    }
+
+    private function persist(): void
+    {
+        $this->subject->persist(
+            0,
+            $this->request(),
+            $this->token,
+            5,
+            new Dn('dc=example,dc=com'),
+        );
+    }
+
+    private function request(): SearchRequest
+    {
+        return (new SearchRequest(Filters::present('objectClass')))
+            ->base('dc=example,dc=com')
+            ->useSubtreeScope();
+    }
+
+    private function firstSent(callable $predicate): ?LdapMessageResponse
+    {
+        foreach ($this->sent as $message) {
+            if ($predicate($message)) {
+                return $message;
+            }
+        }
+
+        return null;
+    }
+
+    private function append(ChangeType $type): void
+    {
+        $this->journal->append(new PendingChange(
+            changeType: $type,
+            dn: new Dn(self::ENTRY_DN),
+            entryUuid: self::ENTRY_UUID,
+            authzId: AuthzId::anonymous(),
+        ));
+    }
+
+    private function entry(): Entry
+    {
+        return Entry::create(
+            self::ENTRY_DN,
+            [
+                'objectClass' => 'inetOrgPerson',
+                'cn' => 'new',
+                'entryUUID' => self::ENTRY_UUID,
+            ],
+        );
+    }
+}


### PR DESCRIPTION
This adds the foundation of what both runners need to refreshAndPersist mode support of sync. Each will need their own internal details, as PCNTL / Swoole will both go about it in different ways. So I will add them under separate PRs.