### PR TITLE
[1.0.0] Enforce the min / max delay for on bind failures for the password policy.

### DIFF
--- a/docs/Server/Password-Policy.md
+++ b/docs/Server/Password-Policy.md
@@ -217,6 +217,14 @@ recent window.
 
 A locked bind returns `INVALID_CREDENTIALS` with the `accountLocked` error.
 
+### Failed Bind Delay
+
+When both `pwdMinDelay` and `pwdMaxDelay` are set to positive values, the server delays the response to a failed
+bind to slow brute-force attempts. The delay starts at `pwdMinDelay` seconds on the first consecutive failure and
+doubles with each subsequent failure, capped at `pwdMaxDelay`.
+
+Note: Either value unset or `0` disables the delay (the default).
+
 ### Idle Lockout
 
 When `pwdMaxIdle` is set, an account with no successful bind within that many seconds is locked, returning
@@ -315,10 +323,6 @@ clients:
 `pwdPolicySubentry`, `pwdStartTime`, and `pwdEndTime` are read from the user entry but managed by the operator.
 
 ## Not Yet Enforced / Limitations
-
-`pwdMinDelay` / `pwdMaxDelay` and not yet supported. No artificial delay is applied after a failed bind.
-
-Additional notes:
 
 - Policy is assumed to apply to `userPassword`. Custom password attributes are not supported.
 - A plain `ldapmodify` stores the submitted value verbatim. Pre-hashed value cannot be inspected.

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Decision/RecordedOutcome.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Decision/RecordedOutcome.php
@@ -21,5 +21,6 @@ final readonly class RecordedOutcome
     public function __construct(
         public PasswordPolicyOutcome $outcome,
         public OperationalChanges $changes,
+        public float $delaySeconds = 0.0,
     ) {}
 }

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Guard/PasswordPolicyBindGuard.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Guard/PasswordPolicyBindGuard.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Server\PasswordPolicy\Guard;
 use FreeDSx\Ldap\Control\PwdPolicyError;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Server\Backend\Write\SystemChangeWriterInterface;
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
@@ -34,6 +35,7 @@ final readonly class PasswordPolicyBindGuard
         private SystemChangeWriterInterface $writer,
         private PasswordPolicyContext $context,
         private EventLogger $eventLogger,
+        private SleeperInterface $sleeper,
     ) {}
 
     /**
@@ -62,7 +64,8 @@ final readonly class PasswordPolicyBindGuard
     }
 
     /**
-     * Surfaces a lockout outcome but never throws (the caller re-throws the credential error).
+     * Surfaces a lockout outcome but never throws (the caller re-throws the credential error), then applies the
+     * configured pwdMinDelay/pwdMaxDelay response delay.
      */
     public function recordFailure(PasswordBindAttempt $attempt): void
     {
@@ -75,15 +78,15 @@ final readonly class PasswordPolicyBindGuard
             $recorded->changes,
         );
 
-        if (!$recorded->outcome->denied) {
-            return;
+        if ($recorded->outcome->denied) {
+            $this->context->setOutcome($recorded->outcome);
+            $this->eventLogger->record(
+                ServerEvent::PasswordPolicyAccountLocked,
+                $this->subjectFor($attempt),
+            );
         }
 
-        $this->context->setOutcome($recorded->outcome);
-        $this->eventLogger->record(
-            ServerEvent::PasswordPolicyAccountLocked,
-            $this->subjectFor($attempt),
-        );
+        $this->sleeper->sleep($recorded->delaySeconds);
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyEngine.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyEngine.php
@@ -90,6 +90,7 @@ final readonly class PasswordPolicyEngine
         return new RecordedOutcome(
             $outcome,
             OperationalChanges::of(...$changes),
+            $this->bindFailureDelay($policy, count($retained)),
         );
     }
 
@@ -336,6 +337,30 @@ final readonly class PasswordPolicyEngine
             $this->isLockoutEffective($state, $policy) => false,
             default => count($retained) >= $policy->lockout->maxFailure,
         };
+    }
+
+    /**
+     * Response delay after a failed bind (draft-behera-10 §5.2.11-5.2.12): starts at pwdMinDelay and doubles per
+     * consecutive failure, capped at pwdMaxDelay. Disabled unless both delays are positive.
+     */
+    private function bindFailureDelay(
+        PasswordPolicy $policy,
+        int $failureCount,
+    ): float {
+        $minDelay = $policy->lockout->minDelay ?? 0;
+        $maxDelay = $policy->lockout->maxDelay ?? 0;
+
+        if ($minDelay <= 0 || $maxDelay <= 0 || $failureCount < 1) {
+            return 0.0;
+        }
+
+        // Cap the exponent so the doubling cannot overflow before the maxDelay clamp applies.
+        $doublings = min($failureCount - 1, 30);
+
+        return (float) min(
+            $minDelay * (2 ** $doublings),
+            $maxDelay,
+        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/ServerProtocolFactory.php
@@ -67,6 +67,9 @@ use FreeDSx\Ldap\Server\Middleware\ResourceLimitMiddleware;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\HandlerInvoker;
 use FreeDSx\Ldap\Server\SearchLimit\SearchLimitResolver;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareChain;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\CoroutineSleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyBindGuard;
 use FreeDSx\Ldap\Protocol\Queue\Response\MetricsResponseInterceptor;
 use FreeDSx\Ldap\Protocol\Queue\Response\PasswordPolicyResponseInterceptor;
@@ -315,7 +318,15 @@ class ServerProtocolFactory implements ServerProtocolFactoryInterface
             $this->systemChangeWriter(),
             $policyContext,
             $eventLogger,
+            $this->makeSleeper(),
         );
+    }
+
+    private function makeSleeper(): SleeperInterface
+    {
+        return $this->options->getUseSwooleRunner()
+            ? new CoroutineSleeper()
+            : new BlockingSleeper();
     }
 
     private function systemChangeWriter(): SystemChangeWriterInterface

--- a/tests/integration/Security/PasswordPolicyBindEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyBindEnforcementTest.php
@@ -35,6 +35,7 @@ use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyBindGuard;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordExpirationRules;
@@ -534,6 +535,7 @@ final class PasswordPolicyBindEnforcementTest extends TestCase
                 $this->logger,
                 EventLogPolicy::all(),
             ),
+            new BlockingSleeper(),
         );
 
         return new PasswordPolicyAwareAuthenticator(

--- a/tests/support/Server/Clock/RecordingSleeper.php
+++ b/tests/support/Server/Clock/RecordingSleeper.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Support\FreeDSx\Ldap\Server\Clock;
+
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
+
+/**
+ * Test sleeper that records every requested duration instead of pausing.
+ */
+final class RecordingSleeper implements SleeperInterface
+{
+    /**
+     * @var list<float>
+     */
+    public array $durations = [];
+
+    public function sleep(float $seconds): void
+    {
+        $this->durations[] = $seconds;
+    }
+}

--- a/tests/unit/Server/Backend/Auth/PasswordPolicyAwareAuthenticatorTest.php
+++ b/tests/unit/Server/Backend/Auth/PasswordPolicyAwareAuthenticatorTest.php
@@ -29,6 +29,7 @@ use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyBindGuard;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
@@ -208,6 +209,7 @@ final class PasswordPolicyAwareAuthenticatorTest extends TestCase
             new SystemChangeWriter(new WriteOperationDispatcher($this->writeHandler)),
             $this->context,
             new EventLogger(null),
+            new BlockingSleeper(),
         );
 
         return new PasswordPolicyAwareAuthenticator(

--- a/tests/unit/Server/Backend/Auth/SaslBindPolicyEnforcerTest.php
+++ b/tests/unit/Server/Backend/Auth/SaslBindPolicyEnforcerTest.php
@@ -32,6 +32,7 @@ use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
 use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyBindGuard;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
@@ -191,6 +192,7 @@ final class SaslBindPolicyEnforcerTest extends TestCase
             new SystemChangeWriter(new WriteOperationDispatcher($this->backend)),
             $this->context,
             new EventLogger(null, EventLogPolicy::all()),
+            new BlockingSleeper(),
         );
 
         return new SaslBindPolicyEnforcer(

--- a/tests/unit/Server/PasswordPolicy/Guard/PasswordPolicyBindGuardTest.php
+++ b/tests/unit/Server/PasswordPolicy/Guard/PasswordPolicyBindGuardTest.php
@@ -39,6 +39,7 @@ use PHPUnit\Framework\TestCase;
 use Tests\Support\FreeDSx\Ldap\Backend\RecordingWriteHandler;
 use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
 use Tests\Support\FreeDSx\Ldap\Logging\RecordingLogger;
+use Tests\Support\FreeDSx\Ldap\Server\Clock\RecordingSleeper;
 
 final class PasswordPolicyBindGuardTest extends TestCase
 {
@@ -54,6 +55,8 @@ final class PasswordPolicyBindGuardTest extends TestCase
 
     private PasswordPolicyContext $context;
 
+    private RecordingSleeper $sleeper;
+
     private PasswordPolicyBindGuard $subject;
 
     protected function setUp(): void
@@ -62,6 +65,7 @@ final class PasswordPolicyBindGuardTest extends TestCase
         $this->writeHandler = new RecordingWriteHandler();
         $this->logger = new RecordingLogger();
         $this->context = new PasswordPolicyContext();
+        $this->sleeper = new RecordingSleeper();
 
         $engine = new PasswordPolicyEngine(
             clock: $this->clock,
@@ -75,6 +79,7 @@ final class PasswordPolicyBindGuardTest extends TestCase
                 $this->logger,
                 EventLogPolicy::all(),
             ),
+            $this->sleeper,
         );
     }
 
@@ -146,6 +151,42 @@ final class PasswordPolicyBindGuardTest extends TestCase
         );
         $this->assertWroteAttribute(PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME);
         $this->assertEventRecorded(ServerEvent::PasswordPolicyAccountLocked);
+    }
+
+    public function test_recordFailure_delays_the_response_by_the_configured_delay(): void
+    {
+        $this->subject->recordFailure($this->attempt(
+            new UserPasswordState(),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    minDelay: 3,
+                    maxDelay: 60,
+                ),
+            ),
+        ));
+
+        self::assertSame(
+            [3.0],
+            $this->sleeper->durations,
+        );
+    }
+
+    public function test_recordFailure_requests_no_delay_when_unconfigured(): void
+    {
+        $this->subject->recordFailure($this->attempt(
+            new UserPasswordState(),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    maxFailure: 3,
+                ),
+            ),
+        ));
+
+        self::assertSame(
+            [0.0],
+            $this->sleeper->durations,
+        );
     }
 
     public function test_recordSuccess_clean_state_stamps_last_success(): void

--- a/tests/unit/Server/PasswordPolicy/PasswordPolicyEngineTest.php
+++ b/tests/unit/Server/PasswordPolicy/PasswordPolicyEngineTest.php
@@ -316,6 +316,104 @@ final class PasswordPolicyEngineTest extends TestCase
         ));
     }
 
+    public function test_recordBindFailure_first_failure_delays_by_min_delay(): void
+    {
+        $result = $this->subject->recordBindFailure(
+            new UserPasswordState(),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    minDelay: 2,
+                    maxDelay: 60,
+                ),
+            ),
+        );
+
+        self::assertSame(
+            2.0,
+            $result->delaySeconds,
+        );
+    }
+
+    public function test_recordBindFailure_delay_doubles_with_each_failure(): void
+    {
+        $result = $this->subject->recordBindFailure(
+            new UserPasswordState(failureTimes: [
+                $this->minutesAgo(3),
+                $this->minutesAgo(2),
+            ]),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    minDelay: 2,
+                    maxDelay: 60,
+                ),
+            ),
+        );
+
+        self::assertSame(
+            8.0,
+            $result->delaySeconds,
+        );
+    }
+
+    public function test_recordBindFailure_delay_is_capped_at_max_delay(): void
+    {
+        $result = $this->subject->recordBindFailure(
+            new UserPasswordState(failureTimes: [
+                $this->minutesAgo(6),
+                $this->minutesAgo(5),
+                $this->minutesAgo(4),
+                $this->minutesAgo(3),
+                $this->minutesAgo(2),
+            ]),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    minDelay: 5,
+                    maxDelay: 20,
+                ),
+            ),
+        );
+
+        self::assertSame(
+            20.0,
+            $result->delaySeconds,
+        );
+    }
+
+    public function test_recordBindFailure_no_delay_when_delays_unset(): void
+    {
+        $result = $this->subject->recordBindFailure(
+            new UserPasswordState(),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    enabled: true,
+                    maxFailure: 3,
+                ),
+            ),
+        );
+
+        self::assertSame(
+            0.0,
+            $result->delaySeconds,
+        );
+    }
+
+    public function test_recordBindFailure_no_delay_when_max_delay_unset(): void
+    {
+        $result = $this->subject->recordBindFailure(
+            new UserPasswordState(),
+            new PasswordPolicy(
+                lockout: new PasswordLockoutRules(
+                    minDelay: 5,
+                ),
+            ),
+        );
+
+        self::assertSame(
+            0.0,
+            $result->delaySeconds,
+        );
+    }
+
     public function test_recordBindSuccess_stamps_last_success(): void
     {
         $result = $this->subject->recordBindSuccess(


### PR DESCRIPTION
This enforces the min / max delay for the password policy. The previous work for sync implemented a sleeper for both runners for some other reason, so I can re-use them here to finish this. That was the only thing remaining from the password policy rfc to implement for the most part.