### PR TITLE
[1.0.0] Add the replica sync to the servers background processes.

### DIFF
--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -26,6 +26,9 @@ use FreeDSx\Ldap\Server\Clock\SystemClock;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Process\BackgroundTask\PcntlBackgroundTasks;
+use FreeDSx\Ldap\Server\Process\BackgroundTask\SwooleBackgroundTasks;
+use FreeDSx\Ldap\Sync\Consumer\LdapReplica;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeRecorder;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
@@ -538,7 +541,7 @@ class Container
                 socketServerFactory: $this->get(SocketServerFactory::class),
                 protocolFactoryProvider: $protocolFactoryProvider,
                 metricsRecorder: $metricsRecorder,
-                retentionSweeper: $this->makeRetentionSweeper(),
+                backgroundTasks: $this->makeSwooleBackgroundTasks(),
             );
         }
 
@@ -551,7 +554,7 @@ class Container
             snapshotPublisher: $this->makeSnapshotPublisher(),
             operationRollup: $this->makeOperationRollup(),
             backend: $this->backendOrNull(),
-            journalRetentionPolicy: $this->journalRetentionPolicyIfSweepable(),
+            backgroundTasks: $this->makePcntlBackgroundTasks(),
         );
     }
 
@@ -609,6 +612,52 @@ class Container
                 $options->getEventLogPolicy(),
             ),
         );
+    }
+
+    private function makeSwooleBackgroundTasks(): SwooleBackgroundTasks
+    {
+        return new SwooleBackgroundTasks(
+            $this->makeRetentionSweeper(),
+            $this->makeReplicaDaemon(hostManagedShutdown: true),
+        );
+    }
+
+    private function makePcntlBackgroundTasks(): PcntlBackgroundTasks
+    {
+        $options = $this->get(ServerOptions::class);
+        $hasSweep = $this->journalRetentionPolicyIfSweepable() !== null;
+        $hasDaemon = $options->getReplicaConfig() !== null;
+
+        return new PcntlBackgroundTasks(
+            makeSweeper: $hasSweep
+                ? fn(): ?RetentionSweeper => $this->makeRetentionSweeper()
+                : null,
+            makeDaemon: $hasDaemon
+                ? fn(): ?LdapReplica => $this->makeReplicaDaemon(hostManagedShutdown: false)
+                : null,
+            sweepIntervalSeconds: RetentionSweeper::DEFAULT_INTERVAL_SECONDS,
+            logger: $options->getLogger(),
+        );
+    }
+
+    /**
+     * The replica sync daemon when replica mode is configured, else null.
+     *
+     * @param bool $hostManagedShutdown true under Swoole (the runner calls stop()), false under PCNTL (the forked child owns its signals)
+     */
+    private function makeReplicaDaemon(bool $hostManagedShutdown): ?LdapReplica
+    {
+        $options = $this->get(ServerOptions::class);
+        $config = $options->getReplicaConfig();
+        $storage = $options->getStorage();
+
+        if ($config === null || $storage === null) {
+            return null;
+        }
+
+        return $hostManagedShutdown
+            ? LdapReplica::forSwoole($config, $storage, $options->getLogger(), signals: null)
+            : LdapReplica::forPcntl($config, $storage, $options->getLogger());
     }
 
     /**

--- a/src/FreeDSx/Ldap/LdapClient.php
+++ b/src/FreeDSx/Ldap/LdapClient.php
@@ -437,6 +437,18 @@ class LdapClient
     }
 
     /**
+     * Immediately close the connection socket without a graceful unbind. Interrupts any in-progress operation.
+     */
+    public function disconnect(): self
+    {
+        $this->container
+            ->get(ClientQueueInstantiator::class)
+            ->close();
+
+        return $this;
+    }
+
+    /**
      * Perform a whoami request and get the returned value.
      *
      * @throws OperationException

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -26,6 +26,7 @@ use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\BackendAwareInterface;
 use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Export\DirectoryDumper;
 use FreeDSx\Ldap\Server\Backend\Storage\Export\DumpOptions;
 use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
@@ -194,6 +195,7 @@ class LdapServer
     private function init(): void
     {
         $this->requireBackendUnlessProxy();
+        $this->requireSharedStorageForForkingReplica();
         $this->options->setAccessControl($this->resolveAccessControl());
     }
 
@@ -205,6 +207,26 @@ class LdapServer
 
         throw new RuntimeException(
             'No storage is configured. Set ServerOptions::setStorage() (or useInMemoryStorage()) before running.',
+        );
+    }
+
+    /**
+     * A forking replica's daemon and connection workers are separate processes, so its storage must be shared;
+     * the in-memory adapter is not.
+     */
+    private function requireSharedStorageForForkingReplica(): void
+    {
+        if ($this->options->getReplicaConfig() === null || $this->options->getUseSwooleRunner()) {
+            return;
+        }
+
+        if (!$this->options->getStorage() instanceof InMemoryStorage) {
+            return;
+        }
+
+        throw new RuntimeException(
+            'A forking (PCNTL) replica requires process-shared storage, but InMemoryStorage is not shared across the '
+            . 'daemon and connection workers. Use PDO/SQLite storage, or run under Swoole.',
         );
     }
 

--- a/src/FreeDSx/Ldap/Protocol/Queue/ClientQueueInstantiator.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/ClientQueueInstantiator.php
@@ -45,4 +45,12 @@ class ClientQueueInstantiator
         return $this->clientQueue !== null
             && $this->clientQueue->isConnected();
     }
+
+    /**
+     * Close the connection socket if the queue was instantiated. It will reconnect on next use.
+     */
+    public function close(): void
+    {
+        $this->clientQueue?->close();
+    }
 }

--- a/src/FreeDSx/Ldap/Server/Process/BackgroundTask/BackgroundTasksInterface.php
+++ b/src/FreeDSx/Ldap/Server/Process/BackgroundTask/BackgroundTasksInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Process\BackgroundTask;
+
+use Closure;
+
+/**
+ * Manages a runner's background maintenance tasks (the journal retention sweep and the replica sync daemon).
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface BackgroundTasksInterface
+{
+    /**
+     * Register a hook run when a child task starts. Do implementation specific cleanup / preparation here.
+     *
+     * @param Closure(): void $onStart
+     */
+    public function onChildStart(Closure $onStart): void;
+
+    /**
+     * Launch the background tasks once the server is ready to accept connections.
+     */
+    public function start(): void;
+
+    /**
+     * Periodic upkeep driven from the accept loop: reap finished workers and re-launch interval tasks.
+     */
+    public function tick(): void;
+
+    /**
+     * Stop and reap all background tasks during shutdown.
+     */
+    public function stop(): void;
+}

--- a/src/FreeDSx/Ldap/Server/Process/BackgroundTask/PcntlBackgroundTasks.php
+++ b/src/FreeDSx/Ldap/Server/Process/BackgroundTask/PcntlBackgroundTasks.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Process\BackgroundTask;
+
+use Closure;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionSweeper;
+use FreeDSx\Ldap\Sync\Consumer\LdapReplica;
+use Psr\Log\LoggerInterface;
+
+use function microtime;
+use function pcntl_fork;
+use function pcntl_waitpid;
+use function posix_kill;
+
+use const SIGTERM;
+use const WNOHANG;
+
+/**
+ * Runs the retention sweep and replica daemon as forked child processes under PCNTL.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class PcntlBackgroundTasks implements BackgroundTasksInterface
+{
+    private ?int $sweepPid = null;
+
+    private ?int $daemonPid = null;
+
+    private float $lastSweepAt = 0.0;
+
+    private Closure $childStart;
+
+    /**
+     * @param ?Closure(): ?RetentionSweeper $makeSweeper builds the sweep worker in the child, or null when not journaling
+     * @param ?Closure(): ?LdapReplica $makeDaemon builds the replica daemon in the child, or null when not a replica
+     * @param float $sweepIntervalSeconds cadence between retention sweeps
+     */
+    public function __construct(
+        private readonly ?Closure $makeSweeper,
+        private readonly ?Closure $makeDaemon,
+        private readonly float $sweepIntervalSeconds,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
+        $this->childStart = static function (): void {};
+    }
+
+    public function onChildStart(Closure $onStart): void
+    {
+        $this->childStart = $onStart;
+    }
+
+    public function start(): void
+    {
+        $this->lastSweepAt = microtime(true);
+
+        if ($this->makeDaemon !== null) {
+            $this->daemonPid = $this->fork($this->runDaemon(...));
+        }
+    }
+
+    public function tick(): void
+    {
+        $this->reapDaemon();
+        $this->maintainSweep();
+    }
+
+    public function stop(): void
+    {
+        $this->endChild($this->daemonPid);
+        $this->daemonPid = null;
+        $this->endChild($this->sweepPid);
+        $this->sweepPid = null;
+    }
+
+    /**
+     * On a fixed cadence, fork a short-lived child to prune the shared journal so the parent keeps accepting.
+     */
+    private function maintainSweep(): void
+    {
+        if ($this->makeSweeper === null) {
+            return;
+        }
+
+        $this->reapSweep();
+
+        if (!$this->isSweepDue()) {
+            return;
+        }
+
+        $this->lastSweepAt = microtime(true);
+        $this->sweepPid = $this->fork($this->runSweep(...));
+    }
+
+    private function isSweepDue(): bool
+    {
+        return $this->sweepPid === null
+            && (microtime(true) - $this->lastSweepAt) >= $this->sweepIntervalSeconds;
+    }
+
+    private function runSweep(): void
+    {
+        if ($this->makeSweeper === null) {
+            return;
+        }
+
+        ($this->makeSweeper)()?->sweep();
+    }
+
+    private function runDaemon(): void
+    {
+        if ($this->makeDaemon === null) {
+            return;
+        }
+
+        ($this->makeDaemon)()?->run();
+    }
+
+    /**
+     * @param Closure(): void $childBody
+     */
+    private function fork(Closure $childBody): ?int
+    {
+        $pid = pcntl_fork();
+
+        if ($pid === -1) {
+            $this->logger?->warning('Unable to fork a background task.');
+
+            return null;
+        }
+
+        if ($pid === 0) {
+            ($this->childStart)();
+            $childBody();
+            exit(0);
+        }
+
+        return $pid;
+    }
+
+    private function reapSweep(): void
+    {
+        if ($this->pidExited($this->sweepPid)) {
+            $this->sweepPid = null;
+        }
+    }
+
+    private function reapDaemon(): void
+    {
+        if ($this->daemonPid === null || !$this->pidExited($this->daemonPid)) {
+            return;
+        }
+
+        $this->daemonPid = null;
+        $this->logger?->warning('The replica synchronization daemon exited unexpectedly.');
+    }
+
+    private function pidExited(?int $pid): bool
+    {
+        if ($pid === null) {
+            return false;
+        }
+
+        $status = 0;
+        $result = pcntl_waitpid(
+            $pid,
+            $status,
+            WNOHANG,
+        );
+
+        return $result === -1 || $result > 0;
+    }
+
+    private function endChild(?int $pid): void
+    {
+        if ($pid === null) {
+            return;
+        }
+
+        posix_kill(
+            $pid,
+            SIGTERM,
+        );
+        $status = 0;
+        pcntl_waitpid(
+            $pid,
+            $status,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Process/BackgroundTask/SwooleBackgroundTasks.php
+++ b/src/FreeDSx/Ldap/Server/Process/BackgroundTask/SwooleBackgroundTasks.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Process\BackgroundTask;
+
+use Closure;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionSweeper;
+use FreeDSx\Ldap\Sync\Consumer\LdapReplica;
+use Swoole\Coroutine;
+use Swoole\Coroutine\Channel;
+
+/**
+ * Runs the retention sweep and replica daemon as background coroutines under Swoole.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class SwooleBackgroundTasks implements BackgroundTasksInterface
+{
+    private bool $stopping = false;
+
+    /**
+     * @var ?Channel<bool>
+     */
+    private ?Channel $sweepWakeup = null;
+
+    public function __construct(
+        private readonly ?RetentionSweeper $sweeper = null,
+        private readonly ?LdapReplica $daemon = null,
+    ) {}
+
+    public function onChildStart(Closure $onStart): void
+    {
+        // Coroutine workers share the parent's memory; there is nothing to release.
+    }
+
+    public function start(): void
+    {
+        $this->startSweep();
+        $this->startDaemon();
+    }
+
+    public function tick(): void
+    {
+        // Coroutines are self-managing; there is nothing to reap between accepts.
+    }
+
+    public function stop(): void
+    {
+        $this->stopping = true;
+        $this->sweepWakeup?->push(true);
+        $this->daemon?->stop();
+    }
+
+    private function startSweep(): void
+    {
+        if ($this->sweeper === null) {
+            return;
+        }
+
+        $sweeper = $this->sweeper;
+        $wakeup = $this->sweepWakeup = new Channel(1);
+
+        Coroutine::create(function () use ($sweeper, $wakeup): void {
+            while (!$this->stopping) {
+                // pop() returns the pushed value on shutdown, or false after the interval elapses.
+                if ($wakeup->pop(RetentionSweeper::DEFAULT_INTERVAL_SECONDS) !== false) {
+                    break;
+                }
+
+                $sweeper->sweep();
+            }
+        });
+    }
+
+    private function startDaemon(): void
+    {
+        if ($this->daemon === null) {
+            return;
+        }
+
+        $daemon = $this->daemon;
+
+        Coroutine::create(static function () use ($daemon): void {
+            $daemon->run();
+        });
+    }
+}

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -17,17 +17,16 @@ use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Server\Backend\ResettableInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionSweeper;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
-use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Metrics\File\SnapshotPublisher;
 use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
 use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
 use FreeDSx\Ldap\Server\Metrics\Recorder\NullMetricsRecorder;
 use FreeDSx\Ldap\Server\Metrics\Rollup\OperationRollupCoordinator;
+use FreeDSx\Ldap\Server\Process\BackgroundTask\BackgroundTasksInterface;
+use FreeDSx\Ldap\Server\Process\BackgroundTask\PcntlBackgroundTasks;
 use FreeDSx\Ldap\Server\Process\ChildChannel;
 use FreeDSx\Ldap\Server\Process\ChildProcess;
 use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
@@ -75,16 +74,9 @@ class PcntlServerRunner implements ServerRunnerInterface
      */
     private array $handledSignals = [];
 
-    private bool $isPosixExtLoaded;
-
     private bool $isShuttingDown = false;
 
-    /**
-     * PID of the in-flight retention-sweep child, or null when none is running.
-     */
-    private ?int $pruneChildPid = null;
-
-    private float $lastSweepAt = 0.0;
+    private readonly BackgroundTasksInterface $backgroundTasks;
 
     /**
      * @var array<string, mixed>
@@ -103,11 +95,15 @@ class PcntlServerRunner implements ServerRunnerInterface
         private readonly ?SnapshotPublisher $snapshotPublisher = null,
         private readonly ?OperationRollupCoordinator $operationRollup = null,
         private readonly ?WritableLdapBackendInterface $backend = null,
-        private readonly ?RetentionPolicy $journalRetentionPolicy = null,
+        BackgroundTasksInterface $backgroundTasks = new PcntlBackgroundTasks(
+            makeSweeper: null,
+            makeDaemon: null,
+            sweepIntervalSeconds: RetentionSweeper::DEFAULT_INTERVAL_SECONDS,
+        ),
     ) {
-        if (!extension_loaded('pcntl')) {
+        if (!extension_loaded('pcntl') || !extension_loaded('posix')) {
             throw new RuntimeException(
-                'The PCNTL extension is needed to fork incoming requests, which is only available on Linux.',
+                'The pcntl and posix extensions are required to fork and manage child processes (Linux only).',
             );
         }
 
@@ -115,8 +111,6 @@ class PcntlServerRunner implements ServerRunnerInterface
         $this->options = $options;
         $this->protocolFactoryProvider = $protocolFactoryProvider;
 
-        // posix_kill needs this...we cannot clean up child processes without it on shutdown...
-        $this->isPosixExtLoaded = extension_loaded('posix');
         // We need to be able to handle signals as they come in, regardless of what is going on...
         pcntl_async_signals(true);
 
@@ -128,6 +122,9 @@ class PcntlServerRunner implements ServerRunnerInterface
         $this->defaultContext = [
             'pid' => posix_getpid(),
         ];
+
+        $backgroundTasks->onChildStart($this->enterChild(...));
+        $this->backgroundTasks = $backgroundTasks;
     }
 
     /**
@@ -269,11 +266,11 @@ class PcntlServerRunner implements ServerRunnerInterface
         $this->logServerStarted($this->defaultContext);
         $this->metricsRecorder->serverStarted(time());
         $this->publishMetricsSnapshot();
-        $this->lastSweepAt = microtime(true);
         $this->options->getOnServerReady()?->__invoke();
+        $this->backgroundTasks->start();
 
         do {
-            $this->runRetentionSweepMaintenance();
+            $this->backgroundTasks->tick();
             $socket = $this->server->accept($this->options->getSocketAcceptTimeout());
 
             if ($this->isShuttingDown) {
@@ -416,14 +413,8 @@ class PcntlServerRunner implements ServerRunnerInterface
         $this->isShuttingDown = true;
         $this->logShutdownStarted($this->defaultContext);
 
-        // We can't do anything else without the posix ext ... :(
-        if (!$this->isPosixExtLoaded) {
-            $this->cleanUpChildProcesses();
-
-            return;
-        }
         // Ask nicely first...
-        $this->endRetentionSweepChild();
+        $this->backgroundTasks->stop();
         $this->endChildProcesses(SIGTERM);
 
         $waitTime = 0;
@@ -537,78 +528,16 @@ class PcntlServerRunner implements ServerRunnerInterface
     }
 
     /**
-     * On a fixed cadence, fork a short-lived child to prune the shared journal so the parent keeps accepting.
+     * Prepare a freshly forked background-task child: drop the inherited server socket, channels and signal
+     * handlers, then reset the backend for a fresh connection.
      */
-    private function runRetentionSweepMaintenance(): void
-    {
-        if ($this->journalRetentionPolicy === null) {
-            return;
-        }
-
-        $this->reapRetentionSweepChild();
-
-        if (!$this->isRetentionSweepDue()) {
-            return;
-        }
-
-        $this->lastSweepAt = microtime(true);
-        $this->forkRetentionSweepChild();
-    }
-
-    private function isRetentionSweepDue(): bool
-    {
-        return $this->pruneChildPid === null
-            && (microtime(true) - $this->lastSweepAt) >= RetentionSweeper::DEFAULT_INTERVAL_SECONDS;
-    }
-
-    private function reapRetentionSweepChild(): void
-    {
-        if ($this->pruneChildPid === null) {
-            return;
-        }
-
-        $status = 0;
-        $result = pcntl_waitpid(
-            $this->pruneChildPid,
-            $status,
-            WNOHANG,
-        );
-
-        if ($result === -1 || $result > 0) {
-            $this->pruneChildPid = null;
-        }
-    }
-
-    private function forkRetentionSweepChild(): void
-    {
-        $pid = pcntl_fork();
-
-        if ($pid === -1) {
-            $this->logInfo(
-                'Unable to fork the journal retention sweep.',
-                $this->defaultContext,
-            );
-
-            return;
-        }
-
-        if ($pid === 0) {
-            $this->runRetentionSweepThenExit();
-        }
-
-        $this->pruneChildPid = $pid;
-    }
-
-    /**
-     * In the sweep child: drop inherited FDs, reset the backend for a fresh connection, prune once, and exit.
-     */
-    private function runRetentionSweepThenExit(): never
+    private function enterChild(): void
     {
         $this->server->close(shutdown: false);
         $this->closeInheritedChannels();
         $this->isMainProcess = false;
 
-        // The child inherited the parent's shutdown/reload handlers; make stop signals just terminate it.
+        // A sweep child is terminated by SIGTERM; the replica daemon installs its own handlers when it runs.
         foreach ($this->handledSignals as $signal) {
             pcntl_signal(
                 $signal,
@@ -623,41 +552,6 @@ class PcntlServerRunner implements ServerRunnerInterface
         if ($this->backend instanceof ResettableInterface) {
             $this->backend->reset();
         }
-
-        $journal = $this->backend instanceof WritableStorageBackend
-            ? $this->backend->changeJournal()
-            : null;
-
-        if ($journal !== null && $this->journalRetentionPolicy !== null) {
-            (new RetentionSweeper(
-                $journal,
-                $this->journalRetentionPolicy,
-                new EventLogger(
-                    $this->options->getLogger(),
-                    $this->options->getEventLogPolicy(),
-                ),
-            ))->sweep();
-        }
-
-        exit(0);
-    }
-
-    private function endRetentionSweepChild(): void
-    {
-        if ($this->pruneChildPid === null || !$this->isPosixExtLoaded) {
-            return;
-        }
-
-        posix_kill(
-            $this->pruneChildPid,
-            SIGTERM,
-        );
-        $status = 0;
-        pcntl_waitpid(
-            $this->pruneChildPid,
-            $status,
-        );
-        $this->pruneChildPid = null;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/ServerRunner/SwooleServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/SwooleServerRunner.php
@@ -15,11 +15,12 @@ namespace FreeDSx\Ldap\Server\ServerRunner;
 
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
-use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionSweeper;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
 use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
 use FreeDSx\Ldap\Server\Metrics\Recorder\NullMetricsRecorder;
+use FreeDSx\Ldap\Server\Process\BackgroundTask\BackgroundTasksInterface;
+use FreeDSx\Ldap\Server\Process\BackgroundTask\SwooleBackgroundTasks;
 use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
 use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Ldap\ServerOptions;
@@ -28,7 +29,6 @@ use FreeDSx\Socket\SocketServer;
 use Closure;
 use Psr\Log\LoggerInterface;
 use Swoole\Coroutine;
-use Swoole\Coroutine\Channel;
 use Swoole\Coroutine\WaitGroup;
 use Swoole\Process;
 use Swoole\Runtime;
@@ -60,13 +60,6 @@ class SwooleServerRunner implements CoroutineServerRunnerInterface
     private bool $isShuttingDown = false;
 
     /**
-     * Wakes the retention-sweep coroutine so shutdown does not wait out its sleep interval.
-     *
-     * @var ?Channel<bool>
-     */
-    private ?Channel $sweepWakeup = null;
-
-    /**
      * Active client sockets keyed by spl_object_id.
      *
      * Used to force-close lingering connections when the drain timeout expires.
@@ -92,7 +85,7 @@ class SwooleServerRunner implements CoroutineServerRunnerInterface
         private readonly SocketServerFactory $socketServerFactory,
         Closure $protocolFactoryProvider,
         private readonly MetricsRecorderInterface $metricsRecorder = new NullMetricsRecorder(),
-        private readonly ?RetentionSweeper $retentionSweeper = null,
+        private readonly BackgroundTasksInterface $backgroundTasks = new SwooleBackgroundTasks(),
     ) {
         if (!extension_loaded('swoole')) {
             throw new RuntimeException(
@@ -115,7 +108,7 @@ class SwooleServerRunner implements CoroutineServerRunnerInterface
         Coroutine\run(function (): void {
             $this->server = $this->socketServerFactory->makeAndBind();
             $this->registerShutdownSignals();
-            $this->startRetentionSweep();
+            $this->backgroundTasks->start();
             $this->acceptClients();
         });
 
@@ -144,37 +137,13 @@ class SwooleServerRunner implements CoroutineServerRunnerInterface
         $this->reloadConfiguration(['signal' => $signal]);
     }
 
-    /**
-     * Runs the journal retention sweep in a background coroutine, sleeping between prunes and yielding on I/O.
-     */
-    private function startRetentionSweep(): void
-    {
-        if ($this->retentionSweeper === null) {
-            return;
-        }
-
-        $sweeper = $this->retentionSweeper;
-        $wakeup = $this->sweepWakeup = new Channel(1);
-
-        Coroutine::create(function () use ($sweeper, $wakeup): void {
-            while (!$this->isShuttingDown) {
-                // pop() returns the pushed value on shutdown, or false after the interval elapses.
-                if ($wakeup->pop(RetentionSweeper::DEFAULT_INTERVAL_SECONDS) !== false) {
-                    break;
-                }
-
-                $sweeper->sweep();
-            }
-        });
-    }
-
     private function handleShutdownSignal(int $signal): void
     {
         if ($this->isShuttingDown) {
             return;
         }
         $this->isShuttingDown = true;
-        $this->sweepWakeup?->push(true);
+        $this->backgroundTasks->stop();
         $this->logShutdownStarted(['signal' => $signal]);
         $this->server->close();
         $this->notifyClientsOfShutdown();
@@ -220,6 +189,8 @@ class SwooleServerRunner implements CoroutineServerRunnerInterface
         $this->options->getOnServerReady()?->__invoke();
 
         while (!$this->isShuttingDown) {
+            $this->backgroundTasks->tick();
+
             try {
                 $socket = $this->server->accept($this->options->getSocketAcceptTimeout());
             } catch (Throwable $e) {

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -876,6 +876,14 @@ final class ServerOptions
         return $this;
     }
 
+    /**
+     * Named constructor for a read-only replica that mirrors an upstream primary over RFC 4533.
+     */
+    public static function forReplica(ReplicaConfig $replicaConfig): self
+    {
+        return (new self())->setReplicaConfig($replicaConfig);
+    }
+
     public function getReplicaConfig(): ?ReplicaConfig
     {
         return $this->replicaConfig;

--- a/src/FreeDSx/Ldap/Sync/Consumer/LdapReplica.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/LdapReplica.php
@@ -43,6 +43,8 @@ final class LdapReplica
 {
     private bool $stopping = false;
 
+    private ?SyncRepl $activeSync = null;
+
     /**
      * @param Closure(): SyncRepl $connect opens a fresh, authenticated sync connection to the primary
      */
@@ -51,7 +53,7 @@ final class LdapReplica
         private readonly ChangeApplierInterface $applier,
         private readonly ReplicationCheckpointInterface $checkpoint,
         private readonly SleeperInterface $sleeper,
-        private readonly ShutdownSignalsInterface $signals,
+        private readonly ?ShutdownSignalsInterface $signals = null,
         private readonly ?LoggerInterface $logger = null,
         private readonly ReconnectBackoff $backoff = new ReconnectBackoff(),
     ) {}
@@ -70,16 +72,20 @@ final class LdapReplica
         );
     }
 
+    /**
+     * @param ?ShutdownSignalsInterface $signals null when a host server owns SIGTERM and drives {@see stop()} instead
+     */
     public static function forSwoole(
         ReplicaConfig $config,
         EntryStorageInterface $storage,
         ?LoggerInterface $logger = null,
+        ?ShutdownSignalsInterface $signals = new SwooleShutdownSignals(),
     ): self {
         return self::create(
             $config,
             $storage,
             new CoroutineSleeper(),
-            new SwooleShutdownSignals(),
+            $signals,
             $logger,
         );
     }
@@ -89,9 +95,7 @@ final class LdapReplica
      */
     public function run(): void
     {
-        $this->signals->onShutdown(function (): void {
-            $this->stopping = true;
-        });
+        $this->signals?->onShutdown($this->stop(...));
         $this->logger?->info('Starting replica synchronization.');
 
         $delay = $this->backoff->initial();
@@ -119,11 +123,20 @@ final class LdapReplica
         $this->logger?->info('Replica synchronization stopped.');
     }
 
+    /**
+     * Stop the daemon and break any in-progress listen; safe to call from a signal handler or another coroutine.
+     */
+    public function stop(): void
+    {
+        $this->stopping = true;
+        $this->activeSync?->disconnect();
+    }
+
     private static function create(
         ReplicaConfig $config,
         EntryStorageInterface $storage,
         SleeperInterface $sleeper,
-        ShutdownSignalsInterface $signals,
+        ?ShutdownSignalsInterface $signals,
         ?LoggerInterface $logger,
     ): self {
         // listen() must not time out its blocking read, or the persist phase would abort each interval.
@@ -165,8 +178,14 @@ final class LdapReplica
             ->useCookieHandler($this->persistCookie(...))
             ->useRefreshDoneHandler($this->reconcileRefresh(...));
 
-        $this->applier->beginRefresh();
-        $syncRepl->listen($this->applyEntry(...));
+        $this->activeSync = $syncRepl;
+
+        try {
+            $this->applier->beginRefresh();
+            $syncRepl->listen($this->applyEntry(...));
+        } finally {
+            $this->activeSync = null;
+        }
     }
 
     private function applyEntry(

--- a/src/FreeDSx/Ldap/Sync/SyncRepl.php
+++ b/src/FreeDSx/Ldap/Sync/SyncRepl.php
@@ -205,6 +205,14 @@ class SyncRepl
         );
     }
 
+    /**
+     * Close the sync connection, ending any in-progress {@see listen()}.
+     */
+    public function disconnect(): void
+    {
+        $this->client->disconnect();
+    }
+
     private function sync(
         int $mode,
         ?Closure $entryHandler,


### PR DESCRIPTION
This integrates the replica sync process into the server runners. It runs similarly to the retention sweep on the journal. So it runs and does not interfere with the normal client accept loop.