### PR TITLE
[1.0.0] Add integration tests and docs for the read-only replica.

### DIFF
--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -47,6 +47,13 @@ LDAP Server Configuration
 * [Directory Synchronization](#directory-synchronization)
     * [ServerOptions:setSyncEnabled](#setsyncenabled)
     * [ServerOptions:setChangeJournalConfig](#setchangejournalconfig)
+* [Read-Only Replica](#read-only-replica)
+    * [ServerOptions:setReplicaConfig](#setreplicaconfig)
+    * [ReplicaConfig:setBind](#setbind)
+    * [ReplicaConfig:setUseStartTls](#setusestarttls)
+    * [ReplicaConfig:setReferWrites](#setreferwrites)
+    * [ReplicaConfig:setFilter](#setfilter)
+    * [ReplicaConfig:setReconnectBackoff](#setreconnectbackoff)
 * [SASL Options](#sasl-options)
     * [ServerOptions:setSaslMechanisms](#setsaslmechanisms)
     * [ServerOptions:setExternalCredentialMapper](#setexternalcredentialmapper)
@@ -678,6 +685,63 @@ $options->setChangeJournalConfig($journalConfig);
 ```
 
 **Default**: origin `local` with no retention limits (the journal is not pruned).
+
+## Read-Only Replica
+
+Run the server as a read-only replica that mirrors a provider over RFC 4533. See
+[Read-Only Replica](Replication.md#read-only-replica) for the full guide.
+
+The `ReplicaConfig` is constructed with the provider's `ClientOptions` (servers, TLS, and the base DN of the subtree to
+mirror) and, optionally, a `ReplicationCheckpointInterface` where the sync cookie is persisted. The checkpoint defaults
+to in-memory; use `FileReplicationCheckpoint` in production so the replica resumes across restarts. The setters below
+configure the rest.
+
+------------------
+#### setReplicaConfig
+
+A `ServerOptions` setter that puts the server into read-only replica mode against the given `ReplicaConfig`. Client
+writes are refused and a background daemon keeps the local storage in step with the provider.
+`ServerOptions::forReplica($config)` is a shortcut that constructs the options with this already set.
+
+**Default**: `null` (the server is a normal read-write directory).
+
+------------------
+#### setBind
+
+A `ReplicaConfig` setter for how the replica authenticates to the provider, as a `BindRequest` from `Operations::bind()`
+(simple) or `Operations::bindSasl()` (SASL, including EXTERNAL for client-certificate auth).
+
+**Default**: none
+
+------------------
+#### setUseStartTls
+
+A `ReplicaConfig` setter for whether to issue StartTLS on the provider connection before binding. LDAPS is configured on
+the primary `ClientOptions` instead.
+
+**Default**: `false`
+
+------------------
+#### setReferWrites
+
+A `ReplicaConfig` setter for whether a client write to the replica is referred to the provider (`true`) or rejected with
+`unwillingToPerform` (`false`).
+
+**Default**: `true`
+
+------------------
+#### setFilter
+
+A `ReplicaConfig` setter for an optional filter restricting which entries are replicated.
+
+**Default**: `null` (all in-scope entries).
+
+------------------
+#### setReconnectBackoff
+
+A `ReplicaConfig` setter for the bounded exponential backoff applied between reconnect attempts to the provider.
+
+**Default**: `new ReconnectBackoff()` (starts at 1s, doubling to a 30s ceiling).
 
 ## Monitoring
 

--- a/docs/Server/Replication.md
+++ b/docs/Server/Replication.md
@@ -17,6 +17,7 @@ Sync is off by default.
 * [Retention](#retention)
 * [Origin and Cookies](#origin-and-cookies)
 * [Operational Notes](#operational-notes)
+* [Read-Only Replica](#read-only-replica)
 
 ## Quick Start
 
@@ -154,3 +155,82 @@ with it. Neither side should try to read or build it by hand; treat it as a toke
   and no window where a change is stored without its record.
 * Consuming the feed: a client uses the [SyncRepl](../Client/SyncRepl.md) helper to poll or listen.
 * Sync has no dedicated `cn=monitor` counters yet. Journal prunes appear in the event log rather than in metrics.
+
+## Read-Only Replica
+
+A FreeDSx server can run as a read-only replica of a provider. It serves reads from a local copy of the directory and
+runs a background daemon that keeps that copy in step with the provider over RFC 4533. Client writes to a replica are not
+accepted; by default they are referred to the provider.
+
+Build the server with `ServerOptions::forReplica(...)`. A `ReplicaConfig` describes how to reach and authenticate to the
+provider; the replica's own listener and storage are configured as usual.
+
+```php
+use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\ReplicaConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqliteStorage;
+use FreeDSx\Ldap\Sync\Consumer\Checkpoint\FileReplicationCheckpoint;
+use FreeDSx\Ldap\ServerOptions;
+
+// Persist the sync cookie so the replica resumes across restarts (the default is in-memory).
+$checkpoint = new FileReplicationCheckpoint('/var/lib/freedsx/replica.cookie');
+
+$replicaConfig = new ReplicaConfig(
+    (new ClientOptions())
+        ->setServers(['provider.example.com'])
+        ->setPort(636)
+        ->setUseSsl(true)
+        ->setBaseDn('dc=example,dc=com'),
+    $checkpoint,
+);
+
+// How the replica authenticates to the provider (a simple bind here; use Operations::bindSasl() for SASL/EXTERNAL).
+$replicaConfig->setBind(Operations::bind('cn=replica,dc=example,dc=com', 'secret'));
+
+$options = ServerOptions::forReplica($replicaConfig)
+    ->setStorage(SqliteStorage::forPcntl('/var/lib/freedsx/replica.sqlite'));
+
+(new LdapServer($options))->run();
+```
+
+The base DN on the primary `ClientOptions` is the subtree the replica mirrors; it must fall within the sync grant the
+provider gives the replica's bind identity.
+
+### How It Works
+
+The replica serves client reads and runs the sync daemon as a managed background task. The daemon connects to the
+provider, performs an initial refresh, then listens for changes and applies them verbatim to the replica's storage,
+preserving the provider's UUIDs and timestamps. It checkpoints its cookie so it resumes where it left off, reconciles
+deletions on a full refresh, and reconnects with bounded backoff if the connection drops. Changes are applied as a leaf;
+the replica does not re-journal them.
+
+### Writes Are Refused
+
+Any client write to a replica (add, modify, delete, rename, password modify) is refused. By default it is returned as a
+referral to the provider; call `ReplicaConfig::setReferWrites(false)` to reject it with `unwillingToPerform` instead.
+Reads, binds, compares, and StartTLS are served normally.
+
+### Storage Requirement
+
+Under the PCNTL runner the sync daemon and the connection workers are separate processes, so the replica's storage must
+be shared across processes (SQLite, MySQL, or JSON file); a forking replica on in-memory storage fails at startup. Under
+Swoole (one process) any storage works.
+
+### Security: Two Gates, and ACLs Do Not Replicate
+
+Access control is enforced independently on each side, and FreeDSx ACL is server configuration that does not replicate:
+
+* On the provider, the read access granted to the replica's bind identity bounds what data reaches the replica.
+* On the replica, its own access control bounds what clients reading from it may see. A replica with a more permissive
+  policy than the provider can expose data the provider would not.
+
+Because the two are separate, configure and review both. A replica does not inherit the provider's policy.
+
+### Password Policy
+
+A replica enforces the password-policy state it receives from the provider (lockout, expiry, grace) but records none of
+its own, so bind failures against a replica are not counted toward lockout there. Account lockout is not a real-time
+defense on a replica; put replicas behind connection rate limiting and/or deploy them in already isolated or trusted
+areas.

--- a/tests/bin/ldap-replica.php
+++ b/tests/bin/ldap-replica.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Console\Application;
+use Tests\Support\FreeDSx\Ldap\LdapReplicaCommand;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$command = new LdapReplicaCommand();
+$app = new Application('LDAP test replica');
+$app->add($command);
+$app->setDefaultCommand(
+    (string) $command->getName(),
+    true,
+);
+$app->run();

--- a/tests/integration/Sync/SyncReplPcntlReplicaTest.php
+++ b/tests/integration/Sync/SyncReplPcntlReplicaTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Sync;
+
+/**
+ * A read-only replica under the PCNTL runner.
+ */
+final class SyncReplPcntlReplicaTest extends SyncReplReplicaTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        if (!extension_loaded('pcntl')) {
+            return;
+        }
+
+        static::initSharedServer(
+            'ldap-replica',
+            'tcp',
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        static::tearDownSharedServer();
+    }
+}

--- a/tests/integration/Sync/SyncReplReplicaTestCase.php
+++ b/tests/integration/Sync/SyncReplReplicaTestCase.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Sync;
+
+use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\ReferralException;
+use FreeDSx\Ldap\LdapClient;
+use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+use Throwable;
+
+/**
+ * A read-only replica mirroring a locally spawned provider over RFC 4533.
+ */
+abstract class SyncReplReplicaTestCase extends ServerTestCase
+{
+    public function setUp(): void
+    {
+        $this->setServerMode('ldap-replica');
+
+        parent::setUp();
+    }
+
+    public function test_seeded_entries_replicate_to_the_replica(): void
+    {
+        self::assertNotNull($this->waitForReplica('cn=alice,ou=people,dc=foo,dc=bar'));
+    }
+
+    public function test_an_add_on_the_provider_propagates_to_the_replica(): void
+    {
+        $this->writeToProvider(static function (LdapClient $provider): void {
+            $provider->create(Entry::fromArray(
+                'cn=dave,ou=people,dc=foo,dc=bar',
+                [
+                    'objectClass' => 'inetOrgPerson',
+                    'cn' => 'dave',
+                    'sn' => 'Davis',
+                ],
+            ));
+        });
+
+        self::assertNotNull($this->waitForReplica('cn=dave,ou=people,dc=foo,dc=bar'));
+    }
+
+    public function test_a_delete_on_the_provider_propagates_to_the_replica(): void
+    {
+        $this->writeToProvider(static function (LdapClient $provider): void {
+            $provider->create(Entry::fromArray(
+                'cn=eve,ou=people,dc=foo,dc=bar',
+                [
+                    'objectClass' => 'inetOrgPerson',
+                    'cn' => 'eve',
+                    'sn' => 'Evans',
+                ],
+            ));
+        });
+        self::assertNotNull($this->waitForReplica('cn=eve,ou=people,dc=foo,dc=bar'));
+
+        $this->writeToProvider(static function (LdapClient $provider): void {
+            $provider->delete('cn=eve,ou=people,dc=foo,dc=bar');
+        });
+        self::assertNull($this->waitForReplicaGone('cn=eve,ou=people,dc=foo,dc=bar'));
+    }
+
+    public function test_a_client_write_to_the_replica_is_referred_to_the_provider(): void
+    {
+        self::assertNotNull($this->waitForReplica('cn=alice,ou=people,dc=foo,dc=bar'));
+
+        $client = $this->buildClient('tcp');
+        $client->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+
+        try {
+            $this->expectException(ReferralException::class);
+            $client->create(Entry::fromArray(
+                'cn=nope,ou=people,dc=foo,dc=bar',
+                [
+                    'objectClass' => 'inetOrgPerson',
+                    'cn' => 'nope',
+                    'sn' => 'Nope',
+                ],
+            ));
+        } finally {
+            $client->unbind();
+        }
+    }
+
+    private function waitForReplica(
+        string $dn,
+        float $timeoutSeconds = 15.0,
+    ): ?Entry {
+        $deadline = microtime(true) + $timeoutSeconds;
+
+        do {
+            $entry = $this->tryReadFromReplica($dn);
+
+            if ($entry !== null) {
+                return $entry;
+            }
+
+            usleep(100_000);
+        } while (microtime(true) < $deadline);
+
+        return null;
+    }
+
+    private function waitForReplicaGone(
+        string $dn,
+        float $timeoutSeconds = 15.0,
+    ): ?Entry {
+        $deadline = microtime(true) + $timeoutSeconds;
+
+        do {
+            $entry = $this->tryReadFromReplica($dn);
+
+            if ($entry === null) {
+                return null;
+            }
+
+            usleep(100_000);
+        } while (microtime(true) < $deadline);
+
+        return $entry;
+    }
+
+    private function tryReadFromReplica(string $dn): ?Entry
+    {
+        try {
+            $client = $this->buildClient('tcp');
+            $client->bind(
+                'cn=user,dc=foo,dc=bar',
+                '12345',
+            );
+            $entry = $client->read($dn);
+            $client->unbind();
+
+            return $entry;
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * @param callable(LdapClient): void $write
+     */
+    private function writeToProvider(callable $write): void
+    {
+        $provider = $this->getClient(
+            (new ClientOptions())
+                ->setPort(10391)
+                ->setServers(['127.0.0.1'])
+                ->setSslValidateCert(false),
+        );
+
+        try {
+            $provider->bind(
+                'cn=user,dc=foo,dc=bar',
+                '12345',
+            );
+            $write($provider);
+        } finally {
+            $provider->unbind();
+        }
+    }
+}

--- a/tests/integration/Sync/SyncReplSwooleReplicaTest.php
+++ b/tests/integration/Sync/SyncReplSwooleReplicaTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Sync;
+
+/**
+ * A read-only replica under the Swoole runner.
+ */
+final class SyncReplSwooleReplicaTest extends SyncReplReplicaTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!extension_loaded('swoole')) {
+            return;
+        }
+
+        static::initSharedServer(
+            'ldap-replica',
+            'tcp',
+            ['--runner=swoole'],
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        static::tearDownSharedServer();
+    }
+
+    public function setUp(): void
+    {
+        if (!extension_loaded('swoole')) {
+            $this->markTestSkipped('The swoole extension is required to run SwooleServerRunner tests.');
+        }
+
+        parent::setUp();
+    }
+}

--- a/tests/support/LdapReplicaCommand.php
+++ b/tests/support/LdapReplicaCommand.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\FreeDSx\Ldap;
+
+use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\ReplicaConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqliteStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\ServerOptions;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Process;
+
+/**
+ * Runs a read-only replica of a provider it spawns locally, mirroring it over RFC 4533.
+ */
+final class LdapReplicaCommand extends Command
+{
+    use ConsoleOptionsTrait;
+
+    private const SEED = __DIR__ . '/../resources/seed/sync-seed.ldif';
+
+    private const VALID_STORAGE = ['json', 'sqlite'];
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('ldap-replica')
+            ->setDescription('Run a read-only replica of a locally spawned provider')
+            ->addOption('transport', null, InputOption::VALUE_REQUIRED, 'The replica transport.', 'tcp')
+            ->addOption('port', null, InputOption::VALUE_REQUIRED, 'The replica listen port.', '10389')
+            ->addOption('provider-port', null, InputOption::VALUE_REQUIRED, 'The provider listen port.', '10391')
+            ->addOption('runner', null, InputOption::VALUE_REQUIRED, 'The server runner (pcntl/swoole).', 'pcntl')
+            ->addOption('storage', null, InputOption::VALUE_REQUIRED, 'Process-shared storage (json/sqlite).', 'sqlite');
+    }
+
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output,
+    ): int {
+        $io = new SymfonyStyle($input, $output);
+        $transport = $this->getStringOption($input, 'transport');
+        $port = (int) $this->getStringOption($input, 'port');
+        $providerPort = (int) $this->getStringOption($input, 'provider-port');
+        $runner = $this->getStringOption($input, 'runner');
+        $storageType = $this->getStringOption($input, 'storage');
+
+        if (!in_array($storageType, self::VALID_STORAGE, true)) {
+            $io->error("Invalid --storage value: {$storageType}. Expected one of: " . implode(', ', self::VALID_STORAGE) . '.');
+
+            return Command::FAILURE;
+        }
+
+        if (!in_array($runner, ['pcntl', 'swoole'], true)) {
+            $io->error("Invalid --runner value: {$runner}. Expected one of: pcntl, swoole.");
+
+            return Command::FAILURE;
+        }
+
+        $provider = $this->startProvider(
+            $providerPort,
+            $runner,
+        );
+        register_shutdown_function(static fn() => $provider->stop());
+
+        $replicaConfig = new ReplicaConfig(
+            (new ClientOptions())
+                ->setServers(['127.0.0.1'])
+                ->setPort($providerPort)
+                ->setBaseDn('dc=foo,dc=bar'),
+        );
+        $replicaConfig->setBind(Operations::bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        ));
+
+        $server = new LdapServer(
+            ServerOptions::forReplica($replicaConfig)
+                ->setPort($port)
+                ->setTransport($transport)
+                ->setUseSwooleRunner($runner === 'swoole')
+                ->setStorage($this->createReplicaStorage($storageType, $runner))
+                ->setSocketAcceptTimeout(0.1)
+                ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL)),
+        );
+
+        $server->run();
+
+        return Command::SUCCESS;
+    }
+
+    private function startProvider(
+        int $providerPort,
+        string $runner,
+    ): Process {
+        $provider = new Process([
+            'php',
+            '-dpcov.enabled=0',
+            __DIR__ . '/../bin/ldap-server.php',
+            '--transport=tcp',
+            '--port=' . $providerPort,
+            '--runner=' . $runner,
+            '--storage=sqlite',
+            '--seed=' . self::SEED,
+            '--allow-sync',
+        ]);
+        $provider->start();
+
+        $deadline = microtime(true) + 10.0;
+        while ($provider->isRunning()) {
+            if (str_contains($provider->getOutput(), 'server starting...')) {
+                break;
+            }
+
+            if (microtime(true) >= $deadline) {
+                break;
+            }
+
+            usleep(50_000);
+        }
+
+        return $provider;
+    }
+
+    private function createReplicaStorage(
+        string $storageType,
+        string $runner,
+    ): EntryStorageInterface {
+        $swoole = $runner === 'swoole';
+
+        if ($storageType === 'json') {
+            $filePath = sys_get_temp_dir() . '/ldap_replica.json';
+
+            if (file_exists($filePath)) {
+                unlink($filePath);
+            }
+
+            return $swoole
+                ? JsonFileStorage::forSwoole($filePath)
+                : JsonFileStorage::forPcntl($filePath);
+        }
+
+        $dbPath = sys_get_temp_dir() . '/ldap_replica.sqlite';
+
+        foreach ([$dbPath, $dbPath . '-wal', $dbPath . '-shm'] as $path) {
+            if (file_exists($path)) {
+                unlink($path);
+            }
+        }
+
+        return $swoole
+            ? SqliteStorage::forSwoole($dbPath)
+            : SqliteStorage::forPcntl($dbPath);
+    }
+}

--- a/tests/unit/LdapServerTest.php
+++ b/tests/unit/LdapServerTest.php
@@ -22,6 +22,7 @@ use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\Backend\Storage\Export\DumpOptions;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\ReplicaConfig;
 use FreeDSx\Ldap\ProxyOptions;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
 use FreeDSx\Ldap\ServerOptions;
@@ -72,6 +73,17 @@ class LdapServerTest extends TestCase
 
     public function test_run_throws_when_no_storage_is_configured(): void
     {
+        $this->expectException(RuntimeException::class);
+
+        $this->subject->run();
+    }
+
+    public function test_run_throws_for_a_forking_replica_on_in_memory_storage(): void
+    {
+        $this->options
+            ->setReplicaConfig(new ReplicaConfig(new ClientOptions()))
+            ->useInMemoryStorage();
+
         $this->expectException(RuntimeException::class);
 
         $this->subject->run();

--- a/tests/unit/ServerOptionsTest.php
+++ b/tests/unit/ServerOptionsTest.php
@@ -40,6 +40,8 @@ use FreeDSx\Ldap\Server\SearchLimit\SearchLimitRule;
 use FreeDSx\Ldap\Server\SearchLimit\SearchLimitRules;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\TlsVersion;
+use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\ReplicaConfig;
 use FreeDSx\Ldap\ServerOptions;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -51,6 +53,24 @@ final class ServerOptionsTest extends TestCase
     protected function setUp(): void
     {
         $this->subject = new ServerOptions();
+    }
+
+    public function test_a_default_server_is_not_a_read_only_replica(): void
+    {
+        self::assertFalse($this->subject->isReadOnly());
+        self::assertNull($this->subject->getReplicaConfig());
+    }
+
+    public function test_for_replica_configures_a_read_only_replica(): void
+    {
+        $config = new ReplicaConfig(new ClientOptions());
+        $options = ServerOptions::forReplica($config);
+
+        self::assertTrue($options->isReadOnly());
+        self::assertSame(
+            $config,
+            $options->getReplicaConfig(),
+        );
     }
 
     public function test_privileged_controls_have_the_expected_defaults(): void


### PR DESCRIPTION
This adds actual integration tests for the read-only replica mirroring and its behavior under both PCNTL and Swoole. It also documents how to configure and use it, as well as its limitations / gotchyas related to security (mostly things you might overlook if wanting to use it or configure it).