### PR TITLE
[1.0.0] Fix tagging option persistence for attributes.

### DIFF
--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonFileStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonFileStorage.php
@@ -243,7 +243,7 @@ final class JsonFileStorage implements EntryStorageInterface, ChangeJournalingIn
     {
         $attributes = [];
         foreach ($entry->getAttributes() as $attribute) {
-            $attributes[$attribute->getName()] = array_values($attribute->getValues());
+            $attributes[$attribute->getDescription()] = array_values($attribute->getValues());
         }
 
         return [

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/UpdateOperation.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/UpdateOperation.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Operation;
 
+use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -53,8 +54,7 @@ final class UpdateOperation
         Change $change,
     ): void {
         $attribute = $change->getAttribute();
-        $attrName = $attribute->getName();
-        $existing = $entry->get($attrName);
+        $existing = $entry->get($attribute, true);
 
         if ($existing === null) {
             $entry->add($attribute);
@@ -64,7 +64,7 @@ final class UpdateOperation
         foreach ($attribute->getValues() as $value) {
             if ($existing->has($value, caseSensitive: false)) {
                 throw new OperationException(
-                    sprintf('Attribute "%s" already contains the given value.', $attrName),
+                    sprintf('Attribute "%s" already contains the given value.', $attribute->getName()),
                     ResultCode::ATTRIBUTE_OR_VALUE_EXISTS,
                 );
             }
@@ -80,15 +80,15 @@ final class UpdateOperation
         Entry $entry,
         Change $change,
     ): void {
-        $attrName = $change->getAttribute()->getName();
-        $values = $change->getAttribute()->getValues();
+        $attribute = $change->getAttribute();
+        $values = $attribute->getValues();
 
         if (count($values) === 0) {
-            $this->deleteWholeAttribute($entry, $attrName);
+            $this->deleteWholeAttribute($entry, $attribute);
             return;
         }
 
-        $this->deleteSpecificValues($entry, $attrName, $values);
+        $this->deleteSpecificValues($entry, $attribute, $values);
     }
 
     /**
@@ -96,23 +96,23 @@ final class UpdateOperation
      */
     private function deleteWholeAttribute(
         Entry $entry,
-        string $attrName,
+        Attribute $attribute,
     ): void {
-        if ($entry->get($attrName) === null) {
+        if ($entry->get($attribute, true) === null) {
             throw new OperationException(
-                sprintf('Attribute "%s" does not exist.', $attrName),
+                sprintf('Attribute "%s" does not exist.', $attribute->getName()),
                 ResultCode::NO_SUCH_ATTRIBUTE,
             );
         }
 
-        if ($this->isRdnAttribute($entry, $attrName)) {
+        if ($this->isRdnAttribute($entry, $attribute->getName())) {
             throw new OperationException(
-                sprintf('Attribute "%s" is the RDN attribute and cannot be removed.', $attrName),
+                sprintf('Attribute "%s" is the RDN attribute and cannot be removed.', $attribute->getName()),
                 ResultCode::NOT_ALLOWED_ON_RDN,
             );
         }
 
-        $entry->reset($attrName);
+        $entry->reset($attribute);
     }
 
     /**
@@ -122,27 +122,27 @@ final class UpdateOperation
      */
     private function deleteSpecificValues(
         Entry $entry,
-        string $attrName,
+        Attribute $attribute,
         array $values,
     ): void {
-        $existing = $entry->get($attrName);
+        $existing = $entry->get($attribute, true);
 
         if ($existing === null) {
             throw new OperationException(
-                sprintf('Attribute "%s" does not exist.', $attrName),
+                sprintf('Attribute "%s" does not exist.', $attribute->getName()),
                 ResultCode::NO_SUCH_ATTRIBUTE,
             );
         }
 
         $rdnValue = $this->getRdnValueForAttribute(
             $entry,
-            $attrName,
+            $attribute->getName(),
         );
 
         foreach ($values as $value) {
             if (!$existing->has($value, caseSensitive: false)) {
                 throw new OperationException(
-                    sprintf('The given value does not exist in attribute "%s".', $attrName),
+                    sprintf('The given value does not exist in attribute "%s".', $attribute->getName()),
                     ResultCode::NO_SUCH_ATTRIBUTE,
                 );
             }
@@ -151,7 +151,7 @@ final class UpdateOperation
                 throw new OperationException(
                     sprintf(
                         'The RDN value of attribute "%s" cannot be removed.',
-                        $attrName,
+                        $attribute->getName(),
                     ),
                     ResultCode::NOT_ALLOWED_ON_RDN,
                 );
@@ -170,25 +170,24 @@ final class UpdateOperation
     private function applyReplace(Entry $entry, Change $change): void
     {
         $attribute = $change->getAttribute();
-        $attrName = $attribute->getName();
         $values = $attribute->getValues();
 
         if (count($values) === 0) {
             $this->clearAttribute(
                 $entry,
-                $attrName,
+                $attribute,
             );
 
             return;
         }
 
-        $rdnValue = $this->getRdnValueForAttribute($entry, $attrName);
+        $rdnValue = $this->getRdnValueForAttribute($entry, $attribute->getName());
 
         if ($rdnValue !== null && !$attribute->has($rdnValue, caseSensitive: false)) {
             throw new OperationException(
                 sprintf(
                     'Replacing attribute "%s" must retain its RDN value.',
-                    $attrName,
+                    $attribute->getName(),
                 ),
                 ResultCode::NOT_ALLOWED_ON_RDN,
             );
@@ -202,16 +201,16 @@ final class UpdateOperation
      */
     private function clearAttribute(
         Entry $entry,
-        string $attrName,
+        Attribute $attribute,
     ): void {
-        if ($this->isRdnAttribute($entry, $attrName)) {
+        if ($this->isRdnAttribute($entry, $attribute->getName())) {
             throw new OperationException(
-                sprintf('Attribute "%s" is the RDN attribute and cannot be cleared.', $attrName),
+                sprintf('Attribute "%s" is the RDN attribute and cannot be cleared.', $attribute->getName()),
                 ResultCode::NOT_ALLOWED_ON_RDN,
             );
         }
 
-        $entry->reset($attrName);
+        $entry->reset($attribute);
     }
 
     private function isRdnAttribute(

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -366,7 +366,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
         $attributes = [];
 
         foreach ($entry->getAttributes() as $attribute) {
-            $attributes[$attribute->getName()] = array_values($attribute->getValues());
+            $attributes[$attribute->getDescription()] = array_values($attribute->getValues());
         }
 
         return serialize($attributes);

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
@@ -71,6 +71,7 @@ trait SqlFilterTranslatorTrait
         return new SqlFilterResult(
             $this->buildPresenceCheck($attribute),
             [],
+            isExact: !$this->attributeHasOption($filter->getAttribute()),
         );
     }
 
@@ -84,7 +85,7 @@ trait SqlFilterTranslatorTrait
         return new SqlFilterResult(
             $this->buildValueExists($attribute, "$alias = ?"),
             [$this->prepareMatchValue($value)],
-            isExact: $this->isExactEquality($value),
+            isExact: $this->isExactEquality($value) && !$this->attributeHasOption($filter->getAttribute()),
             referencedAttributes: [$attribute],
         );
     }
@@ -100,7 +101,7 @@ trait SqlFilterTranslatorTrait
         return new SqlFilterResult(
             $this->buildValueExists($attribute, "$alias = ?"),
             [$this->prepareMatchValue($value)],
-            isExact: $this->isExactEquality($value),
+            isExact: $this->isExactEquality($value) && !$this->attributeHasOption($filter->getAttribute()),
             referencedAttributes: [$attribute],
         );
     }
@@ -116,7 +117,7 @@ trait SqlFilterTranslatorTrait
         return new SqlFilterResult(
             $this->buildValueExists($attribute, "$alias >= ?"),
             [$this->prepareMatchValue($value)],
-            isExact: $this->isExactOrdered($value),
+            isExact: $this->isExactOrdered($value) && !$this->attributeHasOption($filter->getAttribute()),
             referencedAttributes: [$attribute],
         );
     }
@@ -168,7 +169,7 @@ trait SqlFilterTranslatorTrait
             $startsWith,
             $contains,
             $endsWith,
-        );
+        ) && !$this->attributeHasOption($filter->getAttribute());
 
         return new SqlFilterResult(
             $sql,
@@ -369,5 +370,13 @@ trait SqlFilterTranslatorTrait
             $lower,
             2,
         )[0];
+    }
+
+    /**
+     * An option-bearing filter is a SQL superset, since the base-keyed sidecar cannot distinguish the subtype.
+     */
+    private function attributeHasOption(string $attribute): bool
+    {
+        return str_contains($attribute, ';');
     }
 }

--- a/tests/integration/Storage/LdapBackendStorageTest.php
+++ b/tests/integration/Storage/LdapBackendStorageTest.php
@@ -15,6 +15,7 @@ namespace Tests\Integration\FreeDSx\Ldap\Storage;
 
 use FreeDSx\Ldap\Control\Sorting\SortingControl;
 use FreeDSx\Ldap\Control\Sorting\SortKey;
+use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -187,6 +188,38 @@ class LdapBackendStorageTest extends ServerTestCase
                 ->useSubtreeScope(),
         );
         self::assertCount(1, $entries);
+    }
+
+    public function testAddPreservesAttributeOptionsOnRoundTrip(): void
+    {
+        $this->authenticateUser();
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=tagged,dc=foo,dc=bar',
+            [
+                'cn' => 'tagged',
+                'cn;lang-en' => 'Tagged EN',
+                'sn' => 'Tag',
+                'objectClass' => 'inetOrgPerson',
+            ],
+        ));
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::equal('cn;lang-en', 'Tagged EN'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        $tagged = $entries->first();
+        self::assertNotNull($tagged);
+        self::assertSame(
+            ['Tagged EN'],
+            $tagged->get(new Attribute('cn;lang-en'), true)?->getValues(),
+        );
+        self::assertSame(
+            ['tagged'],
+            $tagged->get(new Attribute('cn'), true)?->getValues(),
+        );
     }
 
     public function testAddDuplicateDnFails(): void

--- a/tests/unit/Server/Backend/Storage/Adapter/JsonFileStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/JsonFileStorageTest.php
@@ -103,6 +103,39 @@ final class JsonFileStorageTest extends TestCase
         );
     }
 
+    public function test_attribute_options_round_trip_through_storage(): void
+    {
+        $dn = new Dn('cn=Bob,dc=example,dc=com');
+        $this->subject->add(
+            new AddCommand(
+                new Entry(
+                    $dn,
+                    new Attribute('objectClass', 'person'),
+                    new Attribute('cn', 'Bob'),
+                    new Attribute('cn;lang-en', 'Bobby'),
+                    new Attribute('userCertificate;binary', 'CERTDATA'),
+                ),
+            ),
+            $this->context(),
+        );
+
+        $entry = $this->subject->get($dn);
+
+        self::assertNotNull($entry);
+        self::assertSame(
+            ['Bob'],
+            $entry->get(new Attribute('cn'), true)?->getValues(),
+        );
+        self::assertSame(
+            ['Bobby'],
+            $entry->get(new Attribute('cn;lang-en'), true)?->getValues(),
+        );
+        self::assertSame(
+            ['CERTDATA'],
+            $entry->get(new Attribute('userCertificate;binary'), true)?->getValues(),
+        );
+    }
+
     public function test_get_is_case_insensitive(): void
     {
         $entry = $this->subject->get(new Dn('CN=ALICE,DC=EXAMPLE,DC=COM'));

--- a/tests/unit/Server/Backend/Storage/Adapter/MysqlFilterTranslatorTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/MysqlFilterTranslatorTest.php
@@ -303,6 +303,25 @@ final class MysqlFilterTranslatorTest extends TestCase
         );
     }
 
+    public function test_option_bearing_equality_filter_is_inexact(): void
+    {
+        $result = $this->subject->translate(new EqualityFilter(
+            'cn;lang-en',
+            'x',
+        ));
+
+        self::assertNotNull($result);
+        self::assertFalse($result->isExact);
+    }
+
+    public function test_option_bearing_present_filter_is_inexact(): void
+    {
+        $result = $this->subject->translate(new PresentFilter('cn;lang-en'));
+
+        self::assertNotNull($result);
+        self::assertFalse($result->isExact);
+    }
+
     public function test_numericoid_attribute_translates(): void
     {
         $result = $this->subject->translate(new PresentFilter('2.5.4.3'));

--- a/tests/unit/Server/Backend/Storage/Adapter/Operation/UpdateOperationTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Operation/UpdateOperationTest.php
@@ -367,6 +367,98 @@ final class UpdateOperationTest extends TestCase
         ));
     }
 
+    public function test_type_add_targets_the_option_subtype_without_touching_the_base_attribute(): void
+    {
+        $entry = new Entry(
+            new Dn('uid=asmith,dc=example,dc=com'),
+            new Attribute('uid', 'asmith'),
+            new Attribute('cn', 'Alice Smith'),
+            new Attribute('cn;lang-en', 'Alice'),
+        );
+
+        $result = $this->subject->execute($entry, new UpdateCommand(
+            new Dn('uid=asmith,dc=example,dc=com'),
+            [new Change(Change::TYPE_ADD, 'cn;lang-en', 'Ally')],
+        ));
+
+        self::assertSame(
+            ['Alice Smith'],
+            $result->get(new Attribute('cn'), true)?->getValues(),
+        );
+        self::assertSame(
+            ['Alice', 'Ally'],
+            $result->get(new Attribute('cn;lang-en'), true)?->getValues(),
+        );
+    }
+
+    public function test_type_add_creates_a_distinct_subtype_when_only_the_base_exists(): void
+    {
+        $entry = new Entry(
+            new Dn('uid=asmith,dc=example,dc=com'),
+            new Attribute('uid', 'asmith'),
+            new Attribute('cn', 'Alice'),
+        );
+
+        $result = $this->subject->execute($entry, new UpdateCommand(
+            new Dn('uid=asmith,dc=example,dc=com'),
+            [new Change(Change::TYPE_ADD, 'cn;lang-en', 'Ally')],
+        ));
+
+        self::assertSame(
+            ['Alice'],
+            $result->get(new Attribute('cn'), true)?->getValues(),
+        );
+        self::assertSame(
+            ['Ally'],
+            $result->get(new Attribute('cn;lang-en'), true)?->getValues(),
+        );
+    }
+
+    public function test_type_replace_targets_the_option_subtype_only(): void
+    {
+        $entry = new Entry(
+            new Dn('uid=asmith,dc=example,dc=com'),
+            new Attribute('uid', 'asmith'),
+            new Attribute('cn', 'Alice Smith'),
+            new Attribute('cn;lang-en', 'Alice'),
+        );
+
+        $result = $this->subject->execute($entry, new UpdateCommand(
+            new Dn('uid=asmith,dc=example,dc=com'),
+            [new Change(Change::TYPE_REPLACE, 'cn;lang-en', 'Ally')],
+        ));
+
+        self::assertSame(
+            ['Alice Smith'],
+            $result->get(new Attribute('cn'), true)?->getValues(),
+        );
+        self::assertSame(
+            ['Ally'],
+            $result->get(new Attribute('cn;lang-en'), true)?->getValues(),
+        );
+    }
+
+    public function test_type_delete_removes_only_the_option_subtype(): void
+    {
+        $entry = new Entry(
+            new Dn('uid=asmith,dc=example,dc=com'),
+            new Attribute('uid', 'asmith'),
+            new Attribute('cn', 'Alice Smith'),
+            new Attribute('cn;lang-en', 'Alice'),
+        );
+
+        $result = $this->subject->execute($entry, new UpdateCommand(
+            new Dn('uid=asmith,dc=example,dc=com'),
+            [new Change(Change::TYPE_DELETE, 'cn;lang-en')],
+        ));
+
+        self::assertSame(
+            ['Alice Smith'],
+            $result->get(new Attribute('cn'), true)?->getValues(),
+        );
+        self::assertNull($result->get(new Attribute('cn;lang-en'), true));
+    }
+
     public function test_type_add_with_case_differing_value_throws_attribute_or_value_exists(): void
     {
         self::expectException(OperationException::class);

--- a/tests/unit/Server/Backend/Storage/Adapter/SqliteFilterTranslatorTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/SqliteFilterTranslatorTest.php
@@ -287,6 +287,25 @@ final class SqliteFilterTranslatorTest extends TestCase
         );
     }
 
+    public function test_option_bearing_equality_filter_is_inexact(): void
+    {
+        $result = $this->subject->translate(new EqualityFilter(
+            'cn;lang-en',
+            'x',
+        ));
+
+        self::assertNotNull($result);
+        self::assertFalse($result->isExact);
+    }
+
+    public function test_option_bearing_present_filter_is_inexact(): void
+    {
+        $result = $this->subject->translate(new PresentFilter('cn;lang-en'));
+
+        self::assertNotNull($result);
+        self::assertFalse($result->isExact);
+    }
+
     public function test_numericoid_attribute_translates(): void
     {
         $result = $this->subject->translate(new PresentFilter('2.5.4.3'));

--- a/tests/unit/Server/Backend/Storage/Adapter/SqliteStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/SqliteStorageTest.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Search\Filter\AndFilter;
+use FreeDSx\Ldap\Search\Filter\FilterInterface;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SqliteDialect;
@@ -325,6 +326,72 @@ final class SqliteStorageTest extends TestCase
         self::assertNotNull($entry);
         self::assertSame(['Alice'], $entry->get('cn')?->getValues());
         self::assertSame(['secret'], $entry->get('userPassword')?->getValues());
+    }
+
+    public function test_attribute_options_round_trip_through_storage(): void
+    {
+        $dn = new Dn('uid=tagged,dc=example,dc=com');
+        $this->subject->add(
+            new AddCommand(
+                new Entry(
+                    $dn,
+                    new Attribute('uid', 'tagged'),
+                    new Attribute('cn', 'Common'),
+                    new Attribute('cn;lang-en', 'English'),
+                    new Attribute('userCertificate;binary', 'CERTDATA'),
+                ),
+            ),
+            $this->context(),
+        );
+
+        $entry = $this->subject->get($dn);
+
+        self::assertNotNull($entry);
+        self::assertSame(
+            ['Common'],
+            $entry->get(new Attribute('cn'), true)?->getValues(),
+        );
+        self::assertSame(
+            ['English'],
+            $entry->get(new Attribute('cn;lang-en'), true)?->getValues(),
+        );
+        self::assertSame(
+            ['CERTDATA'],
+            $entry->get(new Attribute('userCertificate;binary'), true)?->getValues(),
+        );
+    }
+
+    public function test_option_bearing_equality_filter_matches_only_the_subtype(): void
+    {
+        $this->subject->add(
+            new AddCommand(
+                new Entry(
+                    new Dn('uid=tagged,dc=example,dc=com'),
+                    new Attribute('uid', 'tagged'),
+                    new Attribute('cn;lang-en', 'shared'),
+                ),
+            ),
+            $this->context(),
+        );
+        $this->subject->add(
+            new AddCommand(
+                new Entry(
+                    new Dn('uid=plain,dc=example,dc=com'),
+                    new Attribute('uid', 'plain'),
+                    new Attribute('cn', 'shared'),
+                ),
+            ),
+            $this->context(),
+        );
+
+        self::assertSame(
+            ['uid=tagged,dc=example,dc=com'],
+            $this->searchDns(Filters::equal('cn;lang-en', 'shared')),
+        );
+        self::assertEqualsCanonicalizing(
+            ['uid=tagged,dc=example,dc=com', 'uid=plain,dc=example,dc=com'],
+            $this->searchDns(Filters::equal('cn', 'shared')),
+        );
     }
 
     public function test_attribute_name_casing_is_preserved_on_round_trip(): void
@@ -912,6 +979,23 @@ final class SqliteStorageTest extends TestCase
         }
 
         return $names;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function searchDns(FilterInterface $filter): array
+    {
+        $request = (new SearchRequest($filter))
+            ->base('dc=example,dc=com')
+            ->useSubtreeScope();
+
+        $dns = [];
+        foreach ($this->subject->search($request)->entries as $entry) {
+            $dns[] = $entry->getDn()->toString();
+        }
+
+        return $dns;
     }
 
     private function context(): WriteContext


### PR DESCRIPTION
Fixing tagging options in attributes, which were not being persisted correctly. Discovered this during the sync work, but fixing it separately.