### PR TITLE
[1.0.0] Address some subsearch scaling issues for the server.

### DIFF
--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilder.php
@@ -39,6 +39,18 @@ final readonly class PdoListQueryBuilder
         ?int $sqlLimit,
         array $sortKeys,
     ): SqlQuery {
+        $streamed = $this->tryBuildStreamingQuery(
+            $base,
+            $subtree,
+            $filterResult,
+            $sqlLimit,
+            $sortKeys,
+        );
+
+        if ($streamed !== null) {
+            return $streamed;
+        }
+
         $query = match (true) {
             !$subtree => $this->buildChildQuery($base, $filterResult),
             $base === '' => $this->buildRootQuery($filterResult),
@@ -57,6 +69,73 @@ final readonly class PdoListQueryBuilder
         }
 
         return $query;
+    }
+
+    /**
+     * The streaming fast path, or null when it does not apply: a single drivable sidecar leaf under a bounded,
+     * unsorted subtree/root search drives off the sidecar index so the limit short-circuits candidate scanning.
+     *
+     * @param SortKey[] $sortKeys
+     */
+    private function tryBuildStreamingQuery(
+        string $base,
+        bool $subtree,
+        ?SqlFilterResult $filterResult,
+        ?int $sqlLimit,
+        array $sortKeys,
+    ): ?SqlQuery {
+        if (!$subtree || $sqlLimit === null || $sortKeys !== []) {
+            return null;
+        }
+
+        if ($filterResult === null || $filterResult->sidecarCondition === null) {
+            return null;
+        }
+
+        return $this->buildStreamingQuery(
+            $filterResult->sidecarCondition,
+            $filterResult->params,
+            $base,
+            $sqlLimit,
+        );
+    }
+
+    /**
+     * Bounds work to $sqlLimit by pushing DISTINCT + subtree scope + LIMIT into the sidecar sub-select, wrapped in a
+     * derived table (portable: MySQL/MariaDB reject LIMIT directly inside IN, and it still streams on SQLite).
+     *
+     * @param list<string> $filterParams
+     */
+    private function buildStreamingQuery(
+        string $sidecarCondition,
+        array $filterParams,
+        string $base,
+        int $sqlLimit,
+    ): SqlQuery {
+        $fetchAll = $this->dialect->queryFetchAll();
+        $params = $filterParams;
+
+        if ($base === '') {
+            $inner = <<<SQL
+                SELECT DISTINCT s.entry_lc_dn AS d FROM entry_attribute_values s
+                    WHERE $sidecarCondition
+                    LIMIT $sqlLimit
+                SQL;
+        } else {
+            $inner = <<<SQL
+                SELECT DISTINCT s.entry_lc_dn AS d FROM entry_attribute_values s
+                    WHERE $sidecarCondition
+                      AND (s.entry_lc_dn = ? OR s.entry_lc_dn LIKE ? ESCAPE '!')
+                    LIMIT $sqlLimit
+                SQL;
+            $params[] = $base;
+            $params[] = '%,' . SqlFilterUtility::escape($base);
+        }
+
+        return new SqlQuery(
+            "$fetchAll WHERE lc_dn IN (SELECT t.d FROM ($inner) t)",
+            $params,
+        );
     }
 
     private function buildChildQuery(

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilder.php
@@ -72,41 +72,12 @@ final readonly class PdoListQueryBuilder
     }
 
     /**
-     * The streaming fast path, or null when it does not apply: a single drivable sidecar leaf under a bounded,
-     * unsorted subtree/root search drives off the sidecar index so the limit short-circuits candidate scanning.
-     *
-     * @param SortKey[] $sortKeys
-     */
-    private function tryBuildStreamingQuery(
-        string $base,
-        bool $subtree,
-        ?SqlFilterResult $filterResult,
-        ?int $sqlLimit,
-        array $sortKeys,
-    ): ?SqlQuery {
-        if (!$subtree || $sqlLimit === null || $sortKeys !== []) {
-            return null;
-        }
-
-        if ($filterResult === null || $filterResult->sidecarCondition === null) {
-            return null;
-        }
-
-        return $this->buildStreamingQuery(
-            $filterResult->sidecarCondition,
-            $filterResult->params,
-            $base,
-            $sqlLimit,
-        );
-    }
-
-    /**
      * Bounds work to $sqlLimit by pushing DISTINCT + subtree scope + LIMIT into the sidecar sub-select, wrapped in a
      * derived table (portable: MySQL/MariaDB reject LIMIT directly inside IN, and it still streams on SQLite).
      *
      * @param list<string> $filterParams
      */
-    private function buildStreamingQuery(
+    public function buildStreamingQuery(
         string $sidecarCondition,
         array $filterParams,
         string $base,
@@ -135,6 +106,37 @@ final readonly class PdoListQueryBuilder
         return new SqlQuery(
             "$fetchAll WHERE lc_dn IN (SELECT t.d FROM ($inner) t)",
             $params,
+        );
+    }
+
+    /**
+     * The streaming fast path, or null when it does not apply.
+     *
+     * A single drivable sidecar leaf under a bounded, unsorted subtree/root search drives off the sidecar index so the
+     * limit short-circuits candidate scanning.
+     *
+     * @param SortKey[] $sortKeys
+     */
+    private function tryBuildStreamingQuery(
+        string $base,
+        bool $subtree,
+        ?SqlFilterResult $filterResult,
+        ?int $sqlLimit,
+        array $sortKeys,
+    ): ?SqlQuery {
+        if (!$subtree || $sqlLimit === null || $sortKeys !== []) {
+            return null;
+        }
+
+        if ($filterResult === null || $filterResult->sidecarCondition === null) {
+            return null;
+        }
+
+        return $this->buildStreamingQuery(
+            $filterResult->sidecarCondition,
+            $filterResult->params,
+            $base,
+            $sqlLimit,
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -23,6 +23,9 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConnectionProviderInterfa
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoListQueryBuilder;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoTransactor;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PooledStatement;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\SqlQuery;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SidecarLeaf;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterResult;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingTrait;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
@@ -60,6 +63,11 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
     public const SCHEMA_VERSION = 1;
 
     private const STATEMENT_CACHE_MAX = 64;
+
+    /**
+     * Match ceiling for a composed AND's drivable leaf: below it the leaf is a cheap, complete driver via a near-free probe.
+     */
+    private const COMPOSED_DRIVER_PROBE_LIMIT = 128;
 
     /**
      * @var array<int, array<string, list<PDOStatement>>> Per-PDO pools keyed by spl_object_id; reset() clears it on connection drop.
@@ -152,10 +160,30 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
 
     public function list(StorageListOptions $options): EntryStream
     {
+        $deadline = $options->timeLimit > 0
+            ? microtime(true) + $options->timeLimit
+            : null;
+
         $filterResult = $this->translator->translate(
             $options->filter,
             $options->isIntegerOrdered(...),
         );
+
+        // A composed filter with a selective drivable leaf streams off that leaf; PHP re-evaluates the full filter.
+        $composed = $this->tryComposedStreamingQuery($filterResult, $options);
+        if ($composed !== null) {
+            return new EntryStream(
+                $this->generateRows(
+                    $this->prepareAndExecute(
+                        $composed->sql,
+                        $composed->params,
+                    ),
+                    $deadline,
+                ),
+                false,
+            );
+        }
+
         $isPreFiltered = $filterResult !== null && $filterResult->isExact;
 
         // Exact is bound by sizeLimit. Inexact is PHP re-evaluated: cap candidate transfer at lookthrough+1.
@@ -172,10 +200,6 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
             $sqlLimit,
             $options->sortKeys,
         );
-
-        $deadline = $options->timeLimit > 0
-            ? microtime(true) + $options->timeLimit
-            : null;
 
         return new EntryStream(
             $this->generateRows(
@@ -271,6 +295,83 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
             $this->dialect,
             $config->origin,
         );
+    }
+
+    /**
+     * Drives a composed AND off its most selective drivable leaf, or null when the fast path does not apply.
+     */
+    private function tryComposedStreamingQuery(
+        ?SqlFilterResult $filterResult,
+        StorageListOptions $options,
+    ): ?SqlQuery {
+        if ($filterResult === null || $filterResult->drivableLeaves === []) {
+            return null;
+        }
+
+        if (!$options->subtree || $options->sortKeys !== []) {
+            return null;
+        }
+
+        $driver = $this->selectDriverLeaf($filterResult->drivableLeaves);
+
+        if ($driver === null) {
+            return null;
+        }
+
+        return $this->queryBuilder->buildStreamingQuery(
+            $driver->condition,
+            $driver->params,
+            $options->baseDn->normalize()->toString(),
+            self::COMPOSED_DRIVER_PROBE_LIMIT,
+        );
+    }
+
+    /**
+     * The drivable leaf with the fewest matches under the probe cap, or null when every leaf is broader than the cap.
+     *
+     * @param list<SidecarLeaf> $leaves
+     */
+    private function selectDriverLeaf(array $leaves): ?SidecarLeaf
+    {
+        $best = null;
+        $bestCount = self::COMPOSED_DRIVER_PROBE_LIMIT;
+
+        foreach ($leaves as $leaf) {
+            $count = $this->probeLeafSelectivity($leaf);
+
+            if ($count < $bestCount) {
+                $best = $leaf;
+                $bestCount = $count;
+            }
+
+            if ($bestCount === 0) {
+                break;
+            }
+        }
+
+        return $best;
+    }
+
+    /**
+     * Counts a leaf's matches up to the probe cap via a near-free bounded index scan.
+     */
+    private function probeLeafSelectivity(SidecarLeaf $leaf): int
+    {
+        $limit = self::COMPOSED_DRIVER_PROBE_LIMIT;
+        $sql = <<<SQL
+            SELECT COUNT(*) AS c FROM (
+                SELECT 1 FROM entry_attribute_values s WHERE {$leaf->condition} LIMIT {$limit}
+            ) probe
+            SQL;
+
+        $row = $this->prepareAndExecute($sql, $leaf->params)->fetch();
+        $count = is_array($row)
+            ? ($row['c'] ?? 0)
+            : 0;
+
+        return is_numeric($count)
+            ? (int) $count
+            : 0;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SidecarLeaf.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SidecarLeaf.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter;
+
+/**
+ * A single sidecar leaf a composed filter can be driven from: its sub-select WHERE body and that body's parameters.
+ */
+final readonly class SidecarLeaf
+{
+    /**
+     * @param list<string> $params
+     */
+    public function __construct(
+        public string $condition,
+        public array $params,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterResult.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterResult.php
@@ -26,6 +26,7 @@ final class SqlFilterResult
      * @param list<string> $params
      * @param list<string> $referencedAttributes Attributes whose absence makes the filter undefined under RFC 4511
      * @param ?string $sidecarCondition Single drivable leaf's sidecar WHERE body for the streaming fast path.
+     * @param list<SidecarLeaf> $drivableLeaves A composed filter's drivable child leaves, for composed-filter streaming.
      */
     public function __construct(
         public readonly string $sql,
@@ -33,5 +34,6 @@ final class SqlFilterResult
         public readonly bool $isExact = true,
         public readonly array $referencedAttributes = [],
         public readonly ?string $sidecarCondition = null,
+        public readonly array $drivableLeaves = [],
     ) {}
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterResult.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterResult.php
@@ -25,11 +25,13 @@ final class SqlFilterResult
     /**
      * @param list<string> $params
      * @param list<string> $referencedAttributes Attributes whose absence makes the filter undefined under RFC 4511
+     * @param ?string $sidecarCondition Single drivable leaf's sidecar WHERE body for the streaming fast path.
      */
     public function __construct(
         public readonly string $sql,
         public readonly array $params,
         public readonly bool $isExact = true,
         public readonly array $referencedAttributes = [],
+        public readonly ?string $sidecarCondition = null,
     ) {}
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
@@ -392,6 +392,7 @@ trait SqlFilterTranslatorTrait
     {
         $parts = [];
         $params = [];
+        $drivableLeaves = [];
         $hasUntranslatable = false;
 
         foreach ($filter->get() as $child) {
@@ -405,6 +406,7 @@ trait SqlFilterTranslatorTrait
             }
             $parts[] = '(' . $result->sql . ')';
             array_push($params, ...$result->params);
+            array_push($drivableLeaves, ...$this->drivableLeavesOf($result));
         }
 
         if ($parts === []) {
@@ -415,7 +417,27 @@ trait SqlFilterTranslatorTrait
             implode(' AND ', $parts),
             $params,
             isExact: !$hasUntranslatable,
+            drivableLeaves: $drivableLeaves,
         );
+    }
+
+    /**
+     * A child's contribution to an AND's drivable-leaf set: itself if a single leaf, or its own leaves if a nested AND.
+     *
+     * @return list<SidecarLeaf>
+     */
+    private function drivableLeavesOf(SqlFilterResult $result): array
+    {
+        if ($result->sidecarCondition !== null) {
+            return [
+                new SidecarLeaf(
+                    $result->sidecarCondition,
+                    $result->params,
+                ),
+            ];
+        }
+
+        return $result->drivableLeaves;
     }
 
     private function translateOr(OrFilter $filter): ?SqlFilterResult

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
@@ -90,6 +90,20 @@ trait SqlFilterTranslatorTrait
      */
     abstract private function castToNumeric(string $expression): string;
 
+    /**
+     * A single leaf's sidecar sub-select WHERE body, mirroring what buildValueExists wraps, for the streaming fast path.
+     */
+    private function sidecarCondition(
+        string $attribute,
+        ?string $inner,
+    ): string {
+        $condition = "s.attr_name_lower = '$attribute'";
+
+        return $inner !== null
+            ? "$condition AND $inner"
+            : $condition;
+    }
+
     private function translatePresent(PresentFilter $filter): ?SqlFilterResult
     {
         $attribute = $this->validateAttribute($filter->getAttribute());
@@ -98,6 +112,10 @@ trait SqlFilterTranslatorTrait
             $this->buildPresenceCheck($attribute),
             [],
             isExact: !$this->attributeHasOption($filter->getAttribute()),
+            sidecarCondition: $this->sidecarCondition(
+                $attribute,
+                null,
+            ),
         );
     }
 
@@ -113,6 +131,10 @@ trait SqlFilterTranslatorTrait
             [$this->prepareMatchValue($value)],
             isExact: $this->isExactEquality($value) && !$this->attributeHasOption($filter->getAttribute()),
             referencedAttributes: [$attribute],
+            sidecarCondition: $this->sidecarCondition(
+                $attribute,
+                "$alias = ?",
+            ),
         );
     }
 
@@ -129,6 +151,10 @@ trait SqlFilterTranslatorTrait
             [$this->prepareMatchValue($value)],
             isExact: $this->isExactEquality($value) && !$this->attributeHasOption($filter->getAttribute()),
             referencedAttributes: [$attribute],
+            sidecarCondition: $this->sidecarCondition(
+                $attribute,
+                "$alias = ?",
+            ),
         );
     }
 
@@ -185,14 +211,21 @@ trait SqlFilterTranslatorTrait
                 [$this->prepareMatchValue($value)],
                 isExact: !$hasOption,
                 referencedAttributes: [$attribute],
+                sidecarCondition: $this->sidecarCondition($attribute, $condition),
             );
         }
 
+        $condition = $this->valueAlias() . " $operator ?";
+
         return new SqlFilterResult(
-            $this->buildValueExists($attribute, $this->valueAlias() . " $operator ?"),
+            $this->buildValueExists($attribute, $condition),
             [$this->prepareMatchValue($value)],
             isExact: $lexicalCanBeExact && $this->isExactOrdered($value) && !$hasOption,
             referencedAttributes: [$attribute],
+            sidecarCondition: $this->sidecarCondition(
+                $attribute,
+                $condition,
+            ),
         );
     }
 
@@ -223,14 +256,23 @@ trait SqlFilterTranslatorTrait
 
         if ($startsWith !== null) {
             $prefix = $this->prepareMatchValue($startsWith);
+            $inner = "$alias LIKE ? ESCAPE '!'";
             $sql = $this->buildValueExists(
                 $attribute,
-                "$alias LIKE ? ESCAPE '!'",
+                $inner,
             );
             $params = [SqlFilterUtility::escape($prefix) . '%'];
+            $sidecar = $this->sidecarCondition(
+                $attribute,
+                $inner,
+            );
         } else {
             $sql = $this->buildPresenceCheck($attribute);
             $params = [];
+            $sidecar = $this->sidecarCondition(
+                $attribute,
+                null,
+            );
         }
 
         $isExact = $this->isExactSubstring(
@@ -244,6 +286,7 @@ trait SqlFilterTranslatorTrait
             $params,
             isExact: $isExact,
             referencedAttributes: [$attribute],
+            sidecarCondition: $sidecar,
         );
     }
 

--- a/tests/performance/Workload/Worker.php
+++ b/tests/performance/Workload/Worker.php
@@ -177,6 +177,8 @@ final class Worker
             'search-suffix' => $this->doSearchSuffix($client),
             'search-range' => $this->doSearchRange($client),
             'search-list' => $this->doSearchList($client),
+            'search-and' => $this->doSearchAnd($client),
+            'search-or' => $this->doSearchOr($client),
             'compare' => $this->doCompare($client),
             'add' => $this->doAdd($client),
             'modify' => $this->doModify($client),
@@ -271,6 +273,40 @@ final class Worker
 
         $client->search(
             Operations::search(Filters::greaterThanOrEqual('uidNumber', (string) $threshold))
+                ->base($this->config->baseDn)
+                ->useSubtreeScope(),
+        );
+    }
+
+    /**
+     * Composed AND with a broad leaf and a selective leaf; streams off the selective leaf, then PHP-verifies the rest.
+     */
+    private function doSearchAnd(LdapClient $client): void
+    {
+        $filter = Filters::and(
+            Filters::equal('objectClass', 'inetOrgPerson'),
+            $this->randomEqualityFilter(),
+        );
+
+        $client->search(
+            Operations::search($filter)
+                ->base($this->config->baseDn)
+                ->useSubtreeScope(),
+        );
+    }
+
+    /**
+     * Composed OR of two selective leaves; exercises the OR-composite path, which streaming does not yet cover.
+     */
+    private function doSearchOr(LdapClient $client): void
+    {
+        $filter = Filters::or(
+            $this->randomEqualityFilter(),
+            $this->randomEqualityFilter(),
+        );
+
+        $client->search(
+            Operations::search($filter)
                 ->base($this->config->baseDn)
                 ->useSubtreeScope(),
         );

--- a/tests/performance/Workload/WorkloadMix.php
+++ b/tests/performance/Workload/WorkloadMix.php
@@ -29,6 +29,8 @@ final class WorkloadMix
         'search-suffix',
         'search-range',
         'search-list',
+        'search-and',
+        'search-or',
         'compare',
         'add',
         'modify',

--- a/tests/unit/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilderTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilderTest.php
@@ -111,6 +111,167 @@ final class PdoListQueryBuilderTest extends TestCase
         );
     }
 
+    public function test_streaming_subtree_pushes_limit_and_scope_into_the_sidecar_subquery(): void
+    {
+        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(
+            'ou=people,dc=foo,dc=bar',
+            true,
+            $this->sidecarLeaf(),
+            500,
+            [],
+        );
+
+        self::assertStringContainsString(
+            'SELECT DISTINCT s.entry_lc_dn AS d',
+            $query->sql,
+        );
+        self::assertStringContainsString(
+            "AND (s.entry_lc_dn = ? OR s.entry_lc_dn LIKE ? ESCAPE '!')",
+            $query->sql,
+        );
+        self::assertStringContainsString(
+            'IN (SELECT t.d FROM (',
+            $query->sql,
+        );
+        self::assertStringContainsString(
+            'LIMIT 500',
+            $query->sql,
+        );
+        self::assertStringNotContainsString(
+            'ORDER BY',
+            $query->sql,
+        );
+        self::assertSame(
+            ['smith', 'ou=people,dc=foo,dc=bar', '%,ou=people,dc=foo,dc=bar'],
+            $query->params,
+        );
+    }
+
+    public function test_streaming_root_query_omits_the_subtree_scope(): void
+    {
+        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(
+            '',
+            true,
+            $this->sidecarLeaf(),
+            500,
+            [],
+        );
+
+        self::assertStringContainsString(
+            'IN (SELECT t.d FROM (',
+            $query->sql,
+        );
+        self::assertStringNotContainsString(
+            's.entry_lc_dn = ?',
+            $query->sql,
+        );
+        self::assertSame(
+            ['smith'],
+            $query->params,
+        );
+    }
+
+    public function test_mysql_produces_the_same_streaming_shape(): void
+    {
+        $query = (new PdoListQueryBuilder(new MysqlDialect()))->build(
+            'ou=people,dc=foo,dc=bar',
+            true,
+            $this->sidecarLeaf(),
+            500,
+            [],
+        );
+
+        self::assertStringContainsString(
+            'SELECT DISTINCT s.entry_lc_dn AS d',
+            $query->sql,
+        );
+        self::assertStringContainsString(
+            'IN (SELECT t.d FROM (',
+            $query->sql,
+        );
+    }
+
+    public function test_sort_keys_disable_the_streaming_fast_path(): void
+    {
+        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(
+            'ou=people,dc=foo,dc=bar',
+            true,
+            $this->sidecarLeaf(),
+            500,
+            [SortKey::ascending('cn')],
+        );
+
+        self::assertStringNotContainsString(
+            'SELECT t.d FROM (',
+            $query->sql,
+        );
+        self::assertStringContainsString(
+            'ORDER BY',
+            $query->sql,
+        );
+    }
+
+    public function test_null_limit_disables_the_streaming_fast_path(): void
+    {
+        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(
+            'ou=people,dc=foo,dc=bar',
+            true,
+            $this->sidecarLeaf(),
+            null,
+            [],
+        );
+
+        self::assertStringNotContainsString(
+            'SELECT t.d FROM (',
+            $query->sql,
+        );
+    }
+
+    public function test_absent_sidecar_condition_disables_the_streaming_fast_path(): void
+    {
+        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(
+            'ou=people,dc=foo,dc=bar',
+            true,
+            new SqlFilterResult('(a) AND (b)', ['x', 'y']),
+            500,
+            [],
+        );
+
+        self::assertStringNotContainsString(
+            'SELECT t.d FROM (',
+            $query->sql,
+        );
+        self::assertStringContainsString(
+            ' LIMIT 500',
+            $query->sql,
+        );
+    }
+
+    public function test_child_scope_disables_the_streaming_fast_path(): void
+    {
+        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(
+            'ou=people,dc=foo,dc=bar',
+            false,
+            $this->sidecarLeaf(),
+            500,
+            [],
+        );
+
+        self::assertStringNotContainsString(
+            'SELECT t.d FROM (',
+            $query->sql,
+        );
+    }
+
+    private function sidecarLeaf(): SqlFilterResult
+    {
+        return new SqlFilterResult(
+            "lc_dn IN (SELECT s.entry_lc_dn FROM entry_attribute_values s WHERE s.attr_name_lower = 'cn' AND s.value_lower = ?)",
+            ['smith'],
+            sidecarCondition: "s.attr_name_lower = 'cn' AND s.value_lower = ?",
+        );
+    }
+
     /**
      * @return array{0: string, 1: list<string>}
      */

--- a/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
@@ -188,6 +188,49 @@ final class PdoStorageTest extends TestCase
         );
     }
 
+    public function test_composed_and_streams_off_a_leaf_and_php_verifies_the_rest(): void
+    {
+        $this->subject->add(
+            new AddCommand(new Entry(
+                new Dn('cn=bob,dc=example,dc=com'),
+                new Attribute('cn', 'bob'),
+                new Attribute('sn', 'common'),
+                new Attribute('objectClass', 'person'),
+            )),
+            $this->context(),
+        );
+        $this->subject->add(
+            new AddCommand(new Entry(
+                new Dn('cn=carol,dc=example,dc=com'),
+                new Attribute('cn', 'carol'),
+                new Attribute('sn', 'common'),
+                new Attribute('objectClass', 'device'),
+            )),
+            $this->context(),
+        );
+
+        // sn=common matches both; the AND drives off a leaf and PHP verifies the rest, so carol (objectClass=device) fails
+        // the objectClass=person branch and is excluded.
+        self::assertSame(
+            ['cn=bob,dc=example,dc=com'],
+            $this->searchDns(Filters::and(
+                Filters::equal('sn', 'common'),
+                Filters::equal('objectClass', 'person'),
+            )),
+        );
+    }
+
+    public function test_composed_and_with_no_matching_leaf_returns_nothing(): void
+    {
+        self::assertSame(
+            [],
+            $this->searchDns(Filters::and(
+                Filters::equal('objectClass', 'person'),
+                Filters::equal('cn', 'nobody'),
+            )),
+        );
+    }
+
     public function test_infix_search_finds_matches_and_rejects_trigram_over_selection(): void
     {
         $this->subject->add(

--- a/tests/unit/Server/Backend/Storage/Adapter/SqliteFilterTranslatorTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/SqliteFilterTranslatorTest.php
@@ -846,4 +846,61 @@ final class SqliteFilterTranslatorTest extends TestCase
         self::assertNotNull($result);
         self::assertNull($result->sidecarCondition);
     }
+
+    public function test_composed_and_exposes_each_childs_drivable_leaf(): void
+    {
+        $result = $this->subject->translate(new AndFilter(
+            new EqualityFilter('objectClass', 'person'),
+            new EqualityFilter('cn', 'alice'),
+        ));
+
+        self::assertNotNull($result);
+        self::assertCount(
+            2,
+            $result->drivableLeaves,
+        );
+        self::assertSame(
+            "s.attr_name_lower = 'objectclass' AND s.value_lower = ?",
+            $result->drivableLeaves[0]->condition,
+        );
+        self::assertSame(
+            ['person'],
+            $result->drivableLeaves[0]->params,
+        );
+        self::assertSame(
+            ['alice'],
+            $result->drivableLeaves[1]->params,
+        );
+    }
+
+    public function test_nested_and_flattens_drivable_leaves(): void
+    {
+        $result = $this->subject->translate(new AndFilter(
+            new AndFilter(
+                new EqualityFilter('a', '1'),
+                new EqualityFilter('b', '2'),
+            ),
+            new EqualityFilter('c', '3'),
+        ));
+
+        self::assertNotNull($result);
+        self::assertCount(
+            3,
+            $result->drivableLeaves,
+        );
+    }
+
+    public function test_or_exposes_no_drivable_leaves(): void
+    {
+        $result = $this->subject->translate(new OrFilter(
+            new EqualityFilter('cn', 'a'),
+            new EqualityFilter('cn', 'b'),
+        ));
+
+        self::assertNotNull($result);
+        self::assertSame(
+            [],
+            $result->drivableLeaves,
+        );
+    }
 }

--- a/tests/unit/Server/Backend/Storage/Adapter/SqliteFilterTranslatorTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/SqliteFilterTranslatorTest.php
@@ -773,4 +773,77 @@ final class SqliteFilterTranslatorTest extends TestCase
             $result->params,
         );
     }
+
+    public function test_equality_exposes_a_sidecar_condition(): void
+    {
+        $result = $this->subject->translate(new EqualityFilter('cn', 'alice'));
+
+        self::assertNotNull($result);
+        self::assertSame(
+            "s.attr_name_lower = 'cn' AND s.value_lower = ?",
+            $result->sidecarCondition,
+        );
+    }
+
+    public function test_present_exposes_a_value_less_sidecar_condition(): void
+    {
+        $result = $this->subject->translate(new PresentFilter('cn'));
+
+        self::assertNotNull($result);
+        self::assertSame(
+            "s.attr_name_lower = 'cn'",
+            $result->sidecarCondition,
+        );
+    }
+
+    public function test_prefix_substring_exposes_a_sidecar_condition(): void
+    {
+        $result = $this->subject->translate((new SubstringFilter('cn'))->setStartsWith('al'));
+
+        self::assertNotNull($result);
+        self::assertSame(
+            "s.attr_name_lower = 'cn' AND s.value_lower LIKE ? ESCAPE '!'",
+            $result->sidecarCondition,
+        );
+    }
+
+    public function test_gte_exposes_a_sidecar_condition(): void
+    {
+        $result = $this->subject->translate(new GreaterThanOrEqualFilter('cn', 'a'));
+
+        self::assertNotNull($result);
+        self::assertSame(
+            "s.attr_name_lower = 'cn' AND s.value_lower >= ?",
+            $result->sidecarCondition,
+        );
+    }
+
+    public function test_composed_and_leaves_the_sidecar_condition_null(): void
+    {
+        $result = $this->subject->translate(new AndFilter(
+            new EqualityFilter('cn', 'alice'),
+            new EqualityFilter('sn', 'smith'),
+        ));
+
+        self::assertNotNull($result);
+        self::assertNull($result->sidecarCondition);
+    }
+
+    public function test_negation_leaves_the_sidecar_condition_null(): void
+    {
+        $result = $this->subject->translate(new NotFilter(new EqualityFilter('cn', 'alice')));
+
+        self::assertNotNull($result);
+        self::assertNull($result->sidecarCondition);
+    }
+
+    public function test_indexed_substring_leaves_the_sidecar_condition_null(): void
+    {
+        $translator = new SqliteFilterTranslator(new TrigramSubstringIndex(['cn']));
+
+        $result = $translator->translate((new SubstringFilter('cn'))->setContains('smith'));
+
+        self::assertNotNull($result);
+        self::assertNull($result->sidecarCondition);
+    }
 }


### PR DESCRIPTION
When the size of the directory scales (1k -> 10k -> 30k) the performance for subsearch server side starts to drop. That is due to PDO sub queries needing having broad selects / scans even though there's always a LIMIT set on the outer query. This addresses two of those cases, but a few still exist that I need to follow up on. I've added additional search types to the load test to validate them.

Most search types are actually either sub-ms or 1 - 2 ms. However, subsearch is basically flat and lands anywhere from 15 - 25 ms (when the search limit is hit + max attributes are selected), and that's largely encoding / decoding time with ASN1. I can perhaps optimize some of that a bit more (but it will be ugly). So these fixes just make sure that timing stays flat rather than balloons when directory size goes up. Current search performance is "acceptable" IMO.