### PR TITLE
[1.0.0] Replica config in server options / read-only middleware.

### DIFF
--- a/src/FreeDSx/Ldap/Server/Backend/Write/NullSystemChangeWriter.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/NullSystemChangeWriter.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Write;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
+
+/**
+ * Discards automated system operational changes so a read-only replica does not persist them locally.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class NullSystemChangeWriter implements SystemChangeWriterInterface
+{
+    public function write(
+        Dn $dn,
+        OperationalChanges $changes,
+    ): void {}
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Write/PasswordPolicyWriteHandler.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/PasswordPolicyWriteHandler.php
@@ -40,7 +40,7 @@ final readonly class PasswordPolicyWriteHandler implements WriteHandlerInterface
     public function __construct(
         private LdapBackendInterface&WriteHandlerInterface $backend,
         private PasswordPolicyChangeGuard $changeGuard,
-        private SystemChangeWriter $systemChangeWriter,
+        private SystemChangeWriterInterface $systemChangeWriter,
         private PasswordHashService $hashService = new PasswordHashService(),
     ) {}
 

--- a/src/FreeDSx/Ldap/Server/Backend/Write/SystemChangeWriter.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/SystemChangeWriter.php
@@ -23,7 +23,7 @@ use FreeDSx\Ldap\Server\Token\SystemToken;
 /**
  * Applies server-generated writes, bypassing schema NO-USER-MODIFICATION and ACL checks.
  */
-final readonly class SystemChangeWriter
+final readonly class SystemChangeWriter implements SystemChangeWriterInterface
 {
     public function __construct(private WriteOperationDispatcher $writeDispatcher) {}
 

--- a/src/FreeDSx/Ldap/Server/Backend/Write/SystemChangeWriterInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/SystemChangeWriterInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Write;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
+
+/**
+ * Persists server-generated operational changes (such as password-policy bind state) to an entry.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface SystemChangeWriterInterface
+{
+    /**
+     * @throws OperationException
+     */
+    public function write(
+        Dn $dn,
+        OperationalChanges $changes,
+    ): void;
+}

--- a/src/FreeDSx/Ldap/Server/Middleware/ReadOnlyMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/ReadOnlyMiddleware.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\LdapResult;
+use FreeDSx\Ldap\Operation\OperationType;
+use FreeDSx\Ldap\Operation\Request\AddRequest;
+use FreeDSx\Ldap\Operation\Request\DeleteRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Response\AddResponse;
+use FreeDSx\Ldap\Operation\Response\DeleteResponse;
+use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
+use FreeDSx\Ldap\Operation\Response\ModifyDnResponse;
+use FreeDSx\Ldap\Operation\Response\ModifyResponse;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\ReplicaConfig;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+
+use function in_array;
+
+/**
+ * Rejects or refers client write operations on a read-only replica.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ReadOnlyMiddleware implements MiddlewareInterface
+{
+    private const DIAGNOSTIC = 'This server is a read-only replica.';
+
+    /**
+     * @var list<OperationType>
+     */
+    private const WRITE_OPERATIONS = [
+        OperationType::Add,
+        OperationType::Modify,
+        OperationType::Delete,
+        OperationType::ModifyDn,
+        OperationType::PasswordModify,
+    ];
+
+    public function __construct(
+        private ServerQueue $queue,
+        private ReplicaConfig $replicaConfig,
+    ) {}
+
+    public function process(
+        ServerRequestContext $context,
+        MiddlewareHandlerInterface $next,
+    ): OperationResult {
+        $request = $context->message->getRequest();
+
+        $isWrite = in_array(
+            OperationType::classify($request),
+            self::WRITE_OPERATIONS,
+            true,
+        );
+
+        if (!$isWrite) {
+            return $next->handle($context);
+        }
+
+        if (!$this->replicaConfig->shouldReferWrites()) {
+            throw new OperationException(
+                self::DIAGNOSTIC,
+                ResultCode::UNWILLING_TO_PERFORM,
+            );
+        }
+
+        $this->queue->sendMessage($this->referralResponse(
+            $request,
+            $context->message->getMessageId(),
+        ));
+
+        return OperationOutcomeResult::failed(ResultCode::REFERRAL);
+    }
+
+    private function referralResponse(
+        RequestInterface $request,
+        int $messageId,
+    ): LdapMessageResponse {
+        $referrals = $this->replicaConfig->referralUrls();
+
+        // The default covers PasswordModify (an extended operation); the write gate guarantees no other type reaches here.
+        $response = match (true) {
+            $request instanceof AddRequest => new AddResponse(
+                ResultCode::REFERRAL,
+                '',
+                self::DIAGNOSTIC,
+                ...$referrals,
+            ),
+            $request instanceof ModifyRequest => new ModifyResponse(
+                ResultCode::REFERRAL,
+                '',
+                self::DIAGNOSTIC,
+                ...$referrals,
+            ),
+            $request instanceof DeleteRequest => new DeleteResponse(
+                ResultCode::REFERRAL,
+                '',
+                self::DIAGNOSTIC,
+                ...$referrals,
+            ),
+            $request instanceof ModifyDnRequest => new ModifyDnResponse(
+                ResultCode::REFERRAL,
+                '',
+                self::DIAGNOSTIC,
+                ...$referrals,
+            ),
+            default => new ExtendedResponse(
+                new LdapResult(
+                    ResultCode::REFERRAL,
+                    '',
+                    self::DIAGNOSTIC,
+                    ...$referrals,
+                ),
+            ),
+        };
+
+        return new LdapMessageResponse(
+            $messageId,
+            $response,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Guard/PasswordPolicyBindGuard.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Guard/PasswordPolicyBindGuard.php
@@ -15,7 +15,7 @@ namespace FreeDSx\Ldap\Server\PasswordPolicy\Guard;
 
 use FreeDSx\Ldap\Control\PwdPolicyError;
 use FreeDSx\Ldap\Exception\OperationException;
-use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
+use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriterInterface;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
@@ -31,7 +31,7 @@ final readonly class PasswordPolicyBindGuard
 {
     public function __construct(
         private PasswordPolicyEngine $engine,
-        private SystemChangeWriter $writer,
+        private SystemChangeWriterInterface $writer,
         private PasswordPolicyContext $context,
         private EventLogger $eventLogger,
     ) {}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyComponentFactory.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyComponentFactory.php
@@ -15,7 +15,9 @@ namespace FreeDSx\Ldap\Server\PasswordPolicy;
 
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Server\Backend\Write\PasswordPolicyWriteHandler;
+use FreeDSx\Ldap\Server\Backend\Write\NullSystemChangeWriter;
 use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
+use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriterInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
@@ -63,7 +65,7 @@ final readonly class PasswordPolicyComponentFactory
         return new PasswordPolicyWriteHandler(
             $backend,
             $guard,
-            new SystemChangeWriter($this->writeDispatcher),
+            $this->systemChangeWriter(),
         );
     }
 
@@ -85,5 +87,14 @@ final readonly class PasswordPolicyComponentFactory
             $passwordPolicyContext,
             $eventLogger,
         );
+    }
+
+    private function systemChangeWriter(): SystemChangeWriterInterface
+    {
+        if ($this->options->isReadOnly()) {
+            return new NullSystemChangeWriter();
+        }
+
+        return new SystemChangeWriter($this->writeDispatcher);
     }
 }

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -41,7 +41,9 @@ use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Sasl\External\SubjectDnCredentialMapper;
 use FreeDSx\Ldap\Server\Backend\Auth\SaslBindPolicyEnforcer;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Write\NullSystemChangeWriter;
 use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriter;
+use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriterInterface;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\OperationAuditor;
@@ -59,6 +61,7 @@ use FreeDSx\Ldap\Server\Middleware\CriticalControlMiddleware;
 use FreeDSx\Ldap\Server\Middleware\OperationAuditMiddleware;
 use FreeDSx\Ldap\Server\Middleware\OperationAuthorizationMiddleware;
 use FreeDSx\Ldap\Server\Middleware\OperationErrorMiddleware;
+use FreeDSx\Ldap\Server\Middleware\ReadOnlyMiddleware;
 use FreeDSx\Ldap\Server\Middleware\RequestValidationMiddleware;
 use FreeDSx\Ldap\Server\Middleware\ResourceLimitMiddleware;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\HandlerInvoker;
@@ -204,6 +207,8 @@ class ServerProtocolFactory implements ServerProtocolFactoryInterface
             metricsSnapshots: $this->metricsSnapshots,
         );
 
+        $replicaConfig = $this->options->getReplicaConfig();
+
         return new ServerProtocolHandler(
             queue: $serverQueue,
             requestPipeline: new MiddlewareChain(
@@ -232,6 +237,14 @@ class ServerProtocolFactory implements ServerProtocolFactoryInterface
                         $this->options->getAccessControl(),
                     ),
                     new OperationAuditMiddleware(new OperationAuditor($eventLogger)),
+                    // Only present on a read-only replica; sits below OperationErrorMiddleware so a rejection renders,
+                    // and before the ACL loop so a write short-circuits early.
+                    ...($replicaConfig !== null
+                        ? [new ReadOnlyMiddleware(
+                            $serverQueue,
+                            $replicaConfig,
+                        )]
+                        : []),
                     new CriticalControlMiddleware($this->routeResolver),
                     new OperationAuthorizationMiddleware(
                         $this->routeResolver,
@@ -299,10 +312,19 @@ class ServerProtocolFactory implements ServerProtocolFactoryInterface
     ): PasswordPolicyBindGuard {
         return new PasswordPolicyBindGuard(
             $this->passwordPolicyEngine,
-            new SystemChangeWriter($this->handlerFactory->makeWriteDispatcher()),
+            $this->systemChangeWriter(),
             $policyContext,
             $eventLogger,
         );
+    }
+
+    private function systemChangeWriter(): SystemChangeWriterInterface
+    {
+        if ($this->options->isReadOnly()) {
+            return new NullSystemChangeWriter();
+        }
+
+        return new SystemChangeWriter($this->handlerFactory->makeWriteDispatcher());
     }
 
     /**

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -210,6 +210,8 @@ final class ServerOptions
 
     private ?ChangeJournalConfig $changeJournalConfig = null;
 
+    private ?ReplicaConfig $replicaConfig = null;
+
     private ?string $monitorSnapshotPath = null;
 
     private ?MetricsRecorderInterface $metricsRecorder = null;
@@ -872,6 +874,26 @@ final class ServerOptions
         $this->changeJournalConfig = $changeJournalConfig;
 
         return $this;
+    }
+
+    public function getReplicaConfig(): ?ReplicaConfig
+    {
+        return $this->replicaConfig;
+    }
+
+    public function setReplicaConfig(ReplicaConfig $replicaConfig): self
+    {
+        $this->replicaConfig = $replicaConfig;
+
+        return $this;
+    }
+
+    /**
+     * Whether this server is a read-only replica, derived from having a replica config.
+     */
+    public function isReadOnly(): bool
+    {
+        return $this->replicaConfig !== null;
     }
 
     public function getMonitorSnapshotPath(): ?string

--- a/tests/unit/Server/Middleware/ReadOnlyMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/ReadOnlyMiddlewareTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\LdapResult;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Response\AddResponse;
+use FreeDSx\Ldap\Operation\Response\DeleteResponse;
+use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
+use FreeDSx\Ldap\Operation\Response\ModifyDnResponse;
+use FreeDSx\Ldap\Operation\Response\ModifyResponse;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\ReplicaConfig;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Middleware\ReadOnlyMiddleware;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class ReadOnlyMiddlewareTest extends TestCase
+{
+    private ServerQueue&MockObject $queue;
+
+    private MiddlewareHandlerInterface&MockObject $next;
+
+    private ReplicaConfig $replicaConfig;
+
+    private ReadOnlyMiddleware $subject;
+
+    protected function setUp(): void
+    {
+        $this->queue = $this->createMock(ServerQueue::class);
+        $this->next = $this->createMock(MiddlewareHandlerInterface::class);
+        $this->replicaConfig = new ReplicaConfig(
+            (new ClientOptions())
+                ->setServers(['primary.example.com'])
+                ->setPort(389),
+        );
+        $this->subject = new ReadOnlyMiddleware(
+            $this->queue,
+            $this->replicaConfig,
+        );
+    }
+
+    /**
+     * @return array<string, array{RequestInterface, class-string<LdapResult>}>
+     */
+    public static function writeRequestProvider(): array
+    {
+        return [
+            'add' => [
+                Operations::add(new Entry('cn=foo,dc=example,dc=com')),
+                AddResponse::class,
+            ],
+            'modify' => [
+                Operations::modify('cn=foo,dc=example,dc=com'),
+                ModifyResponse::class,
+            ],
+            'delete' => [
+                Operations::delete('cn=foo,dc=example,dc=com'),
+                DeleteResponse::class,
+            ],
+            'modifyDn' => [
+                Operations::move('cn=foo,dc=example,dc=com', 'ou=new,dc=example,dc=com'),
+                ModifyDnResponse::class,
+            ],
+            'passwordModify' => [
+                Operations::passwordModify('cn=foo,dc=example,dc=com', 'old', 'new'),
+                ExtendedResponse::class,
+            ],
+        ];
+    }
+
+    /**
+     * @param class-string<LdapResult> $expectedResponse
+     */
+    #[DataProvider('writeRequestProvider')]
+    public function test_a_write_is_referred_to_the_primary_by_default(
+        RequestInterface $request,
+        string $expectedResponse,
+    ): void {
+        $this->next
+            ->expects(self::never())
+            ->method('handle');
+
+        $sent = null;
+        $this->queue
+            ->expects(self::once())
+            ->method('sendMessage')
+            ->willReturnCallback(function (LdapMessageResponse $message) use (&$sent): ServerQueue {
+                $sent = $message;
+
+                return $this->queue;
+            });
+
+        $result = $this->subject->process(
+            $this->context($request),
+            $this->next,
+        );
+
+        self::assertSame(
+            ResultCode::REFERRAL,
+            $result->resultCode(),
+        );
+        self::assertInstanceOf(
+            LdapMessageResponse::class,
+            $sent,
+        );
+
+        $response = $sent->getResponse();
+        self::assertInstanceOf(
+            $expectedResponse,
+            $response,
+        );
+        self::assertSame(
+            ResultCode::REFERRAL,
+            $response->getResultCode(),
+        );
+        self::assertCount(
+            1,
+            $response->getReferrals(),
+        );
+    }
+
+    public function test_a_write_is_rejected_when_referral_is_disabled(): void
+    {
+        $this->replicaConfig->setReferWrites(false);
+        $this->next
+            ->expects(self::never())
+            ->method('handle');
+        $this->queue
+            ->expects(self::never())
+            ->method('sendMessage');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
+
+        $this->subject->process(
+            $this->context(Operations::delete('cn=foo,dc=example,dc=com')),
+            $this->next,
+        );
+    }
+
+    public function test_a_read_passes_through_to_the_next_handler(): void
+    {
+        $context = $this->context(Operations::search(Filters::present('objectClass')));
+        $expected = OperationOutcomeResult::succeeded();
+
+        $this->next
+            ->expects(self::once())
+            ->method('handle')
+            ->with($context)
+            ->willReturn($expected);
+        $this->queue
+            ->expects(self::never())
+            ->method('sendMessage');
+
+        self::assertSame(
+            $expected,
+            $this->subject->process($context, $this->next),
+        );
+    }
+
+    private function context(RequestInterface $request): ServerRequestContext
+    {
+        return new ServerRequestContext(new LdapMessageRequest(
+            1,
+            $request,
+        ));
+    }
+}


### PR DESCRIPTION
Next set of changes for a read-only replica. Adding the middleware, exposing the options, and adding the new system writer change needed to handle that on a read-only server.