### PR TITLE
[1.0.0] Add a retention sweeper for the journal on both runners.

### DIFF
--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -28,6 +28,9 @@ use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeRecorder;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionSweeper;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Backend\Storage\OperationalAttributeGenerator;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use Psr\Log\NullLogger;
@@ -535,6 +538,7 @@ class Container
                 socketServerFactory: $this->get(SocketServerFactory::class),
                 protocolFactoryProvider: $protocolFactoryProvider,
                 metricsRecorder: $metricsRecorder,
+                retentionSweeper: $this->makeRetentionSweeper(),
             );
         }
 
@@ -547,6 +551,63 @@ class Container
             snapshotPublisher: $this->makeSnapshotPublisher(),
             operationRollup: $this->makeOperationRollup(),
             backend: $this->backendOrNull(),
+            journalRetentionPolicy: $this->journalRetentionPolicyIfSweepable(),
+        );
+    }
+
+    /**
+     * The retention policy to sweep on, or null when journaling is off / has no limits.
+     */
+    private function journalRetentionPolicyIfSweepable(): ?RetentionPolicy
+    {
+        $options = $this->get(ServerOptions::class);
+        $backend = $this->backendOrNull();
+
+        if ($backend === null || !$options->isSyncEnabled()) {
+            return null;
+        }
+
+        $journal = $backend->changeJournal();
+
+        if ($journal === null) {
+            return null;
+        }
+
+        $policy = $options->getChangeJournalConfig()->retention;
+
+        return RetentionSweeper::isSweepable(
+            $policy,
+            $journal,
+            $options->getUseSwooleRunner(),
+        )
+            ? $policy
+            : null;
+    }
+
+    private function makeRetentionSweeper(): ?RetentionSweeper
+    {
+        $policy = $this->journalRetentionPolicyIfSweepable();
+
+        if ($policy === null) {
+            return null;
+        }
+
+        // Safe to resolve now: a non-null policy means sync is enabled and the journal is configured.
+        $journal = $this->backendOrNull()?->changeJournal();
+
+        if ($journal === null) {
+            return null;
+        }
+
+        $options = $this->get(ServerOptions::class);
+
+        return new RetentionSweeper(
+            $journal,
+            $policy,
+            new EventLogger(
+                $options->getLogger(),
+                $options->getEventLogPolicy(),
+            ),
         );
     }
 

--- a/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ProtocolHandlerProvider.php
@@ -20,7 +20,6 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerProtocolHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeStream;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
@@ -200,13 +199,7 @@ final readonly class ProtocolHandlerProvider implements ProtocolHandlerProviderI
             return null;
         }
 
-        $storage = $backend->getStorage();
-
-        if (!$storage instanceof ChangeJournalingInterface) {
-            return null;
-        }
-
-        return $storage->changeJournal();
+        return $backend->changeJournal();
     }
 
     private function getDispatchHandler(): ServerProtocolHandler\ServerDispatchHandler

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/RetentionPolicy.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/RetentionPolicy.php
@@ -38,4 +38,12 @@ final readonly class RetentionPolicy
             throw new InvalidArgumentException('maxAgeSeconds must be at least 1 when set.');
         }
     }
+
+    /**
+     * Whether any limit is set.
+     */
+    public function hasLimits(): bool
+    {
+        return $this->maxRecords !== null || $this->maxAgeSeconds !== null;
+    }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/RetentionSweeper.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/RetentionSweeper.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Journal;
+
+use FreeDSx\Ldap\Server\Logging\EventContext;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Logging\ServerEvent;
+use Throwable;
+
+use function microtime;
+
+/**
+ * Prunes the change journal per its retention policy, emitting a structured event with the outcome.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class RetentionSweeper
+{
+    public const DEFAULT_INTERVAL_SECONDS = 60.0;
+
+    public function __construct(
+        private ChangeJournalInterface $journal,
+        private RetentionPolicy $policy,
+        private EventLogger $eventLogger = new EventLogger(null),
+    ) {}
+
+    /**
+     * A sweep is warranted only when the policy sets a limit and the journal is observable by the sweeping process.
+     */
+    public static function isSweepable(
+        RetentionPolicy $policy,
+        ChangeJournalInterface $journal,
+        bool $singleProcess,
+    ): bool {
+        return $policy->hasLimits()
+            && ($singleProcess || $journal->sharesAcrossProcesses());
+    }
+
+    /**
+     * Prune once.
+     *
+     * @return int The number of records removed (0 on failure).
+     */
+    public function sweep(): int
+    {
+        $startedAt = microtime(true);
+
+        try {
+            $removed = $this->journal->prune($this->policy);
+        } catch (Throwable $e) {
+            $this->eventLogger->record(
+                ServerEvent::JournalPruneFailed,
+                $this->eventLogger->exceptionContextFor($e),
+            );
+
+            return 0;
+        }
+
+        if ($removed > 0) {
+            $this->eventLogger->record(
+                ServerEvent::JournalPruned,
+                [
+                    EventContext::REMOVED => $removed,
+                    EventContext::DURATION_SECONDS => microtime(true) - $startedAt,
+                ],
+            );
+        }
+
+        return $removed;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -24,7 +24,9 @@ use FreeDSx\Ldap\Exception\SchemaRuleException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Operation\WriteEntryOperationHandler;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeRecorder;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
 use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\MoveCommand;
@@ -89,6 +91,16 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
     public function getStorage(): EntryStorageInterface
     {
         return $this->storage;
+    }
+
+    /**
+     * The storage's change journal, or null when the storage is not journaling-capable.
+     */
+    public function changeJournal(): ?ChangeJournalInterface
+    {
+        return $this->storage instanceof ChangeJournalingInterface
+            ? $this->storage->changeJournal()
+            : null;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Logging/EventContext.php
+++ b/src/FreeDSx/Ldap/Server/Logging/EventContext.php
@@ -74,6 +74,10 @@ final class EventContext
 
     public const ENTRIES_RETURNED = 'entries_returned';
 
+    public const REMOVED = 'removed';
+
+    public const DURATION_SECONDS = 'duration_seconds';
+
     public const NEW_RDN = 'new_rdn';
 
     public const NEW_SUPERIOR_DN = 'new_superior_dn';

--- a/src/FreeDSx/Ldap/Server/Logging/EventLogPolicy.php
+++ b/src/FreeDSx/Ldap/Server/Logging/EventLogPolicy.php
@@ -60,6 +60,8 @@ final readonly class EventLogPolicy
             ServerEvent::CriticalControlRejected,
             ServerEvent::SchemaViolation,
             ServerEvent::SyncEntrySkipped,
+            ServerEvent::JournalPruned,
+            ServerEvent::JournalPruneFailed,
             ServerEvent::NoticeOfDisconnectSent,
             ServerEvent::WriteTimeout,
             ServerEvent::IdleTimeout,

--- a/src/FreeDSx/Ldap/Server/Logging/ServerEvent.php
+++ b/src/FreeDSx/Ldap/Server/Logging/ServerEvent.php
@@ -44,6 +44,8 @@ enum ServerEvent: string
     case CriticalControlRejected        = 'control.critical.rejected';
     case SchemaViolation                = 'schema.violation';
     case SyncEntrySkipped               = 'sync.entry_skipped';
+    case JournalPruned                  = 'journal.pruned';
+    case JournalPruneFailed             = 'journal.prune_failed';
     case NoticeOfDisconnectSent         = 'session.disconnect_notice';
     case WriteTimeout                   = 'session.write_timeout';
     case IdleTimeout                    = 'session.idle_timeout';
@@ -58,7 +60,8 @@ enum ServerEvent: string
     {
         return match ($this) {
             self::PasswordPolicyAccountLocked,
-            self::SyncEntrySkipped => LogLevel::WARNING,
+            self::SyncEntrySkipped,
+            self::JournalPruneFailed => LogLevel::WARNING,
             self::BindFailure,
             self::StartTlsFailed,
             self::PasswordModifyFailed,

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -17,8 +17,12 @@ use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Server\Backend\ResettableInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionSweeper;
+use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Metrics\File\SnapshotPublisher;
 use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
 use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
@@ -76,6 +80,13 @@ class PcntlServerRunner implements ServerRunnerInterface
     private bool $isShuttingDown = false;
 
     /**
+     * PID of the in-flight retention-sweep child, or null when none is running.
+     */
+    private ?int $pruneChildPid = null;
+
+    private float $lastSweepAt = 0.0;
+
+    /**
      * @var array<string, mixed>
      */
     private array $defaultContext = [];
@@ -92,6 +103,7 @@ class PcntlServerRunner implements ServerRunnerInterface
         private readonly ?SnapshotPublisher $snapshotPublisher = null,
         private readonly ?OperationRollupCoordinator $operationRollup = null,
         private readonly ?WritableLdapBackendInterface $backend = null,
+        private readonly ?RetentionPolicy $journalRetentionPolicy = null,
     ) {
         if (!extension_loaded('pcntl')) {
             throw new RuntimeException(
@@ -257,9 +269,11 @@ class PcntlServerRunner implements ServerRunnerInterface
         $this->logServerStarted($this->defaultContext);
         $this->metricsRecorder->serverStarted(time());
         $this->publishMetricsSnapshot();
+        $this->lastSweepAt = microtime(true);
         $this->options->getOnServerReady()?->__invoke();
 
         do {
+            $this->runRetentionSweepMaintenance();
             $socket = $this->server->accept($this->options->getSocketAcceptTimeout());
 
             if ($this->isShuttingDown) {
@@ -409,6 +423,7 @@ class PcntlServerRunner implements ServerRunnerInterface
             return;
         }
         // Ask nicely first...
+        $this->endRetentionSweepChild();
         $this->endChildProcesses(SIGTERM);
 
         $waitTime = 0;
@@ -519,6 +534,130 @@ class PcntlServerRunner implements ServerRunnerInterface
 
         // Convey a timeout close to the parent through the exit code.
         exit($this->childExitCodeFor($closeReason));
+    }
+
+    /**
+     * On a fixed cadence, fork a short-lived child to prune the shared journal so the parent keeps accepting.
+     */
+    private function runRetentionSweepMaintenance(): void
+    {
+        if ($this->journalRetentionPolicy === null) {
+            return;
+        }
+
+        $this->reapRetentionSweepChild();
+
+        if (!$this->isRetentionSweepDue()) {
+            return;
+        }
+
+        $this->lastSweepAt = microtime(true);
+        $this->forkRetentionSweepChild();
+    }
+
+    private function isRetentionSweepDue(): bool
+    {
+        return $this->pruneChildPid === null
+            && (microtime(true) - $this->lastSweepAt) >= RetentionSweeper::DEFAULT_INTERVAL_SECONDS;
+    }
+
+    private function reapRetentionSweepChild(): void
+    {
+        if ($this->pruneChildPid === null) {
+            return;
+        }
+
+        $status = 0;
+        $result = pcntl_waitpid(
+            $this->pruneChildPid,
+            $status,
+            WNOHANG,
+        );
+
+        if ($result === -1 || $result > 0) {
+            $this->pruneChildPid = null;
+        }
+    }
+
+    private function forkRetentionSweepChild(): void
+    {
+        $pid = pcntl_fork();
+
+        if ($pid === -1) {
+            $this->logInfo(
+                'Unable to fork the journal retention sweep.',
+                $this->defaultContext,
+            );
+
+            return;
+        }
+
+        if ($pid === 0) {
+            $this->runRetentionSweepThenExit();
+        }
+
+        $this->pruneChildPid = $pid;
+    }
+
+    /**
+     * In the sweep child: drop inherited FDs, reset the backend for a fresh connection, prune once, and exit.
+     */
+    private function runRetentionSweepThenExit(): never
+    {
+        $this->server->close(shutdown: false);
+        $this->closeInheritedChannels();
+        $this->isMainProcess = false;
+
+        // The child inherited the parent's shutdown/reload handlers; make stop signals just terminate it.
+        foreach ($this->handledSignals as $signal) {
+            pcntl_signal(
+                $signal,
+                SIG_DFL,
+            );
+        }
+        pcntl_signal(
+            SIGHUP,
+            SIG_IGN,
+        );
+
+        if ($this->backend instanceof ResettableInterface) {
+            $this->backend->reset();
+        }
+
+        $journal = $this->backend instanceof WritableStorageBackend
+            ? $this->backend->changeJournal()
+            : null;
+
+        if ($journal !== null && $this->journalRetentionPolicy !== null) {
+            (new RetentionSweeper(
+                $journal,
+                $this->journalRetentionPolicy,
+                new EventLogger(
+                    $this->options->getLogger(),
+                    $this->options->getEventLogPolicy(),
+                ),
+            ))->sweep();
+        }
+
+        exit(0);
+    }
+
+    private function endRetentionSweepChild(): void
+    {
+        if ($this->pruneChildPid === null || !$this->isPosixExtLoaded) {
+            return;
+        }
+
+        posix_kill(
+            $this->pruneChildPid,
+            SIGTERM,
+        );
+        $status = 0;
+        pcntl_waitpid(
+            $this->pruneChildPid,
+            $status,
+        );
+        $this->pruneChildPid = null;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/ServerRunner/SwooleServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/SwooleServerRunner.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Server\ServerRunner;
 
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionSweeper;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
 use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
@@ -27,6 +28,7 @@ use FreeDSx\Socket\SocketServer;
 use Closure;
 use Psr\Log\LoggerInterface;
 use Swoole\Coroutine;
+use Swoole\Coroutine\Channel;
 use Swoole\Coroutine\WaitGroup;
 use Swoole\Process;
 use Swoole\Runtime;
@@ -58,6 +60,13 @@ class SwooleServerRunner implements CoroutineServerRunnerInterface
     private bool $isShuttingDown = false;
 
     /**
+     * Wakes the retention-sweep coroutine so shutdown does not wait out its sleep interval.
+     *
+     * @var ?Channel<bool>
+     */
+    private ?Channel $sweepWakeup = null;
+
+    /**
      * Active client sockets keyed by spl_object_id.
      *
      * Used to force-close lingering connections when the drain timeout expires.
@@ -83,6 +92,7 @@ class SwooleServerRunner implements CoroutineServerRunnerInterface
         private readonly SocketServerFactory $socketServerFactory,
         Closure $protocolFactoryProvider,
         private readonly MetricsRecorderInterface $metricsRecorder = new NullMetricsRecorder(),
+        private readonly ?RetentionSweeper $retentionSweeper = null,
     ) {
         if (!extension_loaded('swoole')) {
             throw new RuntimeException(
@@ -105,6 +115,7 @@ class SwooleServerRunner implements CoroutineServerRunnerInterface
         Coroutine\run(function (): void {
             $this->server = $this->socketServerFactory->makeAndBind();
             $this->registerShutdownSignals();
+            $this->startRetentionSweep();
             $this->acceptClients();
         });
 
@@ -133,12 +144,37 @@ class SwooleServerRunner implements CoroutineServerRunnerInterface
         $this->reloadConfiguration(['signal' => $signal]);
     }
 
+    /**
+     * Runs the journal retention sweep in a background coroutine, sleeping between prunes and yielding on I/O.
+     */
+    private function startRetentionSweep(): void
+    {
+        if ($this->retentionSweeper === null) {
+            return;
+        }
+
+        $sweeper = $this->retentionSweeper;
+        $wakeup = $this->sweepWakeup = new Channel(1);
+
+        Coroutine::create(function () use ($sweeper, $wakeup): void {
+            while (!$this->isShuttingDown) {
+                // pop() returns the pushed value on shutdown, or false after the interval elapses.
+                if ($wakeup->pop(RetentionSweeper::DEFAULT_INTERVAL_SECONDS) !== false) {
+                    break;
+                }
+
+                $sweeper->sweep();
+            }
+        });
+    }
+
     private function handleShutdownSignal(int $signal): void
     {
         if ($this->isShuttingDown) {
             return;
         }
         $this->isShuttingDown = true;
+        $this->sweepWakeup?->push(true);
         $this->logShutdownStarted(['signal' => $signal]);
         $this->server->close();
         $this->notifyClientsOfShutdown();

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -21,6 +21,8 @@ use FreeDSx\Ldap\Protocol\Factory\ClientProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\Queue\ClientQueueInstantiator;
 use FreeDSx\Ldap\Protocol\RootDseLoader;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
 use FreeDSx\Ldap\Server\Metrics\File\FileSnapshotProvider;
@@ -164,6 +166,45 @@ class ContainerTest extends TestCase
             FileSnapshotProvider::class,
             $container->get(MetricsSnapshotProvider::class),
         );
+    }
+
+    public function test_the_pcntl_runner_builds_with_journaling_and_retention_configured(): void
+    {
+        if (str_starts_with(strtoupper(PHP_OS), 'WIN')) {
+            self::markTestSkipped('Cannot construct the default PCNTL runner on Windows.');
+        }
+
+        $container = $this->containerFor($this->journalingOptions());
+
+        self::assertInstanceOf(
+            ServerRunnerInterface::class,
+            $container->get(ServerRunnerInterface::class),
+        );
+    }
+
+    public function test_the_swoole_runner_builds_with_a_retention_sweeper(): void
+    {
+        if (!extension_loaded('swoole')) {
+            self::markTestSkipped('The swoole extension is required to construct the Swoole runner.');
+        }
+
+        $container = $this->containerFor(
+            $this->journalingOptions()->setUseSwooleRunner(true),
+        );
+
+        self::assertInstanceOf(
+            ServerRunnerInterface::class,
+            $container->get(ServerRunnerInterface::class),
+        );
+    }
+
+    private function journalingOptions(): ServerOptions
+    {
+        return (new ServerOptions())
+            ->setSyncEnabled(true)
+            ->setChangeJournalConfig(new ChangeJournalConfig(
+                retention: new RetentionPolicy(maxRecords: 100),
+            ));
     }
 
     private function containerFor(ServerOptions $options): Container

--- a/tests/unit/Server/Backend/Storage/Journal/RetentionSweeperTest.php
+++ b/tests/unit/Server/Backend/Storage/Journal/RetentionSweeperTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Journal;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\InMemoryChangeJournal;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionSweeper;
+use FreeDSx\Ldap\Server\Logging\EventContext;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
+use FreeDSx\Ldap\Server\Logging\ServerEvent;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
+use Tests\Support\FreeDSx\Ldap\Logging\RecordingLogger;
+
+final class RetentionSweeperTest extends TestCase
+{
+    private RecordingLogger $logger;
+
+    private EventLogger $eventLogger;
+
+    private FrozenClock $clock;
+
+    private InMemoryChangeJournal $journal;
+
+    protected function setUp(): void
+    {
+        $this->logger = new RecordingLogger();
+        $this->eventLogger = new EventLogger(
+            $this->logger,
+            EventLogPolicy::default(),
+        );
+        $this->clock = FrozenClock::fromString('2025-05-15T12:00:00');
+        $this->journal = new InMemoryChangeJournal(
+            new ReplicaId('node-a'),
+            $this->clock,
+        );
+    }
+
+    public function test_sweep_prunes_to_the_record_cap_and_records_the_outcome(): void
+    {
+        $this->appendChanges(5);
+        $sweeper = new RetentionSweeper(
+            $this->journal,
+            new RetentionPolicy(maxRecords: 2),
+            $this->eventLogger,
+        );
+
+        $removed = $sweeper->sweep();
+
+        self::assertSame(
+            3,
+            $removed,
+        );
+        self::assertCount(
+            2,
+            iterator_to_array($this->journal->read()),
+        );
+
+        $event = $this->onlyRecordFor(ServerEvent::JournalPruned);
+        self::assertSame(
+            3,
+            $event['context'][EventContext::REMOVED],
+        );
+        self::assertIsFloat($event['context'][EventContext::DURATION_SECONDS]);
+        self::assertGreaterThanOrEqual(
+            0.0,
+            $event['context'][EventContext::DURATION_SECONDS],
+        );
+    }
+
+    public function test_sweep_prunes_records_past_the_age_horizon(): void
+    {
+        $this->appendChanges(1);
+        $this->clock->setTo($this->clock->now()->modify('+100 seconds'));
+        $this->appendChanges(1);
+        $sweeper = new RetentionSweeper(
+            $this->journal,
+            new RetentionPolicy(maxAgeSeconds: 60),
+            $this->eventLogger,
+        );
+
+        $removed = $sweeper->sweep();
+
+        self::assertSame(
+            1,
+            $removed,
+        );
+        self::assertCount(
+            1,
+            iterator_to_array($this->journal->read()),
+        );
+    }
+
+    public function test_sweep_with_no_limits_prunes_nothing_and_records_no_event(): void
+    {
+        $this->appendChanges(3);
+        $sweeper = new RetentionSweeper(
+            $this->journal,
+            new RetentionPolicy(),
+            $this->eventLogger,
+        );
+
+        $removed = $sweeper->sweep();
+
+        self::assertSame(
+            0,
+            $removed,
+        );
+        self::assertSame(
+            [],
+            $this->recordsFor(ServerEvent::JournalPruned),
+        );
+    }
+
+    public function test_sweep_swallows_a_prune_failure_and_records_it(): void
+    {
+        $journal = $this->createMock(ChangeJournalInterface::class);
+        $journal->method('prune')
+            ->willThrowException(new RuntimeException('boom'));
+        $sweeper = new RetentionSweeper(
+            $journal,
+            new RetentionPolicy(maxRecords: 1),
+            $this->eventLogger,
+        );
+
+        $removed = $sweeper->sweep();
+
+        self::assertSame(
+            0,
+            $removed,
+        );
+        self::assertCount(
+            1,
+            $this->recordsFor(ServerEvent::JournalPruneFailed),
+        );
+    }
+
+    public function test_it_is_sweepable_in_a_single_process_regardless_of_journal_scope(): void
+    {
+        $journal = $this->journalSharing(false);
+
+        self::assertTrue(RetentionSweeper::isSweepable(
+            new RetentionPolicy(maxRecords: 1),
+            $journal,
+            true,
+        ));
+    }
+
+    public function test_it_is_sweepable_when_forking_only_for_a_cross_process_journal(): void
+    {
+        self::assertTrue(RetentionSweeper::isSweepable(
+            new RetentionPolicy(maxRecords: 1),
+            $this->journalSharing(true),
+            false,
+        ));
+        self::assertFalse(RetentionSweeper::isSweepable(
+            new RetentionPolicy(maxRecords: 1),
+            $this->journalSharing(false),
+            false,
+        ));
+    }
+
+    public function test_it_is_never_sweepable_without_a_limit(): void
+    {
+        self::assertFalse(RetentionSweeper::isSweepable(
+            new RetentionPolicy(),
+            $this->journalSharing(true),
+            true,
+        ));
+    }
+
+    private function journalSharing(bool $shares): ChangeJournalInterface
+    {
+        $journal = $this->createMock(ChangeJournalInterface::class);
+        $journal->method('sharesAcrossProcesses')
+            ->willReturn($shares);
+
+        return $journal;
+    }
+
+    private function appendChanges(int $count): void
+    {
+        for ($i = 1; $i <= $count; $i++) {
+            $this->journal->append(new PendingChange(
+                changeType: ChangeType::Add,
+                dn: new Dn("cn=entry-{$i},dc=example,dc=com"),
+                entryUuid: '11111111-1111-4111-8111-111111111111',
+                authzId: AuthzId::anonymous(),
+            ));
+        }
+    }
+
+    /**
+     * @return list<array{level: string, message: string, context: array<string, mixed>}>
+     */
+    private function recordsFor(ServerEvent $event): array
+    {
+        return array_values(array_filter(
+            $this->logger->records,
+            static fn(array $record): bool => $record['message'] === $event->value,
+        ));
+    }
+
+    /**
+     * @return array{level: string, message: string, context: array<string, mixed>}
+     */
+    private function onlyRecordFor(ServerEvent $event): array
+    {
+        $records = $this->recordsFor($event);
+        self::assertCount(
+            1,
+            $records,
+        );
+
+        return $records[0];
+    }
+}


### PR DESCRIPTION
Cleans up the journal per the configured policy on both server runners. I need to refactor the runners at some point, as they are getting quite large / doing a lot with everything that's been added.