### PR TITLE
[1.0.0] Start to add the read-only replica logic.

### DIFF
--- a/src/FreeDSx/Ldap/Operation/Request/SyncRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/SyncRequest.php
@@ -24,6 +24,8 @@ class SyncRequest extends SearchRequest
 
     private ?Closure $cookieHandler = null;
 
+    private ?Closure $refreshDoneHandler = null;
+
     public function __construct(
         ?FilterInterface $filter = null,
         string|Attribute ...$attributes,
@@ -56,5 +58,17 @@ class SyncRequest extends SearchRequest
     public function getCookieHandler(): ?Closure
     {
         return $this->cookieHandler;
+    }
+
+    public function useRefreshDoneHandler(?Closure $refreshDoneHandler): self
+    {
+        $this->refreshDoneHandler = $refreshDoneHandler;
+
+        return $this;
+    }
+
+    public function getRefreshDoneHandler(): ?Closure
+    {
+        return $this->refreshDoneHandler;
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSyncHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSyncHandler.php
@@ -55,6 +55,8 @@ class ClientSyncHandler extends ClientBasicHandler
 
     private ?Closure $cookieHandler = null;
 
+    private ?Closure $refreshDoneHandler = null;
+
     public function __construct(
         private readonly ClientQueue $queue,
         private readonly ClientOptions $options,
@@ -155,6 +157,7 @@ class ClientSyncHandler extends ClientBasicHandler
         $this->syncReferralHandler = $this->syncRequest->getReferralHandler();
         $this->syncIdSetHandler = $this->syncRequest->getIdSetHandler();
         $this->cookieHandler = $this->syncRequest->getCookieHandler();
+        $this->refreshDoneHandler = $this->syncRequest->getRefreshDoneHandler();
 
         $this->syncRequest->useEntryHandler($this->processSyncEntry(...));
         $this->syncRequest->useReferralHandler($this->processSyncReferral(...));
@@ -211,14 +214,14 @@ class ClientSyncHandler extends ClientBasicHandler
         if ($response instanceof SyncRefreshDelete) {
             $this->updateCookie($response->getCookie());
             if ($response->getRefreshDone()) {
-                $this->session->updatePhase(null)->markRefreshComplete();
+                $this->completeRefresh(refreshDeletes: true);
             } else {
                 $this->session->updatePhase(Session::PHASE_DELETE);
             }
         } elseif ($response instanceof SyncRefreshPresent) {
             $this->updateCookie($response->getCookie());
             if ($response->getRefreshDone()) {
-                $this->session->updatePhase(null)->markRefreshComplete();
+                $this->completeRefresh(refreshDeletes: false);
             } else {
                 $this->session->updatePhase(Session::PHASE_PRESENT);
             }
@@ -259,6 +262,24 @@ class ClientSyncHandler extends ClientBasicHandler
         $result = $response->getResponse();
 
         return $result->getResultCode() === ResultCode::SYNCHRONIZATION_REFRESH_REQUIRED;
+    }
+
+    /**
+     * Mark the refresh phase complete and fire the refresh-done handler.
+     *
+     * The refresh-done handler is the deterministic boundary a consumer uses to reconcile a present-phase refresh
+     * before persist notifications begin.
+     */
+    private function completeRefresh(bool $refreshDeletes): void
+    {
+        $this->session->updatePhase(null)->markRefreshComplete($refreshDeletes);
+
+        if ($this->refreshDoneHandler !== null) {
+            call_user_func(
+                $this->refreshDoneHandler,
+                $this->session,
+            );
+        }
     }
 
     /**

--- a/src/FreeDSx/Ldap/ReplicaConfig.php
+++ b/src/FreeDSx/Ldap/ReplicaConfig.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap;
+
+use FreeDSx\Ldap\Search\Filter\FilterInterface;
+use FreeDSx\Ldap\Sync\Consumer\Checkpoint\InMemoryReplicationCheckpoint;
+use FreeDSx\Ldap\Sync\Consumer\Checkpoint\ReplicationCheckpointInterface;
+
+/**
+ * Configures a server as a replica of an upstream primary.
+ *
+ * Replicas currently act as read-only.
+ *
+ * @api
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class ReplicaConfig
+{
+    public function __construct(
+        private readonly ClientOptions $primary,
+        private readonly ReplicationCheckpointInterface $checkpoint = new InMemoryReplicationCheckpoint(),
+        private ?FilterInterface $filter = null,
+        private bool $referWrites = true,
+    ) {}
+
+    /**
+     * The client options for connecting to the upstream primary (servers, TLS, credentials, base DN).
+     */
+    public function getPrimary(): ClientOptions
+    {
+        return $this->primary;
+    }
+
+    /**
+     * Where the sync cookie is persisted so the replica resumes across restarts.
+     */
+    public function getCheckpoint(): ReplicationCheckpointInterface
+    {
+        return $this->checkpoint;
+    }
+
+    /**
+     * The filter selecting which entries to replicate, or null for all in-scope entries.
+     */
+    public function getFilter(): ?FilterInterface
+    {
+        return $this->filter;
+    }
+
+    public function setFilter(?FilterInterface $filter): self
+    {
+        $this->filter = $filter;
+
+        return $this;
+    }
+
+    /**
+     * Whether a client write is referred to the primary (true) or hard-rejected (false).
+     */
+    public function shouldReferWrites(): bool
+    {
+        return $this->referWrites;
+    }
+
+    public function setReferWrites(bool $referWrites): self
+    {
+        $this->referWrites = $referWrites;
+
+        return $this;
+    }
+
+    /**
+     * The primary's LDAP URLs, for referring client writes upstream.
+     *
+     * @return list<LdapUrl>
+     */
+    public function referralUrls(): array
+    {
+        $urls = [];
+
+        foreach ($this->primary->getServers() as $server) {
+            $urls[] = (new LdapUrl($server))
+                ->setPort($this->primary->getPort())
+                ->setUseSsl($this->primary->isUseSsl());
+        }
+
+        return $urls;
+    }
+}

--- a/src/FreeDSx/Ldap/Sync/Consumer/ChangeApplierInterface.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/ChangeApplierInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Sync\Consumer;
+
+use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Session;
+
+/**
+ * Applies sync results from an upstream provider to a local replica.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface ChangeApplierInterface
+{
+    /**
+     * Reset present-set tracking at the start of a new sync's refresh phase.
+     */
+    public function beginRefresh(): void;
+
+    /**
+     * Apply one sync result: add and modify are upserts, delete is a removal.
+     *
+     * During the refresh phase the entry's DN is recorded so {@see self::reconcile()} can find local entries the
+     * upstream no longer has.
+     */
+    public function apply(
+        SyncEntryResult $result,
+        Session $session,
+    ): void;
+
+    /**
+     * Delete local entries not seen during a present-phase refresh (reconcile by absence).
+     *
+     * Only safe after a refresh where {@see Session::hasRefreshDeletes()} is false; an incremental refresh conveys its
+     * deletes explicitly and must not be reconciled this way.
+     */
+    public function reconcile(): void;
+}

--- a/src/FreeDSx/Ldap/Sync/Consumer/Checkpoint/FileReplicationCheckpoint.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/Checkpoint/FileReplicationCheckpoint.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Sync\Consumer\Checkpoint;
+
+use FreeDSx\Ldap\Exception\RuntimeException;
+
+use function file_get_contents;
+use function file_put_contents;
+use function is_file;
+use function rename;
+use function sprintf;
+use function unlink;
+
+use const LOCK_EX;
+
+/**
+ * Stores the sync cookie in a file, replaced atomically via a temp file and rename.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class FileReplicationCheckpoint implements ReplicationCheckpointInterface
+{
+    public function __construct(private string $path) {}
+
+    public function read(): ?string
+    {
+        if (!is_file($this->path)) {
+            return null;
+        }
+
+        $cookie = @file_get_contents($this->path);
+
+        if ($cookie === false) {
+            throw new RuntimeException(sprintf(
+                'Unable to read the replication checkpoint at "%s".',
+                $this->path,
+            ));
+        }
+
+        return $cookie;
+    }
+
+    public function write(string $cookie): void
+    {
+        $tmp = $this->path . '.tmp';
+
+        $written = @file_put_contents(
+            $tmp,
+            $cookie,
+            LOCK_EX,
+        );
+
+        if ($written === false) {
+            throw new RuntimeException(sprintf(
+                'Unable to write the replication checkpoint to "%s".',
+                $tmp,
+            ));
+        }
+
+        if (!@rename($tmp, $this->path)) {
+            @unlink($tmp);
+
+            throw new RuntimeException(sprintf(
+                'Unable to move the replication checkpoint into place at "%s".',
+                $this->path,
+            ));
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Sync/Consumer/Checkpoint/InMemoryReplicationCheckpoint.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/Checkpoint/InMemoryReplicationCheckpoint.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Sync\Consumer\Checkpoint;
+
+/**
+ * Holds the sync cookie in memory only; a restart resumes with a full refresh.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class InMemoryReplicationCheckpoint implements ReplicationCheckpointInterface
+{
+    private ?string $cookie = null;
+
+    public function read(): ?string
+    {
+        return $this->cookie;
+    }
+
+    public function write(string $cookie): void
+    {
+        $this->cookie = $cookie;
+    }
+}

--- a/src/FreeDSx/Ldap/Sync/Consumer/Checkpoint/ReplicationCheckpointInterface.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/Checkpoint/ReplicationCheckpointInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Sync\Consumer\Checkpoint;
+
+/**
+ * Persists the sync cookie so a replica can resume across restarts.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface ReplicationCheckpointInterface
+{
+    /**
+     * The cookie persisted by the last successful sync, or null when no checkpoint exists yet.
+     */
+    public function read(): ?string;
+
+    /**
+     * Persist the cookie as the resume point for the next sync.
+     */
+    public function write(string $cookie): void;
+}

--- a/src/FreeDSx/Ldap/Sync/Consumer/VerbatimStorageApplier.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/VerbatimStorageApplier.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Sync\Consumer;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
+use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Session;
+
+/**
+ * Applies sync results verbatim to a local replica's raw storage, reconciling deletes by absence.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class VerbatimStorageApplier implements ChangeApplierInterface
+{
+    /**
+     * @var array<string, true> Normalized DNs seen during the current refresh phase.
+     *
+     * @todo Held entirely in memory, so a full refresh of a very large directory is costly. Should be refactored to a
+     *       threshold-based on-disk (or generation-marked) present-set.
+     */
+    private array $presentDns = [];
+
+    public function __construct(private readonly EntryStorageInterface $storage) {}
+
+    public function beginRefresh(): void
+    {
+        $this->presentDns = [];
+    }
+
+    public function apply(
+        SyncEntryResult $result,
+        Session $session,
+    ): void {
+        $entry = $result->getEntry();
+        $dn = $entry->getDn()
+            ->normalize();
+
+        if ($result->isDelete()) {
+            $this->storage->remove($dn);
+
+            return;
+        }
+
+        if (!$session->isRefreshComplete()) {
+            $this->presentDns[$dn->toString()] = true;
+        }
+
+        if ($result->isPresent()) {
+            return;
+        }
+
+        $this->storage->store($entry);
+    }
+
+    public function reconcile(): void
+    {
+        $options = StorageListOptions::matchAll(
+            new Dn(''),
+            subtree: true,
+        );
+
+        $stale = [];
+        foreach ($this->storage->list($options)->entries as $entry) {
+            $dn = $entry->getDn()
+                ->normalize();
+
+            if (!isset($this->presentDns[$dn->toString()])) {
+                $stale[] = $dn;
+            }
+        }
+
+        foreach ($stale as $dn) {
+            $this->storage->remove($dn);
+        }
+
+        $this->presentDns = [];
+    }
+}

--- a/src/FreeDSx/Ldap/Sync/Session.php
+++ b/src/FreeDSx/Ldap/Sync/Session.php
@@ -28,6 +28,8 @@ final class Session
 
     public const MODE_LISTEN = SyncRequestControl::MODE_REFRESH_AND_PERSIST;
 
+    private bool $refreshDeletes = false;
+
     public function __construct(
         private readonly int $mode,
         private ?string $cookie,
@@ -77,6 +79,17 @@ final class Session
     }
 
     /**
+     * Whether the completed refresh conveyed deletes explicitly (a delete-phase incremental refresh).
+     *
+     * When false, the refresh was a present phase whose deletes are implied by absence, so a consumer maintaining a
+     * replica must delete local entries not seen during it. Only meaningful once {@see self::isRefreshComplete()}.
+     */
+    public function hasRefreshDeletes(): bool
+    {
+        return $this->refreshDeletes;
+    }
+
+    /**
      * @internal
      */
     public function updatePhase(?int $phase): self
@@ -89,9 +102,10 @@ final class Session
     /**
      * @internal
      */
-    public function markRefreshComplete(): self
+    public function markRefreshComplete(bool $refreshDeletes = false): self
     {
         $this->refreshComplete = true;
+        $this->refreshDeletes = $refreshDeletes;
 
         return $this;
     }
@@ -103,6 +117,7 @@ final class Session
     {
         $this->phase = null;
         $this->refreshComplete = false;
+        $this->refreshDeletes = false;
 
         return $this;
     }

--- a/src/FreeDSx/Ldap/Sync/SyncRepl.php
+++ b/src/FreeDSx/Ldap/Sync/SyncRepl.php
@@ -42,6 +42,8 @@ class SyncRepl
 
     private ?string $cookie = null;
 
+    private ?Closure $cookieHandler = null;
+
     public function __construct(
         LdapClient $client,
         ?FilterInterface $filter = null,
@@ -70,7 +72,7 @@ class SyncRepl
      */
     public function useCookieHandler(Closure $handler): self
     {
-        $this->syncRequest->useCookieHandler($handler);
+        $this->cookieHandler = $handler;
 
         return $this;
     }
@@ -115,6 +117,19 @@ class SyncRepl
     }
 
     /**
+     * Define a closure that fires once the initial refresh phase completes, receiving the {@see Session}.
+     *
+     * This is the deterministic point to reconcile a full refresh, such as deleting local entries not seen during the
+     * present phase, before persist notifications begin.
+     */
+    public function useRefreshDoneHandler(Closure $handler): self
+    {
+        $this->syncRequest->useRefreshDoneHandler($handler);
+
+        return $this;
+    }
+
+    /**
      * A convenience method to set the filter to use for this sync. This can also be set using {@see self::request()}.
      */
     public function useFilter(FilterInterface $filter): self
@@ -133,6 +148,16 @@ class SyncRepl
         $this->cookie = $cookie;
 
         return $this;
+    }
+
+    /**
+     * The most recent cookie seen during the sync.
+     *
+     * After a poll or listen this is the resume point to persist and pass to a later {@see self::useCookie()}.
+     */
+    public function getCookie(): ?string
+    {
+        return $this->cookie;
     }
 
     /**
@@ -188,6 +213,8 @@ class SyncRepl
             $this->useEntryHandler($entryHandler);
         }
 
+        $this->syncRequest->useCookieHandler($this->trackCookie(...));
+
         $this->client->sendAndReceive(
             $this->syncRequest,
             Controls::syncRequest(
@@ -197,5 +224,20 @@ class SyncRepl
             Controls::manageDsaIt(),
             ...$this->controls->toArray(),
         );
+    }
+
+    /**
+     * Track the latest cookie internally and forward it to any user cookie handler.
+     */
+    private function trackCookie(?string $cookie): void
+    {
+        $this->cookie = $cookie;
+
+        if ($this->cookieHandler !== null) {
+            call_user_func(
+                $this->cookieHandler,
+                $cookie,
+            );
+        }
     }
 }

--- a/tests/unit/Protocol/ClientProtocolHandler/ClientSyncHandlerTest.php
+++ b/tests/unit/Protocol/ClientProtocolHandler/ClientSyncHandlerTest.php
@@ -399,7 +399,7 @@ final class ClientSyncHandlerTest extends TestCase
         );
 
         self::assertTrue($capturedSession?->isRefreshComplete());
-        self::assertTrue($capturedSession?->hasRefreshDeletes());
+        self::assertTrue($capturedSession->hasRefreshDeletes());
     }
 
     public function test_a_refresh_present_in_progress_sets_phase_present_and_refresh_is_not_complete(): void
@@ -479,7 +479,7 @@ final class ClientSyncHandlerTest extends TestCase
 
         self::assertNull($capturedSession?->getPhase());
         self::assertTrue($capturedSession?->isRefreshComplete());
-        self::assertFalse($capturedSession?->hasRefreshDeletes());
+        self::assertFalse($capturedSession->hasRefreshDeletes());
     }
 
     public function test_it_should_process_a_sync_referral(): void

--- a/tests/unit/Protocol/ClientProtocolHandler/ClientSyncHandlerTest.php
+++ b/tests/unit/Protocol/ClientProtocolHandler/ClientSyncHandlerTest.php
@@ -364,6 +364,44 @@ final class ClientSyncHandlerTest extends TestCase
         self::assertTrue($capturedSession?->isRefreshComplete());
     }
 
+    public function test_the_refresh_done_handler_fires_when_the_refresh_completes(): void
+    {
+        $capturedSession = null;
+        $messageTo = new LdapMessageRequest(
+            1,
+            (new SyncRequest())
+                ->useRefreshDoneHandler(function (Session $session) use (&$capturedSession): void {
+                    $capturedSession = $session;
+                }),
+            new SyncRequestControl(),
+        );
+
+        $this->mockQueue
+            ->expects($this->exactly(2))
+            ->method('getMessage')
+            ->with(1)
+            ->willReturnOnConsecutiveCalls(
+                new LdapMessageResponse(
+                    1,
+                    new SearchResultEntry(new Entry('bar')),
+                    new SyncStateControl(SyncStateControl::STATE_ADD, 'foo'),
+                ),
+                new LdapMessageResponse(
+                    1,
+                    new SearchResultDone(0, '', ''),
+                    new SyncDoneControl(),
+                ),
+            );
+
+        $this->subject->handleResponse(
+            $messageTo,
+            new LdapMessageResponse(1, new SyncRefreshDelete(refreshDone: true)),
+        );
+
+        self::assertTrue($capturedSession?->isRefreshComplete());
+        self::assertTrue($capturedSession?->hasRefreshDeletes());
+    }
+
     public function test_a_refresh_present_in_progress_sets_phase_present_and_refresh_is_not_complete(): void
     {
         $capturedSession = null;
@@ -441,6 +479,7 @@ final class ClientSyncHandlerTest extends TestCase
 
         self::assertNull($capturedSession?->getPhase());
         self::assertTrue($capturedSession?->isRefreshComplete());
+        self::assertFalse($capturedSession?->hasRefreshDeletes());
     }
 
     public function test_it_should_process_a_sync_referral(): void

--- a/tests/unit/ReplicaConfigTest.php
+++ b/tests/unit/ReplicaConfigTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap;
+
+use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\ReplicaConfig;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Sync\Consumer\Checkpoint\InMemoryReplicationCheckpoint;
+use FreeDSx\Ldap\Sync\Consumer\Checkpoint\ReplicationCheckpointInterface;
+use PHPUnit\Framework\TestCase;
+
+final class ReplicaConfigTest extends TestCase
+{
+    private ReplicaConfig $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new ReplicaConfig(
+            (new ClientOptions())
+                ->setServers(['primary.example.com'])
+                ->setPort(636)
+                ->setUseSsl(true),
+        );
+    }
+
+    public function test_it_defaults_to_an_in_memory_checkpoint(): void
+    {
+        self::assertInstanceOf(
+            InMemoryReplicationCheckpoint::class,
+            $this->subject->getCheckpoint(),
+        );
+    }
+
+    public function test_it_defaults_to_referring_writes_with_no_filter(): void
+    {
+        self::assertTrue($this->subject->shouldReferWrites());
+        self::assertNull($this->subject->getFilter());
+    }
+
+    public function test_it_exposes_the_primary_options(): void
+    {
+        self::assertSame(
+            ['primary.example.com'],
+            $this->subject->getPrimary()->getServers(),
+        );
+    }
+
+    public function test_it_derives_the_primary_referral_urls(): void
+    {
+        $urls = $this->subject->referralUrls();
+
+        self::assertCount(
+            1,
+            $urls,
+        );
+        self::assertSame(
+            'primary.example.com',
+            $urls[0]->getHost(),
+        );
+        self::assertSame(
+            636,
+            $urls[0]->getPort(),
+        );
+        self::assertTrue($urls[0]->getUseSsl());
+    }
+
+    public function test_the_filter_and_write_policy_are_fluent(): void
+    {
+        $filter = Filters::present('objectClass');
+
+        $result = $this->subject
+            ->setFilter($filter)
+            ->setReferWrites(false);
+
+        self::assertSame(
+            $this->subject,
+            $result,
+        );
+        self::assertSame(
+            $filter,
+            $this->subject->getFilter(),
+        );
+        self::assertFalse($this->subject->shouldReferWrites());
+    }
+
+    public function test_a_custom_checkpoint_is_used(): void
+    {
+        $checkpoint = $this->createMock(ReplicationCheckpointInterface::class);
+
+        $config = new ReplicaConfig(
+            new ClientOptions(),
+            $checkpoint,
+        );
+
+        self::assertSame(
+            $checkpoint,
+            $config->getCheckpoint(),
+        );
+    }
+}

--- a/tests/unit/Sync/Consumer/Checkpoint/FileReplicationCheckpointTest.php
+++ b/tests/unit/Sync/Consumer/Checkpoint/FileReplicationCheckpointTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Sync\Consumer\Checkpoint;
+
+use FreeDSx\Ldap\Sync\Consumer\Checkpoint\FileReplicationCheckpoint;
+use FreeDSx\Ldap\Sync\Consumer\Checkpoint\ReplicationCheckpointInterface;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class FileReplicationCheckpointTest extends TestCase
+{
+    private string $path;
+
+    private ReplicationCheckpointInterface $subject;
+
+    protected function setUp(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'freedsx_ckpt')
+            ?: throw new RuntimeException('Unable to create a temp file.');
+        // tempnam creates the file; start the test with no checkpoint present.
+        unlink($file);
+
+        $this->path = $file;
+        $this->subject = new FileReplicationCheckpoint($this->path);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ([$this->path, $this->path . '.tmp'] as $file) {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+    }
+
+    public function test_read_returns_null_when_no_checkpoint_exists(): void
+    {
+        self::assertNull($this->subject->read());
+    }
+
+    public function test_write_then_read_round_trips_the_cookie(): void
+    {
+        $this->subject->write('cookie-123');
+
+        self::assertSame(
+            'cookie-123',
+            $this->subject->read(),
+        );
+    }
+
+    public function test_write_replaces_a_previous_checkpoint(): void
+    {
+        $this->subject->write('first');
+        $this->subject->write('second');
+
+        self::assertSame(
+            'second',
+            $this->subject->read(),
+        );
+    }
+
+    public function test_a_binary_cookie_round_trips(): void
+    {
+        $cookie = "rid=001,csn=\x00\x01\xff\x7f";
+
+        $this->subject->write($cookie);
+
+        self::assertSame(
+            $cookie,
+            $this->subject->read(),
+        );
+    }
+
+    public function test_write_leaves_no_temp_file_behind(): void
+    {
+        $this->subject->write('cookie');
+
+        self::assertFileDoesNotExist($this->path . '.tmp');
+    }
+}

--- a/tests/unit/Sync/Consumer/VerbatimStorageApplierTest.php
+++ b/tests/unit/Sync/Consumer/VerbatimStorageApplierTest.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Sync\Consumer;
+
+use FreeDSx\Ldap\Control\Sync\SyncStateControl;
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Search\Result\EntryResult;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Sync\Consumer\ChangeApplierInterface;
+use FreeDSx\Ldap\Sync\Consumer\VerbatimStorageApplier;
+use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Session;
+use PHPUnit\Framework\TestCase;
+
+final class VerbatimStorageApplierTest extends TestCase
+{
+    private InMemoryStorage $storage;
+
+    private ChangeApplierInterface $subject;
+
+    protected function setUp(): void
+    {
+        $this->storage = new InMemoryStorage();
+        $this->subject = new VerbatimStorageApplier($this->storage);
+    }
+
+    public function test_an_add_stores_the_entry(): void
+    {
+        $this->subject->apply(
+            $this->syncResult(
+                SyncStateControl::STATE_ADD,
+                $this->entry('cn=alice,dc=example,dc=com'),
+            ),
+            $this->refreshSession(),
+        );
+
+        self::assertTrue($this->exists('cn=alice,dc=example,dc=com'));
+    }
+
+    public function test_a_modify_replaces_the_stored_entry(): void
+    {
+        $session = $this->refreshSession();
+
+        $this->subject->apply(
+            $this->syncResult(
+                SyncStateControl::STATE_ADD,
+                new Entry(
+                    'cn=bob,dc=example,dc=com',
+                    new Attribute('cn', 'bob'),
+                    new Attribute('sn', 'Old'),
+                ),
+            ),
+            $session,
+        );
+        $this->subject->apply(
+            $this->syncResult(
+                SyncStateControl::STATE_MODIFY,
+                new Entry(
+                    'cn=bob,dc=example,dc=com',
+                    new Attribute('cn', 'bob'),
+                    new Attribute('sn', 'New'),
+                ),
+            ),
+            $session,
+        );
+
+        self::assertSame(
+            'New',
+            $this->value('cn=bob,dc=example,dc=com', 'sn'),
+        );
+    }
+
+    public function test_a_delete_removes_the_entry(): void
+    {
+        $this->storage->store($this->entry('cn=carol,dc=example,dc=com'));
+
+        $this->subject->apply(
+            $this->syncResult(
+                SyncStateControl::STATE_DELETE,
+                $this->entry('cn=carol,dc=example,dc=com'),
+            ),
+            $this->refreshSession(),
+        );
+
+        self::assertFalse($this->exists('cn=carol,dc=example,dc=com'));
+    }
+
+    public function test_reconcile_removes_locals_absent_from_the_present_phase(): void
+    {
+        foreach (['a', 'b', 'c'] as $cn) {
+            $this->storage->store($this->entry("cn=$cn,dc=example,dc=com"));
+        }
+
+        $session = $this->refreshSession();
+        $this->subject->beginRefresh();
+        $this->subject->apply(
+            $this->syncResult(
+                SyncStateControl::STATE_ADD,
+                $this->entry('cn=a,dc=example,dc=com'),
+            ),
+            $session,
+        );
+        $this->subject->apply(
+            $this->syncResult(
+                SyncStateControl::STATE_ADD,
+                $this->entry('cn=b,dc=example,dc=com'),
+            ),
+            $session,
+        );
+        $this->subject->reconcile();
+
+        self::assertTrue($this->exists('cn=a,dc=example,dc=com'));
+        self::assertTrue($this->exists('cn=b,dc=example,dc=com'));
+        self::assertFalse($this->exists('cn=c,dc=example,dc=com'));
+    }
+
+    public function test_a_rename_deletes_the_old_dn_and_keeps_the_new(): void
+    {
+        // The replica holds the entry at its old DN; the refresh presents it only at the new DN.
+        $this->storage->store($this->entry('cn=old,dc=example,dc=com'));
+
+        $session = $this->refreshSession();
+        $this->subject->beginRefresh();
+        $this->subject->apply(
+            $this->syncResult(
+                SyncStateControl::STATE_ADD,
+                $this->entry('cn=new,dc=example,dc=com'),
+            ),
+            $session,
+        );
+        $this->subject->reconcile();
+
+        self::assertFalse($this->exists('cn=old,dc=example,dc=com'));
+        self::assertTrue($this->exists('cn=new,dc=example,dc=com'));
+    }
+
+    public function test_begin_refresh_clears_the_previous_present_set(): void
+    {
+        $session = $this->refreshSession();
+
+        $this->subject->beginRefresh();
+        $this->subject->apply(
+            $this->syncResult(
+                SyncStateControl::STATE_ADD,
+                $this->entry('cn=a,dc=example,dc=com'),
+            ),
+            $session,
+        );
+
+        // A second refresh presents nothing; the first refresh's present-set must not protect the entry.
+        $this->subject->beginRefresh();
+        $this->subject->reconcile();
+
+        self::assertFalse($this->exists('cn=a,dc=example,dc=com'));
+    }
+
+    private function entry(string $dn): Entry
+    {
+        return new Entry(
+            $dn,
+            new Attribute('cn', 'x'),
+        );
+    }
+
+    private function syncResult(
+        int $state,
+        Entry $entry,
+    ): SyncEntryResult {
+        $message = new LdapMessageResponse(
+            1,
+            new SearchResultEntry($entry),
+            new SyncStateControl($state, 'uuid-' . $entry->getDn()->toString()),
+        );
+
+        return new SyncEntryResult(new EntryResult($message));
+    }
+
+    private function refreshSession(): Session
+    {
+        return new Session(
+            Session::MODE_LISTEN,
+            null,
+        );
+    }
+
+    private function exists(string $dn): bool
+    {
+        return $this->storage->find((new Dn($dn))->normalize()) !== null;
+    }
+
+    private function value(
+        string $dn,
+        string $attribute,
+    ): ?string {
+        $entry = $this->storage->find((new Dn($dn))->normalize());
+
+        if ($entry === null) {
+            return null;
+        }
+
+        $values = $entry->get($attribute)?->getValues() ?? [];
+
+        return $values[0] ?? null;
+    }
+}

--- a/tests/unit/Sync/SyncReplTest.php
+++ b/tests/unit/Sync/SyncReplTest.php
@@ -25,6 +25,7 @@ use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
 use FreeDSx\Ldap\Sync\Result\SyncIdSetResult;
 use FreeDSx\Ldap\Sync\Result\SyncReferralResult;
+use FreeDSx\Ldap\Sync\Session;
 use FreeDSx\Ldap\Sync\SyncRepl;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -222,6 +223,88 @@ final class SyncReplTest extends TestCase
             ));
 
         $this->subject->poll();
+    }
+
+    public function test_it_should_use_the_refresh_done_handler_specified(): void
+    {
+        $handler = fn(Session $session) => $session->getCookie();
+
+        $this->subject->useRefreshDoneHandler($handler);
+
+        $this->mockClient
+            ->expects(self::once())
+            ->method('sendAndReceive')
+            ->with(
+                self::callback(
+                    fn(SyncRequest $request) => $request->getRefreshDoneHandler() === $handler,
+                ),
+                self::anything(),
+                self::anything(),
+            )->willReturn(new LdapMessageResponse(
+                1,
+                new SearchResultDone(0),
+                new SyncDoneControl('foo'),
+            ));
+
+        $this->subject->poll();
+    }
+
+    public function test_it_tracks_the_latest_cookie_and_exposes_it(): void
+    {
+        $this->mockClient
+            ->method('sendAndReceive')
+            ->willReturnCallback(function (SyncRequest $request): LdapMessageResponse {
+                // Simulate the protocol handler delivering a fresh cookie mid-sync.
+                $cookieHandler = $request->getCookieHandler();
+                self::assertNotNull($cookieHandler);
+                $cookieHandler('fresh-cookie');
+
+                return new LdapMessageResponse(
+                    1,
+                    new SearchResultDone(0),
+                    new SyncDoneControl('fresh-cookie'),
+                );
+            });
+
+        $this->subject->poll();
+
+        self::assertSame(
+            'fresh-cookie',
+            $this->subject->getCookie(),
+        );
+    }
+
+    public function test_it_forwards_cookie_updates_to_a_user_cookie_handler(): void
+    {
+        $seen = null;
+        $this->subject->useCookieHandler(function (?string $cookie) use (&$seen): void {
+            $seen = $cookie;
+        });
+
+        $this->mockClient
+            ->method('sendAndReceive')
+            ->willReturnCallback(function (SyncRequest $request): LdapMessageResponse {
+                $cookieHandler = $request->getCookieHandler();
+                self::assertNotNull($cookieHandler);
+                $cookieHandler('handed-over');
+
+                return new LdapMessageResponse(
+                    1,
+                    new SearchResultDone(0),
+                    new SyncDoneControl('handed-over'),
+                );
+            });
+
+        $this->subject->poll();
+
+        self::assertSame(
+            'handed-over',
+            $seen,
+        );
+        self::assertSame(
+            'handed-over',
+            $this->subject->getCookie(),
+        );
     }
 
     public function test_it_should_use_the_continue_strategy_if_specified(): void


### PR DESCRIPTION
With the journal / sync pieces in place, this starts the addition of a read only replica server. The idea is that it runs a normal LdapServer, but also runs a process for a SyncRepl to keep local storage up-to-date. Read only replicas do not produce journal entries / do not allow writes. One issue this raises is handling password policy auth, as it stamps auth attempts / tracks lockout / etc. The mechanism to handle this will be a follow up. But the essential idea is that for password policy state, that will be forwarded by the replica to the primary server over an explicitly ACL gated extended operation.