### PR TITLE
[1.0.0] Move the PDO schema to resource files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ It supports encryption of the LDAP connection through TLS via the OpenSSL extens
   * [Access Control](/docs/Server/Access-Control.md)
   * [Password Policy](/docs/Server/Password-Policy.md)
   * [Directory Synchronization](/docs/Server/Replication.md)
+  * [Database Schema](/docs/Server/Database-Schema.md)
 
 # Getting Started
 

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -267,6 +267,9 @@ $server = new LdapServer((new ServerOptions())->useInMemoryStorage());
 
 For a custom source, pass your own `EntryStorageInterface` implementation to `setStorage()`.
 
+The bundled SQLite and MySQL backends create their tables automatically on first connect. For managing that schema
+yourself, see [Database Schema](Database-Schema.md).
+
 **Note**: a non-proxy server started without a configured storage throws at startup rather than silently
 serving an empty directory.
 

--- a/docs/Server/Database-Schema.md
+++ b/docs/Server/Database-Schema.md
@@ -1,0 +1,66 @@
+# Database Schema (PDO Storage)
+
+The SQLite and MySQL storage backends keep their tables under a fixed schema. The schema ships with the library as SQL
+files, so you can apply and version it with your own database tooling. This page covers how the schema is created and
+how to manage it yourself.
+
+* [Automatic Setup](#automatic-setup)
+* [The Schema Files](#the-schema-files)
+* [Managing the Schema Yourself](#managing-the-schema-yourself)
+* [Versioning](#versioning)
+* [The Change Journal Tables](#the-change-journal-tables)
+
+## Automatic Setup
+
+By default the SQLite and MySQL adapters create their tables the first time they connect, using
+`CREATE TABLE IF NOT EXISTS`, so a fresh database just works. Re-connecting is a no-op. This is convenient for testing
+and development use.
+
+This applies the baseline schema only. The library never runs migration deltas, so automatic setup does not upgrade an
+existing database to a newer schema; it only brings a fresh one up to the current baseline.
+
+## The Schema Files
+
+The schema ships in the package under `resources/schema`:
+
+* `resources/schema/<dialect>/baseline.sql` is the current full schema. Applying it to a fresh database produces a
+  working directory, and applying it again is a no-op.
+* `resources/schema/<dialect>/migrations/` holds versioned delta files, named `V<n>__<description>.sql`, added when the
+  schema changes.
+
+Point your migration tool at these files, or copy them into your project. If you would rather get the baseline as a
+string in code, `SqliteStorage::schemaDdl()` and `MysqlStorage::schemaDdl()` return the same content.
+
+## Managing the Schema Yourself
+
+For a managed database you usually want to apply schema changes with your own tooling rather than have the library issue
+DDL on startup. Turn automatic setup off with the `initializeSchema` flag on the storage factory:
+
+```php
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqliteStorage;
+
+$storage = SqliteStorage::forPcntl(
+    '/var/lib/freedsx/directory.sqlite',
+    initializeSchema: false,
+);
+```
+
+With it off, the adapter never runs any DDL on connect. Creating and updating the tables is entirely up to you, using
+the schema files above. The library does not migrate your database; it ships the schema, and you decide when and how to
+apply it.
+
+## Versioning
+
+`PdoStorage::SCHEMA_VERSION` is the current schema revision. Each release notes any schema change in the CHANGELOG, so
+you can tell whether an upgrade needs a migration and which delta to apply. A fresh database applies the baseline; an
+existing database applies the delta files newer than its current version, with your own migration tool.
+
+## The Change Journal Tables
+
+When [directory synchronization](Replication.md) is enabled, the schema also includes the change journal tables
+(`ldap_change_journal` and `ldap_change_journal_seq`). They are versioned and migrated the same way as the rest of the
+schema.
+
+The journal has two roles: a replication window that consumers read, and, when configured, a durable audit record of
+changes. A replication consumer can always recover by doing a full refresh, but the audit record cannot be recovered
+once it is discarded, so migrate the journal tables like any other table.

--- a/docs/Server/Replication.md
+++ b/docs/Server/Replication.md
@@ -134,6 +134,9 @@ There is a sizing trade-off. Pruning moves the oldest point the journal can stil
 is older than that point cannot be brought up to date incrementally, so it receives a full refresh on its next sync.
 Choose retention limits that cover the longest window a consumer might be offline.
 
+On a PDO backend the journal lives in tables that are part of the storage schema. See
+[Database Schema](Database-Schema.md) for creating and managing it.
+
 ## Origin and Cookies
 
 Each journal has an origin, which defaults to `local`. Set a stable, unique origin for each provider through the

--- a/resources/schema/mysql/baseline.sql
+++ b/resources/schema/mysql/baseline.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS entries (
+    lc_dn         VARCHAR(768) NOT NULL,
+    dn            VARCHAR(768) NOT NULL,
+    lc_parent_dn  VARCHAR(768) NOT NULL DEFAULT '',
+    attributes    LONGBLOB NOT NULL,
+    PRIMARY KEY (lc_dn),
+    INDEX idx_lc_parent_dn (lc_parent_dn)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS entry_attribute_values (
+    entry_lc_dn      VARCHAR(768) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    attr_name_lower  VARCHAR(255) NOT NULL,
+    value_lower      VARCHAR(255) NOT NULL,
+    value_original   TEXT NOT NULL,
+    INDEX idx_eav_attr_value (attr_name_lower, value_lower),
+    INDEX idx_eav_entry (entry_lc_dn),
+    CONSTRAINT fk_eav_entry FOREIGN KEY (entry_lc_dn)
+        REFERENCES entries(lc_dn) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+CREATE TABLE IF NOT EXISTS ldap_change_journal (
+    seq          BIGINT NOT NULL,
+    origin       VARCHAR(255) NOT NULL,
+    created_at   BIGINT NOT NULL,
+    change_type  VARCHAR(16) NOT NULL,
+    dn           TEXT NOT NULL,
+    lc_dn        VARCHAR(768) NOT NULL,
+    lc_parent_dn VARCHAR(768) NOT NULL DEFAULT '',
+    entry_uuid   VARCHAR(255) NOT NULL,
+    authz_id     TEXT NOT NULL,
+    previous_dn  TEXT,
+    pre_image    LONGBLOB,
+    PRIMARY KEY (seq),
+    INDEX idx_journal_created_at (created_at),
+    INDEX idx_journal_lc_dn (lc_dn),
+    INDEX idx_journal_lc_parent_dn (lc_parent_dn)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS ldap_change_journal_seq (
+    id   INT NOT NULL,
+    seq  BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT IGNORE INTO ldap_change_journal_seq (id, seq) VALUES (1, 0);

--- a/resources/schema/sqlite/baseline.sql
+++ b/resources/schema/sqlite/baseline.sql
@@ -1,0 +1,47 @@
+CREATE TABLE IF NOT EXISTS entries (
+    lc_dn         TEXT NOT NULL PRIMARY KEY,
+    dn            TEXT NOT NULL,
+    lc_parent_dn  TEXT NOT NULL DEFAULT '',
+    attributes    BLOB NOT NULL DEFAULT 'a:0:{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_lc_parent_dn ON entries (lc_parent_dn);
+
+CREATE TABLE IF NOT EXISTS entry_attribute_values (
+    entry_lc_dn      TEXT NOT NULL,
+    attr_name_lower  TEXT NOT NULL,
+    value_lower      TEXT NOT NULL,
+    value_original   TEXT NOT NULL,
+    FOREIGN KEY (entry_lc_dn) REFERENCES entries(lc_dn) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_eav_attr_value ON entry_attribute_values (attr_name_lower, value_lower);
+
+CREATE INDEX IF NOT EXISTS idx_eav_entry ON entry_attribute_values (entry_lc_dn);
+
+CREATE TABLE IF NOT EXISTS ldap_change_journal (
+    seq          INTEGER NOT NULL PRIMARY KEY,
+    origin       TEXT NOT NULL,
+    created_at   INTEGER NOT NULL,
+    change_type  TEXT NOT NULL,
+    dn           TEXT NOT NULL,
+    lc_dn        TEXT NOT NULL,
+    lc_parent_dn TEXT NOT NULL DEFAULT '',
+    entry_uuid   TEXT NOT NULL,
+    authz_id     TEXT NOT NULL,
+    previous_dn  TEXT,
+    pre_image    BLOB
+);
+
+CREATE INDEX IF NOT EXISTS idx_journal_created_at ON ldap_change_journal (created_at);
+
+CREATE INDEX IF NOT EXISTS idx_journal_lc_dn ON ldap_change_journal (lc_dn);
+
+CREATE INDEX IF NOT EXISTS idx_journal_lc_parent_dn ON ldap_change_journal (lc_parent_dn);
+
+CREATE TABLE IF NOT EXISTS ldap_change_journal_seq (
+    id   INTEGER NOT NULL PRIMARY KEY,
+    seq  INTEGER NOT NULL DEFAULT 0
+);
+
+INSERT OR IGNORE INTO ldap_change_journal_seq (id, seq) VALUES (1, 0);

--- a/src/FreeDSx/Ldap/Resources.php
+++ b/src/FreeDSx/Ldap/Resources.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap;
+
+/**
+ * Resolves paths to files shipped in the package's resources directory.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class Resources
+{
+    public static function path(string $relative): string
+    {
+        return dirname(__DIR__, 3)
+            . '/resources/'
+            . ltrim($relative, '/');
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/MysqlDialect.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/MysqlDialect.php
@@ -22,58 +22,7 @@ final class MysqlDialect implements PdoDialectInterface
 {
     use PdoDialectTrait;
     use PdoJournalDialectTrait;
-
-    /**
-     * DN columns are 768 chars — the maximum that still fits an InnoDB index.
-     */
-    public function ddlCreateTable(): string
-    {
-        return <<<SQL
-            CREATE TABLE IF NOT EXISTS entries (
-                lc_dn         VARCHAR(768) NOT NULL,
-                dn            VARCHAR(768) NOT NULL,
-                lc_parent_dn  VARCHAR(768) NOT NULL DEFAULT '',
-                attributes    LONGBLOB NOT NULL,
-                PRIMARY KEY (lc_dn),
-                INDEX idx_lc_parent_dn (lc_parent_dn)
-            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
-        SQL;
-    }
-
-    /**
-     * @inheritDoc Inline with ddlCreateTable().
-     */
-    public function ddlCreateIndex(): ?string
-    {
-        return null;
-    }
-
-    /**
-     * entry_lc_dn collation matches entries.lc_dn (FK requirement); value_lower uses utf8mb4_bin so pre-lowered values compare byte-wise.
-     */
-    public function ddlCreateSidecarTable(): string
-    {
-        return <<<SQL
-            CREATE TABLE IF NOT EXISTS entry_attribute_values (
-                entry_lc_dn      VARCHAR(768) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-                attr_name_lower  VARCHAR(255) NOT NULL,
-                value_lower      VARCHAR(255) NOT NULL,
-                value_original   TEXT NOT NULL,
-                INDEX idx_eav_attr_value (attr_name_lower, value_lower),
-                INDEX idx_eav_entry (entry_lc_dn),
-                CONSTRAINT fk_eav_entry FOREIGN KEY (entry_lc_dn)
-                    REFERENCES entries(lc_dn) ON DELETE CASCADE
-            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
-        SQL;
-    }
-
-    /**
-     * @inheritDoc Inline with ddlCreateSidecarTable().
-     */
-    public function ddlCreateSidecarIndexes(): array
-    {
-        return [];
-    }
+    use PdoSchemaTrait;
 
     /**
      * @todo Replace VALUES() with row alias syntax once MariaDB supports it.
@@ -95,47 +44,8 @@ final class MysqlDialect implements PdoDialectInterface
         return 768;
     }
 
-    public function ddlCreateJournalTable(): string
+    protected function schemaName(): string
     {
-        return <<<SQL
-            CREATE TABLE IF NOT EXISTS ldap_change_journal (
-                seq          BIGINT NOT NULL,
-                origin       VARCHAR(255) NOT NULL,
-                created_at   BIGINT NOT NULL,
-                change_type  VARCHAR(16) NOT NULL,
-                dn           TEXT NOT NULL,
-                lc_dn        VARCHAR(768) NOT NULL,
-                lc_parent_dn VARCHAR(768) NOT NULL DEFAULT '',
-                entry_uuid   VARCHAR(255) NOT NULL,
-                authz_id     TEXT NOT NULL,
-                previous_dn  TEXT,
-                pre_image    LONGBLOB,
-                PRIMARY KEY (seq),
-                INDEX idx_journal_created_at (created_at),
-                INDEX idx_journal_lc_dn (lc_dn),
-                INDEX idx_journal_lc_parent_dn (lc_parent_dn)
-            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
-        SQL;
-    }
-
-    public function ddlCreateJournalIndexes(): array
-    {
-        return [];
-    }
-
-    public function ddlCreateJournalSeqTable(): string
-    {
-        return <<<SQL
-            CREATE TABLE IF NOT EXISTS ldap_change_journal_seq (
-                id   INT NOT NULL,
-                seq  BIGINT NOT NULL DEFAULT 0,
-                PRIMARY KEY (id)
-            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
-        SQL;
-    }
-
-    public function queryJournalSeqInit(): string
-    {
-        return 'INSERT IGNORE INTO ldap_change_journal_seq (id, seq) VALUES (1, 0)';
+        return 'mysql';
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectInterface.php
@@ -18,4 +18,17 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-interface PdoDialectInterface extends PdoEntryDialectInterface, PdoJournalDialectInterface {}
+interface PdoDialectInterface extends PdoEntryDialectInterface, PdoJournalDialectInterface
+{
+    /**
+     * The full schema (all tables) as a runnable SQL script.
+     */
+    public function schemaSql(): string;
+
+    /**
+     * The schema script split into individual executable statements.
+     *
+     * @return list<string>
+     */
+    public function schemaStatements(): array;
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoEntryDialectInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoEntryDialectInterface.php
@@ -38,36 +38,6 @@ interface PdoEntryDialectInterface
     public function rollBack(PDO $pdo): void;
 
     /**
-     * DDL for the `entries` table. Required columns:
-     *   lc_dn         — PK, lowercased DN
-     *   dn            — original-case DN
-     *   lc_parent_dn  — lowercased parent DN ('' for root)
-     *   attributes    — JSON object mapping lowercased attribute names to string-value arrays
-     */
-    public function ddlCreateTable(): string;
-
-    /**
-     * DDL to create an index on lc_parent_dn; return null when already defined inline in ddlCreateTable().
-     */
-    public function ddlCreateIndex(): ?string;
-
-    /**
-     * DDL for the `entry_attribute_values` sidecar index table. Required columns:
-     *   entry_lc_dn      — FK to entries.lc_dn ON DELETE CASCADE
-     *   attr_name_lower  — lowercased attribute description (stripped of options)
-     *   value_lower      — lowercased value, truncated to 255 chars (indexed)
-     *   value_original   — original-case full value (not indexed; retained for debugging)
-     */
-    public function ddlCreateSidecarTable(): string;
-
-    /**
-     * DDL statements creating sidecar indexes; empty when indexes are defined inline in ddlCreateSidecarTable().
-     *
-     * @return list<string>
-     */
-    public function ddlCreateSidecarIndexes(): array;
-
-    /**
      * Existence check: `SELECT 1 FROM entries WHERE lc_dn = ? LIMIT 1`. Parameters: [lc_dn]
      */
     public function queryExists(): string;

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoJournalDialectInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoJournalDialectInterface.php
@@ -21,29 +21,6 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
 interface PdoJournalDialectInterface
 {
     /**
-     * DDL for the `ldap_change_journal` table. Columns: seq (PK), origin, created_at (unix seconds),
-     * change_type, dn, entry_uuid, authz_id, previous_dn (null), pre_image (null; base64 of a serialized Entry).
-     */
-    public function ddlCreateJournalTable(): string;
-
-    /**
-     * DDL statements creating journal indexes; empty when indexes are defined inline in ddlCreateJournalTable().
-     *
-     * @return list<string>
-     */
-    public function ddlCreateJournalIndexes(): array;
-
-    /**
-     * DDL for the single-row `ldap_change_journal_seq` counter table holding the monotonic high-water seq.
-     */
-    public function ddlCreateJournalSeqTable(): string;
-
-    /**
-     * Seeds the counter row (id=1, seq=0) if absent; safe to run on every initialize().
-     */
-    public function queryJournalSeqInit(): string;
-
-    /**
      * Inserts one journal record. Parameters: [seq, origin, created_at, change_type, dn, entry_uuid, authz_id, previous_dn, pre_image]
      */
     public function queryJournalInsert(): string;

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoSchemaTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoSchemaTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
+
+use FreeDSx\Ldap\Resources;
+
+/**
+ * Loads a dialect's baseline schema from its shipped .sql resource file.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+trait PdoSchemaTrait
+{
+    public function schemaSql(): string
+    {
+        return $this->schemaFile()
+            ->sql();
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function schemaStatements(): array
+    {
+        return $this->schemaFile()
+            ->statements();
+    }
+
+    /**
+     * The dialect's resource directory name under resources/schema.
+     */
+    abstract protected function schemaName(): string;
+
+    private function schemaFile(): SchemaFile
+    {
+        return new SchemaFile(Resources::path(
+            'schema/' . $this->schemaName() . '/baseline.sql',
+        ));
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SchemaFile.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SchemaFile.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
+
+use FreeDSx\Ldap\Exception\RuntimeException;
+
+use function explode;
+use function file_get_contents;
+use function sprintf;
+use function trim;
+
+/**
+ * Reads a baseline schema .sql file and splits it into executable statements.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class SchemaFile
+{
+    public function __construct(private string $path) {}
+
+    public function sql(): string
+    {
+        $sql = @file_get_contents($this->path);
+
+        if ($sql === false) {
+            throw new RuntimeException(sprintf(
+                'Unable to read the schema file "%s".',
+                $this->path,
+            ));
+        }
+
+        return $sql;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function statements(): array
+    {
+        return self::split($this->sql());
+    }
+
+    /**
+     * Split a schema script into statements. The baseline is authored one `;`-terminated statement per block; no
+     * statement contains a `;` in a literal, so a boundary split is sufficient.
+     *
+     * @return list<string>
+     */
+    public static function split(string $sql): array
+    {
+        $statements = [];
+
+        foreach (explode(';', $sql) as $statement) {
+            $statement = trim($statement);
+
+            if ($statement !== '') {
+                $statements[] = $statement;
+            }
+        }
+
+        return $statements;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SqliteDialect.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SqliteDialect.php
@@ -24,6 +24,7 @@ final class SqliteDialect implements PdoDialectInterface
 {
     use PdoDialectTrait;
     use PdoJournalDialectTrait;
+    use PdoSchemaTrait;
 
     /**
      * `BEGIN IMMEDIATE` acquires the reserved lock up front so concurrent writers wait (honoring `busy_timeout`)
@@ -42,46 +43,6 @@ final class SqliteDialect implements PdoDialectInterface
     public function rollBack(PDO $pdo): void
     {
         $pdo->exec('ROLLBACK');
-    }
-
-    public function ddlCreateTable(): string
-    {
-        return <<<SQL
-            CREATE TABLE IF NOT EXISTS entries (
-                lc_dn         TEXT NOT NULL PRIMARY KEY,
-                dn            TEXT NOT NULL,
-                lc_parent_dn  TEXT NOT NULL DEFAULT '',
-                attributes    BLOB NOT NULL DEFAULT 'a:0:{}'
-            )
-        SQL;
-    }
-
-    public function ddlCreateIndex(): string
-    {
-        return <<<SQL
-            CREATE INDEX IF NOT EXISTS idx_lc_parent_dn ON entries (lc_parent_dn)
-        SQL;
-    }
-
-    public function ddlCreateSidecarTable(): string
-    {
-        return <<<SQL
-            CREATE TABLE IF NOT EXISTS entry_attribute_values (
-                entry_lc_dn      TEXT NOT NULL,
-                attr_name_lower  TEXT NOT NULL,
-                value_lower      TEXT NOT NULL,
-                value_original   TEXT NOT NULL,
-                FOREIGN KEY (entry_lc_dn) REFERENCES entries(lc_dn) ON DELETE CASCADE
-            )
-        SQL;
-    }
-
-    public function ddlCreateSidecarIndexes(): array
-    {
-        return [
-            'CREATE INDEX IF NOT EXISTS idx_eav_attr_value ON entry_attribute_values (attr_name_lower, value_lower)',
-            'CREATE INDEX IF NOT EXISTS idx_eav_entry ON entry_attribute_values (entry_lc_dn)',
-        ];
     }
 
     public function queryUpsert(): string
@@ -118,46 +79,8 @@ final class SqliteDialect implements PdoDialectInterface
         );
     }
 
-    public function ddlCreateJournalTable(): string
+    protected function schemaName(): string
     {
-        return <<<SQL
-            CREATE TABLE IF NOT EXISTS ldap_change_journal (
-                seq          INTEGER NOT NULL PRIMARY KEY,
-                origin       TEXT NOT NULL,
-                created_at   INTEGER NOT NULL,
-                change_type  TEXT NOT NULL,
-                dn           TEXT NOT NULL,
-                lc_dn        TEXT NOT NULL,
-                lc_parent_dn TEXT NOT NULL DEFAULT '',
-                entry_uuid   TEXT NOT NULL,
-                authz_id     TEXT NOT NULL,
-                previous_dn  TEXT,
-                pre_image    BLOB
-            )
-        SQL;
-    }
-
-    public function ddlCreateJournalIndexes(): array
-    {
-        return [
-            'CREATE INDEX IF NOT EXISTS idx_journal_created_at ON ldap_change_journal (created_at)',
-            'CREATE INDEX IF NOT EXISTS idx_journal_lc_dn ON ldap_change_journal (lc_dn)',
-            'CREATE INDEX IF NOT EXISTS idx_journal_lc_parent_dn ON ldap_change_journal (lc_parent_dn)',
-        ];
-    }
-
-    public function ddlCreateJournalSeqTable(): string
-    {
-        return <<<SQL
-            CREATE TABLE IF NOT EXISTS ldap_change_journal_seq (
-                id   INTEGER NOT NULL PRIMARY KEY,
-                seq  INTEGER NOT NULL DEFAULT 0
-            )
-        SQL;
-    }
-
-    public function queryJournalSeqInit(): string
-    {
-        return 'INSERT OR IGNORE INTO ldap_change_journal_seq (id, seq) VALUES (1, 0)';
+        return 'sqlite';
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/MysqlStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/MysqlStorage.php
@@ -39,6 +39,7 @@ final class MysqlStorage implements PdoStorageFactoryInterface
         private readonly string $username,
         #[SensitiveParameter]
         private readonly string $password,
+        private readonly bool $initializeSchema = true,
     ) {}
 
     public static function forPcntl(
@@ -46,11 +47,13 @@ final class MysqlStorage implements PdoStorageFactoryInterface
         string $username,
         #[SensitiveParameter]
         string $password,
+        bool $initializeSchema = true,
     ): PdoStorage {
         return (new self(
             $dsn,
             $username,
             $password,
+            $initializeSchema,
         ))->createShared();
     }
 
@@ -59,12 +62,22 @@ final class MysqlStorage implements PdoStorageFactoryInterface
         string $username,
         #[SensitiveParameter]
         string $password,
+        bool $initializeSchema = true,
     ): PdoStorage {
         return (new self(
             $dsn,
             $username,
             $password,
+            $initializeSchema,
         ))->createPerCoroutine();
+    }
+
+    /**
+     * The MySQL schema as a runnable SQL script, to export or apply with your own migration tooling.
+     */
+    public static function schemaDdl(): string
+    {
+        return PdoStorage::schemaDdl(new MysqlDialect());
     }
 
     protected function dialect(): PdoDialectInterface
@@ -97,7 +110,12 @@ final class MysqlStorage implements PdoStorageFactoryInterface
         $pdo->exec("SET NAMES utf8mb4");
         $pdo->exec("SET time_zone = '+00:00'");
 
-        PdoStorage::initialize($pdo, $dialect);
+        if ($this->initializeSchema) {
+            PdoStorage::initialize(
+                $pdo,
+                $dialect,
+            );
+        }
 
         return $pdo;
     }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -53,6 +53,11 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
 {
     use ChangeJournalingTrait;
 
+    /**
+     * The current schema revision shipped in resources/schema.
+     */
+    public const SCHEMA_VERSION = 1;
+
     private const STATEMENT_CACHE_MAX = 64;
 
     /**
@@ -101,27 +106,17 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
             PDO::FETCH_ASSOC,
         );
 
-        $pdo->exec($dialect->ddlCreateTable());
-
-        $indexDdl = $dialect->ddlCreateIndex();
-        if ($indexDdl !== null) {
-            $pdo->exec($indexDdl);
+        foreach ($dialect->schemaStatements() as $statement) {
+            $pdo->exec($statement);
         }
+    }
 
-        $pdo->exec($dialect->ddlCreateSidecarTable());
-
-        foreach ($dialect->ddlCreateSidecarIndexes() as $indexSql) {
-            $pdo->exec($indexSql);
-        }
-
-        $pdo->exec($dialect->ddlCreateJournalTable());
-
-        foreach ($dialect->ddlCreateJournalIndexes() as $indexSql) {
-            $pdo->exec($indexSql);
-        }
-
-        $pdo->exec($dialect->ddlCreateJournalSeqTable());
-        $pdo->exec($dialect->queryJournalSeqInit());
+    /**
+     * The full schema for a dialect as a runnable SQL script, to export to a file or feed to a migration tool.
+     */
+    public static function schemaDdl(PdoDialectInterface $dialect): string
+    {
+        return $dialect->schemaSql();
     }
 
     public function find(Dn $dn): ?Entry

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqliteStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqliteStorage.php
@@ -47,16 +47,23 @@ final class SqliteStorage implements PdoStorageFactoryInterface
 
     private const PRAGMA_FOREIGN_KEYS_ON = 'PRAGMA foreign_keys = ON';
 
-    public function __construct(private readonly string $dbPath) {}
+    public function __construct(
+        private readonly string $dbPath,
+        private readonly bool $initializeSchema = true,
+    ) {}
 
-    public static function forPcntl(string $dbPath): PdoStorage
-    {
-        return (new self($dbPath))->createShared();
+    public static function forPcntl(
+        string $dbPath,
+        bool $initializeSchema = true,
+    ): PdoStorage {
+        return (new self($dbPath, $initializeSchema))->createShared();
     }
 
-    public static function forSwoole(string $dbPath): EntryStorageInterface
-    {
-        $factory = new self($dbPath);
+    public static function forSwoole(
+        string $dbPath,
+        bool $initializeSchema = true,
+    ): EntryStorageInterface {
+        $factory = new self($dbPath, $initializeSchema);
         $writesStorage = $factory->createShared();
 
         return new WriteSerializingStorage(
@@ -66,6 +73,14 @@ final class SqliteStorage implements PdoStorageFactoryInterface
                 batchWrapper: static fn(Closure $cb) => $writesStorage->atomic(static fn() => $cb()),
             ),
         );
+    }
+
+    /**
+     * The SQLite schema as a runnable SQL script, to export or apply with your own migration tooling.
+     */
+    public static function schemaDdl(): string
+    {
+        return PdoStorage::schemaDdl(new SqliteDialect());
     }
 
     protected function dialect(): PdoDialectInterface
@@ -97,7 +112,12 @@ final class SqliteStorage implements PdoStorageFactoryInterface
         $pdo->exec(self::PRAGMA_JOURNAL_MODE_WAL);
         $pdo->exec(self::PRAGMA_FOREIGN_KEYS_ON);
 
-        PdoStorage::initialize($pdo, $dialect);
+        if ($this->initializeSchema) {
+            PdoStorage::initialize(
+                $pdo,
+                $dialect,
+            );
+        }
 
         return $pdo;
     }

--- a/tests/unit/Server/Backend/Storage/Adapter/Dialect/SchemaFileTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Dialect/SchemaFileTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
+
+use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SchemaFile;
+use PHPUnit\Framework\TestCase;
+
+final class SchemaFileTest extends TestCase
+{
+    public function test_split_returns_trimmed_non_empty_statements(): void
+    {
+        $statements = SchemaFile::split(
+            "CREATE TABLE a (x TEXT);\n\nCREATE INDEX i ON a (x);\n\nINSERT OR IGNORE INTO a VALUES ('y');\n",
+        );
+
+        self::assertSame(
+            [
+                'CREATE TABLE a (x TEXT)',
+                'CREATE INDEX i ON a (x)',
+                "INSERT OR IGNORE INTO a VALUES ('y')",
+            ],
+            $statements,
+        );
+    }
+
+    public function test_split_of_an_empty_script_is_empty(): void
+    {
+        self::assertSame(
+            [],
+            SchemaFile::split("\n  \n"),
+        );
+    }
+
+    public function test_statements_reads_and_splits_the_file(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'schema') ?: throw new RuntimeException('tempnam failed');
+        file_put_contents(
+            $path,
+            "CREATE TABLE a (x TEXT);\nCREATE TABLE b (y TEXT);\n",
+        );
+
+        try {
+            self::assertSame(
+                [
+                    'CREATE TABLE a (x TEXT)',
+                    'CREATE TABLE b (y TEXT)',
+                ],
+                (new SchemaFile($path))->statements(),
+            );
+        } finally {
+            unlink($path);
+        }
+    }
+
+    public function test_reading_a_missing_file_throws(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        (new SchemaFile('/does/not/exist.sql'))->sql();
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Adapter/MysqlStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/MysqlStorageTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Adapter;
+
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\MysqlStorage;
+use PHPUnit\Framework\TestCase;
+
+final class MysqlStorageTest extends TestCase
+{
+    public function test_schema_ddl_exports_the_mysql_baseline(): void
+    {
+        $ddl = MysqlStorage::schemaDdl();
+
+        self::assertStringContainsString(
+            'CREATE TABLE IF NOT EXISTS entries',
+            $ddl,
+        );
+        self::assertStringContainsString(
+            'ENGINE=InnoDB',
+            $ddl,
+        );
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Adapter/SqliteStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/SqliteStorageTest.php
@@ -80,6 +80,78 @@ final class SqliteStorageTest extends TestCase
         );
     }
 
+    public function test_initialize_creates_the_baseline_schema(): void
+    {
+        $pdo = new PDO('sqlite::memory:');
+
+        PdoStorage::initialize(
+            $pdo,
+            new SqliteDialect(),
+        );
+        // Re-running must be a no-op (the baseline is idempotent).
+        PdoStorage::initialize(
+            $pdo,
+            new SqliteDialect(),
+        );
+
+        self::assertSame(
+            [
+                'entries',
+                'entry_attribute_values',
+                'ldap_change_journal',
+                'ldap_change_journal_seq',
+            ],
+            $this->tableNames($pdo),
+        );
+    }
+
+    public function test_schema_ddl_exports_the_sqlite_baseline(): void
+    {
+        $ddl = SqliteStorage::schemaDdl();
+
+        self::assertStringContainsString(
+            'CREATE TABLE IF NOT EXISTS entries',
+            $ddl,
+        );
+        self::assertStringContainsString(
+            'ldap_change_journal',
+            $ddl,
+        );
+    }
+
+    public function test_disabling_initialize_skips_schema_creation(): void
+    {
+        // A named shared-cache in-memory database, so a probe connection sees the same schema.
+        $dsn = 'file:freedsx_init_off?mode=memory&cache=shared';
+
+        // Hold the storage's connection open so the shared in-memory database survives the probe read.
+        $storage = SqliteStorage::forPcntl(
+            $dsn,
+            false,
+        );
+
+        $probe = new PDO(
+            'sqlite:' . $dsn,
+            null,
+            null,
+            [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION],
+        );
+
+        self::assertNotContains(
+            'entries',
+            $this->tableNames($probe),
+        );
+        unset($storage);
+    }
+
+    public function test_schema_version_is_a_positive_integer(): void
+    {
+        self::assertGreaterThanOrEqual(
+            1,
+            PdoStorage::SCHEMA_VERSION,
+        );
+    }
+
     public function test_get_returns_entry_by_dn(): void
     {
         $entry = $this->subject->get(new Dn('cn=Alice,dc=example,dc=com'));
@@ -819,6 +891,29 @@ final class SqliteStorageTest extends TestCase
         return SqliteStorage::forPcntl(':memory:');
     }
 
+    /**
+     * @return list<string>
+     */
+    private function tableNames(PDO $pdo): array
+    {
+        $stmt = $pdo->query(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+        );
+
+        if ($stmt === false) {
+            return [];
+        }
+
+        $names = [];
+        foreach ($stmt->fetchAll(PDO::FETCH_COLUMN) as $name) {
+            if (is_string($name)) {
+                $names[] = $name;
+            }
+        }
+
+        return $names;
+    }
+
     private function context(): WriteContext
     {
         return new WriteContext(
@@ -841,22 +936,8 @@ final class SqliteStorageTest extends TestCase
 
         $sqlite = new SqliteDialect();
         $dialect = $this->createMock(PdoDialectInterface::class);
-        $dialect->method('ddlCreateTable')
-            ->willReturn($sqlite->ddlCreateTable());
-        $dialect->method('ddlCreateIndex')
-            ->willReturn($sqlite->ddlCreateIndex());
-        $dialect->method('ddlCreateSidecarTable')
-            ->willReturn($sqlite->ddlCreateSidecarTable());
-        $dialect->method('ddlCreateSidecarIndexes')
-            ->willReturn($sqlite->ddlCreateSidecarIndexes());
-        $dialect->method('ddlCreateJournalTable')
-            ->willReturn($sqlite->ddlCreateJournalTable());
-        $dialect->method('ddlCreateJournalIndexes')
-            ->willReturn($sqlite->ddlCreateJournalIndexes());
-        $dialect->method('ddlCreateJournalSeqTable')
-            ->willReturn($sqlite->ddlCreateJournalSeqTable());
-        $dialect->method('queryJournalSeqInit')
-            ->willReturn($sqlite->queryJournalSeqInit());
+        $dialect->method('schemaStatements')
+            ->willReturn($sqlite->schemaStatements());
         $dialect->method('queryUpsert')
             ->willReturn($sqlite->queryUpsert());
         $dialect->method('queryExists')


### PR DESCRIPTION
This allows users to manage the schema with their own tooling and turn off / toggle auto schema execution on start-up. Documents how it's intended to work.