### PR TITLE
[1.0.0] A few follow-ups from the security hardening work,

### DIFF
--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordHashService.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordHashService.php
@@ -101,7 +101,10 @@ final readonly class PasswordHashService
             }
         }
 
-        return $plain === $stored;
+        return hash_equals(
+            $stored,
+            $plain,
+        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Server\Middleware;
 
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
@@ -185,10 +186,11 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
         );
 
         if ($request instanceof CompareRequest) {
+            // Normalize away attribute options so a rule on the base type still applies.
             $this->accessControl->authorizeAttribute(
                 $token,
                 $request->getDn(),
-                $request->getFilter()->getAttribute(),
+                $this->attributeFromString($request->getFilter()->getAttribute())->getName(),
                 AttributeAccess::Read,
             );
 
@@ -295,6 +297,14 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
                 );
             }
         }
+    }
+
+    /**
+     * Wraps a raw attribute description so getName() can normalize away any attribute options.
+     */
+    private function attributeFromString(string $attribute): Attribute
+    {
+        return new Attribute($attribute);
     }
 
     /**

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -187,6 +187,13 @@ final class ServerOptions
     private ?AclRules $aclRules = null;
 
     /**
+     * Memoized secure default, rebuilt when the administrator subject changes so it never goes stale.
+     */
+    private ?AccessControlInterface $defaultAccessControl = null;
+
+    private ?AclRules $defaultAclRules = null;
+
+    /**
      * @var list<string>
      */
     private array $privilegedControls = [
@@ -580,6 +587,9 @@ final class ServerOptions
     public function setAdministrators(?SubjectMatcherInterface $administrators): self
     {
         $this->administrators = $administrators;
+        // Drop any memoized secure default so it is rebuilt with the new administrator instead of a stale one.
+        $this->defaultAclRules = null;
+        $this->defaultAccessControl = null;
 
         return $this;
     }
@@ -685,9 +695,9 @@ final class ServerOptions
 
     public function getAccessControl(): AccessControlInterface
     {
-        return $this->accessControl ??= new RuleBasedAccessControl(
+        return $this->accessControl ?? ($this->defaultAccessControl ??= new RuleBasedAccessControl(
             $this->getAclRules(),
-        );
+        ));
     }
 
     public function setAccessControl(AccessControlInterface $accessControl): self
@@ -700,13 +710,15 @@ final class ServerOptions
     public function setAclRules(AclRules $aclRules): self
     {
         $this->aclRules = $aclRules;
+        // Drop any access control derived from the previous rules so it is rebuilt from these.
+        $this->defaultAccessControl = null;
 
         return $this;
     }
 
     public function getAclRules(): AclRules
     {
-        return $this->aclRules ??= AclRules::secureDefault($this->administrators);
+        return $this->aclRules ?? ($this->defaultAclRules ??= AclRules::secureDefault($this->administrators));
     }
 
     /**

--- a/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
@@ -28,6 +28,7 @@ use FreeDSx\Ldap\Protocol\Factory\HandlerId;
 use FreeDSx\Ldap\Protocol\Factory\HandlerRouteResolverInterface;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\Middleware\OperationAuthorizationMiddleware;
@@ -232,6 +233,32 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
         }
 
         self::assertNull($this->next->received);
+    }
+
+    public function test_dispatch_route_compare_normalizes_attribute_options_for_authorization(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $this->accessControl
+            ->expects(self::once())
+            ->method('authorizeAttribute')
+            ->with(
+                self::anything(),
+                self::anything(),
+                'userPassword',
+                AttributeAccess::Read,
+            );
+
+        $message = $this->contextFor(new CompareRequest(
+            'cn=foo,dc=bar',
+            Filters::equal('userPassword;binary', 'secret'),
+        ));
+
+        $this->subject->process(
+            $message,
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
     }
 
     public function test_dispatch_route_authorizes_a_privileged_control_against_the_target(): void

--- a/tests/unit/ServerOptionsTest.php
+++ b/tests/unit/ServerOptionsTest.php
@@ -35,6 +35,7 @@ use FreeDSx\Ldap\Server\RequestHandler\RootDseHandlerInterface;
 use FreeDSx\Ldap\Server\Metrics\Recorder\InMemoryMetricsRecorder;
 use FreeDSx\Ldap\Server\Metrics\Recorder\NullMetricsRecorder;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
+use FreeDSx\Ldap\Server\AccessControl\AclRules;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\SearchLimit\SearchLimitRule;
 use FreeDSx\Ldap\Server\SearchLimit\SearchLimitRules;
@@ -1023,6 +1024,48 @@ final class ServerOptionsTest extends TestCase
         self::assertCount(
             15,
             $this->subject->getSaslMechanisms(),
+        );
+    }
+
+    public function test_setting_administrators_after_reading_access_control_rebuilds_the_secure_default(): void
+    {
+        $before = $this->subject->getAccessControl();
+
+        $this->subject->setAdministrators(
+            Subject::dn('uid=admin,dc=foo,dc=bar'),
+        );
+
+        self::assertNotSame(
+            $before,
+            $this->subject->getAccessControl(),
+        );
+    }
+
+    public function test_setting_administrators_after_reading_acl_rules_rebuilds_the_secure_default(): void
+    {
+        $before = $this->subject->getAclRules();
+
+        $this->subject->setAdministrators(
+            Subject::dn('uid=admin,dc=foo,dc=bar'),
+        );
+
+        self::assertNotSame(
+            $before,
+            $this->subject->getAclRules(),
+        );
+    }
+
+    public function test_setting_acl_rules_after_reading_access_control_rebuilds_it(): void
+    {
+        $before = $this->subject->getAccessControl();
+
+        $this->subject->setAclRules(
+            AclRules::fromEmpty(),
+        );
+
+        self::assertNotSame(
+            $before,
+            $this->subject->getAccessControl(),
         );
     }
 }


### PR DESCRIPTION
* use hash_equals in password verification to compare in constant time.
* For a compare operation, make sure to normal attribute tags.
* Take the memoized AclRules / AccessControl into account when the manager is set on the options.

I'm going to actually redesign the manager account concept. Going to do that separately though.