### PR TITLE
[1.0.0] Make replica local password state changes atomic with a lock.

### DIFF
--- a/resources/schema/mysql/baseline.sql
+++ b/resources/schema/mysql/baseline.sql
@@ -45,7 +45,9 @@ CREATE TABLE IF NOT EXISTS ldap_change_journal_seq (
 INSERT IGNORE INTO ldap_change_journal_seq (id, seq) VALUES (1, 0);
 
 CREATE TABLE IF NOT EXISTS ldap_replica_pwpolicy_state (
-    lc_dn  VARCHAR(768) NOT NULL,
-    state  JSON NOT NULL,
+    lc_dn          VARCHAR(768) NOT NULL,
+    state          JSON NOT NULL,
+    seq            BIGINT NOT NULL DEFAULT 0,
+    forwarded_seq  BIGINT NOT NULL DEFAULT 0,
     PRIMARY KEY (lc_dn)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/resources/schema/sqlite/baseline.sql
+++ b/resources/schema/sqlite/baseline.sql
@@ -47,6 +47,8 @@ CREATE TABLE IF NOT EXISTS ldap_change_journal_seq (
 INSERT OR IGNORE INTO ldap_change_journal_seq (id, seq) VALUES (1, 0);
 
 CREATE TABLE IF NOT EXISTS ldap_replica_pwpolicy_state (
-    lc_dn  TEXT NOT NULL PRIMARY KEY,
-    state  TEXT NOT NULL
+    lc_dn          TEXT NOT NULL PRIMARY KEY,
+    state          TEXT NOT NULL,
+    seq            INTEGER NOT NULL DEFAULT 0,
+    forwarded_seq  INTEGER NOT NULL DEFAULT 0
 );

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/MysqlDialect.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/MysqlDialect.php
@@ -34,16 +34,17 @@ final class MysqlDialect implements PdoDialectInterface
         return new MysqlFilterTranslator($substringIndex);
     }
 
-    public function lockEntryForWrite(
+    public function lockRowForWrite(
         PDO $pdo,
+        string $table,
         string $lcDn,
     ): void {
         $statement = $pdo->prepare(<<<SQL
             SELECT lc_dn
-            FROM entries
+            FROM $table
             WHERE lc_dn = ?
             FOR UPDATE
-        SQL);
+            SQL);
         $statement->execute([$lcDn]);
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
@@ -38,10 +38,11 @@ trait PdoDialectTrait
     }
 
     /**
-     * Default no-op: not all implementations need this.
+     * Default no-op: SQLite already holds the write lock from `BEGIN IMMEDIATE`, so no per-row lock is needed.
      */
-    public function lockEntryForWrite(
+    public function lockRowForWrite(
         PDO $pdo,
+        string $table,
         string $lcDn,
     ): void {}
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoEntryDialectInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoEntryDialectInterface.php
@@ -33,10 +33,13 @@ interface PdoEntryDialectInterface
     public function commit(PDO $pdo): void;
 
     /**
-     * Take an exclusive lock on the entry row within the current transaction so concurrent writers to it serialize.
+     * Take an exclusive lock on the lc_dn row of $table within the current transaction so concurrent writers serialize.
+     *
+     * @param string $table A fixed internal table identifier, never client input, so implementations may interpolate it.
      */
-    public function lockEntryForWrite(
+    public function lockRowForWrite(
         PDO $pdo,
+        string $table,
         string $lcDn,
     ): void;
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoColumnCastTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoColumnCastTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo;
+
+use function is_numeric;
+use function is_string;
+
+/**
+ * Narrows loosely-typed PDO fetched column values to their expected scalar type.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+trait PdoColumnCastTrait
+{
+    private function stringColumn(mixed $value): string
+    {
+        return is_string($value)
+            ? $value
+            : '';
+    }
+
+    private function intColumn(mixed $value): int
+    {
+        return is_numeric($value)
+            ? (int) $value
+            : 0;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoReplicaPasswordStateStore.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoReplicaPasswordStateStore.php
@@ -14,16 +14,20 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter;
 
 use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoEntryDialectInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoColumnCastTrait;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoTransactor;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaForwardState;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordState;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
+use PDO;
 
 use function is_array;
-use function is_string;
 use function json_decode;
 use function json_encode;
+use function max;
 
 /**
  * Replica-local password-policy state persisted as a JSON row per subject, sharing a PdoStorage connection.
@@ -32,21 +36,18 @@ use function json_encode;
  */
 final readonly class PdoReplicaPasswordStateStore implements ReplicaPasswordStateStoreInterface
 {
+    use PdoColumnCastTrait;
+
     private const TABLE = 'ldap_replica_pwpolicy_state';
 
-    public function __construct(private PdoTransactor $transactor) {}
+    public function __construct(
+        private PdoTransactor $transactor,
+        private PdoEntryDialectInterface $dialect,
+    ) {}
 
     public function load(Dn $dn): ReplicaPasswordState
     {
-        $statement = $this->transactor
-            ->pdo()
-            ->prepare('SELECT state FROM ' . self::TABLE . ' WHERE lc_dn = ?');
-        $statement->execute([$this->key($dn)]);
-        $state = $statement->fetchColumn();
-
-        return is_string($state)
-            ? $this->decode($state)
-            : ReplicaPasswordState::empty();
+        return $this->loadRecord($dn)->state;
     }
 
     /**
@@ -57,33 +58,102 @@ final readonly class PdoReplicaPasswordStateStore implements ReplicaPasswordStat
         callable $merge,
     ): void {
         $this->transactor->atomic(function () use ($dn, $merge): void {
-            $key = $this->key($dn);
-            $current = $this->load($dn);
-            $changes = $merge($current);
+            $this->dialect->lockRowForWrite(
+                $this->transactor->pdo(),
+                self::TABLE,
+                $this->key($dn),
+            );
 
+            $record = $this->loadRecord($dn);
+            $changes = $merge($record->state);
             if ($changes->isEmpty()) {
                 return;
             }
 
-            $next = $current->withChanges($changes);
-
-            $this->transactor
-                ->pdo()
-                ->prepare('DELETE FROM ' . self::TABLE . ' WHERE lc_dn = ?')
-                ->execute([$key]);
-
-            if ($next->isEmpty()) {
+            $next = $record->state->withChanges($changes);
+            if ($record->state->equals($next)) {
                 return;
             }
 
-            $this->transactor
-                ->pdo()
-                ->prepare('INSERT INTO ' . self::TABLE . ' (lc_dn, state) VALUES (?, ?)')
-                ->execute([
-                    $key,
-                    $this->encode($next),
-                ]);
+            $this->upsert($record->applied($next));
         });
+    }
+
+    public function listUnforwarded(int $limit = 100): array
+    {
+        $statement = $this->transactor
+            ->pdo()
+            ->prepare(
+                'SELECT lc_dn, state, seq, forwarded_seq FROM ' . self::TABLE
+                . ' WHERE seq > forwarded_seq ORDER BY seq ASC LIMIT ' . max(0, $limit),
+            );
+        $statement->execute();
+
+        $pending = [];
+        /** @var array<string, mixed> $row */
+        foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $pending[] = new ReplicaForwardState(
+                new Dn($this->stringColumn($row['lc_dn'])),
+                $this->decode($this->stringColumn($row['state'])),
+                $this->intColumn($row['seq']),
+                $this->intColumn($row['forwarded_seq']),
+            );
+        }
+
+        return $pending;
+    }
+
+    public function markForwarded(
+        Dn $dn,
+        int $sequence,
+    ): void {
+        $this->transactor
+            ->pdo()
+            ->prepare(
+                'UPDATE ' . self::TABLE
+                . ' SET forwarded_seq = ? WHERE lc_dn = ? AND forwarded_seq < ? AND seq >= ?',
+            )
+            ->execute([
+                $sequence,
+                $this->key($dn),
+                $sequence,
+                $sequence,
+            ]);
+    }
+
+    private function loadRecord(Dn $dn): ReplicaForwardState
+    {
+        $statement = $this->transactor
+            ->pdo()
+            ->prepare('SELECT state, seq, forwarded_seq FROM ' . self::TABLE . ' WHERE lc_dn = ?');
+        $statement->execute([$this->key($dn)]);
+        $row = $statement->fetch(PDO::FETCH_ASSOC);
+        if (!is_array($row)) {
+            return ReplicaForwardState::initial($dn);
+        }
+
+        return new ReplicaForwardState(
+            $dn,
+            $this->decode($this->stringColumn($row['state'])),
+            $this->intColumn($row['seq']),
+            $this->intColumn($row['forwarded_seq']),
+        );
+    }
+
+    private function upsert(ReplicaForwardState $record): void
+    {
+        $key = $this->key($record->dn);
+        $pdo = $this->transactor->pdo();
+
+        $pdo->prepare('DELETE FROM ' . self::TABLE . ' WHERE lc_dn = ?')
+            ->execute([$key]);
+        $pdo->prepare('INSERT INTO ' . self::TABLE . ' (lc_dn, state, seq, forwarded_seq) VALUES (?, ?, ?, ?)')
+            ->execute([
+                $key,
+                $this->encode($record->state),
+                $record->sequence,
+                $record->forwarded,
+            ]);
     }
 
     private function key(Dn $dn): string

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -293,15 +293,19 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
 
     public function lockForWrite(Dn $dn): void
     {
-        $this->dialect->lockEntryForWrite(
+        $this->dialect->lockRowForWrite(
             $this->transactor->pdo(),
+            'entries',
             $dn->normalize()->toString(),
         );
     }
 
     public function replicaPasswordStateStore(): ReplicaPasswordStateStoreInterface
     {
-        return new PdoReplicaPasswordStateStore($this->transactor);
+        return new PdoReplicaPasswordStateStore(
+            $this->transactor,
+            $this->dialect,
+        );
     }
 
     protected function buildJournal(ChangeJournalConfig $config): ChangeJournalInterface

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/InMemoryReplicaPasswordStateStore.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/InMemoryReplicaPasswordStateStore.php
@@ -16,22 +16,23 @@ namespace FreeDSx\Ldap\Server\PasswordPolicy\Replica;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
 
+use function count;
+
 /**
- * Holds replica-observed password-policy state in memory.
+ * Holds replica-observed password-policy state in memory, with a per-subject forward watermark.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 final class InMemoryReplicaPasswordStateStore implements ReplicaPasswordStateStoreInterface
 {
     /**
-     * @var array<string, ReplicaPasswordState>
+     * @var array<string, ReplicaForwardState>
      */
-    private array $states = [];
+    private array $records = [];
 
     public function load(Dn $dn): ReplicaPasswordState
     {
-        return $this->states[$this->key($dn)]
-            ?? ReplicaPasswordState::empty();
+        return ($this->records[$this->key($dn)] ?? ReplicaForwardState::initial($dn))->state;
     }
 
     /**
@@ -42,20 +43,51 @@ final class InMemoryReplicaPasswordStateStore implements ReplicaPasswordStateSto
         callable $merge,
     ): void {
         $key = $this->key($dn);
-        $current = $this->states[$key] ?? ReplicaPasswordState::empty();
-        $changes = $merge($current);
+        $record = $this->records[$key] ?? ReplicaForwardState::initial($dn);
+        $changes = $merge($record->state);
+
         if ($changes->isEmpty()) {
             return;
         }
 
-        $state = $current->withChanges($changes);
-        if ($state->isEmpty()) {
-            unset($this->states[$key]);
-
+        $next = $record->state->withChanges($changes);
+        if ($record->state->equals($next)) {
             return;
         }
 
-        $this->states[$key] = $state;
+        $this->records[$key] = $record->applied($next);
+    }
+
+    public function listUnforwarded(int $limit = 100): array
+    {
+        $pending = [];
+
+        foreach ($this->records as $record) {
+            if (!$record->isPending()) {
+                continue;
+            }
+
+            $pending[] = $record;
+            if (count($pending) >= $limit) {
+                break;
+            }
+        }
+
+        return $pending;
+    }
+
+    public function markForwarded(
+        Dn $dn,
+        int $sequence,
+    ): void {
+        $key = $this->key($dn);
+        $record = $this->records[$key] ?? null;
+
+        if ($record === null || !$record->canAdvanceTo($sequence)) {
+            return;
+        }
+
+        $this->records[$key] = $record->advancedTo($sequence);
     }
 
     private function key(Dn $dn): string

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/ReplicaForwardState.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/ReplicaForwardState.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Replica;
+
+use FreeDSx\Ldap\Entry\Dn;
+
+/**
+ * A subject's replica-local password-policy state plus its forward watermark (current vs last-forwarded sequence).
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ReplicaForwardState
+{
+    public function __construct(
+        public Dn $dn,
+        public ReplicaPasswordState $state,
+        public int $sequence,
+        public int $forwarded = 0,
+    ) {}
+
+    public static function initial(Dn $dn): self
+    {
+        return new self(
+            $dn,
+            ReplicaPasswordState::empty(),
+            0,
+        );
+    }
+
+    /**
+     * Whether the state has advanced past the last-forwarded watermark and is awaiting forward.
+     */
+    public function isPending(): bool
+    {
+        return $this->sequence > $this->forwarded;
+    }
+
+    /**
+     * Whether the forwarded watermark may advance to $sequence: it is newer than the last forward, but not newer than
+     * the state actually recorded.
+     */
+    public function canAdvanceTo(int $sequence): bool
+    {
+        return $sequence > $this->forwarded && $sequence <= $this->sequence;
+    }
+
+    public function advancedTo(int $sequence): self
+    {
+        return new self(
+            $this->dn,
+            $this->state,
+            $this->sequence,
+            $sequence,
+        );
+    }
+
+    public function applied(ReplicaPasswordState $state): self
+    {
+        return new self(
+            $this->dn,
+            $state,
+            $this->sequence + 1,
+            $this->forwarded,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/ReplicaPasswordState.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/ReplicaPasswordState.php
@@ -71,6 +71,11 @@ final readonly class ReplicaPasswordState
         return $this->attributes === [];
     }
 
+    public function equals(self $other): bool
+    {
+        return $this->toArray() == $other->toArray();
+    }
+
     /**
      * @return array<string, list<string>>
      */

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/ReplicaPasswordStateStoreInterface.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/ReplicaPasswordStateStoreInterface.php
@@ -30,12 +30,27 @@ interface ReplicaPasswordStateStoreInterface
 
     /**
      * Atomically read the subject's current local state, derive changes from it via $merge, and apply them under an
-     * exclusive lock so concurrent binds cannot lose an update.
+     * exclusive lock so concurrent binds cannot lose an update; a state-changing apply advances the forward watermark.
      *
      * @param callable(ReplicaPasswordState): OperationalChanges $merge
      */
     public function atomicMutate(
         Dn $dn,
         callable $merge,
+    ): void;
+
+    /**
+     * Subjects whose local state has advanced past the last forwarded watermark, oldest first, capped at $limit.
+     *
+     * @return list<ReplicaForwardState>
+     */
+    public function listUnforwarded(int $limit = 100): array;
+
+    /**
+     * Advance a subject's forwarded watermark to $sequence, so state no newer than it is no longer pending forward.
+     */
+    public function markForwarded(
+        Dn $dn,
+        int $sequence,
     ): void;
 }

--- a/tests/unit/Server/Backend/Storage/Adapter/PdoReplicaPasswordStateStoreTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/PdoReplicaPasswordStateStoreTest.php
@@ -121,6 +121,74 @@ final class PdoReplicaPasswordStateStoreTest extends TestCase
         );
     }
 
+    public function test_a_recorded_change_becomes_a_pending_forward(): void
+    {
+        $this->applyFailure('20260520120000Z');
+
+        $pending = $this->subject->listUnforwarded();
+
+        self::assertCount(
+            1,
+            $pending,
+        );
+        self::assertSame(
+            self::DN,
+            $pending[0]->dn->toString(),
+        );
+        self::assertSame(
+            1,
+            $pending[0]->sequence,
+        );
+    }
+
+    public function test_marking_forwarded_clears_the_pending_entry(): void
+    {
+        $this->applyFailure('20260520120000Z');
+
+        $this->subject->markForwarded(
+            new Dn(self::DN),
+            1,
+        );
+
+        self::assertSame(
+            [],
+            $this->subject->listUnforwarded(),
+        );
+    }
+
+    public function test_marking_a_stale_sequence_leaves_a_newer_change_pending(): void
+    {
+        $this->applyFailure('20260520120000Z');
+        $this->applyFailure('20260520120500Z');
+
+        $this->subject->markForwarded(
+            new Dn(self::DN),
+            1,
+        );
+
+        $pending = $this->subject->listUnforwarded();
+
+        self::assertCount(
+            1,
+            $pending,
+        );
+        self::assertSame(
+            2,
+            $pending[0]->sequence,
+        );
+    }
+
+    private function applyFailure(string $time): void
+    {
+        $this->applyChanges(
+            new Dn(self::DN),
+            OperationalChanges::of(Change::replace(
+                PasswordPolicyOid::NAME_PWD_FAILURE_TIME,
+                $time,
+            )),
+        );
+    }
+
     private function applyChanges(
         Dn $dn,
         OperationalChanges $changes,

--- a/tests/unit/Server/PasswordPolicy/Replica/InMemoryReplicaPasswordStateStoreTest.php
+++ b/tests/unit/Server/PasswordPolicy/Replica/InMemoryReplicaPasswordStateStoreTest.php
@@ -86,6 +86,96 @@ final class InMemoryReplicaPasswordStateStoreTest extends TestCase
         self::assertFalse($this->subject->load(new Dn(self::DN))->isEmpty());
     }
 
+    public function test_a_recorded_change_becomes_a_pending_forward(): void
+    {
+        $this->applyFailure('20260520120000Z');
+
+        $pending = $this->subject->listUnforwarded();
+
+        self::assertCount(
+            1,
+            $pending,
+        );
+        self::assertSame(
+            self::DN,
+            $pending[0]->dn->toString(),
+        );
+        self::assertSame(
+            1,
+            $pending[0]->sequence,
+        );
+    }
+
+    public function test_marking_forwarded_clears_the_pending_entry(): void
+    {
+        $this->applyFailure('20260520120000Z');
+
+        $this->subject->markForwarded(
+            new Dn(self::DN),
+            1,
+        );
+
+        self::assertSame(
+            [],
+            $this->subject->listUnforwarded(),
+        );
+    }
+
+    public function test_a_change_after_forwarding_re_lists_at_a_higher_sequence(): void
+    {
+        $this->applyFailure('20260520120000Z');
+        $this->subject->markForwarded(
+            new Dn(self::DN),
+            1,
+        );
+        $this->applyFailure('20260520120500Z');
+
+        $pending = $this->subject->listUnforwarded();
+
+        self::assertCount(
+            1,
+            $pending,
+        );
+        self::assertSame(
+            2,
+            $pending[0]->sequence,
+        );
+    }
+
+    public function test_marking_a_stale_sequence_leaves_a_newer_change_pending(): void
+    {
+        $this->applyFailure('20260520120000Z');
+        $this->applyFailure('20260520120500Z');
+
+        // A worker that read sequence 1 and marks it must not retire the sequence-2 change it never saw.
+        $this->subject->markForwarded(
+            new Dn(self::DN),
+            1,
+        );
+
+        $pending = $this->subject->listUnforwarded();
+
+        self::assertCount(
+            1,
+            $pending,
+        );
+        self::assertSame(
+            2,
+            $pending[0]->sequence,
+        );
+    }
+
+    private function applyFailure(string $time): void
+    {
+        $this->applyChanges(
+            new Dn(self::DN),
+            OperationalChanges::of(Change::replace(
+                PasswordPolicyOid::NAME_PWD_FAILURE_TIME,
+                $time,
+            )),
+        );
+    }
+
     private function applyChanges(
         Dn $dn,
         OperationalChanges $changes,


### PR DESCRIPTION
Similar to the binds, the local password policy state on replicas also needs to be atomic with a lock. Also, we need sequencing markers so we can tell what has been forwarded upstream vs what hasn't (avoiding more race conditions).

A follow up will actually implement the forwarding logic.