### PR TITLE
[1.0.0] Add an NIS schema / fix integer ordering performance.

### DIFF
--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -494,6 +494,7 @@ class Container
             validator: $this->buildSchemaValidator(),
             operationalAttrs: new OperationalAttributeGenerator($schema),
             changeRecorder: $this->changeRecorderFor($storage),
+            schema: $options->getSchema(),
         );
     }
 

--- a/src/FreeDSx/Ldap/Schema/Definition/Nis/AttributeTypeOid.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/Nis/AttributeTypeOid.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Definition\Nis;
+
+/**
+ * OIDs, names, and descriptions for the RFC 2307 POSIX account/group/shadow attribute types.
+ */
+final class AttributeTypeOid
+{
+    public const OID_UID_NUMBER = '1.3.6.1.1.1.1.0';
+
+    public const NAME_UID_NUMBER = 'uidNumber';
+
+    public const DESC_UID_NUMBER = 'an integer uniquely identifying a user in an administrative domain';
+
+    public const OID_GID_NUMBER = '1.3.6.1.1.1.1.1';
+
+    public const NAME_GID_NUMBER = 'gidNumber';
+
+    public const DESC_GID_NUMBER = 'an integer uniquely identifying a group in an administrative domain';
+
+    public const OID_GECOS = '1.3.6.1.1.1.1.2';
+
+    public const NAME_GECOS = 'gecos';
+
+    public const DESC_GECOS = 'the GECOS field; the common name';
+
+    public const OID_HOME_DIRECTORY = '1.3.6.1.1.1.1.3';
+
+    public const NAME_HOME_DIRECTORY = 'homeDirectory';
+
+    public const DESC_HOME_DIRECTORY = 'the absolute path to the home directory';
+
+    public const OID_LOGIN_SHELL = '1.3.6.1.1.1.1.4';
+
+    public const NAME_LOGIN_SHELL = 'loginShell';
+
+    public const DESC_LOGIN_SHELL = 'the path to the login shell';
+
+    public const OID_SHADOW_LAST_CHANGE = '1.3.6.1.1.1.1.5';
+
+    public const NAME_SHADOW_LAST_CHANGE = 'shadowLastChange';
+
+    public const DESC_SHADOW_LAST_CHANGE = 'days since the epoch that the password was last changed';
+
+    public const OID_SHADOW_MIN = '1.3.6.1.1.1.1.6';
+
+    public const NAME_SHADOW_MIN = 'shadowMin';
+
+    public const DESC_SHADOW_MIN = 'minimum days between password changes';
+
+    public const OID_SHADOW_MAX = '1.3.6.1.1.1.1.7';
+
+    public const NAME_SHADOW_MAX = 'shadowMax';
+
+    public const DESC_SHADOW_MAX = 'maximum days a password remains valid';
+
+    public const OID_SHADOW_WARNING = '1.3.6.1.1.1.1.8';
+
+    public const NAME_SHADOW_WARNING = 'shadowWarning';
+
+    public const DESC_SHADOW_WARNING = 'days before expiry that the user is warned';
+
+    public const OID_SHADOW_INACTIVE = '1.3.6.1.1.1.1.9';
+
+    public const NAME_SHADOW_INACTIVE = 'shadowInactive';
+
+    public const DESC_SHADOW_INACTIVE = 'days after expiry that the account is disabled';
+
+    public const OID_SHADOW_EXPIRE = '1.3.6.1.1.1.1.10';
+
+    public const NAME_SHADOW_EXPIRE = 'shadowExpire';
+
+    public const DESC_SHADOW_EXPIRE = 'days since the epoch that the account expires';
+
+    public const OID_SHADOW_FLAG = '1.3.6.1.1.1.1.11';
+
+    public const NAME_SHADOW_FLAG = 'shadowFlag';
+
+    public const DESC_SHADOW_FLAG = 'reserved shadow map flag';
+
+    public const OID_MEMBER_UID = '1.3.6.1.1.1.1.12';
+
+    public const NAME_MEMBER_UID = 'memberUid';
+
+    public const DESC_MEMBER_UID = 'the login name of a group member';
+
+    private function __construct() {}
+}

--- a/src/FreeDSx/Ldap/Schema/Definition/Nis/ObjectClassOid.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/Nis/ObjectClassOid.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Definition\Nis;
+
+/**
+ * OIDs, names, and descriptions for the RFC 2307 POSIX account/group/shadow object classes.
+ */
+final class ObjectClassOid
+{
+    public const OID_POSIX_ACCOUNT = '1.3.6.1.1.1.2.0';
+
+    public const NAME_POSIX_ACCOUNT = 'posixAccount';
+
+    public const DESC_POSIX_ACCOUNT = 'abstraction of an account with POSIX attributes';
+
+    public const OID_SHADOW_ACCOUNT = '1.3.6.1.1.1.2.1';
+
+    public const NAME_SHADOW_ACCOUNT = 'shadowAccount';
+
+    public const DESC_SHADOW_ACCOUNT = 'additional attributes for shadow passwords';
+
+    public const OID_POSIX_GROUP = '1.3.6.1.1.1.2.2';
+
+    public const NAME_POSIX_GROUP = 'posixGroup';
+
+    public const DESC_POSIX_GROUP = 'abstraction of a group of accounts';
+
+    private function __construct() {}
+}

--- a/src/FreeDSx/Ldap/Schema/NisSchemaProvider.php
+++ b/src/FreeDSx/Ldap/Schema/NisSchemaProvider.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema;
+
+use FreeDSx\Ldap\Schema\Definition\AttributeType;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
+use FreeDSx\Ldap\Schema\Definition\MatchingRuleOid;
+use FreeDSx\Ldap\Schema\Definition\Nis\AttributeTypeOid as NisAttributeTypeOid;
+use FreeDSx\Ldap\Schema\Definition\Nis\ObjectClassOid as NisObjectClassOid;
+use FreeDSx\Ldap\Schema\Definition\ObjectClass;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassOid;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassType;
+use FreeDSx\Ldap\Schema\Definition\SyntaxOid;
+
+/**
+ * Builds the RFC 2307 POSIX account/group/shadow schema.
+ *
+ * @api
+ */
+final class NisSchemaProvider
+{
+    private function __construct() {}
+
+    public static function build(): Schema
+    {
+        $schema = new Schema();
+
+        foreach (self::attributeTypes() as $type) {
+            $schema->addAttributeType($type);
+        }
+        foreach (self::objectClasses() as $class) {
+            $schema->addObjectClass($class);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * @return list<AttributeType>
+     */
+    private static function attributeTypes(): array
+    {
+        return [
+            self::integer(
+                NisAttributeTypeOid::OID_UID_NUMBER,
+                NisAttributeTypeOid::NAME_UID_NUMBER,
+                NisAttributeTypeOid::DESC_UID_NUMBER,
+            ),
+            self::integer(
+                NisAttributeTypeOid::OID_GID_NUMBER,
+                NisAttributeTypeOid::NAME_GID_NUMBER,
+                NisAttributeTypeOid::DESC_GID_NUMBER,
+            ),
+            self::integer(
+                NisAttributeTypeOid::OID_SHADOW_LAST_CHANGE,
+                NisAttributeTypeOid::NAME_SHADOW_LAST_CHANGE,
+                NisAttributeTypeOid::DESC_SHADOW_LAST_CHANGE,
+            ),
+            self::integer(
+                NisAttributeTypeOid::OID_SHADOW_MIN,
+                NisAttributeTypeOid::NAME_SHADOW_MIN,
+                NisAttributeTypeOid::DESC_SHADOW_MIN,
+            ),
+            self::integer(
+                NisAttributeTypeOid::OID_SHADOW_MAX,
+                NisAttributeTypeOid::NAME_SHADOW_MAX,
+                NisAttributeTypeOid::DESC_SHADOW_MAX,
+            ),
+            self::integer(
+                NisAttributeTypeOid::OID_SHADOW_WARNING,
+                NisAttributeTypeOid::NAME_SHADOW_WARNING,
+                NisAttributeTypeOid::DESC_SHADOW_WARNING,
+            ),
+            self::integer(
+                NisAttributeTypeOid::OID_SHADOW_INACTIVE,
+                NisAttributeTypeOid::NAME_SHADOW_INACTIVE,
+                NisAttributeTypeOid::DESC_SHADOW_INACTIVE,
+            ),
+            self::integer(
+                NisAttributeTypeOid::OID_SHADOW_EXPIRE,
+                NisAttributeTypeOid::NAME_SHADOW_EXPIRE,
+                NisAttributeTypeOid::DESC_SHADOW_EXPIRE,
+            ),
+            self::integer(
+                NisAttributeTypeOid::OID_SHADOW_FLAG,
+                NisAttributeTypeOid::NAME_SHADOW_FLAG,
+                NisAttributeTypeOid::DESC_SHADOW_FLAG,
+            ),
+            self::ia5(
+                NisAttributeTypeOid::OID_GECOS,
+                NisAttributeTypeOid::NAME_GECOS,
+                MatchingRuleOid::OID_CASE_IGNORE_IA5_MATCH,
+                true,
+                NisAttributeTypeOid::DESC_GECOS,
+            ),
+            self::ia5(
+                NisAttributeTypeOid::OID_HOME_DIRECTORY,
+                NisAttributeTypeOid::NAME_HOME_DIRECTORY,
+                MatchingRuleOid::OID_CASE_EXACT_IA5_MATCH,
+                true,
+                NisAttributeTypeOid::DESC_HOME_DIRECTORY,
+            ),
+            self::ia5(
+                NisAttributeTypeOid::OID_LOGIN_SHELL,
+                NisAttributeTypeOid::NAME_LOGIN_SHELL,
+                MatchingRuleOid::OID_CASE_EXACT_IA5_MATCH,
+                true,
+                NisAttributeTypeOid::DESC_LOGIN_SHELL,
+            ),
+            self::ia5(
+                NisAttributeTypeOid::OID_MEMBER_UID,
+                NisAttributeTypeOid::NAME_MEMBER_UID,
+                MatchingRuleOid::OID_CASE_EXACT_IA5_MATCH,
+                false,
+                NisAttributeTypeOid::DESC_MEMBER_UID,
+            ),
+        ];
+    }
+
+    private static function integer(
+        string $oid,
+        string $name,
+        string $desc,
+    ): AttributeType {
+        return new AttributeType(
+            $oid,
+            [$name],
+            equalityOid: MatchingRuleOid::OID_INTEGER_MATCH,
+            syntaxOid: SyntaxOid::OID_INTEGER,
+            singleValue: true,
+            desc: $desc,
+        );
+    }
+
+    private static function ia5(
+        string $oid,
+        string $name,
+        string $equalityOid,
+        bool $singleValue,
+        string $desc,
+    ): AttributeType {
+        return new AttributeType(
+            $oid,
+            [$name],
+            equalityOid: $equalityOid,
+            syntaxOid: SyntaxOid::OID_IA5_STRING,
+            singleValue: $singleValue,
+            desc: $desc,
+        );
+    }
+
+    /**
+     * @return list<ObjectClass>
+     */
+    private static function objectClasses(): array
+    {
+        return [
+            new ObjectClass(
+                NisObjectClassOid::OID_POSIX_ACCOUNT,
+                [NisObjectClassOid::NAME_POSIX_ACCOUNT],
+                type: ObjectClassType::AuxiliaryClass,
+                superClassOids: [ObjectClassOid::OID_TOP],
+                must: [
+                    AttributeTypeOid::NAME_CN,
+                    AttributeTypeOid::NAME_UID,
+                    NisAttributeTypeOid::NAME_UID_NUMBER,
+                    NisAttributeTypeOid::NAME_GID_NUMBER,
+                    NisAttributeTypeOid::NAME_HOME_DIRECTORY,
+                ],
+                may: [
+                    AttributeTypeOid::NAME_USER_PASSWORD,
+                    NisAttributeTypeOid::NAME_LOGIN_SHELL,
+                    NisAttributeTypeOid::NAME_GECOS,
+                    AttributeTypeOid::NAME_DESCRIPTION,
+                ],
+                desc: NisObjectClassOid::DESC_POSIX_ACCOUNT,
+            ),
+            new ObjectClass(
+                NisObjectClassOid::OID_SHADOW_ACCOUNT,
+                [NisObjectClassOid::NAME_SHADOW_ACCOUNT],
+                type: ObjectClassType::AuxiliaryClass,
+                superClassOids: [ObjectClassOid::OID_TOP],
+                must: [AttributeTypeOid::NAME_UID],
+                may: [
+                    AttributeTypeOid::NAME_USER_PASSWORD,
+                    NisAttributeTypeOid::NAME_SHADOW_LAST_CHANGE,
+                    NisAttributeTypeOid::NAME_SHADOW_MIN,
+                    NisAttributeTypeOid::NAME_SHADOW_MAX,
+                    NisAttributeTypeOid::NAME_SHADOW_WARNING,
+                    NisAttributeTypeOid::NAME_SHADOW_INACTIVE,
+                    NisAttributeTypeOid::NAME_SHADOW_EXPIRE,
+                    NisAttributeTypeOid::NAME_SHADOW_FLAG,
+                    AttributeTypeOid::NAME_DESCRIPTION,
+                ],
+                desc: NisObjectClassOid::DESC_SHADOW_ACCOUNT,
+            ),
+            new ObjectClass(
+                NisObjectClassOid::OID_POSIX_GROUP,
+                [NisObjectClassOid::NAME_POSIX_GROUP],
+                type: ObjectClassType::StructuralClass,
+                superClassOids: [ObjectClassOid::OID_TOP],
+                must: [
+                    AttributeTypeOid::NAME_CN,
+                    NisAttributeTypeOid::NAME_GID_NUMBER,
+                ],
+                may: [
+                    AttributeTypeOid::NAME_USER_PASSWORD,
+                    NisAttributeTypeOid::NAME_MEMBER_UID,
+                    AttributeTypeOid::NAME_DESCRIPTION,
+                ],
+                desc: NisObjectClassOid::DESC_POSIX_GROUP,
+            ),
+        ];
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Schema.php
+++ b/src/FreeDSx/Ldap/Schema/Schema.php
@@ -16,7 +16,9 @@ namespace FreeDSx\Ldap\Schema;
 use FreeDSx\Ldap\Schema\Definition\AttributeType;
 use FreeDSx\Ldap\Schema\Definition\LdapSyntax;
 use FreeDSx\Ldap\Schema\Definition\MatchingRule;
+use FreeDSx\Ldap\Schema\Definition\MatchingRuleOid;
 use FreeDSx\Ldap\Schema\Definition\ObjectClass;
+use FreeDSx\Ldap\Schema\Definition\SyntaxOid;
 use FreeDSx\Ldap\Schema\Matching\MatchingRuleComparatorInterface;
 
 /**
@@ -88,6 +90,24 @@ final class Schema
         return $this->attributeTypes[$nameOrOid]
             ?? $this->attributeTypes[strtolower($nameOrOid)]
             ?? null;
+    }
+
+    /**
+     * Whether the attribute orders numerically.
+     */
+    public function isIntegerOrdered(string $nameOrOid): ?bool
+    {
+        $attributeType = $this->getAttributeType($nameOrOid);
+
+        if ($attributeType === null) {
+            return null;
+        }
+
+        if ($attributeType->orderingOid !== null) {
+            return $attributeType->orderingOid === MatchingRuleOid::OID_INTEGER_ORDERING_MATCH;
+        }
+
+        return $attributeType->syntaxOid === SyntaxOid::OID_INTEGER;
     }
 
     public function getObjectClass(string $nameOrOid): ?ObjectClass

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -152,7 +152,10 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
 
     public function list(StorageListOptions $options): EntryStream
     {
-        $filterResult = $this->translator->translate($options->filter);
+        $filterResult = $this->translator->translate(
+            $options->filter,
+            $options->isIntegerOrdered(...),
+        );
         $isPreFiltered = $filterResult !== null && $filterResult->isExact;
 
         // Exact is bound by sizeLimit. Inexact is PHP re-evaluated: cap candidate transfer at lookthrough+1.

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/FilterTranslatorInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/FilterTranslatorInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter;
 
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
+use Closure;
 
 /**
  * Translates FilterInterface into a SQL WHERE fragment.
@@ -25,5 +26,11 @@ use FreeDSx\Ldap\Search\Filter\FilterInterface;
  */
 interface FilterTranslatorInterface
 {
-    public function translate(FilterInterface $filter): ?SqlFilterResult;
+    /**
+     * @param (\Closure(string): (bool|null))|null $isIntegerOrdered Resolves whether an attribute orders numerically.
+     */
+    public function translate(
+        FilterInterface $filter,
+        ?Closure $isIntegerOrdered = null,
+    ): ?SqlFilterResult;
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/MysqlFilterTranslator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/MysqlFilterTranslator.php
@@ -51,4 +51,9 @@ final class MysqlFilterTranslator implements FilterTranslatorInterface
     {
         return 's.value_lower';
     }
+
+    private function castToNumeric(string $expression): string
+    {
+        return "CAST($expression AS SIGNED)";
+    }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
@@ -26,6 +26,7 @@ use FreeDSx\Ldap\Search\Filter\OrFilter;
 use FreeDSx\Ldap\Search\Filter\PresentFilter;
 use FreeDSx\Ldap\Search\Filter\SubstringFilter;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SubstringIndex\SubstringIndexInterface;
+use Closure;
 
 /**
  * Translates LDAP filters to SQL against the `entry_attribute_values` sidecar index.
@@ -36,7 +37,24 @@ trait SqlFilterTranslatorTrait
 {
     private ?SubstringIndexInterface $substringIndex = null;
 
-    public function translate(FilterInterface $filter): ?SqlFilterResult
+    /**
+     * @var (\Closure(string): (bool|null))|null Resolves whether an attribute orders numerically, for the current call.
+     */
+    private ?Closure $integerOrderedResolver = null;
+
+    /**
+     * @param (\Closure(string): (bool|null))|null $isIntegerOrdered Resolves numeric ordering; null = unknown.
+     */
+    public function translate(
+        FilterInterface $filter,
+        ?Closure $isIntegerOrdered = null,
+    ): ?SqlFilterResult {
+        $this->integerOrderedResolver = $isIntegerOrdered;
+
+        return $this->dispatch($filter);
+    }
+
+    private function dispatch(FilterInterface $filter): ?SqlFilterResult
     {
         return match (true) {
             $filter instanceof AndFilter => $this->translateAnd($filter),
@@ -66,6 +84,11 @@ trait SqlFilterTranslatorTrait
     ): string;
 
     abstract private function valueAlias(): string;
+
+    /**
+     * Wraps an expression in a dialect-specific integer cast for numeric ordering comparisons.
+     */
+    abstract private function castToNumeric(string $expression): string;
 
     private function translatePresent(PresentFilter $filter): ?SqlFilterResult
     {
@@ -109,34 +132,66 @@ trait SqlFilterTranslatorTrait
         );
     }
 
+    /**
+     * Truncation preserves lexical GTE when query <= 255 chars: full >= query implies its prefix >= query.
+     */
     private function translateGte(GreaterThanOrEqualFilter $filter): ?SqlFilterResult
     {
-        $attribute = $this->validateAttribute($filter->getAttribute());
-
-        $alias = $this->valueAlias();
-        $value = $filter->getValue();
-
-        // Truncation preserves GTE when query <= 255 chars: full >= query implies its prefix >= query.
-        return new SqlFilterResult(
-            $this->buildValueExists($attribute, "$alias >= ?"),
-            [$this->prepareMatchValue($value)],
-            isExact: $this->isExactOrdered($value) && !$this->attributeHasOption($filter->getAttribute()),
-            referencedAttributes: [$attribute],
+        return $this->translateOrdered(
+            $filter->getAttribute(),
+            $filter->getValue(),
+            '>=',
+            lexicalCanBeExact: true,
         );
     }
 
+    /**
+     * Lexical LTE under truncation admits false positives (stored value > 255 whose prefix equals query).
+     */
     private function translateLte(LessThanOrEqualFilter $filter): ?SqlFilterResult
     {
-        $attribute = $this->validateAttribute($filter->getAttribute());
+        return $this->translateOrdered(
+            $filter->getAttribute(),
+            $filter->getValue(),
+            '<=',
+            lexicalCanBeExact: false,
+        );
+    }
 
-        $alias = $this->valueAlias();
-        $value = $filter->getValue();
+    /**
+     * Integer-ordered attributes narrow numerically (CAST, exact); others keep the lexical comparison, whose
+     * exactness the caller bounds via $lexicalCanBeExact (GTE can be exact, LTE cannot under truncation).
+     */
+    private function translateOrdered(
+        string $rawAttribute,
+        string $value,
+        string $operator,
+        bool $lexicalCanBeExact,
+    ): SqlFilterResult {
+        $attribute = $this->validateAttribute($rawAttribute);
+        $hasOption = $this->attributeHasOption($rawAttribute);
+        $resolver = $this->integerOrderedResolver;
 
-        // LTE under truncation admits false positives (stored value > 255 whose prefix equals query); always inexact.
+        if ($resolver !== null && $resolver($rawAttribute) === true) {
+            $condition = sprintf(
+                '%s %s %s',
+                $this->castToNumeric($this->valueAlias()),
+                $operator,
+                $this->castToNumeric('?'),
+            );
+
+            return new SqlFilterResult(
+                $this->buildValueExists($attribute, $condition),
+                [$this->prepareMatchValue($value)],
+                isExact: !$hasOption,
+                referencedAttributes: [$attribute],
+            );
+        }
+
         return new SqlFilterResult(
-            $this->buildValueExists($attribute, "$alias <= ?"),
+            $this->buildValueExists($attribute, $this->valueAlias() . " $operator ?"),
             [$this->prepareMatchValue($value)],
-            isExact: false,
+            isExact: $lexicalCanBeExact && $this->isExactOrdered($value) && !$hasOption,
             referencedAttributes: [$attribute],
         );
     }
@@ -297,7 +352,7 @@ trait SqlFilterTranslatorTrait
         $hasUntranslatable = false;
 
         foreach ($filter->get() as $child) {
-            $result = $this->translate($child);
+            $result = $this->dispatch($child);
             if ($result === null) {
                 $hasUntranslatable = true;
                 continue;
@@ -327,7 +382,7 @@ trait SqlFilterTranslatorTrait
         $hasInexact = false;
 
         foreach ($filter->get() as $child) {
-            $result = $this->translate($child);
+            $result = $this->dispatch($child);
             if ($result === null) {
                 return null;
             }
@@ -352,7 +407,7 @@ trait SqlFilterTranslatorTrait
     private function translateNot(NotFilter $filter): ?SqlFilterResult
     {
         $inner = $filter->get();
-        $result = $this->translate($inner);
+        $result = $this->dispatch($inner);
 
         if ($result === null) {
             return null;

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqliteFilterTranslator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqliteFilterTranslator.php
@@ -51,4 +51,9 @@ final class SqliteFilterTranslator implements FilterTranslatorInterface
     {
         return 's.value_lower';
     }
+
+    private function castToNumeric(string $expression): string
+    {
+        return "CAST($expression AS INTEGER)";
+    }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/FilterEvaluator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/FilterEvaluator.php
@@ -17,7 +17,9 @@ use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Definition\SyntaxOid;
 use FreeDSx\Ldap\Schema\Matching\CaseIgnoreComparator;
+use FreeDSx\Ldap\Schema\Matching\IntegerComparator;
 use FreeDSx\Ldap\Schema\Matching\MatchingRuleComparatorInterface;
 use FreeDSx\Ldap\Schema\Matching\SubstringAssertion;
 use FreeDSx\Ldap\Schema\Schema;
@@ -77,9 +79,12 @@ final class FilterEvaluator implements FilterEvaluatorInterface
 
     private readonly CaseIgnoreComparator $defaultComparator;
 
+    private readonly IntegerComparator $integerComparator;
+
     public function __construct(private readonly ?Schema $schema = null)
     {
         $this->defaultComparator = new CaseIgnoreComparator();
+        $this->integerComparator = new IntegerComparator();
         $this->substringCache = new WeakMap();
         $this->orderedDigitCache = new WeakMap();
     }
@@ -472,11 +477,19 @@ final class FilterEvaluator implements FilterEvaluatorInterface
             return null;
         }
 
-        if ($attrType->orderingOid !== null) {
-            return $this->schema->getComparator($attrType->orderingOid) ?? $this->defaultComparator;
+        // An explicit, registered ordering rule wins
+        $comparator = $attrType->orderingOid !== null
+            ? $this->schema->getComparator($attrType->orderingOid)
+            : null;
+
+        if ($comparator !== null) {
+            return $comparator;
         }
 
-        return $this->defaultComparator;
+        // Otherwise infer numeric ordering from an INTEGER syntax, else order as a string.
+        return $attrType->syntaxOid === SyntaxOid::OID_INTEGER
+            ? $this->integerComparator
+            : $this->defaultComparator;
     }
 
     private function buildSubstringAssertion(SubstringFilter $filter): SubstringAssertion

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Control\Sorting\SortKey;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Search\Filter\AndFilter;
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
+use Closure;
 
 /**
  * DTO for EntryStorageInterface::list(), decoupled from LDAP protocol objects.
@@ -27,6 +28,7 @@ final class StorageListOptions
 {
     /**
      * @param SortKey[] $sortKeys
+     * @param (\Closure(string): (bool|null))|null $isIntegerOrderedResolver Resolves whether an attribute orders numerically.
      */
     public function __construct(
         public readonly Dn $baseDn,
@@ -36,7 +38,18 @@ final class StorageListOptions
         public readonly int $sizeLimit = 0,
         public readonly array $sortKeys = [],
         public readonly int $lookthroughLimit = 0,
+        public readonly ?Closure $isIntegerOrderedResolver = null,
     ) {}
+
+    /**
+     * Whether the attribute orders numerically. null when unresolved (no schema was supplied).
+     */
+    public function isIntegerOrdered(string $attribute): ?bool
+    {
+        return $this->isIntegerOrderedResolver !== null
+            ? ($this->isIntegerOrderedResolver)($attribute)
+            : null;
+    }
 
     /**
      * Match-all options for internal callers (e.g. hasChildren) and tests that do not need a meaningful filter.

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -36,6 +36,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Exception\DnTooLongException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\InvalidAttributeException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
+use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\Backend\Write\SchemaViolationDisposition;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
@@ -66,6 +67,7 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         private readonly OperationalAttributeGenerator $operationalAttrs = new OperationalAttributeGenerator(),
         private readonly WriteEntryOperationHandler $entryHandler = new WriteEntryOperationHandler(),
         private readonly ?ChangeRecorder $changeRecorder = null,
+        private readonly ?Schema $schema = null,
     ) {
         $this->searchStream = new SearchStreamBuilder(
             $this->storage,
@@ -203,6 +205,7 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
                 ? $sortingControl->getSortKeys()
                 : [],
             lookthroughLimit: $limits->maxSearchLookthrough,
+            isIntegerOrderedResolver: fn(string $attribute): ?bool => $this->schema?->isIntegerOrdered($attribute),
         );
 
         try {

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -19,7 +19,9 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactory;
 use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
+use FreeDSx\Ldap\Schema\NisSchemaProvider;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
+use FreeDSx\Ldap\Schema\StandardSchemaProvider;
 use FreeDSx\Ldap\ServerOptions;
 use PDO;
 use Symfony\Component\Console\Command\Command;
@@ -201,6 +203,7 @@ final class LdapBackendStorageCommand extends Command
             ->setTransport($transport)
             ->setSocketAcceptTimeout(0.1)
             ->setSchemaValidationMode($validationMode)
+            ->setSchema(StandardSchemaProvider::buildCore()->merge(NisSchemaProvider::build()))
             ->setMonitorEnabled((bool) $input->getOption('monitor'))
             ->setMaxSearchLookthrough((int) $this->getStringOption($input, 'max-search-lookthrough'))
             ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL));

--- a/tests/unit/Schema/NisSchemaProviderTest.php
+++ b/tests/unit/Schema/NisSchemaProviderTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema;
+
+use FreeDSx\Ldap\Schema\Definition\MatchingRuleOid;
+use FreeDSx\Ldap\Schema\Definition\Nis\AttributeTypeOid;
+use FreeDSx\Ldap\Schema\Definition\Nis\ObjectClassOid;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassType;
+use FreeDSx\Ldap\Schema\Definition\SyntaxOid;
+use FreeDSx\Ldap\Schema\NisSchemaProvider;
+use FreeDSx\Ldap\Schema\Schema;
+use PHPUnit\Framework\TestCase;
+
+final class NisSchemaProviderTest extends TestCase
+{
+    private Schema $schema;
+
+    protected function setUp(): void
+    {
+        $this->schema = NisSchemaProvider::build();
+    }
+
+    public function test_registers_all_13_attribute_types(): void
+    {
+        self::assertCount(
+            13,
+            $this->schema->getAttributeTypes(),
+        );
+    }
+
+    public function test_uid_number_uses_integer_syntax_and_equality_with_no_ordering(): void
+    {
+        $uidNumber = $this->schema->getAttributeType(AttributeTypeOid::NAME_UID_NUMBER);
+
+        self::assertNotNull($uidNumber);
+        self::assertSame(
+            SyntaxOid::OID_INTEGER,
+            $uidNumber->syntaxOid,
+        );
+        self::assertSame(
+            MatchingRuleOid::OID_INTEGER_MATCH,
+            $uidNumber->equalityOid,
+        );
+        self::assertNull($uidNumber->orderingOid);
+        self::assertTrue($uidNumber->singleValue);
+    }
+
+    public function test_posix_account_requires_the_core_posix_attributes(): void
+    {
+        $posixAccount = $this->schema->getObjectClass(ObjectClassOid::NAME_POSIX_ACCOUNT);
+
+        self::assertNotNull($posixAccount);
+        self::assertSame(
+            ObjectClassType::AuxiliaryClass,
+            $posixAccount->type,
+        );
+        self::assertContains(
+            AttributeTypeOid::NAME_UID_NUMBER,
+            $posixAccount->must,
+        );
+        self::assertContains(
+            AttributeTypeOid::NAME_GID_NUMBER,
+            $posixAccount->must,
+        );
+    }
+
+    public function test_integer_attributes_resolve_as_integer_ordered_via_syntax(): void
+    {
+        self::assertTrue($this->schema->isIntegerOrdered(AttributeTypeOid::NAME_UID_NUMBER));
+        self::assertTrue($this->schema->isIntegerOrdered(AttributeTypeOid::NAME_SHADOW_MAX));
+    }
+
+    public function test_string_attributes_do_not_resolve_as_integer_ordered(): void
+    {
+        self::assertFalse($this->schema->isIntegerOrdered(AttributeTypeOid::NAME_HOME_DIRECTORY));
+    }
+}

--- a/tests/unit/Schema/SchemaTest.php
+++ b/tests/unit/Schema/SchemaTest.php
@@ -16,7 +16,9 @@ namespace Tests\Unit\FreeDSx\Ldap\Schema;
 use FreeDSx\Ldap\Schema\Definition\AttributeType;
 use FreeDSx\Ldap\Schema\Definition\LdapSyntax;
 use FreeDSx\Ldap\Schema\Definition\MatchingRule;
+use FreeDSx\Ldap\Schema\Definition\MatchingRuleOid;
 use FreeDSx\Ldap\Schema\Definition\ObjectClass;
+use FreeDSx\Ldap\Schema\Definition\SyntaxOid;
 use FreeDSx\Ldap\Schema\Matching\CaseIgnoreComparator;
 use FreeDSx\Ldap\Schema\Schema;
 use PHPUnit\Framework\TestCase;
@@ -305,5 +307,45 @@ final class SchemaTest extends TestCase
             $schema,
             $schema->addSyntax($this->dirString),
         );
+    }
+
+    public function test_is_integer_ordered_is_null_for_an_unknown_attribute(): void
+    {
+        self::assertNull($this->subject->isIntegerOrdered('doesNotExist'));
+    }
+
+    public function test_is_integer_ordered_is_true_for_an_explicit_integer_ordering_rule(): void
+    {
+        $this->subject->addAttributeType(new AttributeType(
+            oid: '1.2.3.4',
+            names: ['explicitInt'],
+            orderingOid: MatchingRuleOid::OID_INTEGER_ORDERING_MATCH,
+            syntaxOid: SyntaxOid::OID_DIRECTORY_STRING,
+        ));
+
+        self::assertTrue($this->subject->isIntegerOrdered('explicitInt'));
+    }
+
+    public function test_is_integer_ordered_is_inferred_from_integer_syntax_without_an_ordering_rule(): void
+    {
+        $this->subject->addAttributeType(new AttributeType(
+            oid: '1.2.3.5',
+            names: ['syntaxInt'],
+            syntaxOid: SyntaxOid::OID_INTEGER,
+        ));
+
+        self::assertTrue($this->subject->isIntegerOrdered('syntaxInt'));
+    }
+
+    public function test_is_integer_ordered_lets_an_explicit_ordering_rule_win_over_the_syntax(): void
+    {
+        $this->subject->addAttributeType(new AttributeType(
+            oid: '1.2.3.6',
+            names: ['stringOrdered'],
+            orderingOid: MatchingRuleOid::OID_CASE_IGNORE_ORDERING_MATCH,
+            syntaxOid: SyntaxOid::OID_INTEGER,
+        ));
+
+        self::assertFalse($this->subject->isIntegerOrdered('stringOrdered'));
     }
 }

--- a/tests/unit/Server/Backend/Storage/Adapter/MysqlFilterTranslatorTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/MysqlFilterTranslatorTest.php
@@ -204,6 +204,21 @@ final class MysqlFilterTranslatorTest extends TestCase
         );
     }
 
+    public function test_gte_emits_numeric_cast_for_integer_ordered_attribute(): void
+    {
+        $result = $this->subject->translate(
+            new GreaterThanOrEqualFilter('uidNumber', '30'),
+            fn(string $attribute): bool => true,
+        );
+
+        self::assertNotNull($result);
+        self::assertStringContainsString(
+            'CAST(s.value_lower AS SIGNED) >= CAST(? AS SIGNED)',
+            $result->sql,
+        );
+        self::assertTrue($result->isExact);
+    }
+
     public function test_gte_filter_with_digit_value_is_inexact(): void
     {
         $result = $this->subject->translate(new GreaterThanOrEqualFilter(

--- a/tests/unit/Server/Backend/Storage/Adapter/SqliteFilterTranslatorTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/SqliteFilterTranslatorTest.php
@@ -173,21 +173,36 @@ final class SqliteFilterTranslatorTest extends TestCase
         );
     }
 
-    public function test_gte_emits_sidecar_value_gte(): void
+    public function test_gte_emits_numeric_cast_for_integer_ordered_attribute(): void
     {
-        $result = $this->subject->translate(new GreaterThanOrEqualFilter(
-            'age',
-            '30',
-        ));
+        $result = $this->subject->translate(
+            new GreaterThanOrEqualFilter('uidNumber', '30'),
+            fn(string $attribute): bool => true,
+        );
+
+        self::assertNotNull($result);
+        self::assertStringContainsString(
+            'CAST(s.value_lower AS INTEGER) >= CAST(? AS INTEGER)',
+            $result->sql,
+        );
+        self::assertTrue($result->isExact);
+        self::assertSame(
+            ['30'],
+            $result->params,
+        );
+    }
+
+    public function test_gte_emits_lexical_comparison_for_non_integer_attribute(): void
+    {
+        $result = $this->subject->translate(
+            new GreaterThanOrEqualFilter('cn', '30'),
+            fn(string $attribute): bool => false,
+        );
 
         self::assertNotNull($result);
         self::assertStringContainsString(
             's.value_lower >= ?',
             $result->sql,
-        );
-        self::assertSame(
-            ['30'],
-            $result->params,
         );
     }
 
@@ -226,16 +241,16 @@ final class SqliteFilterTranslatorTest extends TestCase
         self::assertFalse($result->isExact);
     }
 
-    public function test_lte_emits_sidecar_value_lte(): void
+    public function test_lte_emits_numeric_cast_for_integer_ordered_attribute(): void
     {
-        $result = $this->subject->translate(new LessThanOrEqualFilter(
-            'age',
-            '50',
-        ));
+        $result = $this->subject->translate(
+            new LessThanOrEqualFilter('uidNumber', '50'),
+            fn(string $attribute): bool => true,
+        );
 
         self::assertNotNull($result);
         self::assertStringContainsString(
-            's.value_lower <= ?',
+            'CAST(s.value_lower AS INTEGER) <= CAST(? AS INTEGER)',
             $result->sql,
         );
         self::assertSame(

--- a/tests/unit/Server/Backend/Storage/FilterEvaluatorTest.php
+++ b/tests/unit/Server/Backend/Storage/FilterEvaluatorTest.php
@@ -24,6 +24,7 @@ use FreeDSx\Ldap\Search\Filter\MatchingRuleFilter;
 use FreeDSx\Ldap\Search\Filter\PresentFilter;
 use FreeDSx\Ldap\Search\Filter\SubstringFilter;
 use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Schema\NisSchemaProvider;
 use FreeDSx\Ldap\Schema\StandardSchemaProvider;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluator;
 use PHPUnit\Framework\TestCase;
@@ -972,6 +973,26 @@ final class FilterEvaluatorTest extends TestCase
         $entry = new Entry(
             new Dn('cn=Test,dc=example,dc=com'),
             new Attribute('uidNumber', '99'),
+        );
+
+        self::assertFalse($subject->evaluate(
+            $entry,
+            Filters::greaterThanOrEqual('uidNumber', '100'),
+        ));
+    }
+
+    /**
+     * uidNumber has INTEGER syntax but no ORDERING in RFC 2307; '50' >= '100' is false numerically yet true
+     * lexically, so this proves the syntax drives numeric ordering rather than the string default.
+     */
+    public function test_schema_gte_infers_numeric_ordering_from_integer_syntax(): void
+    {
+        $subject = new FilterEvaluator(
+            StandardSchemaProvider::buildCore()->merge(NisSchemaProvider::build()),
+        );
+        $entry = new Entry(
+            new Dn('cn=Test,dc=example,dc=com'),
+            new Attribute('uidNumber', '50'),
         );
 
         self::assertFalse($subject->evaluate(


### PR DESCRIPTION
The current way that integers are compared in PDO happens lexicographically (as the underlying data is stored as strings for attribute => values). When someone uses a GTE / LTE filter, this over-selects, causing us to have to filter the result set via PHP. To fix this we need to determine if the attribute being compared is an integer / numeric. Then PDO can cast the value to an integer and compare it normally. This fixes directory scaling issues with range related filters. I also need a follow up to fix scaling issues with subsearch filters in general so we page through / cap as we go in PDO, since results can be inexact by nature.