### PR TITLE
[1.0.0] Add the LdapReplica consumer.

### DIFF
--- a/src/FreeDSx/Ldap/ReplicaConfig.php
+++ b/src/FreeDSx/Ldap/ReplicaConfig.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap;
 
+use FreeDSx\Ldap\Operation\Request\BindRequest;
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
 use FreeDSx\Ldap\Sync\Consumer\Checkpoint\InMemoryReplicationCheckpoint;
 use FreeDSx\Ldap\Sync\Consumer\Checkpoint\ReplicationCheckpointInterface;
+use FreeDSx\Ldap\Sync\Consumer\ReconnectBackoff;
 
 /**
  * Configures a server as a replica of an upstream primary.
@@ -28,19 +30,68 @@ use FreeDSx\Ldap\Sync\Consumer\Checkpoint\ReplicationCheckpointInterface;
  */
 final class ReplicaConfig
 {
+    private ?ReconnectBackoff $reconnectBackoff = null;
+
     public function __construct(
         private readonly ClientOptions $primary,
         private readonly ReplicationCheckpointInterface $checkpoint = new InMemoryReplicationCheckpoint(),
         private ?FilterInterface $filter = null,
         private bool $referWrites = true,
+        private ?BindRequest $bind = null,
+        private bool $useStartTls = false,
     ) {}
 
     /**
-     * The client options for connecting to the upstream primary (servers, TLS, credentials, base DN).
+     * The client options for connecting to the upstream primary (servers, LDAPS/mTLS, base DN).
      */
     public function getPrimary(): ClientOptions
     {
         return $this->primary;
+    }
+
+    /**
+     * How the replica authenticates to the primary (via Operations::bind() or Operations::bindSasl()), or null for none.
+     */
+    public function getBind(): ?BindRequest
+    {
+        return $this->bind;
+    }
+
+    public function setBind(BindRequest $bind): self
+    {
+        $this->bind = $bind;
+
+        return $this;
+    }
+
+    /**
+     * Whether the replica issues StartTLS on the primary connection before binding (LDAPS is set on the primary options).
+     */
+    public function getUseStartTls(): bool
+    {
+        return $this->useStartTls;
+    }
+
+    public function setUseStartTls(bool $useStartTls): self
+    {
+        $this->useStartTls = $useStartTls;
+
+        return $this;
+    }
+
+    /**
+     * The bounded backoff applied between reconnect attempts to the primary.
+     */
+    public function getReconnectBackoff(): ReconnectBackoff
+    {
+        return $this->reconnectBackoff ??= new ReconnectBackoff();
+    }
+
+    public function setReconnectBackoff(ReconnectBackoff $reconnectBackoff): self
+    {
+        $this->reconnectBackoff = $reconnectBackoff;
+
+        return $this;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Process/Signals/PcntlShutdownSignals.php
+++ b/src/FreeDSx/Ldap/Server/Process/Signals/PcntlShutdownSignals.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Process\Signals;
+
+use function pcntl_async_signals;
+use function pcntl_signal;
+
+use const SIGINT;
+use const SIGTERM;
+
+/**
+ * Installs POSIX termination-signal handlers via ext-pcntl for graceful shutdown.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class PcntlShutdownSignals implements ShutdownSignalsInterface
+{
+    /**
+     * @var list<int>
+     */
+    private const SIGNALS = [
+        SIGINT,
+        SIGTERM,
+    ];
+
+    public function onShutdown(callable $handler): void
+    {
+        pcntl_async_signals(true);
+
+        foreach (self::SIGNALS as $signal) {
+            pcntl_signal(
+                $signal,
+                static function () use ($handler): void {
+                    $handler();
+                },
+            );
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Process/Signals/ShutdownSignalsInterface.php
+++ b/src/FreeDSx/Ldap/Server/Process/Signals/ShutdownSignalsInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Process\Signals;
+
+/**
+ * Installs termination-signal handling so a long-running process can shut down gracefully.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface ShutdownSignalsInterface
+{
+    /**
+     * Register a handler invoked when a termination signal (SIGINT/SIGTERM) is received.
+     */
+    public function onShutdown(callable $handler): void;
+}

--- a/src/FreeDSx/Ldap/Server/Process/Signals/SwooleShutdownSignals.php
+++ b/src/FreeDSx/Ldap/Server/Process/Signals/SwooleShutdownSignals.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Process\Signals;
+
+use Swoole\Process;
+
+use const SIGINT;
+use const SIGTERM;
+
+/**
+ * Installs termination-signal handlers via the Swoole event loop for graceful shutdown.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class SwooleShutdownSignals implements ShutdownSignalsInterface
+{
+    /**
+     * @var list<int>
+     */
+    private const SIGNALS = [
+        SIGINT,
+        SIGTERM,
+    ];
+
+    public function onShutdown(callable $handler): void
+    {
+        foreach (self::SIGNALS as $signal) {
+            Process::signal(
+                $signal,
+                static function () use ($handler): void {
+                    $handler();
+                },
+            );
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Sync/Consumer/LdapReplica.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/LdapReplica.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Sync\Consumer;
+
+use Closure;
+use FreeDSx\Ldap\Exception\CancelRequestException;
+use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Ldap\ReplicaConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\CoroutineSleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
+use FreeDSx\Ldap\Server\Logging\ExceptionLogging;
+use FreeDSx\Ldap\Server\Process\Signals\PcntlShutdownSignals;
+use FreeDSx\Ldap\Server\Process\Signals\ShutdownSignalsInterface;
+use FreeDSx\Ldap\Server\Process\Signals\SwooleShutdownSignals;
+use FreeDSx\Ldap\Sync\Consumer\Checkpoint\ReplicationCheckpointInterface;
+use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Session;
+use FreeDSx\Ldap\Sync\SyncRepl;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Keeps a local replica in sync with an upstream primary over RFC 4533.
+ *
+ * @api
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class LdapReplica
+{
+    private bool $stopping = false;
+
+    /**
+     * @param Closure(): SyncRepl $connect opens a fresh, authenticated sync connection to the primary
+     */
+    public function __construct(
+        private readonly Closure $connect,
+        private readonly ChangeApplierInterface $applier,
+        private readonly ReplicationCheckpointInterface $checkpoint,
+        private readonly SleeperInterface $sleeper,
+        private readonly ShutdownSignalsInterface $signals,
+        private readonly ?LoggerInterface $logger = null,
+        private readonly ReconnectBackoff $backoff = new ReconnectBackoff(),
+    ) {}
+
+    public static function forPcntl(
+        ReplicaConfig $config,
+        EntryStorageInterface $storage,
+        ?LoggerInterface $logger = null,
+    ): self {
+        return self::create(
+            $config,
+            $storage,
+            new BlockingSleeper(),
+            new PcntlShutdownSignals(),
+            $logger,
+        );
+    }
+
+    public static function forSwoole(
+        ReplicaConfig $config,
+        EntryStorageInterface $storage,
+        ?LoggerInterface $logger = null,
+    ): self {
+        return self::create(
+            $config,
+            $storage,
+            new CoroutineSleeper(),
+            new SwooleShutdownSignals(),
+            $logger,
+        );
+    }
+
+    /**
+     * Consume from the primary until a shutdown signal, reconnecting with bounded backoff on failure.
+     */
+    public function run(): void
+    {
+        $this->signals->onShutdown(function (): void {
+            $this->stopping = true;
+        });
+        $this->logger?->info('Starting replica synchronization.');
+
+        $delay = $this->backoff->initial();
+
+        while (!$this->stopping) {
+            try {
+                $this->sync();
+                $delay = $this->backoff->initial();
+            } catch (CancelRequestException) {
+                // A shutdown was requested; listen() was cancelled cleanly by the entry handler.
+            } catch (Throwable $e) {
+                if ($this->stopping) {
+                    break;
+                }
+
+                $this->logger?->warning(
+                    'Replica synchronization failed; reconnecting after backoff.',
+                    ExceptionLogging::makeLogContext($e) + ['backoff_seconds' => $delay],
+                );
+                $this->sleeper->sleep($delay);
+                $delay = $this->backoff->next($delay);
+            }
+        }
+
+        $this->logger?->info('Replica synchronization stopped.');
+    }
+
+    private static function create(
+        ReplicaConfig $config,
+        EntryStorageInterface $storage,
+        SleeperInterface $sleeper,
+        ShutdownSignalsInterface $signals,
+        ?LoggerInterface $logger,
+    ): self {
+        // listen() must not time out its blocking read, or the persist phase would abort each interval.
+        $config->getPrimary()
+            ->setTimeoutRead(-1);
+
+        return new self(
+            connect: static fn(): SyncRepl => self::connect($config),
+            applier: new VerbatimStorageApplier($storage),
+            checkpoint: $config->getCheckpoint(),
+            sleeper: $sleeper,
+            signals: $signals,
+            logger: $logger,
+            backoff: $config->getReconnectBackoff(),
+        );
+    }
+
+    private static function connect(ReplicaConfig $config): SyncRepl
+    {
+        $client = new LdapClient($config->getPrimary());
+
+        if ($config->getUseStartTls()) {
+            $client->startTls();
+        }
+
+        $bind = $config->getBind();
+        if ($bind !== null) {
+            $client->sendAndReceive($bind);
+        }
+
+        return $client->syncRepl($config->getFilter());
+    }
+
+    private function sync(): void
+    {
+        $syncRepl = ($this->connect)();
+        $syncRepl
+            ->useCookie($this->checkpoint->read())
+            ->useCookieHandler($this->persistCookie(...))
+            ->useRefreshDoneHandler($this->reconcileRefresh(...));
+
+        $this->applier->beginRefresh();
+        $syncRepl->listen($this->applyEntry(...));
+    }
+
+    private function applyEntry(
+        SyncEntryResult $result,
+        Session $session,
+    ): void {
+        if ($this->stopping) {
+            throw new CancelRequestException();
+        }
+
+        $this->applier->apply(
+            $result,
+            $session,
+        );
+    }
+
+    private function reconcileRefresh(Session $session): void
+    {
+        if (!$session->hasRefreshDeletes()) {
+            $this->applier->reconcile();
+        }
+    }
+
+    private function persistCookie(?string $cookie): void
+    {
+        if ($cookie !== null) {
+            $this->checkpoint->write($cookie);
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Sync/Consumer/ReconnectBackoff.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/ReconnectBackoff.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Sync\Consumer;
+
+use function min;
+
+/**
+ * A bounded exponential backoff for reconnect attempts.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ReconnectBackoff
+{
+    public function __construct(
+        private float $baseSeconds = 1.0,
+        private float $maxSeconds = 30.0,
+    ) {}
+
+    /**
+     * The delay to start from (and reset to after a successful connection).
+     */
+    public function initial(): float
+    {
+        return $this->baseSeconds;
+    }
+
+    /**
+     * The next delay after the current one, doubling up to the ceiling.
+     */
+    public function next(float $current): float
+    {
+        return min(
+            $current * 2.0,
+            $this->maxSeconds,
+        );
+    }
+}

--- a/tests/unit/Server/Process/Signals/PcntlShutdownSignalsTest.php
+++ b/tests/unit/Server/Process/Signals/PcntlShutdownSignalsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Process\Signals;
+
+use FreeDSx\Ldap\Server\Process\Signals\PcntlShutdownSignals;
+use FreeDSx\Ldap\Server\Process\Signals\ShutdownSignalsInterface;
+use PHPUnit\Framework\TestCase;
+
+final class PcntlShutdownSignalsTest extends TestCase
+{
+    private ShutdownSignalsInterface $subject;
+
+    protected function setUp(): void
+    {
+        // pcntl_* is ext-pcntl; posix_kill/posix_getpid (used to raise the signal) is ext-posix.
+        if (!extension_loaded('pcntl') || !extension_loaded('posix')) {
+            $this->markTestSkipped('The pcntl and posix extensions are required for this test.');
+        }
+
+        $this->subject = new PcntlShutdownSignals();
+    }
+
+    protected function tearDown(): void
+    {
+        if (!extension_loaded('pcntl')) {
+            return;
+        }
+
+        pcntl_signal(SIGINT, SIG_DFL);
+        pcntl_signal(SIGTERM, SIG_DFL);
+    }
+
+    public function test_the_handler_runs_on_a_termination_signal(): void
+    {
+        $fired = false;
+        $this->subject->onShutdown(function () use (&$fired): void {
+            $fired = true;
+        });
+
+        posix_kill(posix_getpid(), SIGTERM);
+        pcntl_signal_dispatch();
+
+        self::assertTrue($fired);
+    }
+}

--- a/tests/unit/Server/Process/Signals/SwooleShutdownSignalsTest.php
+++ b/tests/unit/Server/Process/Signals/SwooleShutdownSignalsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Process\Signals;
+
+use FreeDSx\Ldap\Server\Process\Signals\SwooleShutdownSignals;
+use PHPUnit\Framework\TestCase;
+use Swoole\Coroutine;
+use Swoole\Coroutine\Channel;
+
+final class SwooleShutdownSignalsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!extension_loaded('swoole') || !extension_loaded('posix')) {
+            $this->markTestSkipped('The swoole and posix extensions are required for this test.');
+        }
+    }
+
+    public function test_the_handler_runs_on_a_termination_signal(): void
+    {
+        $fired = false;
+
+        Coroutine\run(function () use (&$fired): void {
+            $channel = new Channel(1);
+            (new SwooleShutdownSignals())->onShutdown(function () use ($channel): void {
+                $channel->push(true);
+            });
+
+            posix_kill(posix_getpid(), SIGTERM);
+            $fired = $channel->pop(2.0) === true;
+        });
+
+        self::assertTrue($fired);
+    }
+}

--- a/tests/unit/Sync/Consumer/LdapReplicaTest.php
+++ b/tests/unit/Sync/Consumer/LdapReplicaTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Sync\Consumer;
+
+use Closure;
+use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\ReplicaConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
+use FreeDSx\Ldap\Server\Process\Signals\ShutdownSignalsInterface;
+use FreeDSx\Ldap\Sync\Consumer\ChangeApplierInterface;
+use FreeDSx\Ldap\Sync\Consumer\Checkpoint\InMemoryReplicationCheckpoint;
+use FreeDSx\Ldap\Sync\Consumer\LdapReplica;
+use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Session;
+use FreeDSx\Ldap\Sync\SyncRepl;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class LdapReplicaTest extends TestCase
+{
+    private ChangeApplierInterface&MockObject $applier;
+
+    private InMemoryReplicationCheckpoint $checkpoint;
+
+    private SleeperInterface&MockObject $sleeper;
+
+    private ShutdownSignalsInterface&MockObject $signals;
+
+    private SyncRepl&MockObject $syncRepl;
+
+    private LdapReplica $subject;
+
+    private Closure $shutdown;
+
+    private Closure $refreshDoneHandler;
+
+    private Closure $cookieHandler;
+
+    private ?string $usedCookie = null;
+
+    protected function setUp(): void
+    {
+        $noop = static function (): void {};
+        $this->shutdown = $noop;
+        $this->refreshDoneHandler = $noop;
+        $this->cookieHandler = $noop;
+
+        $this->applier = $this->createMock(ChangeApplierInterface::class);
+        $this->checkpoint = new InMemoryReplicationCheckpoint();
+        $this->sleeper = $this->createMock(SleeperInterface::class);
+        $this->signals = $this->createMock(ShutdownSignalsInterface::class);
+        $this->signals->method('onShutdown')
+            ->willReturnCallback(function (callable $handler): void {
+                $this->shutdown = Closure::fromCallable($handler);
+            });
+
+        $this->syncRepl = $this->createMock(SyncRepl::class);
+        $this->syncRepl->method('useCookie')
+            ->willReturnCallback(function (?string $cookie): SyncRepl {
+                $this->usedCookie = $cookie;
+
+                return $this->syncRepl;
+            });
+        $this->syncRepl->method('useCookieHandler')
+            ->willReturnCallback(function (Closure $handler): SyncRepl {
+                $this->cookieHandler = $handler;
+
+                return $this->syncRepl;
+            });
+        $this->syncRepl->method('useRefreshDoneHandler')
+            ->willReturnCallback(function (Closure $handler): SyncRepl {
+                $this->refreshDoneHandler = $handler;
+
+                return $this->syncRepl;
+            });
+
+        $this->subject = new LdapReplica(
+            connect: fn(): SyncRepl => $this->syncRepl,
+            applier: $this->applier,
+            checkpoint: $this->checkpoint,
+            sleeper: $this->sleeper,
+            signals: $this->signals,
+        );
+    }
+
+    public function test_a_present_phase_refresh_applies_reconciles_and_checkpoints(): void
+    {
+        $entry = $this->createMock(SyncEntryResult::class);
+        $session = new Session(
+            Session::MODE_LISTEN,
+            'from-primary',
+        );
+
+        $this->syncRepl->method('listen')
+            ->willReturnCallback(function (Closure $entryHandler) use ($entry, $session): void {
+                $entryHandler($entry, $session);
+                ($this->refreshDoneHandler)($session);
+                ($this->cookieHandler)('cookie-after');
+                ($this->shutdown)();
+            });
+
+        $this->applier->expects(self::once())
+            ->method('beginRefresh');
+        $this->applier->expects(self::once())
+            ->method('apply')
+            ->with(
+                $entry,
+                $session,
+            );
+        $this->applier->expects(self::once())
+            ->method('reconcile');
+
+        $this->subject->run();
+
+        self::assertSame(
+            'cookie-after',
+            $this->checkpoint->read(),
+        );
+    }
+
+    public function test_an_incremental_refresh_applies_without_reconciling(): void
+    {
+        $entry = $this->createMock(SyncEntryResult::class);
+        $session = (new Session(
+            Session::MODE_LISTEN,
+            'from-primary',
+        ))->markRefreshComplete(true);
+
+        $this->syncRepl->method('listen')
+            ->willReturnCallback(function (Closure $entryHandler) use ($entry, $session): void {
+                $entryHandler($entry, $session);
+                ($this->refreshDoneHandler)($session);
+                ($this->shutdown)();
+            });
+
+        $this->applier->expects(self::once())
+            ->method('apply');
+        $this->applier->expects(self::never())
+            ->method('reconcile');
+
+        $this->subject->run();
+    }
+
+    public function test_it_resumes_from_the_stored_checkpoint_cookie(): void
+    {
+        $this->checkpoint->write('resume-me');
+        $this->syncRepl->method('listen')
+            ->willReturnCallback(function (): void {
+                ($this->shutdown)();
+            });
+
+        $this->subject->run();
+
+        self::assertSame(
+            'resume-me',
+            $this->usedCookie,
+        );
+    }
+
+    public function test_it_backs_off_before_reconnecting_after_a_failure(): void
+    {
+        $this->syncRepl->method('listen')
+            ->willReturnCallback(function (): void {
+                throw new RuntimeException('connection lost');
+            });
+        $this->sleeper->expects(self::once())
+            ->method('sleep')
+            ->with(1.0)
+            ->willReturnCallback(function (): void {
+                ($this->shutdown)();
+            });
+
+        $this->subject->run();
+    }
+
+    public function test_for_pcntl_builds_a_replica(): void
+    {
+        if (!extension_loaded('pcntl')) {
+            $this->markTestSkipped('The pcntl extension is required for this test.');
+        }
+
+        $this->expectNotToPerformAssertions();
+
+        LdapReplica::forPcntl(
+            new ReplicaConfig(new ClientOptions()),
+            new InMemoryStorage(),
+        );
+    }
+
+    public function test_for_swoole_builds_a_replica(): void
+    {
+        if (!extension_loaded('swoole')) {
+            $this->markTestSkipped('The swoole extension is required for this test.');
+        }
+
+        $this->expectNotToPerformAssertions();
+
+        LdapReplica::forSwoole(
+            new ReplicaConfig(new ClientOptions()),
+            new InMemoryStorage(),
+        );
+    }
+}

--- a/tests/unit/Sync/Consumer/ReconnectBackoffTest.php
+++ b/tests/unit/Sync/Consumer/ReconnectBackoffTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Sync\Consumer;
+
+use FreeDSx\Ldap\Sync\Consumer\ReconnectBackoff;
+use PHPUnit\Framework\TestCase;
+
+final class ReconnectBackoffTest extends TestCase
+{
+    public function test_initial_returns_the_base_delay(): void
+    {
+        self::assertSame(
+            2.0,
+            (new ReconnectBackoff(baseSeconds: 2.0))->initial(),
+        );
+    }
+
+    public function test_next_doubles_the_current_delay(): void
+    {
+        self::assertSame(
+            4.0,
+            (new ReconnectBackoff())->next(2.0),
+        );
+    }
+
+    public function test_next_caps_at_the_maximum(): void
+    {
+        self::assertSame(
+            30.0,
+            (new ReconnectBackoff(maxSeconds: 30.0))->next(20.0),
+        );
+    }
+}


### PR DESCRIPTION
This adds the replica consumer that will run in the server process on a read-only server. It will run similar to the process that does the journal housekeeping / pruning. That will actually get implemented in a follow up PR to this.