### PR TITLE
[1.0.0] Add a long lived worker to forward password policy state on the replica.

### DIFF
--- a/resources/schema/mysql/baseline.sql
+++ b/resources/schema/mysql/baseline.sql
@@ -49,5 +49,6 @@ CREATE TABLE IF NOT EXISTS ldap_replica_pwpolicy_state (
     state          JSON NOT NULL,
     seq            BIGINT NOT NULL DEFAULT 0,
     forwarded_seq  BIGINT NOT NULL DEFAULT 0,
-    PRIMARY KEY (lc_dn)
+    PRIMARY KEY (lc_dn),
+    FOREIGN KEY (lc_dn) REFERENCES entries(lc_dn) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/resources/schema/sqlite/baseline.sql
+++ b/resources/schema/sqlite/baseline.sql
@@ -50,5 +50,6 @@ CREATE TABLE IF NOT EXISTS ldap_replica_pwpolicy_state (
     lc_dn          TEXT NOT NULL PRIMARY KEY,
     state          TEXT NOT NULL,
     seq            INTEGER NOT NULL DEFAULT 0,
-    forwarded_seq  INTEGER NOT NULL DEFAULT 0
+    forwarded_seq  INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (lc_dn) REFERENCES entries(lc_dn) ON DELETE CASCADE
 );

--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -764,9 +764,25 @@ class Container
             return null;
         }
 
+        // Pair reconciliation with forwarding: the store drops forwarded state once the primary's entry replicates back.
+        $passwordStateStore = $options->isPasswordPolicyEnabled()
+            ? $this->get(ReplicaPasswordStateStoreInterface::class)
+            : null;
+
         return $hostManagedShutdown
-            ? LdapReplica::forSwoole($config, $storage, $options->getLogger(), signals: null)
-            : LdapReplica::forPcntl($config, $storage, $options->getLogger());
+            ? LdapReplica::forSwoole(
+                $config,
+                $storage,
+                $options->getLogger(),
+                signals: null,
+                passwordStateStore: $passwordStateStore,
+            )
+            : LdapReplica::forPcntl(
+                $config,
+                $storage,
+                $options->getLogger(),
+                passwordStateStore: $passwordStateStore,
+            );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -27,9 +27,17 @@ use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\ReplicaPasswordStateStoreProviderInterface;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\CoroutineSleeper;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\LdapClientForwardStateSender;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\PasswordPolicyForwardWorker;
+use FreeDSx\Ldap\Server\Process\BackgroundTask\LongLivedTask;
 use FreeDSx\Ldap\Server\Process\BackgroundTask\PcntlBackgroundTasks;
+use FreeDSx\Ldap\Server\Process\BackgroundTask\PeriodicTask;
 use FreeDSx\Ldap\Server\Process\BackgroundTask\SwooleBackgroundTasks;
+use FreeDSx\Ldap\Server\Process\Signals\PcntlShutdownSignals;
 use FreeDSx\Ldap\Sync\Consumer\LdapReplica;
+use FreeDSx\Ldap\Sync\Consumer\PrimaryConnectionFactory;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeRecorder;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
@@ -639,26 +647,104 @@ class Container
 
     private function makeSwooleBackgroundTasks(): SwooleBackgroundTasks
     {
+        $periodicTasks = [];
+        $sweeper = $this->makeRetentionSweeper();
+        if ($sweeper !== null) {
+            $periodicTasks[] = new PeriodicTask(
+                RetentionSweeper::TASK_NAME,
+                RetentionSweeper::DEFAULT_INTERVAL_SECONDS,
+                static function () use ($sweeper): void {
+                    $sweeper->sweep();
+                },
+            );
+        }
+
+        $longLivedTasks = [];
+        $daemon = $this->makeReplicaDaemon(hostManagedShutdown: true);
+        if ($daemon !== null) {
+            $longLivedTasks[] = new LongLivedTask(
+                LdapReplica::TASK_NAME,
+                $daemon->run(...),
+                $daemon->stop(...),
+            );
+        }
+        $forwardWorker = $this->makeForwardWorker(useCoroutineSleeper: true);
+        if ($forwardWorker !== null) {
+            $longLivedTasks[] = new LongLivedTask(
+                PasswordPolicyForwardWorker::TASK_NAME,
+                $forwardWorker->run(...),
+                $forwardWorker->stop(...),
+            );
+        }
+
         return new SwooleBackgroundTasks(
-            $this->makeRetentionSweeper(),
-            $this->makeReplicaDaemon(hostManagedShutdown: true),
+            $periodicTasks,
+            $longLivedTasks,
+            $this->get(ServerOptions::class)->getLogger(),
         );
     }
 
     private function makePcntlBackgroundTasks(): PcntlBackgroundTasks
     {
         $options = $this->get(ServerOptions::class);
-        $hasSweep = $this->journalRetentionPolicyIfSweepable() !== null;
-        $hasDaemon = $options->getReplicaConfig() !== null;
+
+        $periodicTasks = [];
+        if ($this->journalRetentionPolicyIfSweepable() !== null) {
+            $periodicTasks[] = new PeriodicTask(
+                RetentionSweeper::TASK_NAME,
+                RetentionSweeper::DEFAULT_INTERVAL_SECONDS,
+                function (): void {
+                    $this->makeRetentionSweeper()?->sweep();
+                },
+            );
+        }
+
+        $longLivedTasks = [];
+        if ($options->getReplicaConfig() !== null) {
+            $longLivedTasks[] = new LongLivedTask(
+                LdapReplica::TASK_NAME,
+                function (): void {
+                    $this->makeReplicaDaemon(hostManagedShutdown: false)?->run();
+                },
+            );
+        }
+        if ($this->makeForwardWorker(useCoroutineSleeper: false) !== null) {
+            $longLivedTasks[] = new LongLivedTask(
+                PasswordPolicyForwardWorker::TASK_NAME,
+                function (): void {
+                    $this->makeForwardWorker(useCoroutineSleeper: false)?->run();
+                },
+            );
+        }
 
         return new PcntlBackgroundTasks(
-            makeSweeper: $hasSweep
-                ? fn(): ?RetentionSweeper => $this->makeRetentionSweeper()
-                : null,
-            makeDaemon: $hasDaemon
-                ? fn(): ?LdapReplica => $this->makeReplicaDaemon(hostManagedShutdown: false)
-                : null,
-            sweepIntervalSeconds: RetentionSweeper::DEFAULT_INTERVAL_SECONDS,
+            periodicTasks: $periodicTasks,
+            longLivedTasks: $longLivedTasks,
+            logger: $options->getLogger(),
+        );
+    }
+
+    /**
+     * The replica password-policy forward worker when replica mode + password policy are configured, else null.
+     */
+    private function makeForwardWorker(bool $useCoroutineSleeper): ?PasswordPolicyForwardWorker
+    {
+        $options = $this->get(ServerOptions::class);
+        $config = $options->getReplicaConfig();
+
+        if ($config === null || !$options->isPasswordPolicyEnabled()) {
+            return null;
+        }
+
+        return new PasswordPolicyForwardWorker(
+            $this->get(ReplicaPasswordStateStoreInterface::class),
+            new LdapClientForwardStateSender(new PrimaryConnectionFactory($config)),
+            $useCoroutineSleeper
+                ? new CoroutineSleeper()
+                : new BlockingSleeper(),
+            signals: $useCoroutineSleeper
+                ? null
+                : new PcntlShutdownSignals(),
             logger: $options->getLogger(),
         );
     }

--- a/src/FreeDSx/Ldap/Exception/ForwardStateException.php
+++ b/src/FreeDSx/Ldap/Exception/ForwardStateException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Exception;
+
+/**
+ * Thrown when a replica cannot deliver a password-policy forward to the primary.
+ */
+class ForwardStateException extends RuntimeException {}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoReplicaPasswordStateStore.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoReplicaPasswordStateStore.php
@@ -22,6 +22,7 @@ use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaForwardState;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordState;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
 use PDO;
 
 use function is_array;
@@ -119,6 +120,34 @@ final readonly class PdoReplicaPasswordStateStore implements ReplicaPasswordStat
                 $sequence,
                 $sequence,
             ]);
+    }
+
+    /**
+     * The row lock plus re-load makes the supersession check atomic, so a failure from a racing bind is never dropped.
+     */
+    public function discardIfSuperseded(
+        Dn $dn,
+        UserPasswordState $authoritative,
+    ): void {
+        $this->transactor->atomic(function () use ($dn, $authoritative): void {
+            $this->dialect->lockRowForWrite(
+                $this->transactor->pdo(),
+                self::TABLE,
+                $this->key($dn),
+            );
+
+            $local = $this->loadRecord($dn)
+                ->state
+                ->toUserPasswordState($dn);
+            if (!$local->isSupersededBy($authoritative)) {
+                return;
+            }
+
+            $this->transactor
+                ->pdo()
+                ->prepare('DELETE FROM ' . self::TABLE . ' WHERE lc_dn = ?')
+                ->execute([$this->key($dn)]);
+        });
     }
 
     private function loadRecord(Dn $dn): ReplicaForwardState

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/RetentionSweeper.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/RetentionSweeper.php
@@ -27,6 +27,8 @@ use function microtime;
  */
 final readonly class RetentionSweeper
 {
+    public const TASK_NAME = 'retention-sweep';
+
     public const DEFAULT_INTERVAL_SECONDS = 60.0;
 
     public function __construct(

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/Forward/ForwardStateSenderInterface.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/Forward/ForwardStateSenderInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward;
+
+use FreeDSx\Ldap\Operation\Request\ForwardPasswordPolicyStateRequest;
+
+/**
+ * Delivers a replica's password-policy forward request to the primary over the sync identity connection.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface ForwardStateSenderInterface
+{
+    /**
+     * Deliver the request to the primary, throwing when it could not be delivered or the primary rejected it.
+     *
+     * The caller leaves the subject pending and retries later.
+     */
+    public function send(ForwardPasswordPolicyStateRequest $request): void;
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/Forward/LdapClientForwardStateSender.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/Forward/LdapClientForwardStateSender.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward;
+
+use FreeDSx\Ldap\Exception\ForwardStateException;
+use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Ldap\Operation\Request\ForwardPasswordPolicyStateRequest;
+use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Sync\Consumer\PrimaryConnectionFactory;
+use Throwable;
+
+use function sprintf;
+
+/**
+ * Sends password-policy forward requests to the primary over a dedicated client using the replica's sync identity,
+ * reconnecting on the next attempt after a transport failure.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class LdapClientForwardStateSender implements ForwardStateSenderInterface
+{
+    private ?LdapClient $client = null;
+
+    public function __construct(private readonly PrimaryConnectionFactory $connectionFactory) {}
+
+    /**
+     * @throws ForwardStateException
+     */
+    public function send(ForwardPasswordPolicyStateRequest $request): void
+    {
+        $this->assertAccepted($this->exchange($request));
+    }
+
+    /**
+     * @throws ForwardStateException on a transport failure (the connection is dropped so the next send reconnects).
+     */
+    private function exchange(ForwardPasswordPolicyStateRequest $request): object
+    {
+        try {
+            return $this->connect()
+                ->sendAndReceive($request)
+                ->getResponse();
+        } catch (Throwable $e) {
+            $this->reset();
+
+            throw new ForwardStateException(
+                'Failed to deliver the password-policy forward to the primary.',
+                $e->getCode(),
+                $e,
+            );
+        }
+    }
+
+    private function connect(): LdapClient
+    {
+        return $this->client ??= $this->connectionFactory->connectLdapClient();
+    }
+
+    /**
+     * @throws ForwardStateException when the primary rejected the forward (the connection stays open for a retry).
+     */
+    private function assertAccepted(object $response): void
+    {
+        if (!$response instanceof ExtendedResponse) {
+            throw new ForwardStateException('The primary returned an unexpected response to the password-policy forward.');
+        }
+        if ($response->getResultCode() !== ResultCode::SUCCESS) {
+            throw new ForwardStateException(sprintf(
+                'The primary rejected the password-policy forward with result code %d.',
+                $response->getResultCode(),
+            ));
+        }
+    }
+
+    private function reset(): void
+    {
+        $this->client?->disconnect();
+        $this->client = null;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwardWorker.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwardWorker.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward;
+
+use FreeDSx\Ldap\Operation\Request\ForwardPasswordPolicyStateRequest;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaForwardState;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
+
+/**
+ * Drains the replica-local password-policy forward queue and delivers each pending subject's state to the primary.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+readonly class PasswordPolicyForwardWorker
+{
+    public function __construct(
+        private ReplicaPasswordStateStoreInterface $store,
+        private ForwardStateSenderInterface $sender,
+        private int $batchLimit = 100,
+    ) {}
+
+    /**
+     * Forward every pending subject in watermark order, advancing the watermark after each successful delivery; a
+     * delivery failure stops the drain so the remainder stays pending for the next run.
+     *
+     * @return int the number of subjects forwarded
+     */
+    public function forwardOnce(): int
+    {
+        $forwarded = 0;
+
+        foreach ($this->store->listUnforwarded($this->batchLimit) as $pending) {
+            $this->sender->send($this->requestFor($pending));
+            $this->store->markForwarded(
+                $pending->dn,
+                $pending->sequence,
+            );
+            ++$forwarded;
+        }
+
+        return $forwarded;
+    }
+
+    private function requestFor(ReplicaForwardState $pending): ForwardPasswordPolicyStateRequest
+    {
+        $state = $pending->state->toUserPasswordState($pending->dn);
+
+        return new ForwardPasswordPolicyStateRequest(
+            $pending->dn,
+            failureTimes: $state->failureTimes,
+            lastSuccess: $state->lastSuccess,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwardWorker.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwardWorker.php
@@ -13,35 +13,85 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward;
 
+use FreeDSx\Ldap\Exception\ForwardStateException;
 use FreeDSx\Ldap\Operation\Request\ForwardPasswordPolicyStateRequest;
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
+use FreeDSx\Ldap\Server\Logging\ExceptionLogging;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaForwardState;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
+use FreeDSx\Ldap\Server\Process\Signals\ShutdownSignalsInterface;
+use FreeDSx\Ldap\Sync\Consumer\ReconnectBackoff;
+use Psr\Log\LoggerInterface;
 
 /**
- * Drains the replica-local password-policy forward queue and delivers each pending subject's state to the primary.
+ * Drains the replica-local password-policy forward queue on a loop, delivering each pending subject's state to the
+ * primary over a reused connection and backing off when the primary is unreachable.
  *
  * @internal
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-readonly class PasswordPolicyForwardWorker
+class PasswordPolicyForwardWorker
 {
+    public const TASK_NAME = 'password-policy-forward';
+
+    public const DEFAULT_INTERVAL_SECONDS = 5.0;
+
+    private bool $stopping = false;
+
     public function __construct(
-        private ReplicaPasswordStateStoreInterface $store,
-        private ForwardStateSenderInterface $sender,
-        private int $batchLimit = 100,
+        private readonly ReplicaPasswordStateStoreInterface $store,
+        private readonly ForwardStateSenderInterface $sender,
+        private readonly SleeperInterface $sleeper,
+        private readonly ReconnectBackoff $backoff = new ReconnectBackoff(),
+        private readonly ?ShutdownSignalsInterface $signals = null,
+        private readonly ?LoggerInterface $logger = null,
     ) {}
+
+    /**
+     * Drain the queue until stopped, sleeping the poll interval between drains and backing off on delivery failure.
+     */
+    public function run(): void
+    {
+        $this->signals?->onShutdown($this->stop(...));
+
+        $delay = $this->backoff->initial();
+
+        while (!$this->stopping) {
+            try {
+                $this->forwardOnce();
+                $delay = $this->backoff->initial();
+                $this->sleeper->sleep(self::DEFAULT_INTERVAL_SECONDS);
+            } catch (ForwardStateException $e) {
+                $this->logger?->warning(
+                    'Password-policy forwarding failed; retrying after backoff.',
+                    ExceptionLogging::makeLogContext($e) + ['backoff_seconds' => $delay],
+                );
+                $this->sleeper->sleep($delay);
+                $delay = $this->backoff->next($delay);
+            }
+        }
+    }
+
+    /**
+     * Stop the loop; safe to call from a signal handler or another coroutine.
+     */
+    public function stop(): void
+    {
+        $this->stopping = true;
+    }
 
     /**
      * Forward every pending subject in watermark order, advancing the watermark after each successful delivery; a
      * delivery failure stops the drain so the remainder stays pending for the next run.
      *
      * @return int the number of subjects forwarded
+     * @throws ForwardStateException
      */
     public function forwardOnce(): int
     {
         $forwarded = 0;
 
-        foreach ($this->store->listUnforwarded($this->batchLimit) as $pending) {
+        foreach ($this->store->listUnforwarded() as $pending) {
             $this->sender->send($this->requestFor($pending));
             $this->store->markForwarded(
                 $pending->dn,

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/InMemoryReplicaPasswordStateStore.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/InMemoryReplicaPasswordStateStore.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Server\PasswordPolicy\Replica;
 
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
 
 use function count;
 
@@ -88,6 +89,21 @@ final class InMemoryReplicaPasswordStateStore implements ReplicaPasswordStateSto
         }
 
         $this->records[$key] = $record->advancedTo($sequence);
+    }
+
+    public function discardIfSuperseded(
+        Dn $dn,
+        UserPasswordState $authoritative,
+    ): void {
+        $key = $this->key($dn);
+        $record = $this->records[$key] ?? null;
+        if ($record === null) {
+            return;
+        }
+
+        if ($record->state->toUserPasswordState($dn)->isSupersededBy($authoritative)) {
+            unset($this->records[$key]);
+        }
     }
 
     private function key(Dn $dn): string

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/ReplicaPasswordStateStoreInterface.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/ReplicaPasswordStateStoreInterface.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Server\PasswordPolicy\Replica;
 
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
 
 /**
  * Persists replica-observed password-policy bind state locally, separate from replicated entries.
@@ -52,5 +53,14 @@ interface ReplicaPasswordStateStoreInterface
     public function markForwarded(
         Dn $dn,
         int $sequence,
+    ): void;
+
+    /**
+     * Drop a subject's local state when the replicated $authoritative entry supersedes it, so the entry becomes the
+     * single source of truth. It's a no-op while the local state still enforces something the entry has not yet reflected.
+     */
+    public function discardIfSuperseded(
+        Dn $dn,
+        UserPasswordState $authoritative,
     ): void;
 }

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/UserPasswordState.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/UserPasswordState.php
@@ -97,6 +97,38 @@ final readonly class UserPasswordState
     }
 
     /**
+     * True when $authoritative (the primary's replicated entry) supersedes this local volatile state so it can be
+     * dropped, which holds when the entry:
+     *
+     *   - is authoritatively locked, or
+     *   - records a success past our newest failure, or
+     *   - records a credential change past our newest failure.
+     */
+    public function isSupersededBy(self $authoritative): bool
+    {
+        if ($authoritative->isLocked()) {
+            return true;
+        }
+
+        if ($this->isLocked()) {
+            return false;
+        }
+
+        $newestFailure = $this->newestFailureTime();
+        if ($newestFailure === null) {
+            return true;
+        }
+
+        return self::isAfter(
+            $authoritative->lastSuccess,
+            $newestFailure,
+        ) || self::isAfter(
+            $authoritative->changedAt,
+            $newestFailure,
+        );
+    }
+
+    /**
      * Count failures recorded at or after $threshold; used to honor pwdFailureCountInterval.
      *
      * @return int<0, max>
@@ -112,6 +144,27 @@ final readonly class UserPasswordState
         }
 
         return $count;
+    }
+
+    private function newestFailureTime(): ?DateTimeImmutable
+    {
+        $newest = null;
+
+        foreach ($this->failureTimes as $time) {
+            if ($newest === null || $time > $newest) {
+                $newest = $time;
+            }
+        }
+
+        return $newest;
+    }
+
+    private static function isAfter(
+        ?DateTimeImmutable $candidate,
+        DateTimeImmutable $threshold,
+    ): bool {
+        return $candidate !== null
+            && $candidate > $threshold;
     }
 
     private static function readLockedAt(Entry $entry): ?DateTimeImmutable

--- a/src/FreeDSx/Ldap/Server/Process/BackgroundTask/LongLivedTask.php
+++ b/src/FreeDSx/Ldap/Server/Process/BackgroundTask/LongLivedTask.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Process\BackgroundTask;
+
+use Closure;
+
+/**
+ * A unit of background work that runs continuously until shutdown.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class LongLivedTask
+{
+    /**
+     * @param Closure(): void $run blocks until shutdown
+     * @param ?Closure(): void $stop optional cooperative stop for a host that shares the task's memory.
+     */
+    public function __construct(
+        public string $name,
+        public Closure $run,
+        public ?Closure $stop = null,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/Process/BackgroundTask/PcntlBackgroundTasks.php
+++ b/src/FreeDSx/Ldap/Server/Process/BackgroundTask/PcntlBackgroundTasks.php
@@ -14,42 +14,43 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Process\BackgroundTask;
 
 use Closure;
-use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionSweeper;
-use FreeDSx\Ldap\Sync\Consumer\LdapReplica;
 use Psr\Log\LoggerInterface;
 
 use function microtime;
 use function pcntl_fork;
 use function pcntl_waitpid;
 use function posix_kill;
+use function sprintf;
 
 use const SIGTERM;
 use const WNOHANG;
 
 /**
- * Runs the retention sweep and replica daemon as forked child processes under PCNTL.
+ * Runs periodic and long-lived background tasks as forked child processes under PCNTL.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 final class PcntlBackgroundTasks implements BackgroundTasksInterface
 {
-    private ?int $sweepPid = null;
+    /**
+     * @var array<int, PeriodicTaskState>
+     */
+    private array $periodicState = [];
 
-    private ?int $daemonPid = null;
-
-    private float $lastSweepAt = 0.0;
+    /**
+     * @var array<int, ?int>
+     */
+    private array $longLivedPids = [];
 
     private Closure $childStart;
 
     /**
-     * @param ?Closure(): ?RetentionSweeper $makeSweeper builds the sweep worker in the child, or null when not journaling
-     * @param ?Closure(): ?LdapReplica $makeDaemon builds the replica daemon in the child, or null when not a replica
-     * @param float $sweepIntervalSeconds cadence between retention sweeps
+     * @param list<PeriodicTask> $periodicTasks
+     * @param list<LongLivedTask> $longLivedTasks
      */
     public function __construct(
-        private readonly ?Closure $makeSweeper,
-        private readonly ?Closure $makeDaemon,
-        private readonly float $sweepIntervalSeconds,
+        private readonly array $periodicTasks,
+        private readonly array $longLivedTasks,
         private readonly ?LoggerInterface $logger = null,
     ) {
         $this->childStart = static function (): void {};
@@ -62,68 +63,65 @@ final class PcntlBackgroundTasks implements BackgroundTasksInterface
 
     public function start(): void
     {
-        $this->lastSweepAt = microtime(true);
-
-        if ($this->makeDaemon !== null) {
-            $this->daemonPid = $this->fork($this->runDaemon(...));
+        foreach ($this->longLivedTasks as $index => $task) {
+            $this->longLivedPids[$index] = $this->fork($task->run);
         }
     }
 
     public function tick(): void
     {
-        $this->reapDaemon();
-        $this->maintainSweep();
+        $this->reapLongLived();
+        $this->maintainPeriodic();
     }
 
     public function stop(): void
     {
-        $this->endChild($this->daemonPid);
-        $this->daemonPid = null;
-        $this->endChild($this->sweepPid);
-        $this->sweepPid = null;
+        foreach ($this->longLivedTasks as $index => $task) {
+            $this->endChild($this->longLivedPids[$index] ?? null);
+            $this->longLivedPids[$index] = null;
+        }
+        foreach ($this->periodicState as $state) {
+            $this->endChild($state->pid);
+            $state->pid = null;
+        }
     }
 
     /**
-     * On a fixed cadence, fork a short-lived child to prune the shared journal so the parent keeps accepting.
+     * On each task's cadence, fork a short-lived child to do one iteration so the parent keeps accepting.
      */
-    private function maintainSweep(): void
+    private function maintainPeriodic(): void
     {
-        if ($this->makeSweeper === null) {
-            return;
+        $now = microtime(true);
+
+        foreach ($this->periodicTasks as $index => $task) {
+            $state = $this->periodicState[$index] ??= new PeriodicTaskState($now);
+
+            if ($state->pid !== null && $this->pidExited($state->pid)) {
+                $state->pid = null;
+            }
+            if ($state->pid !== null || ($now - $state->lastRunAt) < $task->intervalSeconds) {
+                continue;
+            }
+
+            $state->lastRunAt = $now;
+            $state->pid = $this->fork($task->run);
         }
-
-        $this->reapSweep();
-
-        if (!$this->isSweepDue()) {
-            return;
-        }
-
-        $this->lastSweepAt = microtime(true);
-        $this->sweepPid = $this->fork($this->runSweep(...));
     }
 
-    private function isSweepDue(): bool
+    private function reapLongLived(): void
     {
-        return $this->sweepPid === null
-            && (microtime(true) - $this->lastSweepAt) >= $this->sweepIntervalSeconds;
-    }
+        foreach ($this->longLivedTasks as $index => $task) {
+            $pid = $this->longLivedPids[$index] ?? null;
+            if ($pid === null || !$this->pidExited($pid)) {
+                continue;
+            }
 
-    private function runSweep(): void
-    {
-        if ($this->makeSweeper === null) {
-            return;
+            $this->longLivedPids[$index] = null;
+            $this->logger?->warning(sprintf(
+                'The "%s" background task exited unexpectedly.',
+                $task->name,
+            ));
         }
-
-        ($this->makeSweeper)()?->sweep();
-    }
-
-    private function runDaemon(): void
-    {
-        if ($this->makeDaemon === null) {
-            return;
-        }
-
-        ($this->makeDaemon)()?->run();
     }
 
     /**
@@ -146,23 +144,6 @@ final class PcntlBackgroundTasks implements BackgroundTasksInterface
         }
 
         return $pid;
-    }
-
-    private function reapSweep(): void
-    {
-        if ($this->pidExited($this->sweepPid)) {
-            $this->sweepPid = null;
-        }
-    }
-
-    private function reapDaemon(): void
-    {
-        if ($this->daemonPid === null || !$this->pidExited($this->daemonPid)) {
-            return;
-        }
-
-        $this->daemonPid = null;
-        $this->logger?->warning('The replica synchronization daemon exited unexpectedly.');
     }
 
     private function pidExited(?int $pid): bool

--- a/src/FreeDSx/Ldap/Server/Process/BackgroundTask/PeriodicTask.php
+++ b/src/FreeDSx/Ldap/Server/Process/BackgroundTask/PeriodicTask.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Process\BackgroundTask;
+
+use Closure;
+
+/**
+ * A unit of background work to run on a fixed cadence.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class PeriodicTask
+{
+    /**
+     * @param Closure(): void $run one iteration of the task
+     */
+    public function __construct(
+        public string $name,
+        public float $intervalSeconds,
+        public Closure $run,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/Process/BackgroundTask/PeriodicTaskState.php
+++ b/src/FreeDSx/Ldap/Server/Process/BackgroundTask/PeriodicTaskState.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Process\BackgroundTask;
+
+/**
+ * Mutable runtime scheduling state for one forked periodic task.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class PeriodicTaskState
+{
+    public ?int $pid = null;
+
+    public function __construct(public float $lastRunAt) {}
+}

--- a/src/FreeDSx/Ldap/Server/Process/BackgroundTask/SwooleBackgroundTasks.php
+++ b/src/FreeDSx/Ldap/Server/Process/BackgroundTask/SwooleBackgroundTasks.php
@@ -14,13 +14,16 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Process\BackgroundTask;
 
 use Closure;
-use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionSweeper;
-use FreeDSx\Ldap\Sync\Consumer\LdapReplica;
+use FreeDSx\Ldap\Server\Logging\ExceptionLogging;
+use Psr\Log\LoggerInterface;
 use Swoole\Coroutine;
 use Swoole\Coroutine\Channel;
+use Throwable;
+
+use function sprintf;
 
 /**
- * Runs the retention sweep and replica daemon as background coroutines under Swoole.
+ * Runs periodic and long-lived background tasks as background coroutines under Swoole.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -29,13 +32,18 @@ final class SwooleBackgroundTasks implements BackgroundTasksInterface
     private bool $stopping = false;
 
     /**
-     * @var ?Channel<bool>
+     * @var list<Channel<bool>>
      */
-    private ?Channel $sweepWakeup = null;
+    private array $wakeups = [];
 
+    /**
+     * @param list<PeriodicTask> $periodicTasks
+     * @param list<LongLivedTask> $longLivedTasks
+     */
     public function __construct(
-        private readonly ?RetentionSweeper $sweeper = null,
-        private readonly ?LdapReplica $daemon = null,
+        private readonly array $periodicTasks,
+        private readonly array $longLivedTasks,
+        private readonly ?LoggerInterface $logger = null,
     ) {}
 
     public function onChildStart(Closure $onStart): void
@@ -45,8 +53,12 @@ final class SwooleBackgroundTasks implements BackgroundTasksInterface
 
     public function start(): void
     {
-        $this->startSweep();
-        $this->startDaemon();
+        foreach ($this->periodicTasks as $task) {
+            $this->startPeriodic($task);
+        }
+        foreach ($this->longLivedTasks as $task) {
+            Coroutine::create(fn(): null => $this->guard($task->name, $task->run));
+        }
     }
 
     public function tick(): void
@@ -57,41 +69,50 @@ final class SwooleBackgroundTasks implements BackgroundTasksInterface
     public function stop(): void
     {
         $this->stopping = true;
-        $this->sweepWakeup?->push(true);
-        $this->daemon?->stop();
+
+        foreach ($this->wakeups as $wakeup) {
+            $wakeup->push(true);
+        }
+        foreach ($this->longLivedTasks as $task) {
+            if ($task->stop !== null) {
+                ($task->stop)();
+            }
+        }
     }
 
-    private function startSweep(): void
+    private function startPeriodic(PeriodicTask $task): void
     {
-        if ($this->sweeper === null) {
-            return;
-        }
+        $wakeup = new Channel(1);
+        $this->wakeups[] = $wakeup;
 
-        $sweeper = $this->sweeper;
-        $wakeup = $this->sweepWakeup = new Channel(1);
-
-        Coroutine::create(function () use ($sweeper, $wakeup): void {
+        Coroutine::create(function () use ($task, $wakeup): void {
             while (!$this->stopping) {
                 // pop() returns the pushed value on shutdown, or false after the interval elapses.
-                if ($wakeup->pop(RetentionSweeper::DEFAULT_INTERVAL_SECONDS) !== false) {
+                if ($wakeup->pop($task->intervalSeconds) !== false) {
                     break;
                 }
 
-                $sweeper->sweep();
+                $this->guard($task->name, $task->run);
             }
         });
     }
 
-    private function startDaemon(): void
-    {
-        if ($this->daemon === null) {
-            return;
+    /**
+     * Run a task body, logging any failure by name so an unhandled exception does not silently kill the coroutine.
+     *
+     * @param Closure(): void $run
+     */
+    private function guard(
+        string $name,
+        Closure $run,
+    ): void {
+        try {
+            $run();
+        } catch (Throwable $e) {
+            $this->logger?->error(
+                sprintf('The "%s" background task failed.', $name),
+                ExceptionLogging::makeLogContext($e),
+            );
         }
-
-        $daemon = $this->daemon;
-
-        Coroutine::create(static function () use ($daemon): void {
-            $daemon->run();
-        });
     }
 }

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -17,7 +17,6 @@ use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Server\Backend\ResettableInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionSweeper;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Metrics\File\SnapshotPublisher;
@@ -96,9 +95,8 @@ class PcntlServerRunner implements ServerRunnerInterface
         private readonly ?OperationRollupCoordinator $operationRollup = null,
         private readonly ?WritableLdapBackendInterface $backend = null,
         BackgroundTasksInterface $backgroundTasks = new PcntlBackgroundTasks(
-            makeSweeper: null,
-            makeDaemon: null,
-            sweepIntervalSeconds: RetentionSweeper::DEFAULT_INTERVAL_SECONDS,
+            periodicTasks: [],
+            longLivedTasks: [],
         ),
     ) {
         if (!extension_loaded('pcntl') || !extension_loaded('posix')) {

--- a/src/FreeDSx/Ldap/Server/ServerRunner/SwooleServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/SwooleServerRunner.php
@@ -85,7 +85,10 @@ class SwooleServerRunner implements CoroutineServerRunnerInterface
         private readonly SocketServerFactory $socketServerFactory,
         Closure $protocolFactoryProvider,
         private readonly MetricsRecorderInterface $metricsRecorder = new NullMetricsRecorder(),
-        private readonly BackgroundTasksInterface $backgroundTasks = new SwooleBackgroundTasks(),
+        private readonly BackgroundTasksInterface $backgroundTasks = new SwooleBackgroundTasks(
+            periodicTasks: [],
+            longLivedTasks: [],
+        ),
     ) {
         if (!extension_loaded('swoole')) {
             throw new RuntimeException(

--- a/src/FreeDSx/Ldap/Sync/Consumer/LdapReplica.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/LdapReplica.php
@@ -39,6 +39,8 @@ use Throwable;
  */
 final class LdapReplica
 {
+    public const TASK_NAME = 'replica-sync';
+
     private bool $stopping = false;
 
     private ?SyncRepl $activeSync = null;

--- a/src/FreeDSx/Ldap/Sync/Consumer/LdapReplica.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/LdapReplica.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Sync\Consumer;
 use FreeDSx\Ldap\Exception\CancelRequestException;
 use FreeDSx\Ldap\ReplicaConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
 use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
 use FreeDSx\Ldap\Server\Clock\Sleeper\CoroutineSleeper;
 use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
@@ -60,6 +61,7 @@ final class LdapReplica
         EntryStorageInterface $storage,
         ?LoggerInterface $logger = null,
         ?PrimaryConnectionFactory $connectionFactory = null,
+        ?ReplicaPasswordStateStoreInterface $passwordStateStore = null,
     ): self {
         return self::create(
             $config,
@@ -68,6 +70,7 @@ final class LdapReplica
             new PcntlShutdownSignals(),
             $logger,
             $connectionFactory,
+            $passwordStateStore,
         );
     }
 
@@ -80,6 +83,7 @@ final class LdapReplica
         ?LoggerInterface $logger = null,
         ?ShutdownSignalsInterface $signals = new SwooleShutdownSignals(),
         ?PrimaryConnectionFactory $connectionFactory = null,
+        ?ReplicaPasswordStateStoreInterface $passwordStateStore = null,
     ): self {
         return self::create(
             $config,
@@ -88,6 +92,7 @@ final class LdapReplica
             $signals,
             $logger,
             $connectionFactory,
+            $passwordStateStore,
         );
     }
 
@@ -140,14 +145,19 @@ final class LdapReplica
         ?ShutdownSignalsInterface $signals,
         ?LoggerInterface $logger,
         ?PrimaryConnectionFactory $connectionFactory = null,
+        ?ReplicaPasswordStateStoreInterface $passwordStateStore = null,
     ): self {
         // listen() must not time out its blocking read, or the persist phase would abort each interval.
         $config->getPrimary()
             ->setTimeoutRead(-1);
 
+        $applier = new VerbatimStorageApplier($storage);
+
         return new self(
             connectionFactory: $connectionFactory ?? new PrimaryConnectionFactory($config),
-            applier: new VerbatimStorageApplier($storage),
+            applier: $passwordStateStore !== null
+                ? new ReconcilingChangeApplier($applier, $passwordStateStore)
+                : $applier,
             checkpoint: $config->getCheckpoint(),
             sleeper: $sleeper,
             signals: $signals,

--- a/src/FreeDSx/Ldap/Sync/Consumer/LdapReplica.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/LdapReplica.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Sync\Consumer;
 
-use Closure;
 use FreeDSx\Ldap\Exception\CancelRequestException;
-use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\ReplicaConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
@@ -45,11 +43,8 @@ final class LdapReplica
 
     private ?SyncRepl $activeSync = null;
 
-    /**
-     * @param Closure(): SyncRepl $connect opens a fresh, authenticated sync connection to the primary
-     */
     public function __construct(
-        private readonly Closure $connect,
+        private readonly PrimaryConnectionFactory $connectionFactory,
         private readonly ChangeApplierInterface $applier,
         private readonly ReplicationCheckpointInterface $checkpoint,
         private readonly SleeperInterface $sleeper,
@@ -62,6 +57,7 @@ final class LdapReplica
         ReplicaConfig $config,
         EntryStorageInterface $storage,
         ?LoggerInterface $logger = null,
+        ?PrimaryConnectionFactory $connectionFactory = null,
     ): self {
         return self::create(
             $config,
@@ -69,6 +65,7 @@ final class LdapReplica
             new BlockingSleeper(),
             new PcntlShutdownSignals(),
             $logger,
+            $connectionFactory,
         );
     }
 
@@ -80,6 +77,7 @@ final class LdapReplica
         EntryStorageInterface $storage,
         ?LoggerInterface $logger = null,
         ?ShutdownSignalsInterface $signals = new SwooleShutdownSignals(),
+        ?PrimaryConnectionFactory $connectionFactory = null,
     ): self {
         return self::create(
             $config,
@@ -87,6 +85,7 @@ final class LdapReplica
             new CoroutineSleeper(),
             $signals,
             $logger,
+            $connectionFactory,
         );
     }
 
@@ -138,13 +137,14 @@ final class LdapReplica
         SleeperInterface $sleeper,
         ?ShutdownSignalsInterface $signals,
         ?LoggerInterface $logger,
+        ?PrimaryConnectionFactory $connectionFactory = null,
     ): self {
         // listen() must not time out its blocking read, or the persist phase would abort each interval.
         $config->getPrimary()
             ->setTimeoutRead(-1);
 
         return new self(
-            connect: static fn(): SyncRepl => self::connect($config),
+            connectionFactory: $connectionFactory ?? new PrimaryConnectionFactory($config),
             applier: new VerbatimStorageApplier($storage),
             checkpoint: $config->getCheckpoint(),
             sleeper: $sleeper,
@@ -154,25 +154,9 @@ final class LdapReplica
         );
     }
 
-    private static function connect(ReplicaConfig $config): SyncRepl
-    {
-        $client = new LdapClient($config->getPrimary());
-
-        if ($config->getUseStartTls()) {
-            $client->startTls();
-        }
-
-        $bind = $config->getBind();
-        if ($bind !== null) {
-            $client->sendAndReceive($bind);
-        }
-
-        return $client->syncRepl($config->getFilter());
-    }
-
     private function sync(): void
     {
-        $syncRepl = ($this->connect)();
+        $syncRepl = $this->connectionFactory->connectSyncRepl();
         $syncRepl
             ->useCookie($this->checkpoint->read())
             ->useCookieHandler($this->persistCookie(...))

--- a/src/FreeDSx/Ldap/Sync/Consumer/PrimaryConnectionFactory.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/PrimaryConnectionFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Sync\Consumer;
+
+use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Ldap\ReplicaConfig;
+use FreeDSx\Ldap\Sync\SyncRepl;
+
+/**
+ * Opens an authenticated connection to the primary using the replica's sync identity (StartTLS then bind).
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+readonly class PrimaryConnectionFactory
+{
+    public function __construct(private ReplicaConfig $config) {}
+
+    public function connectLdapClient(): LdapClient
+    {
+        $client = new LdapClient($this->config->getPrimary());
+
+        if ($this->config->getUseStartTls()) {
+            $client->startTls();
+        }
+
+        $bind = $this->config->getBind();
+        if ($bind !== null) {
+            $client->sendAndReceive($bind);
+        }
+
+        return $client;
+    }
+
+    public function connectSyncRepl(): SyncRepl
+    {
+        return $this->connectLdapClient()
+            ->syncRepl($this->config->getFilter());
+    }
+}

--- a/src/FreeDSx/Ldap/Sync/Consumer/ReconcilingChangeApplier.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/ReconcilingChangeApplier.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Sync\Consumer;
+
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
+use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Session;
+
+/**
+ * Wraps an applier to drop a subject's replica-local password-policy state once the primary's authoritative entry
+ * supersedes it, so the entry becomes the single source of truth.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+readonly class ReconcilingChangeApplier implements ChangeApplierInterface
+{
+    public function __construct(
+        private ChangeApplierInterface $baseApplier,
+        private ReplicaPasswordStateStoreInterface $passwordStateStore,
+    ) {}
+
+    public function beginRefresh(): void
+    {
+        $this->baseApplier->beginRefresh();
+    }
+
+    public function apply(
+        SyncEntryResult $result,
+        Session $session,
+    ): void {
+        $this->baseApplier->apply($result, $session);
+
+        // Only an add or modify carries authoritative state that can supersede local accumulation; present is a no-op
+        // and a delete drops the subject, whose local state cascades with the entry row.
+        if (!$result->isAdd() && !$result->isModify()) {
+            return;
+        }
+
+        $this->passwordStateStore->discardIfSuperseded(
+            $result->getEntry()->getDn()->normalize(),
+            UserPasswordState::fromEntry($result->getEntry()),
+        );
+    }
+
+    public function reconcile(): void
+    {
+        $this->baseApplier->reconcile();
+    }
+}

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -307,6 +307,7 @@ final class LdapBackendStorageCommand extends Command
                 $password,
                 [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION],
             );
+            $cleanup->exec('DROP TABLE IF EXISTS ldap_replica_pwpolicy_state');
             $cleanup->exec('DROP TABLE IF EXISTS entry_attribute_trigrams');
             $cleanup->exec('DROP TABLE IF EXISTS entry_attribute_values');
             $cleanup->exec('DROP TABLE IF EXISTS entries');

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -374,6 +374,7 @@ final class LdapServerCommand extends Command
                 $password,
                 [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION],
             );
+            $cleanup->exec('DROP TABLE IF EXISTS ldap_replica_pwpolicy_state');
             $cleanup->exec('DROP TABLE IF EXISTS entry_attribute_values');
             $cleanup->exec('DROP TABLE IF EXISTS entries');
             unset($cleanup);

--- a/tests/unit/Server/Backend/Storage/Adapter/PdoReplicaPasswordStateStoreTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/PdoReplicaPasswordStateStoreTest.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SqliteDialect;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\SharedPdoConnectionProvider;
@@ -24,6 +25,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\PdoStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqliteFilterTranslator;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
 use PDO;
 use PHPUnit\Framework\TestCase;
 
@@ -176,6 +178,52 @@ final class PdoReplicaPasswordStateStoreTest extends TestCase
             2,
             $pending[0]->sequence,
         );
+    }
+
+    public function test_discard_drops_local_state_when_the_entry_is_authoritatively_locked(): void
+    {
+        $this->applyFailure('20260520120000Z');
+
+        $this->subject->discardIfSuperseded(
+            new Dn(self::DN),
+            new UserPasswordState(accountLockedAt: GeneralizedTime::parse('20260520120500Z')),
+        );
+
+        self::assertTrue($this->subject->load(new Dn(self::DN))->isEmpty());
+    }
+
+    public function test_discard_drops_local_state_when_a_success_is_newer_than_the_failure(): void
+    {
+        $this->applyFailure('20260520120000Z');
+
+        $this->subject->discardIfSuperseded(
+            new Dn(self::DN),
+            new UserPasswordState(lastSuccess: GeneralizedTime::parse('20260520120500Z')),
+        );
+
+        self::assertTrue($this->subject->load(new Dn(self::DN))->isEmpty());
+    }
+
+    public function test_discard_keeps_sub_threshold_state_the_entry_has_not_reflected(): void
+    {
+        $this->applyFailure('20260520120000Z');
+
+        $this->subject->discardIfSuperseded(
+            new Dn(self::DN),
+            new UserPasswordState(),
+        );
+
+        self::assertFalse($this->subject->load(new Dn(self::DN))->isEmpty());
+    }
+
+    public function test_discard_is_a_noop_for_an_unknown_subject(): void
+    {
+        $this->subject->discardIfSuperseded(
+            new Dn(self::DN),
+            new UserPasswordState(accountLockedAt: GeneralizedTime::parse('20260520120500Z')),
+        );
+
+        self::assertTrue($this->subject->load(new Dn(self::DN))->isEmpty());
     }
 
     private function applyFailure(string $time): void

--- a/tests/unit/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwardWorkerTest.php
+++ b/tests/unit/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwardWorkerTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward;
+
+use FreeDSx\Ldap\Entry\Change;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Exception\ForwardStateException;
+use FreeDSx\Ldap\Operation\Request\ForwardPasswordPolicyStateRequest;
+use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\ForwardStateSenderInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\PasswordPolicyForwardWorker;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\InMemoryReplicaPasswordStateStore;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class PasswordPolicyForwardWorkerTest extends TestCase
+{
+    private const DN = 'cn=foo,dc=example,dc=com';
+
+    private InMemoryReplicaPasswordStateStore $store;
+
+    private ForwardStateSenderInterface&MockObject $sender;
+
+    /**
+     * @var list<ForwardPasswordPolicyStateRequest>
+     */
+    private array $sent;
+
+    private PasswordPolicyForwardWorker $subject;
+
+    protected function setUp(): void
+    {
+        $this->store = new InMemoryReplicaPasswordStateStore();
+        $this->sent = [];
+        $this->sender = $this->createMock(ForwardStateSenderInterface::class);
+        $this->subject = new PasswordPolicyForwardWorker(
+            $this->store,
+            $this->sender,
+        );
+    }
+
+    public function test_it_forwards_pending_state_and_advances_the_watermark(): void
+    {
+        $this->recordSends();
+        $this->seedFailure('20260520120000Z');
+
+        $forwarded = $this->subject->forwardOnce();
+
+        self::assertSame(
+            1,
+            $forwarded,
+        );
+        self::assertCount(
+            1,
+            $this->sent,
+        );
+        self::assertSame(
+            self::DN,
+            $this->sent[0]->getDn()->toString(),
+        );
+        self::assertSame(
+            ['20260520120000Z'],
+            array_map(
+                static fn($time): string => GeneralizedTime::format($time),
+                $this->sent[0]->getFailureTimes(),
+            ),
+        );
+        self::assertSame(
+            [],
+            $this->store->listUnforwarded(),
+        );
+    }
+
+    public function test_it_drains_every_pending_subject(): void
+    {
+        $this->recordSends();
+        $this->seedFailure('20260520120000Z', 'cn=a,dc=example,dc=com');
+        $this->seedFailure('20260520120000Z', 'cn=b,dc=example,dc=com');
+
+        self::assertSame(
+            2,
+            $this->subject->forwardOnce(),
+        );
+        self::assertSame(
+            [],
+            $this->store->listUnforwarded(),
+        );
+    }
+
+    public function test_a_send_failure_leaves_the_subject_pending(): void
+    {
+        $this->sender
+            ->method('send')
+            ->willThrowException(new ForwardStateException('primary is unreachable'));
+        $this->seedFailure('20260520120000Z');
+
+        $this->expectException(ForwardStateException::class);
+
+        try {
+            $this->subject->forwardOnce();
+        } finally {
+            self::assertCount(
+                1,
+                $this->store->listUnforwarded(),
+            );
+        }
+    }
+
+    private function recordSends(): void
+    {
+        $this->sender
+            ->method('send')
+            ->willReturnCallback(function (ForwardPasswordPolicyStateRequest $request): void {
+                $this->sent[] = $request;
+            });
+    }
+
+    private function seedFailure(
+        string $time,
+        string $dn = self::DN,
+    ): void {
+        $this->store->atomicMutate(
+            new Dn($dn),
+            static fn(): OperationalChanges => OperationalChanges::of(Change::replace(
+                PasswordPolicyOid::NAME_PWD_FAILURE_TIME,
+                $time,
+            )),
+        );
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwardWorkerTest.php
+++ b/tests/unit/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwardWorkerTest.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Exception\ForwardStateException;
 use FreeDSx\Ldap\Operation\Request\ForwardPasswordPolicyStateRequest;
 use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\ForwardStateSenderInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\PasswordPolicyForwardWorker;
@@ -39,16 +40,32 @@ final class PasswordPolicyForwardWorkerTest extends TestCase
      */
     private array $sent;
 
+    /**
+     * @var list<float>
+     */
+    private array $slept;
+
     private PasswordPolicyForwardWorker $subject;
 
     protected function setUp(): void
     {
         $this->store = new InMemoryReplicaPasswordStateStore();
         $this->sent = [];
+        $this->slept = [];
         $this->sender = $this->createMock(ForwardStateSenderInterface::class);
+
+        // Stop after each sleep so run() executes exactly one drain iteration per test.
+        $sleeper = $this->createMock(SleeperInterface::class);
+        $sleeper->method('sleep')
+            ->willReturnCallback(function (float $seconds): void {
+                $this->slept[] = $seconds;
+                $this->subject->stop();
+            });
+
         $this->subject = new PasswordPolicyForwardWorker(
             $this->store,
             $this->sender,
+            $sleeper,
         );
     }
 
@@ -117,6 +134,46 @@ final class PasswordPolicyForwardWorkerTest extends TestCase
                 $this->store->listUnforwarded(),
             );
         }
+    }
+
+    public function test_run_drains_then_sleeps_the_poll_interval(): void
+    {
+        $this->recordSends();
+        $this->seedFailure('20260520120000Z');
+
+        $this->subject->run();
+
+        self::assertCount(
+            1,
+            $this->sent,
+        );
+        self::assertSame(
+            [PasswordPolicyForwardWorker::DEFAULT_INTERVAL_SECONDS],
+            $this->slept,
+        );
+        self::assertSame(
+            [],
+            $this->store->listUnforwarded(),
+        );
+    }
+
+    public function test_run_backs_off_and_leaves_state_pending_on_a_delivery_failure(): void
+    {
+        $this->sender
+            ->method('send')
+            ->willThrowException(new ForwardStateException('primary is unreachable'));
+        $this->seedFailure('20260520120000Z');
+
+        $this->subject->run();
+
+        self::assertSame(
+            [1.0],
+            $this->slept,
+        );
+        self::assertCount(
+            1,
+            $this->store->listUnforwarded(),
+        );
     }
 
     private function recordSends(): void

--- a/tests/unit/Server/PasswordPolicy/Replica/InMemoryReplicaPasswordStateStoreTest.php
+++ b/tests/unit/Server/PasswordPolicy/Replica/InMemoryReplicaPasswordStateStoreTest.php
@@ -15,9 +15,11 @@ namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy\Replica;
 
 use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\InMemoryReplicaPasswordStateStore;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
 use PHPUnit\Framework\TestCase;
 
 final class InMemoryReplicaPasswordStateStoreTest extends TestCase
@@ -163,6 +165,64 @@ final class InMemoryReplicaPasswordStateStoreTest extends TestCase
             2,
             $pending[0]->sequence,
         );
+    }
+
+    public function test_discard_drops_local_state_when_the_entry_is_authoritatively_locked(): void
+    {
+        $this->applyFailure('20260520120000Z');
+
+        $this->subject->discardIfSuperseded(
+            new Dn(self::DN),
+            new UserPasswordState(accountLockedAt: GeneralizedTime::parse('20260520120500Z')),
+        );
+
+        self::assertTrue($this->subject->load(new Dn(self::DN))->isEmpty());
+    }
+
+    public function test_discard_drops_local_state_when_a_success_is_newer_than_the_failure(): void
+    {
+        $this->applyFailure('20260520120000Z');
+
+        $this->subject->discardIfSuperseded(
+            new Dn(self::DN),
+            new UserPasswordState(lastSuccess: GeneralizedTime::parse('20260520120500Z')),
+        );
+
+        self::assertTrue($this->subject->load(new Dn(self::DN))->isEmpty());
+    }
+
+    public function test_discard_keeps_sub_threshold_state_the_entry_has_not_reflected(): void
+    {
+        $this->applyFailure('20260520120000Z');
+
+        $this->subject->discardIfSuperseded(
+            new Dn(self::DN),
+            new UserPasswordState(),
+        );
+
+        self::assertFalse($this->subject->load(new Dn(self::DN))->isEmpty());
+    }
+
+    public function test_discard_keeps_local_state_when_the_success_predates_the_failure(): void
+    {
+        $this->applyFailure('20260520120000Z');
+
+        $this->subject->discardIfSuperseded(
+            new Dn(self::DN),
+            new UserPasswordState(lastSuccess: GeneralizedTime::parse('20260520115500Z')),
+        );
+
+        self::assertFalse($this->subject->load(new Dn(self::DN))->isEmpty());
+    }
+
+    public function test_discard_is_a_noop_for_an_unknown_subject(): void
+    {
+        $this->subject->discardIfSuperseded(
+            new Dn(self::DN),
+            new UserPasswordState(accountLockedAt: GeneralizedTime::parse('20260520120500Z')),
+        );
+
+        self::assertTrue($this->subject->load(new Dn(self::DN))->isEmpty());
     }
 
     private function applyFailure(string $time): void

--- a/tests/unit/Sync/Consumer/LdapReplicaTest.php
+++ b/tests/unit/Sync/Consumer/LdapReplicaTest.php
@@ -22,6 +22,7 @@ use FreeDSx\Ldap\Server\Process\Signals\ShutdownSignalsInterface;
 use FreeDSx\Ldap\Sync\Consumer\ChangeApplierInterface;
 use FreeDSx\Ldap\Sync\Consumer\Checkpoint\InMemoryReplicationCheckpoint;
 use FreeDSx\Ldap\Sync\Consumer\LdapReplica;
+use FreeDSx\Ldap\Sync\Consumer\PrimaryConnectionFactory;
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
 use FreeDSx\Ldap\Sync\Session;
 use FreeDSx\Ldap\Sync\SyncRepl;
@@ -87,8 +88,12 @@ final class LdapReplicaTest extends TestCase
                 return $this->syncRepl;
             });
 
+        $connectionFactory = $this->createMock(PrimaryConnectionFactory::class);
+        $connectionFactory->method('connectSyncRepl')
+            ->willReturn($this->syncRepl);
+
         $this->subject = new LdapReplica(
-            connect: fn(): SyncRepl => $this->syncRepl,
+            connectionFactory: $connectionFactory,
             applier: $this->applier,
             checkpoint: $this->checkpoint,
             sleeper: $this->sleeper,

--- a/tests/unit/Sync/Consumer/ReconcilingChangeApplierTest.php
+++ b/tests/unit/Sync/Consumer/ReconcilingChangeApplierTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Sync\Consumer;
+
+use FreeDSx\Ldap\Control\Sync\SyncStateControl;
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Search\Result\EntryResult;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
+use FreeDSx\Ldap\Sync\Consumer\ChangeApplierInterface;
+use FreeDSx\Ldap\Sync\Consumer\ReconcilingChangeApplier;
+use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Session;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class ReconcilingChangeApplierTest extends TestCase
+{
+    private const DN = 'cn=alice,dc=example,dc=com';
+
+    private ChangeApplierInterface&MockObject $baseApplier;
+
+    private ReplicaPasswordStateStoreInterface&MockObject $passwordStateStore;
+
+    private ReconcilingChangeApplier $subject;
+
+    protected function setUp(): void
+    {
+        $this->baseApplier = $this->createMock(ChangeApplierInterface::class);
+        $this->passwordStateStore = $this->createMock(ReplicaPasswordStateStoreInterface::class);
+        $this->subject = new ReconcilingChangeApplier(
+            $this->baseApplier,
+            $this->passwordStateStore,
+        );
+    }
+
+    public function test_begin_refresh_delegates_to_the_base_applier(): void
+    {
+        $this->baseApplier
+            ->expects(self::once())
+            ->method('beginRefresh');
+
+        $this->subject->beginRefresh();
+    }
+
+    public function test_reconcile_delegates_to_the_base_applier(): void
+    {
+        $this->baseApplier
+            ->expects(self::once())
+            ->method('reconcile');
+
+        $this->subject->reconcile();
+    }
+
+    public function test_apply_delegates_the_result_to_the_base_applier(): void
+    {
+        $result = $this->syncResult(
+            SyncStateControl::STATE_ADD,
+            $this->entry(),
+        );
+        $session = $this->session();
+
+        $this->baseApplier
+            ->expects(self::once())
+            ->method('apply')
+            ->with(
+                $result,
+                $session,
+            );
+
+        $this->subject->apply(
+            $result,
+            $session,
+        );
+    }
+
+    public function test_an_add_reconciles_the_local_state_against_the_entry(): void
+    {
+        $this->passwordStateStore
+            ->expects(self::once())
+            ->method('discardIfSuperseded')
+            ->with(
+                self::callback(static fn(Dn $dn): bool => $dn->toString() === (new Dn(self::DN))->normalize()->toString()),
+                self::callback(static fn(UserPasswordState $state): bool => $state->isLocked()),
+            );
+
+        $this->subject->apply(
+            $this->syncResult(
+                SyncStateControl::STATE_ADD,
+                $this->lockedEntry(),
+            ),
+            $this->session(),
+        );
+    }
+
+    public function test_a_modify_reconciles_the_local_state_against_the_entry(): void
+    {
+        $this->passwordStateStore
+            ->expects(self::once())
+            ->method('discardIfSuperseded');
+
+        $this->subject->apply(
+            $this->syncResult(
+                SyncStateControl::STATE_MODIFY,
+                $this->lockedEntry(),
+            ),
+            $this->session(),
+        );
+    }
+
+    public function test_a_present_marker_does_not_reconcile(): void
+    {
+        $this->passwordStateStore
+            ->expects(self::never())
+            ->method('discardIfSuperseded');
+
+        $this->subject->apply(
+            $this->syncResult(
+                SyncStateControl::STATE_PRESENT,
+                $this->entry(),
+            ),
+            $this->session(),
+        );
+    }
+
+    public function test_a_delete_does_not_reconcile_and_leaves_orphan_cleanup_to_storage(): void
+    {
+        $this->passwordStateStore
+            ->expects(self::never())
+            ->method('discardIfSuperseded');
+
+        $this->subject->apply(
+            $this->syncResult(
+                SyncStateControl::STATE_DELETE,
+                $this->entry(),
+            ),
+            $this->session(),
+        );
+    }
+
+    private function entry(): Entry
+    {
+        return new Entry(
+            self::DN,
+            new Attribute('cn', 'alice'),
+        );
+    }
+
+    private function lockedEntry(): Entry
+    {
+        return new Entry(
+            self::DN,
+            new Attribute('cn', 'alice'),
+            new Attribute(
+                PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME,
+                '20260520120000Z',
+            ),
+        );
+    }
+
+    private function syncResult(
+        int $state,
+        Entry $entry,
+    ): SyncEntryResult {
+        $message = new LdapMessageResponse(
+            1,
+            new SearchResultEntry($entry),
+            new SyncStateControl(
+                $state,
+                'uuid-' . $entry->getDn()->toString(),
+            ),
+        );
+
+        return new SyncEntryResult(new EntryResult($message));
+    }
+
+    private function session(): Session
+    {
+        return new Session(
+            Session::MODE_LISTEN,
+            null,
+        );
+    }
+}


### PR DESCRIPTION
This closes the long tail of forwarding password policy state from the replica to the primary. The original state of the replica was not great, but now it seems fairly solid:

1. Replicas maintain local password policy state. The state is checked between the current state of the entry and the local password policy state. Worse case wins.
2. The state is forwarded to the upstream primary in a long lived process with retries / backoffs / sequence markers for ordering / race conditions.
3. The primary reconciles the changes (from 1 or many replicas), and it makes its way back to the replica (and any other replicas) via SyncRepl.
4. The replica reconciles its own local password policy state during its SyncRepl process to determine if the local state should be flushed.

The forwarding is locked down to a specific privileged op that must be granted to a subject via ACL. This is distinct from other implementations that just do a straight up modify request to the primary (assumes an account in use configured to overwrite system attributes). So this will be noted in interoperability docs, because forwards won't work to a server that doesn't have the custom extended operation.

Still need to update the docs and add a real integration test + whatever followups may be needed after I poke at it some more.