### PR TITLE
[1.0.0] Support swoole based refreshAndPersist for sync.

### DIFF
--- a/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
@@ -25,7 +25,8 @@ use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeStream;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
-use FreeDSx\Ldap\Server\Clock\BlockingSleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\CoroutineSleeper;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
@@ -163,7 +164,9 @@ final readonly class ProtocolHandlerProvider implements ProtocolHandlerProviderI
                 backend: $backend,
                 projector: $projector,
                 stream: $stream,
-                sleeper: new BlockingSleeper(),
+                sleeper: $this->options->getUseSwooleRunner()
+                    ? new CoroutineSleeper()
+                    : new BlockingSleeper(),
             );
             // Persist can only deliver writes made on other connections: a single process (Swoole)
             // shares them in memory, otherwise the journal itself must be cross-process.

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/WriteSerializingStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/WriteSerializingStorage.php
@@ -15,9 +15,14 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Writer;
 
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Server\Backend\ResettableInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 
 /**
@@ -25,7 +30,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final readonly class WriteSerializingStorage implements EntryStorageInterface, ResettableInterface
+final readonly class WriteSerializingStorage implements EntryStorageInterface, ResettableInterface, ChangeJournalingInterface
 {
     public function __construct(
         private EntryStorageInterface $reads,
@@ -91,5 +96,43 @@ final readonly class WriteSerializingStorage implements EntryStorageInterface, R
         if ($this->writes instanceof ResettableInterface) {
             $this->writes->reset();
         }
+    }
+
+    /**
+     * Configures the journal on both storages.
+     *
+     * The writer captures changes and the reader serves sync polls.
+     */
+    public function configureJournal(ChangeJournalConfig $config): void
+    {
+        $this->journaling($this->writes)->configureJournal($config);
+        $this->journaling($this->reads)->configureJournal($config);
+    }
+
+    /**
+     * Defensive delegate.
+     *
+     * The journal appends actually run on the write storage.
+     */
+    public function appendChange(PendingChange $change): void
+    {
+        $this->journaling($this->writes)->appendChange($change);
+    }
+
+    /**
+     * Reads through the per-coroutine storage so sync polls never contend with the serialized writer.
+     */
+    public function changeJournal(): ChangeJournalInterface
+    {
+        return $this->journaling($this->reads)->changeJournal();
+    }
+
+    private function journaling(EntryStorageInterface $storage): ChangeJournalingInterface
+    {
+        if (!$storage instanceof ChangeJournalingInterface) {
+            throw new InvalidArgumentException('The underlying storage does not support change journaling.');
+        }
+
+        return $storage;
     }
 }

--- a/src/FreeDSx/Ldap/Server/Clock/Sleeper/BlockingSleeper.php
+++ b/src/FreeDSx/Ldap/Server/Clock/Sleeper/BlockingSleeper.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Clock\Sleeper;
+
+use function usleep;
+
+/**
+ * Blocking sleeper.
+ */
+final class BlockingSleeper implements SleeperInterface
+{
+    public function sleep(float $seconds): void
+    {
+        if ($seconds <= 0.0) {
+            return;
+        }
+
+        usleep((int) ($seconds * 1_000_000));
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Clock/Sleeper/CoroutineSleeper.php
+++ b/src/FreeDSx/Ldap/Server/Clock/Sleeper/CoroutineSleeper.php
@@ -11,16 +11,14 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap\Server\Clock;
+namespace FreeDSx\Ldap\Server\Clock\Sleeper;
 
-use function usleep;
+use Swoole\Coroutine;
 
 /**
- * Blocking sleeper.
- *
- * PCNTL runs per-process, so it's fine. Yields under coroutines like Swoole (via the SWOOLE_HOOK_SLEEP runtime hook).
+ * Yields the current coroutine for a swoole safe sleeper.
  */
-final class BlockingSleeper implements Sleeper
+final class CoroutineSleeper implements SleeperInterface
 {
     public function sleep(float $seconds): void
     {
@@ -28,6 +26,6 @@ final class BlockingSleeper implements Sleeper
             return;
         }
 
-        usleep((int) ($seconds * 1_000_000));
+        Coroutine::sleep($seconds);
     }
 }

--- a/src/FreeDSx/Ldap/Server/Clock/Sleeper/SleeperInterface.php
+++ b/src/FreeDSx/Ldap/Server/Clock/Sleeper/SleeperInterface.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap\Server\Clock;
+namespace FreeDSx\Ldap\Server\Clock\Sleeper;
 
 /**
- * Pauses execution for a duration, cooperating with the runner.
+ * Pauses execution for a duration (which has runner-specific requirements).
  */
-interface Sleeper
+interface SleeperInterface
 {
     public function sleep(float $seconds): void;
 }

--- a/src/FreeDSx/Ldap/Sync/Provider/SyncPersistStreamer.php
+++ b/src/FreeDSx/Ldap/Sync/Provider/SyncPersistStreamer.php
@@ -31,7 +31,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeScope;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeStream;
-use FreeDSx\Ldap\Server\Clock\Sleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -51,7 +51,7 @@ final readonly class SyncPersistStreamer
         private LdapBackendInterface $backend,
         private SyncResultProjector $projector,
         private ChangeStream $stream,
-        private Sleeper $sleeper,
+        private SleeperInterface $sleeper,
         private float $pollInterval = self::DEFAULT_POLL_INTERVAL,
     ) {}
 

--- a/tests/integration/Sync/SyncReplPcntlPersistTest.php
+++ b/tests/integration/Sync/SyncReplPcntlPersistTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Sync;
+
+/**
+ * refreshAndPersist under the PCNTL runner, with SqliteStorage supplying the cross-process journal.
+ */
+final class SyncReplPcntlPersistTest extends SyncReplPersistTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        if (!extension_loaded('pcntl')) {
+            return;
+        }
+
+        static::initSharedServer(
+            'ldap-server',
+            'tcp',
+            static::persistServerArgs(),
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        static::tearDownSharedServer();
+    }
+}

--- a/tests/integration/Sync/SyncReplPersistTestCase.php
+++ b/tests/integration/Sync/SyncReplPersistTestCase.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Sync;
+
+use Closure;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\CancelRequestException;
+use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Session;
+use FreeDSx\Ldap\Sync\SyncRepl;
+use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+
+/**
+ * Shared end-to-end RFC 4533 refreshAndPersist coverage.
+ */
+abstract class SyncReplPersistTestCase extends ServerTestCase
+{
+    protected const SEED_LDIF = __DIR__ . '/../../resources/seed/sync-seed.ldif';
+
+    private const LISTEN_READ_TIMEOUT = 20;
+
+    public function setUp(): void
+    {
+        $this->setServerMode('ldap-server');
+
+        parent::setUp();
+    }
+
+    public function testListenReceivesAnAddMadeDuringThePersistPhase(): void
+    {
+        $dn = 'cn=persist-add,dc=foo,dc=bar';
+        $cookies = [];
+        $seenRefresh = false;
+        $result = null;
+        $wrote = false;
+
+        $syncRepl = $this->boundSync();
+        $syncRepl->useCookieHandler(function (string $cookie) use (&$cookies): void {
+            $cookies[] = $cookie;
+        });
+
+        $syncRepl->listen(function (SyncEntryResult $entry, Session $session) use (&$seenRefresh, &$result, &$wrote, $dn): void {
+            if (!$session->isRefreshComplete()) {
+                $seenRefresh = true;
+
+                if (!$wrote) {
+                    $wrote = true;
+                    $this->onAnotherConnection(fn(LdapClient $w) => $w->create(Entry::fromArray(
+                        $dn,
+                        [
+                            'cn' => 'persist-add',
+                            'sn' => 'Added',
+                            'objectClass' => 'inetOrgPerson',
+                        ],
+                    )));
+                }
+
+                return;
+            }
+
+            $result = $entry;
+
+            throw new CancelRequestException();
+        });
+
+        self::assertTrue($seenRefresh);
+        self::assertInstanceOf(
+            SyncEntryResult::class,
+            $result,
+        );
+        self::assertTrue(
+            $result->isAdd(),
+            'The persisted change is delivered as an add state.',
+        );
+        self::assertSame(
+            $dn,
+            strtolower($result->getEntry()->getDn()->toString()),
+        );
+        self::assertNotEmpty(
+            $cookies,
+            'The refresh boundary and persist phase advance the cookie via SyncInfo messages.',
+        );
+    }
+
+    public function testPersistDeliversADeletion(): void
+    {
+        $dn = 'cn=persist-delete,dc=foo,dc=bar';
+        $result = null;
+        $wrote = false;
+
+        $syncRepl = $this->boundSync();
+
+        $syncRepl->listen(function (SyncEntryResult $entry, Session $session) use (&$result, &$wrote, $dn): void {
+            if (!$session->isRefreshComplete()) {
+                if (!$wrote) {
+                    $wrote = true;
+                    // Add then delete the same entry after the refresh boundary.
+                    $this->onAnotherConnection(function (LdapClient $w) use ($dn): void {
+                        $w->create(Entry::fromArray(
+                            $dn,
+                            [
+                                'cn' => 'persist-delete',
+                                'sn' => 'Doomed',
+                                'objectClass' => 'inetOrgPerson',
+                            ],
+                        ));
+                        $w->delete($dn);
+                    });
+                }
+
+                return;
+            }
+
+            $result = $entry;
+
+            throw new CancelRequestException();
+        });
+
+        self::assertInstanceOf(
+            SyncEntryResult::class,
+            $result,
+        );
+        self::assertTrue(
+            $result->isDelete(),
+            'A removal is delivered with the delete sync state.',
+        );
+        self::assertSame(
+            $dn,
+            strtolower($result->getEntry()->getDn()->toString()),
+        );
+    }
+
+    public function testListenResumesFromACookieWithAnIncrementalRefresh(): void
+    {
+        $dn = 'cn=persist-resume,dc=foo,dc=bar';
+
+        // A cookieless poll gives us the current position, then a change is made past it.
+        $cookie = $this->currentCookie();
+        $this->onAnotherConnection(fn(LdapClient $w) => $w->create(Entry::fromArray(
+            $dn,
+            [
+                'cn' => 'persist-resume',
+                'sn' => 'Resumed',
+                'objectClass' => 'inetOrgPerson',
+            ],
+        )));
+
+        $seen = null;
+
+        $syncRepl = $this->boundSync();
+        $syncRepl->useCookie($cookie);
+
+        // Resuming from the cookie makes the refresh phase incremental (a SyncRefreshDelete boundary)
+        $syncRepl->listen(function (SyncEntryResult $entry) use (&$seen): void {
+            $seen = strtolower($entry->getEntry()->getDn()->toString());
+
+            throw new CancelRequestException();
+        });
+
+        self::assertSame(
+            $dn,
+            $seen,
+        );
+    }
+
+    /**
+     * Server flags shared by every runner.
+     *
+     * @return list<string>
+     */
+    protected static function persistServerArgs(): array
+    {
+        return [
+            '--storage=sqlite',
+            '--seed=' . self::SEED_LDIF,
+            '--allow-sync',
+        ];
+    }
+
+    private function currentCookie(): string
+    {
+        $cookie = null;
+        $sync = $this->boundSync();
+        $sync->useCookieHandler(function (string $value) use (&$cookie): void {
+            $cookie = $value;
+        });
+        $sync->poll();
+
+        self::assertNotNull(
+            $cookie,
+            'A poll returns the current sync cookie.',
+        );
+
+        return $cookie;
+    }
+
+    private function onAnotherConnection(Closure $do): void
+    {
+        $writer = $this->buildClient('tcp');
+
+        try {
+            $writer->bind('cn=user,dc=foo,dc=bar', '12345');
+            $do($writer);
+        } finally {
+            $writer->unbind();
+        }
+    }
+
+    private function boundSync(): SyncRepl
+    {
+        $client = $this->listenClient();
+        $client->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $syncRepl = $client->syncRepl();
+        $syncRepl->request()
+            ->base('dc=foo,dc=bar')
+            ->useSubtreeScope();
+
+        return $syncRepl;
+    }
+
+    private function listenClient(): LdapClient
+    {
+        return $this->getClient(
+            $this->makeOptions()
+                ->setPort(10389)
+                ->setTransport('tcp')
+                ->setServers(['127.0.0.1'])
+                ->setSslValidateCert(false)
+                ->setTimeoutRead(self::LISTEN_READ_TIMEOUT),
+        );
+    }
+}

--- a/tests/integration/Sync/SyncReplSwoolePersistTest.php
+++ b/tests/integration/Sync/SyncReplSwoolePersistTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Sync;
+
+/**
+ * refreshAndPersist under the Swoole runner.
+ */
+final class SyncReplSwoolePersistTest extends SyncReplPersistTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!extension_loaded('swoole')) {
+            return;
+        }
+
+        static::initSharedServer(
+            'ldap-server',
+            'tcp',
+            [
+                ...static::persistServerArgs(),
+                '--runner=swoole',
+            ],
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        static::tearDownSharedServer();
+    }
+
+    public function setUp(): void
+    {
+        if (!extension_loaded('swoole')) {
+            $this->markTestSkipped('The swoole extension is required to run SwooleServerRunner tests.');
+        }
+
+        parent::setUp();
+    }
+}

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -32,6 +32,8 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+use function Swoole\Coroutine\run;
+
 final class LdapServerCommand extends Command
 {
     use ConsoleOptionsTrait;
@@ -62,6 +64,13 @@ final class LdapServerCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Port to listen on',
                 '10389',
+            )
+            ->addOption(
+                'runner',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Server runner (pcntl, swoole)',
+                'pcntl',
             )
             ->addOption(
                 'storage',
@@ -166,6 +175,7 @@ final class LdapServerCommand extends Command
         $transport = $this->getStringOption($input, 'transport');
         $port = (int) $this->getStringOption($input, 'port');
         $storageType = $this->getStringOption($input, 'storage');
+        $runner = $this->getStringOption($input, 'runner');
         $entryCount = (int) $this->getStringOption($input, 'entries');
         $sasl = $input->getOption('sasl') === true;
         $external = $input->getOption('external') === true;
@@ -178,6 +188,12 @@ final class LdapServerCommand extends Command
 
         if (!in_array($storageType, self::VALID_STORAGE, true)) {
             $io->error("Invalid --storage value: {$storageType}. Expected one of: " . implode(', ', self::VALID_STORAGE) . '.');
+
+            return Command::FAILURE;
+        }
+
+        if (!in_array($runner, ['pcntl', 'swoole'], true)) {
+            $io->error("Invalid --runner value: {$runner}. Expected one of: pcntl, swoole.");
 
             return Command::FAILURE;
         }
@@ -213,7 +229,7 @@ final class LdapServerCommand extends Command
             );
         }
 
-        $storage = $this->createStorage($storageType);
+        $storage = $this->createStorage($storageType, $runner);
 
         $options = (new ServerOptions())
             ->setPort($port)
@@ -222,6 +238,7 @@ final class LdapServerCommand extends Command
             ->setSslCert(self::SSL_CERT)
             ->setSslCertKey(self::SSL_KEY)
             ->setUseSsl($useSsl)
+            ->setUseSwooleRunner($runner === 'swoole')
             ->setAllowAnonymous($allowAnonymous)
             ->setSocketAcceptTimeout(0.1)
             ->setMaxSearchLookthrough((int) $this->getStringOption($input, 'max-search-lookthrough'))
@@ -287,18 +304,26 @@ final class LdapServerCommand extends Command
 
         $server->getOptions()->setStorage($storage);
 
-        if ($seedFile !== '') {
-            $server->seed(new FileLdifLoader($seedFile));
+        $loadData = function () use ($server, $storage, $seedFile, $entries, $changesFile, $dumpFile): void {
+            if ($seedFile !== '') {
+                $server->seed(new FileLdifLoader($seedFile));
+            } else {
+                (new LdapImporter($storage))->importEntries($entries);
+            }
+
+            if ($changesFile !== '') {
+                $server->applyChanges(new FileLdifLoader($changesFile));
+            }
+
+            if ($dumpFile !== '') {
+                $server->dump(new FileLdifOutput($dumpFile));
+            }
+        };
+
+        if ($runner === 'swoole') {
+            run($loadData);
         } else {
-            (new LdapImporter($storage))->importEntries($entries);
-        }
-
-        if ($changesFile !== '') {
-            $server->applyChanges(new FileLdifLoader($changesFile));
-        }
-
-        if ($dumpFile !== '') {
-            $server->dump(new FileLdifOutput($dumpFile));
+            $loadData();
         }
 
         $server->run();
@@ -306,8 +331,12 @@ final class LdapServerCommand extends Command
         return Command::SUCCESS;
     }
 
-    private function createStorage(string $storageType): EntryStorageInterface
-    {
+    private function createStorage(
+        string $storageType,
+        string $runner,
+    ): EntryStorageInterface {
+        $swoole = $runner === 'swoole';
+
         if ($storageType === 'json') {
             $filePath = sys_get_temp_dir() . '/ldap_test_server.json';
 
@@ -315,7 +344,9 @@ final class LdapServerCommand extends Command
                 unlink($filePath);
             }
 
-            return JsonFileStorage::forPcntl($filePath);
+            return $swoole
+                ? JsonFileStorage::forSwoole($filePath)
+                : JsonFileStorage::forPcntl($filePath);
         }
 
         if ($storageType === 'sqlite') {
@@ -327,7 +358,9 @@ final class LdapServerCommand extends Command
                 }
             }
 
-            return SqliteStorage::forPcntl($dbPath);
+            return $swoole
+                ? SqliteStorage::forSwoole($dbPath)
+                : SqliteStorage::forPcntl($dbPath);
         }
 
         if ($storageType === 'mysql') {
@@ -345,7 +378,9 @@ final class LdapServerCommand extends Command
             $cleanup->exec('DROP TABLE IF EXISTS entries');
             unset($cleanup);
 
-            return MysqlStorage::forPcntl($dsn, $user, $password);
+            return $swoole
+                ? MysqlStorage::forSwoole($dsn, $user, $password)
+                : MysqlStorage::forPcntl($dsn, $user, $password);
         }
 
         return new InMemoryStorage();

--- a/tests/support/Server/Clock/CallbackSleeper.php
+++ b/tests/support/Server/Clock/CallbackSleeper.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
 namespace Tests\Support\FreeDSx\Ldap\Server\Clock;
 
 use Closure;
-use FreeDSx\Ldap\Server\Clock\Sleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
 use RuntimeException;
 
 /**
  * Test sleeper that runs an optional callback each tick and caps iterations so a runaway loop fails fast.
  */
-final class CallbackSleeper implements Sleeper
+final class CallbackSleeper implements SleeperInterface
 {
     private int $ticks = 0;
 

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSyncHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSyncHandlerTest.php
@@ -45,7 +45,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
 use FreeDSx\Ldap\Server\Operation\OperationOutcome;
 use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
-use FreeDSx\Ldap\Server\Clock\BlockingSleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
 use FreeDSx\Ldap\Sync\Provider\SyncCookie;
 use FreeDSx\Ldap\Sync\Provider\SyncPersistStreamer;
 use FreeDSx\Ldap\Sync\Provider\SyncResultProjector;


### PR DESCRIPTION
This adds support for the coroutine based refreshAndPersist that the swoole runner needs. Additionally, fixes the journaling sync under swoole as the `WriteSerializingStorage` was a missed detail in prior PRs. But we now have integration tests covering both runners for refresh / refreshAndPersist across various storage. I may add some kind of load test with it as well, as I'm unsure how the journal itself will impact load and if it needs any optimizations.