### PR TITLE
[1.0.0] Consolidate server queue writing to one spot (Part 1)

### DIFF
--- a/src/FreeDSx/Ldap/Container/HandlerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/HandlerContainerProvider.php
@@ -71,33 +71,29 @@ final class HandlerContainerProvider implements ContainerProviderInterface
         return new ProtocolHandlerFactoryMap([
             HandlerId::Abandon->value => static fn(): ServerProtocolHandlerInterface
                 => new ServerAbandonHandler(),
-            HandlerId::Cancel->value => static fn(HandlerContext $context): ServerProtocolHandlerInterface
-                => new ServerCancelHandler($context->queue),
-            HandlerId::WhoAmI->value => static fn(HandlerContext $context): ServerProtocolHandlerInterface
-                => new ServerWhoAmIHandler($context->queue),
+            HandlerId::Cancel->value => static fn(): ServerProtocolHandlerInterface
+                => new ServerCancelHandler(),
+            HandlerId::WhoAmI->value => static fn(): ServerProtocolHandlerInterface
+                => new ServerWhoAmIHandler(),
             HandlerId::PasswordModify->value => fn(HandlerContext $context): ServerProtocolHandlerInterface
                 => $this->makePasswordModifyHandler($container, $context),
-            HandlerId::PasswordPolicyForward->value => fn(HandlerContext $context): ServerProtocolHandlerInterface
-                => $this->makeForwardHandler($container, $context),
+            HandlerId::PasswordPolicyForward->value => fn(): ServerProtocolHandlerInterface
+                => $this->makeForwardHandler($container),
             HandlerId::StartTls->value => static fn(HandlerContext $context): ServerProtocolHandlerInterface
                 => new ServerStartTlsHandler(
                     options: $container->get(ServerOptions::class),
-                    queue: $context->queue,
+                    connection: $context->queue,
                     eventLogger: $context->eventLogger,
                 ),
-            HandlerId::UnsupportedExtended->value => static fn(HandlerContext $context): ServerProtocolHandlerInterface
-                => new ServerUnsupportedExtendedHandler($context->queue),
-            HandlerId::RootDse->value => fn(HandlerContext $context): ServerProtocolHandlerInterface
-                => $this->makeRootDseHandler($container, $context),
-            HandlerId::Subschema->value => static fn(HandlerContext $context): ServerProtocolHandlerInterface
-                => new ServerSubschemaHandler(
-                    options: $container->get(ServerOptions::class),
-                    queue: $context->queue,
-                ),
-            HandlerId::Monitor->value => static fn(HandlerContext $context): ServerProtocolHandlerInterface
+            HandlerId::UnsupportedExtended->value => static fn(): ServerProtocolHandlerInterface
+                => new ServerUnsupportedExtendedHandler(),
+            HandlerId::RootDse->value => fn(): ServerProtocolHandlerInterface
+                => $this->makeRootDseHandler($container),
+            HandlerId::Subschema->value => static fn(): ServerProtocolHandlerInterface
+                => new ServerSubschemaHandler($container->get(ServerOptions::class)),
+            HandlerId::Monitor->value => static fn(): ServerProtocolHandlerInterface
                 => new ServerMonitorHandler(
                     options: $container->get(ServerOptions::class),
-                    queue: $context->queue,
                     snapshots: $container->get(MetricsSnapshotProvider::class),
                 ),
             HandlerId::Paging->value => fn(HandlerContext $context, ?SearchLimits $limits): ServerProtocolHandlerInterface
@@ -105,9 +101,9 @@ final class HandlerContainerProvider implements ContainerProviderInterface
             HandlerId::Sync->value => fn(HandlerContext $context, ?SearchLimits $limits): ServerProtocolHandlerInterface
                 => $this->makeSyncHandler($container, $context, $limits),
             HandlerId::Search->value => fn(HandlerContext $context, ?SearchLimits $limits): ServerProtocolHandlerInterface
-                => $this->makeSearchHandler($container, $context, $limits),
-            HandlerId::Unbind->value => static fn(HandlerContext $context): ServerProtocolHandlerInterface
-                => new ServerUnbindHandler($context->queue),
+                => $this->makeSearchHandler($container, $limits),
+            HandlerId::Unbind->value => static fn(): ServerProtocolHandlerInterface
+                => new ServerUnbindHandler(),
             HandlerId::Dispatch->value => fn(HandlerContext $context): ServerProtocolHandlerInterface
                 => $this->makeDispatchHandler($container, $context),
         ]);
@@ -120,7 +116,6 @@ final class HandlerContainerProvider implements ContainerProviderInterface
         $policyComponentFactory = $container->get(PasswordPolicyComponentFactory::class);
 
         return new ServerPasswordModifyHandler(
-            queue: $context->queue,
             service: new PasswordModifyService(
                 targetResolver: $container->get(PasswordModifyTargetResolver::class),
                 accessControl: $container->get(ServerOptions::class)->getAccessControl(),
@@ -135,33 +130,27 @@ final class HandlerContainerProvider implements ContainerProviderInterface
         );
     }
 
-    private function makeForwardHandler(
-        Container $container,
-        HandlerContext $context,
-    ): ServerProtocolHandlerInterface {
+    private function makeForwardHandler(Container $container): ServerProtocolHandlerInterface
+    {
         $backend = $container->get(HandlerFactoryInterface::class)->makeBackend();
         if (!$backend instanceof WritableLdapBackendInterface) {
-            return new ServerUnsupportedExtendedHandler($context->queue);
+            return new ServerUnsupportedExtendedHandler();
         }
 
         return new ServerPasswordPolicyForwardHandler(
-            queue: $context->queue,
             backend: $backend,
             policyResolver: $container->get(PasswordPolicyComponentFactory::class)->makeResolver(),
             engine: $container->get(PasswordPolicyEngine::class),
         );
     }
 
-    private function makeRootDseHandler(
-        Container $container,
-        HandlerContext $context,
-    ): ServerRootDseHandler {
+    private function makeRootDseHandler(Container $container): ServerRootDseHandler
+    {
         $handlerFactory = $container->get(HandlerFactoryInterface::class);
         $backend = $handlerFactory->makeBackend();
 
         return new ServerRootDseHandler(
             options: $container->get(ServerOptions::class),
-            queue: $context->queue,
             backend: $backend,
             rootDseHandler: $handlerFactory->makeRootDseHandler(),
             supportsSync: $this->syncJournalFor($container, $backend) !== null,
@@ -223,7 +212,6 @@ final class HandlerContainerProvider implements ContainerProviderInterface
         );
 
         return new ServerDispatchHandler(
-            queue: $context->queue,
             backend: $handlerFactory->makeBackend(),
             writeDispatcher: $policyWriteHandler !== null
                 ? $handlerFactory->makeWriteDispatcher($policyWriteHandler)
@@ -235,13 +223,11 @@ final class HandlerContainerProvider implements ContainerProviderInterface
 
     private function makeSearchHandler(
         Container $container,
-        HandlerContext $context,
         ?SearchLimits $searchLimits,
     ): ServerSearchHandler {
         $options = $container->get(ServerOptions::class);
 
         return new ServerSearchHandler(
-            queue: $context->queue,
             backend: $container->get(HandlerFactoryInterface::class)->makeBackend(),
             filterEvaluator: $options->getFilterEvaluator(),
             accessControl: $options->getAccessControl(),
@@ -258,7 +244,6 @@ final class HandlerContainerProvider implements ContainerProviderInterface
         $options = $container->get(ServerOptions::class);
 
         return new ServerPagingHandler(
-            queue: $context->queue,
             backend: $container->get(HandlerFactoryInterface::class)->makeBackend(),
             filterEvaluator: $options->getFilterEvaluator(),
             accessControl: $options->getAccessControl(),

--- a/src/FreeDSx/Ldap/Protocol/Queue/ConnectionControl.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/ConnectionControl.php
@@ -24,4 +24,6 @@ interface ConnectionControl
     public function isEncrypted(): bool;
 
     public function encrypt(): static;
+
+    public function close(): void;
 }

--- a/src/FreeDSx/Ldap/Protocol/Queue/ConnectionControl.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/ConnectionControl.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Queue;
+
+/**
+ * A narrow connection-lifecycle seam handlers use for post-write socket actions without the queue.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface ConnectionControl
+{
+    public function isEncrypted(): bool;
+
+    public function encrypt(): static;
+}

--- a/src/FreeDSx/Ldap/Protocol/Queue/Response/Cancellation.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/Response/Cancellation.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\Queue\Response;
 
+use FreeDSx\Ldap\Operation\Request\AbandonRequest;
+use FreeDSx\Ldap\Operation\Request\CancelRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 
 /**
@@ -39,6 +41,16 @@ final class Cancellation
     public function isSignalled(): bool
     {
         return $this->signal !== null;
+    }
+
+    public function isAbandoned(): bool
+    {
+        return $this->signal?->getRequest() instanceof AbandonRequest;
+    }
+
+    public function isCanceled(): bool
+    {
+        return $this->signal?->getRequest() instanceof CancelRequest;
     }
 
     public function signal(): ?LdapMessageRequest

--- a/src/FreeDSx/Ldap/Protocol/Queue/Response/Cancellation.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/Response/Cancellation.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Queue\Response;
+
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+
+/**
+ * The control channel between the response writer (which polls the queue) and a streaming producer
+ * (which reads the offered abandon/cancel signal after each yield).
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class Cancellation
+{
+    private ?LdapMessageRequest $signal = null;
+
+    /**
+     * The writer offers each poll result; nulls are ignored so a real signal is never overwritten.
+     */
+    public function offer(?LdapMessageRequest $signal): void
+    {
+        if ($signal !== null) {
+            $this->signal = $signal;
+        }
+    }
+
+    public function isSignalled(): bool
+    {
+        return $this->signal !== null;
+    }
+
+    public function signal(): ?LdapMessageRequest
+    {
+        return $this->signal;
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Queue/Response/QueueWriterConfig.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/Response/QueueWriterConfig.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Queue\Response;
+
+/**
+ * Tells the response writer how to drive a stream; defaults to the fully-batched, unpolled fast path.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class QueueWriterConfig
+{
+    /**
+     * @param int $signalInterval poll for a cancel/abandon signal every N messages; 0 disables it.
+     * @param bool $flushPerMessage flush the socket after each message instead of the default buffering.
+     */
+    public function __construct(
+        public int $signalInterval = 0,
+        public bool $flushPerMessage = false,
+    ) {}
+
+    public function mustFlushOrSignal(): bool
+    {
+        return $this->signalInterval > 0 || $this->flushPerMessage;
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Queue/Response/ResponseStream.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/Response/ResponseStream.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Queue\Response;
+
+use Closure;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+use Generator;
+
+/**
+ * The messages a handler wants written, plus the outcome resolved once they are drained.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ResponseStream
+{
+    /**
+     * @param iterable<LdapMessageResponse> $messages streamed to the socket in order.
+     * @param Closure(): OperationResult $outcome resolved after the stream is fully drained.
+     * @param QueueWriterConfig $writerConfig how the writer batches, flushes, and polls this stream.
+     * @param ?Cancellation $cancellation the writer offers polled signals here; the producer reads it.
+     * @param ?Closure(): void $onComplete run by the writer once the stream is drained and flushed.
+     */
+    private function __construct(
+        public iterable $messages,
+        private Closure $outcome,
+        public QueueWriterConfig $writerConfig = new QueueWriterConfig(),
+        public ?Cancellation $cancellation = null,
+        public ?Closure $onComplete = null,
+    ) {}
+
+    public function outcome(): OperationResult
+    {
+        return ($this->outcome)();
+    }
+
+    /**
+     * A response whose outcome is already known; the default writer config bulk-sends it.
+     *
+     * @param iterable<LdapMessageResponse> $messages
+     * @param ?Closure(): void $onComplete
+     */
+    public static function of(
+        iterable $messages,
+        OperationResult $outcome,
+        ?Closure $onComplete = null,
+    ): self {
+        return new self(
+            messages: $messages,
+            outcome: static fn(): OperationResult => $outcome,
+            onComplete: $onComplete,
+        );
+    }
+
+    /**
+     * A stepped streaming response whose outcome is resolved after draining.
+     *
+     * @param Generator<LdapMessageResponse> $messages
+     * @param Closure(): OperationResult $outcome
+     */
+    public static function streaming(
+        Generator $messages,
+        Closure $outcome,
+        QueueWriterConfig $writerConfig,
+        ?Cancellation $cancellation = null,
+    ): self {
+        return new self(
+            messages: $messages,
+            outcome: $outcome,
+            writerConfig: $writerConfig,
+            cancellation: $cancellation,
+        );
+    }
+
+    /**
+     * @param ?Closure(): void $onComplete
+     */
+    public static function none(
+        OperationResult $outcome,
+        ?Closure $onComplete = null,
+    ): self {
+        return self::of(
+            messages: [],
+            outcome: $outcome,
+            onComplete: $onComplete,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Queue/Response/ResponseStream.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/Response/ResponseStream.php
@@ -14,9 +14,15 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\Queue\Response;
 
 use Closure;
+use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Operation\Response\ResponseInterface;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\ConnectionControl;
 use FreeDSx\Ldap\Server\Operation\OperationResult;
 use Generator;
+
+use function array_map;
 
 /**
  * The messages a handler wants written, plus the outcome resolved once they are drained.
@@ -31,7 +37,8 @@ final readonly class ResponseStream
      * @param Closure(): OperationResult $outcome resolved after the stream is fully drained.
      * @param QueueWriterConfig $writerConfig how the writer batches, flushes, and polls this stream.
      * @param ?Cancellation $cancellation the writer offers polled signals here; the producer reads it.
-     * @param ?Closure(): void $onComplete run by the writer once the stream is drained and flushed.
+     * @param ?Closure(ConnectionControl): void $onComplete a post-write connection action the writer
+     *        runs once the stream is drained and flushed.
      */
     private function __construct(
         public iterable $messages,
@@ -47,25 +54,73 @@ final readonly class ResponseStream
     }
 
     /**
-     * A response whose outcome is already known; the default writer config bulk-sends it.
+     * A copy of this stream with a post-write connection action the writer runs after draining.
      *
-     * @param iterable<LdapMessageResponse> $messages
-     * @param ?Closure(): void $onComplete
+     * @param Closure(ConnectionControl): void $onComplete
      */
-    public static function of(
-        iterable $messages,
-        OperationResult $outcome,
-        ?Closure $onComplete = null,
-    ): self {
+    public function withOnComplete(Closure $onComplete): self
+    {
         return new self(
-            messages: $messages,
-            outcome: static fn(): OperationResult => $outcome,
-            onComplete: $onComplete,
+            $this->messages,
+            $this->outcome,
+            $this->writerConfig,
+            $this->cancellation,
+            $onComplete,
         );
     }
 
     /**
-     * A stepped streaming response whose outcome is resolved after draining.
+     * The message generator for a stepped stream; only a generator can be polled and flushed per message.
+     *
+     * @return Generator<LdapMessageResponse>
+     * @throws RuntimeException if the stream was not built for stepping via streaming().
+     */
+    public function generator(): Generator
+    {
+        if (!$this->messages instanceof Generator) {
+            throw new RuntimeException('A stepped response stream must carry a generator.');
+        }
+
+        return $this->messages;
+    }
+
+    /**
+     * A response whose outcome is already known; the default writer config bulk-sends it.
+     *
+     * @param iterable<LdapMessageResponse> $messages
+     */
+    public static function of(
+        iterable $messages,
+        OperationResult $outcome,
+    ): self {
+        return new self(
+            messages: $messages,
+            outcome: static fn(): OperationResult => $outcome,
+        );
+    }
+
+    /**
+     * One or more inner responses, each wrapped in an envelope addressed to the request's message ID.
+     */
+    public static function reply(
+        LdapMessageRequest $message,
+        OperationResult $outcome,
+        ResponseInterface ...$responses,
+    ): self {
+        $messageId = $message->getMessageId();
+
+        return self::of(
+            array_map(
+                static fn(ResponseInterface $response): LdapMessageResponse
+                    => new LdapMessageResponse($messageId, $response),
+                $responses,
+            ),
+            $outcome,
+        );
+    }
+
+    /**
+     * A streaming response whose outcome is resolved after draining; steps only when the config asks.
      *
      * @param Generator<LdapMessageResponse> $messages
      * @param Closure(): OperationResult $outcome
@@ -73,7 +128,7 @@ final readonly class ResponseStream
     public static function streaming(
         Generator $messages,
         Closure $outcome,
-        QueueWriterConfig $writerConfig,
+        QueueWriterConfig $writerConfig = new QueueWriterConfig(),
         ?Cancellation $cancellation = null,
     ): self {
         return new self(
@@ -84,17 +139,11 @@ final readonly class ResponseStream
         );
     }
 
-    /**
-     * @param ?Closure(): void $onComplete
-     */
-    public static function none(
-        OperationResult $outcome,
-        ?Closure $onComplete = null,
-    ): self {
+    public static function none(OperationResult $outcome): self
+    {
         return self::of(
-            messages: [],
-            outcome: $outcome,
-            onComplete: $onComplete,
+            [],
+            $outcome,
         );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/Queue/Response/ResponseWriter.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/Response/ResponseWriter.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\Queue\Response;
+
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
+
+use function count;
+
+/**
+ * Drains a handler's ResponseStream to the queue and resolves its outcome.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ResponseWriter
+{
+    public function __construct(private ServerQueue $queue) {}
+
+    public function write(
+        ResponseStream $stream,
+        int $messageId,
+    ): OperationResult {
+        if ($stream->writerConfig->mustFlushOrSignal()) {
+            $this->step(
+                $stream,
+                $messageId,
+            );
+        } else {
+            $this->queue->sendMessages($stream->messages);
+        }
+
+        // Post-write connection side effect (e.g. StartTLS encrypt) — the bytes are on the wire now.
+        if ($stream->onComplete !== null) {
+            ($stream->onComplete)($this->queue);
+        }
+
+        return $stream->outcome();
+    }
+
+    /**
+     * Walk the generator, flushing in batches and offering polled cancel signals at the configured interval.
+     */
+    private function step(
+        ResponseStream $stream,
+        int $messageId,
+    ): void {
+        $config = $stream->writerConfig;
+        // Flush per message for liveness, else batch up to the poll interval.
+        $flushEvery = $config->flushPerMessage
+            ? 1
+            : max(1, $config->signalInterval);
+        $chunk = [];
+        $sincePoll = 0;
+
+        // The producer reads the offered signal from the Cancellation token when foreach resumes it.
+        foreach ($stream->generator() as $message) {
+            $chunk[] = $message;
+            $sincePoll++;
+
+            if (count($chunk) >= $flushEvery) {
+                $this->queue->sendMessages($chunk);
+                $chunk = [];
+            }
+
+            if ($config->signalInterval > 0 && $sincePoll >= $config->signalInterval) {
+                $sincePoll = 0;
+                $stream->cancellation?->offer($this->queue->peekForCancelSignal($messageId));
+            }
+        }
+
+        if ($chunk !== []) {
+            $this->queue->sendMessages($chunk);
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Queue/ServerQueue.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/ServerQueue.php
@@ -42,7 +42,7 @@ use function strlen;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class ServerQueue extends LdapQueue
+class ServerQueue extends LdapQueue implements ConnectionControl
 {
     /**
      * @var LdapMessageRequest[]

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/SearchResultState.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/SearchResultState.php
@@ -14,17 +14,12 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Operation\ResultCode;
-use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 
 /**
  * Late-bound result code / diagnostic for a streaming search.
  */
 final class SearchResultState
 {
-    public bool $isAbandoned = false;
-
-    public ?LdapMessageRequest $cancelSignal = null;
-
     public int $entriesReturned = 0;
 
     public function __construct(

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAbandonHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerAbandonHandler.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -28,7 +28,7 @@ final class ServerAbandonHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): OperationResult {
-        return OperationOutcomeResult::succeeded();
+    ): ResponseStream {
+        return ResponseStream::none(OperationOutcomeResult::succeeded());
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerCancelHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerCancelHandler.php
@@ -13,15 +13,12 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
-use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -31,21 +28,14 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  */
 readonly class ServerCancelHandler implements ServerProtocolHandlerInterface
 {
-    public function __construct(private ServerQueue $queue) {}
-
-    /**
-     * {@inheritDoc}
-     * @throws EncoderException
-     */
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): OperationResult {
-        $this->queue->sendMessage(new LdapMessageResponse(
-            $message->getMessageId(),
+    ): ResponseStream {
+        return ResponseStream::reply(
+            $message,
+            OperationOutcomeResult::failed(ResultCode::NO_SUCH_OPERATION),
             new ExtendedResponse(new LdapResult(ResultCode::NO_SUCH_OPERATION)),
-        ));
-
-        return OperationOutcomeResult::failed(ResultCode::NO_SUCH_OPERATION);
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -22,7 +22,7 @@ use FreeDSx\Ldap\Operation\Request;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Operation\OperationType;
@@ -34,7 +34,6 @@ use FreeDSx\Ldap\Server\Backend\Write\WriteCommandFactory;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\Operation\CompareOperationResult;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Operation\WriteOperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
@@ -48,7 +47,6 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
     private ReadEntryControlHandler $readEntryControlHandler;
 
     public function __construct(
-        private ServerQueue $queue,
         private LdapBackendInterface $backend,
         private WriteOperationDispatcher $writeDispatcher,
         private AccessControlInterface $accessControl,
@@ -71,7 +69,7 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): OperationResult {
+    ): ResponseStream {
         $schemaViolations = new SchemaViolations();
         $request = $message->getRequest();
         $controls = $message->controls();
@@ -99,21 +97,23 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
     private function handleCompare(
         LdapMessageRequest $message,
         Request\CompareRequest $request,
-    ): OperationResult {
+    ): ResponseStream {
         $match = $this->backend->compare(
             $request->getDn(),
             $request->getFilter(),
         );
-        $this->queue->sendMessage($this->responseFactory->getStandardResponse(
-            $message,
-            $match
-                ? ResultCode::COMPARE_TRUE
-                : ResultCode::COMPARE_FALSE,
-        ));
 
-        return CompareOperationResult::completed(
-            $message,
-            $match,
+        return ResponseStream::of(
+            [$this->responseFactory->getStandardResponse(
+                $message,
+                $match
+                    ? ResultCode::COMPARE_TRUE
+                    : ResultCode::COMPARE_FALSE,
+            )],
+            CompareOperationResult::completed(
+                $message,
+                $match,
+            ),
         );
     }
 
@@ -127,7 +127,7 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
         ControlBag $controls,
         TokenInterface $token,
         SchemaViolations $schemaViolations,
-    ): OperationResult {
+    ): ResponseStream {
         $preRead = $this->readEntryControlHandler->preReadFor($request, $controls);
 
         $this->dispatchWrite(
@@ -139,17 +139,18 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
 
         $postRead = $this->readEntryControlHandler->postReadFor($request, $controls);
 
-        $this->queue->sendMessage($this->responseFactory->getStandardResponse(
-            $message,
-            ResultCode::SUCCESS,
-            '',
-            null,
-            ...$this->successControls($preRead, $postRead),
-        ));
-
-        return WriteOperationResult::success(
-            $message,
-            $schemaViolations,
+        return ResponseStream::of(
+            [$this->responseFactory->getStandardResponse(
+                $message,
+                ResultCode::SUCCESS,
+                '',
+                null,
+                ...$this->successControls($preRead, $postRead),
+            )],
+            WriteOperationResult::success(
+                $message,
+                $schemaViolations,
+            ),
         );
     }
 

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerMonitorHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerMonitorHandler.php
@@ -18,12 +18,10 @@ use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
 use FreeDSx\Ldap\Server\Metrics\Snapshot\MetricsSnapshot;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\ServerRunner\CoroutineServerRunnerInterface;
 use FreeDSx\Ldap\Server\ServerRunner\PcntlServerRunner;
 use FreeDSx\Ldap\Server\ServerRunner\SwooleServerRunner;
@@ -47,31 +45,24 @@ class ServerMonitorHandler implements ServerProtocolHandlerInterface
 
     public function __construct(
         private readonly ServerOptions $options,
-        private readonly ServerQueue $queue,
         private readonly MetricsSnapshotProvider $snapshots,
     ) {}
 
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): OperationResult {
+    ): ResponseStream {
         $entry = Entry::fromArray(
             self::DN,
             $this->attributes($this->snapshots->snapshot()),
         );
 
-        $this->queue->sendMessage(
-            new LdapMessageResponse(
-                $message->getMessageId(),
-                new SearchResultEntry($entry),
-            ),
-            new LdapMessageResponse(
-                $message->getMessageId(),
-                new SearchResultDone(ResultCode::SUCCESS),
-            ),
+        return ResponseStream::reply(
+            $message,
+            OperationOutcomeResult::succeeded(),
+            new SearchResultEntry($entry),
+            new SearchResultDone(ResultCode::SUCCESS),
         );
-
-        return OperationOutcomeResult::succeeded();
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -21,7 +21,8 @@ use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\Response\Cancellation;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
@@ -30,7 +31,6 @@ use FreeDSx\Ldap\Server\Paging\PagingRequestComparator;
 use FreeDSx\Ldap\Server\Paging\PagingResponse;
 use FreeDSx\Ldap\Server\RequestHistory;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Operation\SearchOperationResult;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -48,7 +48,6 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
     use MatchedDnAccessFilterTrait;
 
     public function __construct(
-        private readonly ServerQueue $queue,
         private readonly LdapBackendInterface $backend,
         private readonly FilterEvaluatorInterface $filterEvaluator,
         private readonly AccessControlInterface $accessControl,
@@ -65,7 +64,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): OperationResult {
+    ): ResponseStream {
         $pagingRequest = $this->findOrMakePagingRequest($message);
         $searchRequest = $this->getSearchRequestFromMessage($message);
 
@@ -144,14 +143,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
             $this->requestHistory->removePagingGenerator($pagingRequest->getNextCookie());
         }
 
-        $this->sendEntriesToClient(
-            $searchResult,
-            $message,
-            $this->queue,
-            ...$controls,
-        );
-
-        return $failure !== null
+        $outcome = $failure !== null
             ? SearchOperationResult::failure(
                 $message,
                 $failure,
@@ -160,6 +152,17 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
                 $message,
                 $entriesReturned,
             );
+
+        // A page is pre-collected and bounded, so it is bulk-sent without mid-page cancel polling.
+        return ResponseStream::of(
+            $this->buildResponseStream(
+                $searchResult,
+                $message->getMessageId(),
+                new Cancellation(),
+                ...$controls,
+            ),
+            $outcome,
+        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordModifyHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordModifyHandler.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
-use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
@@ -22,9 +21,7 @@ use FreeDSx\Ldap\Operation\Response\PasswordModifyResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\Operation\PasswordModifyOperationResult;
 use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyResult;
 use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyService;
@@ -32,56 +29,51 @@ use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
- * Adapts RFC 3062 Password Modify requests to {@see PasswordModifyService}: decode, delegate, encode the response.
+ * Adapts RFC 3062 Password Modify requests to {@see PasswordModifyService}: decode, delegate, build the response.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 readonly class ServerPasswordModifyHandler implements ServerProtocolHandlerInterface
 {
     public function __construct(
-        private ServerQueue $queue,
         private PasswordModifyService $service,
         private ResponseFactory $responseFactory = new ResponseFactory(),
     ) {}
 
-    /**
-     * {@inheritDoc}
-     *
-     * @throws EncoderException
-     */
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): OperationResult {
-        $targetDn = null;
-
+    ): ResponseStream {
         try {
             $result = $this->changePassword(
                 $message,
                 $token,
             );
-            $targetDn = $result->targetDn;
-            $this->sendSuccess(
-                $message,
-                $result,
-            );
         } catch (OperationException $e) {
-            $this->queue->sendMessage($this->responseFactory->getStandardResponse(
-                $message,
-                $e->getCode(),
-                $e->getMessage(),
-            ));
-
-            return PasswordModifyOperationResult::failure(
-                $message,
-                $e,
-                $targetDn,
+            return ResponseStream::of(
+                [$this->responseFactory->getStandardResponse(
+                    $message,
+                    $e->getCode(),
+                    $e->getMessage(),
+                )],
+                PasswordModifyOperationResult::failure(
+                    $message,
+                    $e,
+                    null,
+                ),
             );
         }
 
-        return PasswordModifyOperationResult::success(
+        return ResponseStream::reply(
             $message,
-            $targetDn,
+            PasswordModifyOperationResult::success(
+                $message,
+                $result->targetDn,
+            ),
+            new PasswordModifyResponse(
+                new LdapResult(ResultCode::SUCCESS),
+                $result->generatedPassword,
+            ),
         );
     }
 
@@ -107,18 +99,5 @@ readonly class ServerPasswordModifyHandler implements ServerProtocolHandlerInter
             $token,
             $message->controls(),
         );
-    }
-
-    private function sendSuccess(
-        LdapMessageRequest $message,
-        PasswordModifyResult $result,
-    ): void {
-        $this->queue->sendMessage(new LdapMessageResponse(
-            $message->getMessageId(),
-            new PasswordModifyResponse(
-                new LdapResult(ResultCode::SUCCESS),
-                $result->generatedPassword,
-            ),
-        ));
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandler.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
-use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -22,12 +21,10 @@ use FreeDSx\Ldap\Operation\Request\ForwardPasswordPolicyStateRequest;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
 use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
@@ -43,7 +40,6 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
 readonly class ServerPasswordPolicyForwardHandler implements ServerProtocolHandlerInterface
 {
     public function __construct(
-        private ServerQueue $queue,
         private WritableLdapBackendInterface $backend,
         private PasswordPolicyResolver $policyResolver,
         private PasswordPolicyEngine $engine,
@@ -52,13 +48,12 @@ readonly class ServerPasswordPolicyForwardHandler implements ServerProtocolHandl
     /**
      * {@inheritDoc}
      *
-     * @throws EncoderException
      * @throws OperationException
      */
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): OperationResult {
+    ): ResponseStream {
         $request = $message->getRequest();
         if (!$request instanceof ForwardPasswordPolicyStateRequest) {
             throw new OperationException(
@@ -69,12 +64,11 @@ readonly class ServerPasswordPolicyForwardHandler implements ServerProtocolHandl
 
         $this->apply($request);
 
-        $this->queue->sendMessage(new LdapMessageResponse(
-            $message->getMessageId(),
+        return ResponseStream::reply(
+            $message,
+            OperationOutcomeResult::succeeded(),
             new ExtendedResponse(new LdapResult(ResultCode::SUCCESS)),
-        ));
-
-        return OperationOutcomeResult::succeeded();
+        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerProtocolHandlerInterface.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerProtocolHandlerInterface.php
@@ -15,7 +15,7 @@ namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Socket\Exception\ConnectionException;
 
@@ -28,7 +28,7 @@ use FreeDSx\Socket\Exception\ConnectionException;
 interface ServerProtocolHandlerInterface
 {
     /**
-     * Handle protocol actions specific to the request received and return its outcome.
+     * Handle a request and return the responses to write plus the resolved outcome.
      *
      * @throws OperationException
      * @throws ConnectionException
@@ -36,5 +36,5 @@ interface ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): OperationResult;
+    ): ResponseStream;
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
-use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
@@ -22,10 +21,8 @@ use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\RequestContext;
@@ -54,20 +51,15 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
 
     public function __construct(
         private readonly ServerOptions $options,
-        private readonly ServerQueue $queue,
         private readonly LdapBackendInterface $backend,
         private readonly ?RootDseHandlerInterface $rootDseHandler = null,
         private readonly bool $supportsSync = false,
     ) {}
 
-    /**
-     * {@inheritDoc}
-     * @throws EncoderException
-     */
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): OperationResult {
+    ): ResponseStream {
         $entry = Entry::fromArray('', [
             'namingContexts' => array_map(
                 fn(Dn $dn): string => $dn->toString(),
@@ -135,18 +127,12 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
 
         $this->filterEntryAttributes($request, $entry);
 
-        $this->queue->sendMessage(
-            new LdapMessageResponse(
-                $message->getMessageId(),
-                new SearchResultEntry($entry),
-            ),
-            new LdapMessageResponse(
-                $message->getMessageId(),
-                new SearchResultDone(ResultCode::SUCCESS),
-            ),
+        return ResponseStream::reply(
+            $message,
+            OperationOutcomeResult::succeeded(),
+            new SearchResultEntry($entry),
+            new SearchResultDone(ResultCode::SUCCESS),
         );
-
-        return OperationOutcomeResult::succeeded();
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -14,18 +14,17 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Entry\Entry;
-use FreeDSx\Ldap\Operation\Request\AbandonRequest;
-use FreeDSx\Ldap\Operation\Request\CancelRequest;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\Response\Cancellation;
+use FreeDSx\Ldap\Protocol\Queue\Response\QueueWriterConfig;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Operation\SearchOperationResult;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -43,7 +42,6 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
     private const CANCEL_CHECK_INTERVAL = 50;
 
     public function __construct(
-        private readonly ServerQueue $queue,
         private readonly LdapBackendInterface $backend,
         private readonly FilterEvaluatorInterface $filterEvaluator,
         private readonly AccessControlInterface $accessControl,
@@ -57,9 +55,10 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): OperationResult {
+    ): ResponseStream {
         $request = $this->getSearchRequestFromMessage($message);
         $state = new SearchResultState();
+        $cancellation = new Cancellation();
 
         $this->assertBaseDnProvided($request);
 
@@ -80,7 +79,6 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
                 $request,
                 $state,
                 $token,
-                $message->getMessageId(),
                 $projection,
             ),
             (string) $request->getBaseDn(),
@@ -95,23 +93,24 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
             ? [$sortResponse]
             : [];
 
-        $this->sendEntriesToClient(
-            $searchResult,
-            $message,
-            $this->queue,
-            ...$responseControls,
-        );
-
-        return SearchOperationResult::success(
-            $message,
-            $state->entriesReturned,
+        return ResponseStream::streaming(
+            $this->buildResponseStream(
+                $searchResult,
+                $message->getMessageId(),
+                $cancellation,
+                ...$responseControls,
+            ),
+            static fn(): SearchOperationResult => SearchOperationResult::success(
+                $message,
+                $state->entriesReturned,
+            ),
+            new QueueWriterConfig(signalInterval: self::CANCEL_CHECK_INTERVAL),
+            $cancellation,
         );
     }
 
     /**
      * Streams filtered + attribute-projected entries from the backend.
-     *
-     * Checks for cancel signals periodically.
      *
      * @return Generator<Entry>
      */
@@ -120,7 +119,6 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         SearchRequest $request,
         SearchResultState $state,
         TokenInterface $token,
-        int $messageId,
         AttributeProjection $projection,
     ): Generator {
         $sizeLimit = $this->effectiveSizeLimit(
@@ -131,10 +129,6 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         $emitted = 0;
 
         foreach ($backend->entries as $entry) {
-            if ($this->shouldCancelSearch($emitted, $messageId, $state)) {
-                return;
-            }
-
             $filtered = $this->accessControl->filterEntry(
                 $token,
                 $entry,
@@ -158,33 +152,5 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
                 return;
             }
         }
-    }
-
-    private function shouldCancelSearch(
-        int $emitted,
-        int $messageId,
-        SearchResultState $state,
-    ): bool {
-        if ($emitted === 0 || $emitted % self::CANCEL_CHECK_INTERVAL !== 0) {
-            return false;
-        }
-
-        $signal = $this->queue->peekForCancelSignal($messageId);
-        if ($signal === null) {
-            return false;
-        }
-
-        $request = $signal->getRequest();
-        if ($request instanceof AbandonRequest) {
-            $state->isAbandoned = true;
-
-            return true;
-        }
-
-        if ($request instanceof CancelRequest) {
-            $state->cancelSignal = $signal;
-        }
-
-        return true;
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
@@ -22,7 +22,6 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Operation\LdapResult;
-use FreeDSx\Ldap\Operation\Request\CancelRequest;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
@@ -30,25 +29,12 @@ use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\Response\Cancellation;
 use FreeDSx\Ldap\Schema\Schema;
 use Generator;
 
 trait ServerSearchTrait
 {
-    private function sendEntriesToClient(
-        SearchResult $searchResult,
-        LdapMessageRequest $message,
-        ServerQueue $queue,
-        Control ...$controls,
-    ): void {
-        $queue->sendMessages($this->buildResponseStream(
-            $searchResult,
-            $message->getMessageId(),
-            ...$controls,
-        ));
-    }
-
     /**
      * Yields a SearchResultEntry per backend entry followed by the terminal SearchResultDone.
      * Yields nothing for abandoned requests; yields CANCELED + SUCCESS for cancelled requests.
@@ -58,23 +44,28 @@ trait ServerSearchTrait
     private function buildResponseStream(
         SearchResult $searchResult,
         int $messageId,
+        Cancellation $cancellation,
         Control ...$controls,
     ): Generator {
+        $state = $searchResult->getState();
+
         foreach ($searchResult->getEntries() as $entry) {
             yield new LdapMessageResponse(
                 $messageId,
                 new SearchResultEntry($entry),
             );
+
+            if ($cancellation->isSignalled()) {
+                break;
+            }
         }
 
-        $state = $searchResult->getState();
-
-        if ($state->isAbandoned) {
+        if ($cancellation->isAbandoned()) {
             return;
         }
-        $cancelSignal = $state->cancelSignal;
+        $cancelSignal = $cancellation->signal();
 
-        if ($cancelSignal !== null && $cancelSignal->getRequest() instanceof CancelRequest) {
+        if ($cancelSignal !== null && $cancellation->isCanceled()) {
             yield new LdapMessageResponse(
                 $messageId,
                 new SearchResultDone(

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
@@ -13,22 +13,19 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
-use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\ConnectionControl;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\ServerOptions;
-use FreeDSx\Socket\Exception\ConnectionException;
 
 use function extension_loaded;
 
@@ -43,7 +40,7 @@ class ServerStartTlsHandler implements ServerProtocolHandlerInterface
 
     public function __construct(
         private readonly ServerOptions $options,
-        private readonly ServerQueue $queue,
+        private readonly ConnectionControl $connection,
         private readonly EventLogger $eventLogger = new EventLogger(null),
     ) {
         if (self::$hasOpenssl === null) {
@@ -51,64 +48,69 @@ class ServerStartTlsHandler implements ServerProtocolHandlerInterface
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * @throws ConnectionException
-     * @throws EncoderException
-     */
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): OperationResult {
+    ): ResponseStream {
         # RFC 4511 §4.14.2: return unavailable (not protocolError) when the server cannot negotiate TLS.
         if ($this->options->getSslCert() === null || !self::$hasOpenssl) {
-            $this->queue->sendMessage(new LdapMessageResponse($message->getMessageId(), new ExtendedResponse(
-                new LdapResult(
-                    ResultCode::UNAVAILABLE,
-                    '',
-                    'The server is not configured to provide TLS.',
-                ),
-                ExtendedRequest::OID_START_TLS,
-            )));
-            $this->eventLogger->record(
-                ServerEvent::StartTlsFailed,
-                [
-                    EventContext::RESULT_CODE => ResultCode::UNAVAILABLE,
-                    EventContext::REASON => 'The server is not configured to provide TLS.',
-                ],
-                message: $message,
+            return $this->failure(
+                $message,
+                ResultCode::UNAVAILABLE,
+                'The server is not configured to provide TLS.',
             );
-
-            return OperationOutcomeResult::failed(ResultCode::UNAVAILABLE);
         }
         # If we are already encrypted, then consider this an operations error...
-        if ($this->queue->isEncrypted()) {
-            $this->queue->sendMessage(new LdapMessageResponse($message->getMessageId(), new ExtendedResponse(
-                new LdapResult(ResultCode::OPERATIONS_ERROR, '', 'The current LDAP session is already encrypted.'),
-                ExtendedRequest::OID_START_TLS,
-            )));
-            $this->eventLogger->record(
-                ServerEvent::StartTlsFailed,
-                [
-                    EventContext::RESULT_CODE => ResultCode::OPERATIONS_ERROR,
-                    EventContext::REASON => 'The current LDAP session is already encrypted.',
-                ],
-                message: $message,
+        if ($this->connection->isEncrypted()) {
+            return $this->failure(
+                $message,
+                ResultCode::OPERATIONS_ERROR,
+                'The current LDAP session is already encrypted.',
             );
-
-            return OperationOutcomeResult::failed(ResultCode::OPERATIONS_ERROR);
         }
 
-        $this->queue->sendMessage(new LdapMessageResponse($message->getMessageId(), new ExtendedResponse(
-            new LdapResult(ResultCode::SUCCESS),
-            ExtendedRequest::OID_START_TLS,
-        )));
-        $this->queue->encrypt();
+        # The socket is upgraded in onComplete, after the writer has flushed this SUCCESS in plaintext.
+        return ResponseStream::reply(
+            $message,
+            OperationOutcomeResult::succeeded(),
+            new ExtendedResponse(
+                new LdapResult(ResultCode::SUCCESS),
+                ExtendedRequest::OID_START_TLS,
+            ),
+        )->withOnComplete(function (ConnectionControl $connection) use ($message): void {
+            $connection->encrypt();
+            $this->eventLogger->record(
+                ServerEvent::StartTlsSucceeded,
+                message: $message,
+            );
+        });
+    }
+
+    private function failure(
+        LdapMessageRequest $message,
+        int $resultCode,
+        string $reason,
+    ): ResponseStream {
         $this->eventLogger->record(
-            ServerEvent::StartTlsSucceeded,
+            ServerEvent::StartTlsFailed,
+            [
+                EventContext::RESULT_CODE => $resultCode,
+                EventContext::REASON => $reason,
+            ],
             message: $message,
         );
 
-        return OperationOutcomeResult::succeeded();
+        return ResponseStream::reply(
+            $message,
+            OperationOutcomeResult::failed($resultCode),
+            new ExtendedResponse(
+                new LdapResult(
+                    $resultCode,
+                    '',
+                    $reason,
+                ),
+                ExtendedRequest::OID_START_TLS,
+            ),
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSubschemaHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSubschemaHandler.php
@@ -18,13 +18,11 @@ use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Schema\Definition\ObjectClassOid;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\ServerOptions;
 
@@ -35,15 +33,12 @@ use FreeDSx\Ldap\ServerOptions;
  */
 class ServerSubschemaHandler implements ServerProtocolHandlerInterface
 {
-    public function __construct(
-        private readonly ServerOptions $options,
-        private readonly ServerQueue $queue,
-    ) {}
+    public function __construct(private readonly ServerOptions $options) {}
 
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): OperationResult {
+    ): ResponseStream {
         $schemaDn = $this->options->getSubschemaEntry();
         $rdn = $schemaDn->getRdn();
         $schema = $this->options->getSchema();
@@ -76,18 +71,12 @@ class ServerSubschemaHandler implements ServerProtocolHandlerInterface
             ]),
         );
 
-        $this->queue->sendMessage(
-            new LdapMessageResponse(
-                $message->getMessageId(),
-                new SearchResultEntry($entry),
-            ),
-            new LdapMessageResponse(
-                $message->getMessageId(),
-                new SearchResultDone(ResultCode::SUCCESS),
-            ),
+        return ResponseStream::reply(
+            $message,
+            OperationOutcomeResult::succeeded(),
+            new SearchResultEntry($entry),
+            new SearchResultDone(ResultCode::SUCCESS),
         );
-
-        return OperationOutcomeResult::succeeded();
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSyncHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSyncHandler.php
@@ -26,10 +26,10 @@ use FreeDSx\Ldap\Operation\Response\SyncInfoMessage;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeStream;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Operation\SearchOperationResult;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -60,12 +60,14 @@ final class ServerSyncHandler implements ServerProtocolHandlerInterface
     ) {}
 
     /**
+     * Phase 1: sync (refresh + persist) stays a direct writer; it is folded into the writer in Phase 2.
+     *
      * @throws OperationException
      */
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): OperationResult {
+    ): ResponseStream {
         $request = $this->getSearchRequestFromMessage($message);
         $control = $this->syncRequestControl($message);
         $stream = $this->changeStream;
@@ -118,10 +120,10 @@ final class ServerSyncHandler implements ServerProtocolHandlerInterface
             ));
         }
 
-        return SearchOperationResult::success(
+        return ResponseStream::none(SearchOperationResult::success(
             $message,
             $state->entriesReturned,
-        );
+        ));
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnbindHandler.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\ConnectionControl;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -26,17 +26,13 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  */
 class ServerUnbindHandler implements ServerProtocolHandlerInterface
 {
-    public function __construct(private readonly ServerQueue $queue) {}
-
-    /**
-     * {@inheritDoc}
-     */
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): OperationResult {
-        $this->queue->close();
-
-        return OperationOutcomeResult::succeeded();
+    ): ResponseStream {
+        return ResponseStream::none(OperationOutcomeResult::succeeded())
+            ->withOnComplete(static function (ConnectionControl $connection): void {
+                $connection->close();
+            });
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnsupportedExtendedHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnsupportedExtendedHandler.php
@@ -13,17 +13,14 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
-use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -33,25 +30,19 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  */
 final readonly class ServerUnsupportedExtendedHandler implements ServerProtocolHandlerInterface
 {
-    public function __construct(private ServerQueue $queue) {}
-
-    /**
-     * {@inheritDoc}
-     *
-     * @throws EncoderException
-     */
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): OperationResult {
+    ): ResponseStream {
         $request = $message->getRequest();
 
         if (!$request instanceof ExtendedRequest) {
             throw new RuntimeException('The extended operation handler was routed a non-extended request.');
         }
 
-        $this->queue->sendMessage(new LdapMessageResponse(
-            $message->getMessageId(),
+        return ResponseStream::reply(
+            $message,
+            OperationOutcomeResult::failed(ResultCode::PROTOCOL_ERROR),
             new ExtendedResponse(
                 new LdapResult(
                     ResultCode::PROTOCOL_ERROR,
@@ -60,8 +51,6 @@ final readonly class ServerUnsupportedExtendedHandler implements ServerProtocolH
                 ),
                 $request->getName(),
             ),
-        ));
-
-        return OperationOutcomeResult::failed(ResultCode::PROTOCOL_ERROR);
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerWhoAmIHandler.php
@@ -13,15 +13,12 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
-use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
-use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
@@ -32,27 +29,24 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  */
 class ServerWhoAmIHandler implements ServerProtocolHandlerInterface
 {
-    public function __construct(private readonly ServerQueue $queue) {}
-
-    /**
-     * {@inheritDoc}
-     * @throws EncoderException
-     */
     public function handleRequest(
         LdapMessageRequest $message,
         TokenInterface $token,
-    ): OperationResult {
+    ): ResponseStream {
         $userId = null;
 
         if ($token instanceof AuthenticatedTokenInterface) {
             $userId = $token->getAuthzId()->toString();
         }
 
-        $this->queue->sendMessage(new LdapMessageResponse(
-            $message->getMessageId(),
-            new ExtendedResponse(new LdapResult(ResultCode::SUCCESS), null, $userId),
-        ));
-
-        return OperationOutcomeResult::succeeded();
+        return ResponseStream::reply(
+            $message,
+            OperationOutcomeResult::succeeded(),
+            new ExtendedResponse(
+                new LdapResult(ResultCode::SUCCESS),
+                null,
+                $userId,
+            ),
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
+++ b/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
@@ -33,6 +33,7 @@ use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\Queue\Response\MetricsResponseInterceptor;
 use FreeDSx\Ldap\Protocol\Queue\Response\PasswordPolicyResponseInterceptor;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseWriter;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
@@ -412,7 +413,7 @@ final class ConnectionHandlerBuilder implements ConnectionHandlerBuilderInterfac
             ],
             new HandlerInvoker(
                 $handlerProvider,
-                $queue,
+                new ResponseWriter($queue),
             ),
         );
     }

--- a/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
+++ b/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
@@ -410,7 +410,10 @@ final class ConnectionHandlerBuilder implements ConnectionHandlerBuilderInterfac
                 $this->container->get(OperationAuthorizationMiddleware::class),
                 $this->container->get(AssertionMiddleware::class),
             ],
-            new HandlerInvoker($handlerProvider),
+            new HandlerInvoker(
+                $handlerProvider,
+                $queue,
+            ),
         );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Middleware/Pipeline/HandlerInvoker.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/Pipeline/HandlerInvoker.php
@@ -14,11 +14,8 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Middleware\Pipeline;
 
 use FreeDSx\Ldap\Protocol\Factory\ProtocolHandlerProviderInterface;
-use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseWriter;
 use FreeDSx\Ldap\Server\Operation\OperationResult;
-
-use function count;
 
 /**
  * Terminal handler that resolves the per-request handler, writes its response, and returns its outcome.
@@ -30,7 +27,7 @@ final readonly class HandlerInvoker implements MiddlewareHandlerInterface
 {
     public function __construct(
         private ProtocolHandlerProviderInterface $protocolHandlerProvider,
-        private ServerQueue $queue,
+        private ResponseWriter $responseWriter,
     ) {}
 
     public function handle(ServerRequestContext $context): OperationResult
@@ -45,66 +42,10 @@ final readonly class HandlerInvoker implements MiddlewareHandlerInterface
             $context->message,
             $context->tokenOrFail(),
         );
-        $this->write(
+
+        return $this->responseWriter->write(
             $stream,
             $context->message->getMessageId(),
         );
-
-        return $stream->outcome();
-    }
-
-    private function write(
-        ResponseStream $stream,
-        int $messageId,
-    ): void {
-        if ($stream->writerConfig->mustFlushOrSignal()) {
-            $this->step(
-                $stream,
-                $messageId,
-            );
-        } else {
-            $this->queue->sendMessages($stream->messages);
-        }
-
-        // Post-write connection side effect (e.g. StartTLS encrypt) — the bytes are on the wire now.
-        if ($stream->onComplete !== null) {
-            ($stream->onComplete)($this->queue);
-        }
-    }
-
-    /**
-     * Walk the generator, flushing in batches and offering polled cancel signals at the configured interval.
-     */
-    private function step(
-        ResponseStream $stream,
-        int $messageId,
-    ): void {
-        $config = $stream->writerConfig;
-        // Flush per message for liveness, else batch up to the poll interval.
-        $flushEvery = $config->flushPerMessage
-            ? 1
-            : max(1, $config->signalInterval);
-        $chunk = [];
-        $sincePoll = 0;
-
-        // The producer reads the offered signal from the Cancellation token when foreach resumes it.
-        foreach ($stream->generator() as $message) {
-            $chunk[] = $message;
-            $sincePoll++;
-
-            if (count($chunk) >= $flushEvery) {
-                $this->queue->sendMessages($chunk);
-                $chunk = [];
-            }
-
-            if ($config->signalInterval > 0 && $sincePoll >= $config->signalInterval) {
-                $sincePoll = 0;
-                $stream->cancellation?->offer($this->queue->peekForCancelSignal($messageId));
-            }
-        }
-
-        if ($chunk !== []) {
-            $this->queue->sendMessages($chunk);
-        }
     }
 }

--- a/src/FreeDSx/Ldap/Server/Middleware/Pipeline/HandlerInvoker.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/Pipeline/HandlerInvoker.php
@@ -14,17 +14,24 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Middleware\Pipeline;
 
 use FreeDSx\Ldap\Protocol\Factory\ProtocolHandlerProviderInterface;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\Operation\OperationResult;
 
+use function count;
+
 /**
- * Terminal handler that resolves and invokes the per-request protocol handler.
+ * Terminal handler that resolves the per-request handler, writes its response, and returns its outcome.
  *
  * @internal
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 final readonly class HandlerInvoker implements MiddlewareHandlerInterface
 {
-    public function __construct(private ProtocolHandlerProviderInterface $protocolHandlerProvider) {}
+    public function __construct(
+        private ProtocolHandlerProviderInterface $protocolHandlerProvider,
+        private ServerQueue $queue,
+    ) {}
 
     public function handle(ServerRequestContext $context): OperationResult
     {
@@ -34,9 +41,70 @@ final readonly class HandlerInvoker implements MiddlewareHandlerInterface
             $context->searchLimits(),
         );
 
-        return $handler->handleRequest(
+        $stream = $handler->handleRequest(
             $context->message,
             $context->tokenOrFail(),
         );
+        $this->write(
+            $stream,
+            $context->message->getMessageId(),
+        );
+
+        return $stream->outcome();
+    }
+
+    private function write(
+        ResponseStream $stream,
+        int $messageId,
+    ): void {
+        if ($stream->writerConfig->mustFlushOrSignal()) {
+            $this->step(
+                $stream,
+                $messageId,
+            );
+        } else {
+            $this->queue->sendMessages($stream->messages);
+        }
+
+        // Post-write connection side effect (e.g. StartTLS encrypt) — the bytes are on the wire now.
+        if ($stream->onComplete !== null) {
+            ($stream->onComplete)($this->queue);
+        }
+    }
+
+    /**
+     * Walk the generator, flushing in batches and offering polled cancel signals at the configured interval.
+     */
+    private function step(
+        ResponseStream $stream,
+        int $messageId,
+    ): void {
+        $config = $stream->writerConfig;
+        // Flush per message for liveness, else batch up to the poll interval.
+        $flushEvery = $config->flushPerMessage
+            ? 1
+            : max(1, $config->signalInterval);
+        $chunk = [];
+        $sincePoll = 0;
+
+        // The producer reads the offered signal from the Cancellation token when foreach resumes it.
+        foreach ($stream->generator() as $message) {
+            $chunk[] = $message;
+            $sincePoll++;
+
+            if (count($chunk) >= $flushEvery) {
+                $this->queue->sendMessages($chunk);
+                $chunk = [];
+            }
+
+            if ($config->signalInterval > 0 && $sincePoll >= $config->signalInterval) {
+                $sincePoll = 0;
+                $stream->cancellation?->offer($this->queue->peekForCancelSignal($messageId));
+            }
+        }
+
+        if ($chunk !== []) {
+            $this->queue->sendMessages($chunk);
+        }
     }
 }

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyProtocolFactory.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Protocol\Authenticator;
 use FreeDSx\Ldap\Protocol\Authorization\DispatchAuthorizer;
 use FreeDSx\Ldap\Protocol\Bind\SimpleBind;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseWriter;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerStartTlsHandler;
@@ -90,6 +91,7 @@ final class ProxyProtocolFactory implements ServerProtocolFactoryInterface
                     $upstream,
                     $queue,
                 ),
+                new ResponseWriter($queue),
             ),
         );
 

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyRequestPipeline.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyRequestPipeline.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Proxy;
 
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseWriter;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerProtocolHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
@@ -29,6 +30,7 @@ final readonly class ProxyRequestPipeline implements MiddlewareHandlerInterface
     public function __construct(
         private ServerProtocolHandlerInterface $startTlsHandler,
         private MiddlewareHandlerInterface $forwarder,
+        private ResponseWriter $responseWriter,
     ) {}
 
     /**
@@ -39,9 +41,14 @@ final readonly class ProxyRequestPipeline implements MiddlewareHandlerInterface
         $request = $context->message->getRequest();
 
         if ($request instanceof ExtendedRequest && $request->getName() === ExtendedRequest::OID_START_TLS) {
-            return $this->startTlsHandler->handleRequest(
+            $stream = $this->startTlsHandler->handleRequest(
                 $context->message,
                 $context->tokenOrFail(),
+            );
+
+            return $this->responseWriter->write(
+                $stream,
+                $context->message->getMessageId(),
             );
         }
 

--- a/tests/integration/Security/PasswordPolicyChangeEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyChangeEnforcementTest.php
@@ -25,7 +25,6 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\Response\PasswordPolicyResponseInterceptor;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
@@ -55,6 +54,7 @@ use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordChangeRules;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerPasswordModifyHandler;
 use FreeDSx\Ldap\Server\Token\BindToken;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\TestCase;
 use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
 
@@ -90,7 +90,8 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
             [PasswordPolicyOid::NAME_PWD_HISTORY => $this->historyValue('previous-pass')],
         );
 
-        $handler->handleRequest(
+        $this->handle(
+            $handler,
             $this->request(self::OLD_PASSWORD, 'previous-pass'),
             $this->selfToken(),
         );
@@ -106,7 +107,8 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
             [PasswordPolicyOid::NAME_PWD_CHANGED_TIME => $this->minutesAgo(30)],
         );
 
-        $handler->handleRequest(
+        $this->handle(
+            $handler,
             $this->request(self::OLD_PASSWORD, 'a-fresh-password'),
             $this->selfToken(),
         );
@@ -121,7 +123,8 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
             new PasswordPolicy(change: new PasswordChangeRules(safeModify: true)),
         );
 
-        $handler->handleRequest(
+        $this->handle(
+            $handler,
             $this->request(null, 'a-fresh-password'),
             $this->selfToken(),
         );
@@ -136,7 +139,8 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
             new PasswordPolicy(change: new PasswordChangeRules(allowUserChange: false)),
         );
 
-        $handler->handleRequest(
+        $this->handle(
+            $handler,
             $this->request(self::OLD_PASSWORD, 'a-fresh-password'),
             $this->selfToken(),
         );
@@ -152,7 +156,8 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
             [PasswordPolicyOid::NAME_PWD_RESET => 'TRUE'],
         );
 
-        $handler->handleRequest(
+        $this->handle(
+            $handler,
             $this->request(self::OLD_PASSWORD, 'a-fresh-password'),
             $this->selfToken(),
         );
@@ -185,7 +190,8 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
             new PasswordPolicy(change: new PasswordChangeRules(mustChange: true)),
         );
 
-        $handler->handleRequest(
+        $this->handle(
+            $handler,
             $this->request(
                 null,
                 'admin-set-password',
@@ -214,7 +220,8 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
             [PasswordPolicyOid::NAME_PWD_RESET => 'TRUE'],
         );
 
-        $handler->handleRequest(
+        $this->handle(
+            $handler,
             $this->request(
                 self::OLD_PASSWORD,
                 'a-fresh-password',
@@ -239,7 +246,8 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
         $token = $this->selfToken();
         $token->markMustChangePassword();
 
-        $handler->handleRequest(
+        $this->handle(
+            $handler,
             $this->request(
                 self::OLD_PASSWORD,
                 'a-fresh-password',
@@ -284,7 +292,6 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
         ]));
 
         return new ServerPasswordModifyHandler(
-            queue: $this->capturingQueue(),
             service: new PasswordModifyService(
                 targetResolver: new PasswordModifyTargetResolver(
                     $this->backend,
@@ -321,19 +328,15 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
         );
     }
 
-    private function capturingQueue(): ServerQueue
-    {
-        $interceptor = new PasswordPolicyResponseInterceptor($this->context);
-        $queue = $this->createMock(ServerQueue::class);
-        $queue
-            ->method('sendMessage')
-            ->willReturnCallback(function (LdapMessageResponse $response) use ($queue, $interceptor): ServerQueue {
-                $this->response = $interceptor->intercept($response);
-
-                return $queue;
-            });
-
-        return $queue;
+    private function handle(
+        ServerPasswordModifyHandler $handler,
+        LdapMessageRequest $request,
+        TokenInterface $token,
+    ): void {
+        $stream = $handler->handleRequest($request, $token);
+        $messages = [...$stream->messages];
+        self::assertCount(1, $messages);
+        $this->response = (new PasswordPolicyResponseInterceptor($this->context))->intercept($messages[0]);
     }
 
     private function request(

--- a/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
@@ -25,7 +25,6 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\Response\PasswordPolicyResponseInterceptor;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Schema\Schema;
@@ -53,6 +52,7 @@ use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\DefaultPasswordQualityChecke
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordChangeRules;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
 use FreeDSx\Ldap\Server\Token\BindToken;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\TestCase;
 use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
 
@@ -117,7 +117,8 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
             [PasswordPolicyOid::NAME_PWD_RESET => 'TRUE'],
         );
 
-        $handler->handleRequest(
+        $this->handle(
+            $handler,
             $this->modify('a-fresh-password'),
             $this->token(),
         );
@@ -213,7 +214,8 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
             new PasswordPolicy(change: new PasswordChangeRules(safeModify: true)),
         );
 
-        $handler->handleRequest(
+        $this->handle(
+            $handler,
             $this->modifyWithOld('original-pass', 'a-fresh-password'),
             $this->token(),
         );
@@ -239,7 +241,8 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
         $token = $this->token();
         $token->markMustChangePassword();
 
-        $handler->handleRequest(
+        $this->handle(
+            $handler,
             $this->modify('a-fresh-password'),
             $token,
         );
@@ -311,7 +314,6 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
         );
 
         return new ServerDispatchHandler(
-            queue: $this->capturingQueue(),
             backend: $this->backend,
             writeDispatcher: new WriteOperationDispatcher(
                 $policyWriteHandler,
@@ -322,19 +324,15 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
         );
     }
 
-    private function capturingQueue(): ServerQueue
-    {
-        $interceptor = new PasswordPolicyResponseInterceptor($this->context);
-        $queue = $this->createMock(ServerQueue::class);
-        $queue
-            ->method('sendMessage')
-            ->willReturnCallback(function (LdapMessageResponse $response) use ($queue, $interceptor): ServerQueue {
-                $this->response = $interceptor->intercept($response);
-
-                return $queue;
-            });
-
-        return $queue;
+    private function handle(
+        ServerDispatchHandler $handler,
+        LdapMessageRequest $request,
+        TokenInterface $token,
+    ): void {
+        $stream = $handler->handleRequest($request, $token);
+        $messages = [...$stream->messages];
+        self::assertCount(1, $messages);
+        $this->response = (new PasswordPolicyResponseInterceptor($this->context))->intercept($messages[0]);
     }
 
     private function modify(string $newPassword): LdapMessageRequest

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerAbandonHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerAbandonHandlerTest.php
@@ -15,7 +15,6 @@ namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerAbandonHandler;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -23,31 +22,29 @@ use PHPUnit\Framework\TestCase;
 
 final class ServerAbandonHandlerTest extends TestCase
 {
-    private ServerQueue&MockObject $mockQueue;
-
     private TokenInterface&MockObject $mockToken;
 
     private ServerAbandonHandler $subject;
 
     protected function setUp(): void
     {
-        $this->mockQueue = $this->createMock(ServerQueue::class);
         $this->mockToken = $this->createMock(TokenInterface::class);
         $this->subject = new ServerAbandonHandler();
     }
 
     public function test_it_sends_no_response_per_rfc4511(): void
     {
-        $this->mockQueue
-            ->expects(self::never())
-            ->method('sendMessage');
-
-        $this->subject->handleRequest(
+        $stream = $this->subject->handleRequest(
             new LdapMessageRequest(
                 2,
                 new AbandonRequest(1),
             ),
             $this->mockToken,
+        );
+
+        $this->assertSame(
+            [],
+            [...$stream->messages],
         );
     }
 }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerCancelHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerCancelHandlerTest.php
@@ -19,7 +19,6 @@ use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerCancelHandler;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -27,32 +26,29 @@ use PHPUnit\Framework\TestCase;
 
 final class ServerCancelHandlerTest extends TestCase
 {
-    private ServerQueue&MockObject $mockQueue;
-
     private TokenInterface&MockObject $mockToken;
 
     private ServerCancelHandler $subject;
 
     protected function setUp(): void
     {
-        $this->mockQueue = $this->createMock(ServerQueue::class);
         $this->mockToken = $this->createMock(TokenInterface::class);
-        $this->subject = new ServerCancelHandler($this->mockQueue);
+        $this->subject = new ServerCancelHandler();
     }
 
     public function test_it_sends_no_such_operation_when_target_already_completed(): void
     {
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->with(self::equalTo(new LdapMessageResponse(
-                3,
-                new ExtendedResponse(new LdapResult(ResultCode::NO_SUCH_OPERATION)),
-            )));
-
-        $this->subject->handleRequest(
+        $stream = $this->subject->handleRequest(
             new LdapMessageRequest(3, new CancelRequest(2)),
             $this->mockToken,
+        );
+
+        $this->assertEquals(
+            [new LdapMessageResponse(
+                3,
+                new ExtendedResponse(new LdapResult(ResultCode::NO_SUCH_OPERATION)),
+            )],
+            [...$stream->messages],
         );
     }
 }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
@@ -23,7 +23,6 @@ use FreeDSx\Ldap\Operation\Request\CompareRequest;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerDispatchHandler;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
@@ -48,8 +47,6 @@ final class ServerDispatchHandlerTest extends TestCase
 
     private WriteHandlerInterface&MockObject $mockWriteHandler;
 
-    private ServerQueue&MockObject $mockQueue;
-
     private TokenInterface&MockObject $mockToken;
 
     private AccessControlInterface&MockObject $mockAccessControl;
@@ -57,21 +54,15 @@ final class ServerDispatchHandlerTest extends TestCase
     protected function setUp(): void
     {
         $this->mockToken = $this->createMock(TokenInterface::class);
-        $this->mockQueue = $this->createMock(ServerQueue::class);
         $this->mockBackend = $this->createMock(LdapBackendInterface::class);
         $this->mockWriteHandler = $this->createMock(WriteHandlerInterface::class);
         $this->mockAccessControl = $this->createMock(AccessControlInterface::class);
-
-        $this->mockQueue
-            ->method('sendMessage')
-            ->willReturnSelf();
 
         $this->mockWriteHandler
             ->method('supports')
             ->willReturn(true);
 
         $this->subject = new ServerDispatchHandler(
-            queue: $this->mockQueue,
             backend: $this->mockBackend,
             writeDispatcher: new WriteOperationDispatcher($this->mockWriteHandler),
             accessControl: $this->mockAccessControl,
@@ -88,12 +79,12 @@ final class ServerDispatchHandlerTest extends TestCase
             ->method('handle')
             ->with(self::isInstanceOf(WriteRequestInterface::class));
 
-        $result = $this->subject->handleRequest($add, $this->mockToken);
+        $outcome = $this->subject->handleRequest($add, $this->mockToken)->outcome();
 
-        self::assertInstanceOf(WriteOperationResult::class, $result);
+        self::assertInstanceOf(WriteOperationResult::class, $outcome);
         self::assertSame(
             OperationOutcome::Succeeded,
-            $result->outcome(),
+            $outcome->outcome(),
         );
     }
 
@@ -132,9 +123,9 @@ final class ServerDispatchHandlerTest extends TestCase
             )
             ->willReturn(true);
 
-        $result = $this->subject->handleRequest($compare, $this->mockToken);
+        $outcome = $this->subject->handleRequest($compare, $this->mockToken)->outcome();
 
-        self::assertInstanceOf(CompareOperationResult::class, $result);
+        self::assertInstanceOf(CompareOperationResult::class, $outcome);
     }
 
     public function test_it_lets_operation_exceptions_from_backend_compare_bubble(): void
@@ -157,7 +148,6 @@ final class ServerDispatchHandlerTest extends TestCase
     public function test_it_throws_when_no_write_handler_supports_the_operation(): void
     {
         $subject = new ServerDispatchHandler(
-            queue: $this->mockQueue,
             backend: $this->mockBackend,
             writeDispatcher: new WriteOperationDispatcher(),
             accessControl: $this->mockAccessControl,

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerMonitorHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerMonitorHandlerTest.php
@@ -21,7 +21,6 @@ use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerMonitorHandler;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
@@ -36,8 +35,6 @@ use PHPUnit\Framework\TestCase;
 
 final class ServerMonitorHandlerTest extends TestCase
 {
-    private ServerQueue&MockObject $mockQueue;
-
     private TokenInterface&MockObject $mockToken;
 
     private InMemoryMetricsRecorder $metrics;
@@ -46,40 +43,38 @@ final class ServerMonitorHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mockQueue = $this->createMock(ServerQueue::class);
         $this->mockToken = $this->createMock(TokenInterface::class);
         $this->metrics = new InMemoryMetricsRecorder();
 
         $this->subject = new ServerMonitorHandler(
             options: new ServerOptions(),
-            queue: $this->mockQueue,
             snapshots: $this->metrics,
         );
     }
 
     public function test_it_serves_the_cn_monitor_entry(): void
     {
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with(
-                self::callback(static function (LdapMessageResponse $response): bool {
-                    /** @var SearchResultEntry $result */
-                    $result = $response->getResponse();
-                    $entry = $result->getEntry();
-
-                    return $entry->getDn()->toString() === 'cn=monitor'
-                        && ($entry->get('objectClass')?->has('extensibleObject') ?? false);
-                }),
-                self::equalTo(new LdapMessageResponse(
-                    1,
-                    new SearchResultDone(ResultCode::SUCCESS),
-                )),
-            );
-
-        $this->subject->handleRequest(
+        $stream = $this->subject->handleRequest(
             $this->makeMessage(),
             $this->mockToken,
+        );
+        $messages = [...$stream->messages];
+
+        /** @var SearchResultEntry $result */
+        $result = $messages[0]->getResponse();
+        $entry = $result->getEntry();
+
+        self::assertSame(
+            'cn=monitor',
+            $entry->getDn()->toString(),
+        );
+        self::assertTrue($entry->get('objectClass')?->has('extensibleObject') ?? false);
+        self::assertEquals(
+            new LdapMessageResponse(
+                1,
+                new SearchResultDone(ResultCode::SUCCESS),
+            ),
+            $messages[1],
         );
     }
 
@@ -310,7 +305,6 @@ final class ServerMonitorHandlerTest extends TestCase
 
         $subject = new ServerMonitorHandler(
             options: (new ServerOptions())->setUseSwooleRunner(true),
-            queue: $this->mockQueue,
             snapshots: $this->metrics,
         );
 
@@ -334,29 +328,15 @@ final class ServerMonitorHandlerTest extends TestCase
 
     private function handleAndCaptureEntry(?ServerMonitorHandler $subject = null): Entry
     {
-        $captured = null;
-
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with(
-                self::callback(static function (LdapMessageResponse $response) use (&$captured): bool {
-                    /** @var SearchResultEntry $result */
-                    $result = $response->getResponse();
-                    $captured = $result->getEntry();
-
-                    return true;
-                }),
-                self::anything(),
-            );
-
-        ($subject ?? $this->subject)->handleRequest(
+        $stream = ($subject ?? $this->subject)->handleRequest(
             $this->makeMessage(),
             $this->mockToken,
         );
+        $messages = [...$stream->messages];
 
-        assert($captured instanceof Entry);
+        /** @var SearchResultEntry $result */
+        $result = $messages[0]->getResponse();
 
-        return $captured;
+        return $result->getEntry();
     }
 }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
@@ -28,6 +28,7 @@ use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseWriter;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerPagingHandler;
 use FreeDSx\Ldap\Schema\Schema;
@@ -40,6 +41,7 @@ use FreeDSx\Ldap\Server\Paging\PagingRequest;
 use FreeDSx\Ldap\Server\RequestHistory;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Operation\OperationOutcome;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Operation\SearchOperationResult;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -104,7 +106,6 @@ class ServerPagingHandlerTest extends TestCase
             });
 
         $this->subject = new ServerPagingHandler(
-            queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $this->mockFilterEvaluator,
             accessControl: $this->mockAccessControl,
@@ -126,9 +127,9 @@ class ServerPagingHandlerTest extends TestCase
             ->with(self::isInstanceOf(SearchRequest::class))
             ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
 
-        $result = $this->subject->handleRequest(
+        $result = $this->drive(
+            $this->subject,
             $message,
-            $this->mockToken,
         );
 
         self::assertEquals(
@@ -160,9 +161,9 @@ class ServerPagingHandlerTest extends TestCase
             ->method('search')
             ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
 
-        $this->subject->handleRequest(
+        $this->drive(
+            $this->subject,
             $message,
-            $this->mockToken,
         );
 
         self::assertEquals(
@@ -186,7 +187,7 @@ class ServerPagingHandlerTest extends TestCase
             ->method('search')
             ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
 
-        $this->subject->handleRequest($firstMessage, $this->mockToken);
+        $this->drive($this->subject, $firstMessage);
 
         $capturedCookie = $this->donePagingControl()->getCookie();
         self::assertNotSame('', $capturedCookie);
@@ -199,7 +200,7 @@ class ServerPagingHandlerTest extends TestCase
             searchRequest: $pagingReq->getSearchRequest(),
         );
 
-        $this->subject->handleRequest($secondMessage, $this->mockToken);
+        $this->drive($this->subject, $secondMessage);
     }
 
     public function test_it_should_send_the_correct_response_if_paging_is_abandoned(): void
@@ -215,9 +216,9 @@ class ServerPagingHandlerTest extends TestCase
             ->expects(self::never())
             ->method('search');
 
-        $this->subject->handleRequest(
+        $this->drive(
+            $this->subject,
             $message,
-            $this->mockToken,
         );
 
         self::assertSame([], $this->entryMessages());
@@ -237,9 +238,9 @@ class ServerPagingHandlerTest extends TestCase
             ->expects(self::never())
             ->method('search');
 
-        $this->subject->handleRequest(
+        $this->drive(
+            $this->subject,
             $message,
-            $this->mockToken,
         );
 
         self::assertEquals(
@@ -282,9 +283,9 @@ class ServerPagingHandlerTest extends TestCase
             ->expects(self::never())
             ->method('search');
 
-        $result = $this->subject->handleRequest(
+        $result = $this->drive(
+            $this->subject,
             $message,
-            $this->mockToken,
         );
 
         self::assertSame([], $this->entryMessages());
@@ -330,7 +331,7 @@ class ServerPagingHandlerTest extends TestCase
             ->method('search')
             ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
 
-        $this->subject->handleRequest($message, $this->mockToken);
+        $this->drive($this->subject, $message);
 
         self::assertEquals(
             [new LdapMessageResponse(2, new SearchResultEntry($entry1))],
@@ -360,9 +361,9 @@ class ServerPagingHandlerTest extends TestCase
             ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2, $entry3, $entry4)));
 
         // First page: pageSize=1, sizeLimit=2 — gets entry1, stores generator
-        $this->subject->handleRequest(
+        $this->drive(
+            $this->subject,
             $this->makeSearchMessage(size: 1, searchRequest: $searchRequest),
-            $this->mockToken,
         );
 
         $capturedCookie = $this->donePagingControl()->getCookie();
@@ -370,9 +371,9 @@ class ServerPagingHandlerTest extends TestCase
 
         // Second page: pageSize=10, sizeLimit=2 — gets entry2+entry3 (hits limit), entry4 still in generator → SIZE_LIMIT_EXCEEDED
         $pagingReq = $this->requestHistory->pagingRequest()->findByNextCookie($capturedCookie);
-        $this->subject->handleRequest(
+        $this->drive(
+            $this->subject,
             $this->makeSearchMessage(size: 10, cookie: $capturedCookie, searchRequest: $pagingReq->getSearchRequest()),
-            $this->mockToken,
         );
 
         $sizeLimitExceededSeen = false;
@@ -403,7 +404,6 @@ class ServerPagingHandlerTest extends TestCase
             ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
 
         $subject = new ServerPagingHandler(
-            queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $this->mockFilterEvaluator,
             accessControl: $this->mockAccessControl,
@@ -411,7 +411,7 @@ class ServerPagingHandlerTest extends TestCase
             schema: $this->schema,
             limits: new SearchLimits(maxSearchSize: 1),
         );
-        $subject->handleRequest($message, $this->mockToken);
+        $this->drive($subject, $message);
 
         self::assertEquals(
             [new LdapMessageResponse(2, new SearchResultEntry($entry1))],
@@ -435,7 +435,6 @@ class ServerPagingHandlerTest extends TestCase
             ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
 
         $subject = new ServerPagingHandler(
-            queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $this->mockFilterEvaluator,
             accessControl: $this->mockAccessControl,
@@ -443,7 +442,7 @@ class ServerPagingHandlerTest extends TestCase
             schema: $this->schema,
             limits: new SearchLimits(maxSearchPageSize: 1),
         );
-        $subject->handleRequest($message, $this->mockToken);
+        $this->drive($subject, $message);
 
         // Only 1 entry returned despite client requesting page size 10.
         self::assertEquals(
@@ -468,7 +467,6 @@ class ServerPagingHandlerTest extends TestCase
             ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2, $entry3)));
 
         $subject = new ServerPagingHandler(
-            queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $this->mockFilterEvaluator,
             accessControl: $this->mockAccessControl,
@@ -476,7 +474,7 @@ class ServerPagingHandlerTest extends TestCase
             schema: $this->schema,
             limits: new SearchLimits(maxSearchPageSize: 2),
         );
-        $subject->handleRequest($message, $this->mockToken);
+        $this->drive($subject, $message);
 
         // Server applies its max of 2 entries per page.
         self::assertCount(2, $this->entryMessages());
@@ -496,7 +494,6 @@ class ServerPagingHandlerTest extends TestCase
             ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
 
         $subject = new ServerPagingHandler(
-            queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $this->mockFilterEvaluator,
             accessControl: $this->mockAccessControl,
@@ -504,7 +501,7 @@ class ServerPagingHandlerTest extends TestCase
             schema: $this->schema,
             limits: new SearchLimits(maxSearchPageSize: 5),
         );
-        $subject->handleRequest($message, $this->mockToken);
+        $this->drive($subject, $message);
 
         // Client requested 1 per page; server max is 5 — client's lower value wins.
         self::assertEquals(
@@ -541,14 +538,13 @@ class ServerPagingHandlerTest extends TestCase
             )));
 
         $subject = new ServerPagingHandler(
-            queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $this->mockFilterEvaluator,
             accessControl: $mockAccessControl,
             requestHistory: $this->requestHistory,
             schema: $this->schema,
         );
-        $subject->handleRequest($message, $this->mockToken);
+        $this->drive($subject, $message);
 
         self::assertEquals(
             [new LdapMessageResponse(2, new SearchResultEntry($entry2))],
@@ -583,14 +579,13 @@ class ServerPagingHandlerTest extends TestCase
             ->willReturn(new EntryStream($this->makeGenerator($entry)));
 
         $subject = new ServerPagingHandler(
-            queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $mockFilterEvaluator,
             accessControl: $mockAccessControl,
             requestHistory: $this->requestHistory,
             schema: $this->schema,
         );
-        $subject->handleRequest($message, $this->mockToken);
+        $this->drive($subject, $message);
 
         self::assertSame([], $this->entryMessages());
     }
@@ -608,9 +603,9 @@ class ServerPagingHandlerTest extends TestCase
             ->method('search')
             ->willReturn(new EntryStream($this->makeGenerator()));
 
-        $this->subject->handleRequest(
+        $this->drive(
+            $this->subject,
             $message,
-            $this->mockToken,
         );
 
         $sortControl = $this->doneMessage()->controls()->get(Control::OID_SORTING_RESPONSE);
@@ -637,9 +632,9 @@ class ServerPagingHandlerTest extends TestCase
             ->method('search')
             ->willReturn(new EntryStream($this->makeGenerator()));
 
-        $this->subject->handleRequest(
+        $this->drive(
+            $this->subject,
             $message,
-            $this->mockToken,
         );
 
         $sortControl = $this->doneMessage()->controls()->get(Control::OID_SORTING_RESPONSE);
@@ -665,9 +660,9 @@ class ServerPagingHandlerTest extends TestCase
             ->method('search')
             ->willReturn(new EntryStream($this->makeGenerator()));
 
-        $this->subject->handleRequest(
+        $this->drive(
+            $this->subject,
             $message,
-            $this->mockToken,
         );
 
         self::assertNull(
@@ -694,9 +689,9 @@ class ServerPagingHandlerTest extends TestCase
             ->method('get')
             ->willReturn($matchedEntry);
 
-        $this->subject->handleRequest(
+        $this->drive(
+            $this->subject,
             $message,
-            $this->mockToken,
         );
 
         $done = $this->doneMessage()->getResponse();
@@ -736,7 +731,6 @@ class ServerPagingHandlerTest extends TestCase
             ->willReturn(null);
 
         $subject = new ServerPagingHandler(
-            queue: $this->mockQueue,
             backend: $this->mockBackend,
             filterEvaluator: $this->mockFilterEvaluator,
             accessControl: $mockAccessControl,
@@ -744,9 +738,9 @@ class ServerPagingHandlerTest extends TestCase
             schema: $this->schema,
         );
 
-        $subject->handleRequest(
+        $this->drive(
+            $subject,
             $message,
-            $this->mockToken,
         );
 
         $done = $this->doneMessage()->getResponse();
@@ -758,6 +752,21 @@ class ServerPagingHandlerTest extends TestCase
         self::assertSame(
             '',
             $done->getDn()->toString(),
+        );
+    }
+
+    private function drive(
+        ServerPagingHandler $subject,
+        LdapMessageRequest $message,
+    ): OperationResult {
+        $stream = $subject->handleRequest(
+            $message,
+            $this->mockToken,
+        );
+
+        return (new ResponseWriter($this->mockQueue))->write(
+            $stream,
+            $message->getMessageId(),
         );
     }
 

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordModifyHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordModifyHandlerTest.php
@@ -16,12 +16,12 @@ namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\PasswordModifyRequest;
 use FreeDSx\Ldap\Operation\Response\PasswordModifyResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerPasswordModifyHandler;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
@@ -39,13 +39,11 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Covers the transport seam: decoding, response encoding, and error mapping. The use case itself is exercised by
+ * Covers the transport seam: decoding, response building, and error mapping. The use case itself is exercised by
  * {@see \Tests\Unit\FreeDSx\Ldap\Server\PasswordModify\PasswordModifyServiceTest}.
  */
 final class ServerPasswordModifyHandlerTest extends TestCase
 {
-    private ServerQueue&MockObject $mockQueue;
-
     private LdapBackendInterface&MockObject $mockBackend;
 
     private ServerPasswordModifyHandler $subject;
@@ -56,11 +54,9 @@ final class ServerPasswordModifyHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mockQueue = $this->createMock(ServerQueue::class);
         $this->mockBackend = $this->createMock(LdapBackendInterface::class);
         $mockWriteHandler = $this->createMock(WriteHandlerInterface::class);
 
-        $this->mockQueue->method('sendMessage')->willReturnSelf();
         $mockWriteHandler->method('supports')->willReturn(true);
 
         $this->userEntry = new Entry(
@@ -72,7 +68,6 @@ final class ServerPasswordModifyHandlerTest extends TestCase
         );
 
         $this->subject = new ServerPasswordModifyHandler(
-            queue: $this->mockQueue,
             service: new PasswordModifyService(
                 targetResolver: new PasswordModifyTargetResolver(
                     $this->mockBackend,
@@ -91,16 +86,7 @@ final class ServerPasswordModifyHandlerTest extends TestCase
             ->method('get')
             ->willReturn($this->userEntry);
 
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->with(self::callback(
-                fn(LdapMessageResponse $r)
-                => $r->getResponse() instanceof PasswordModifyResponse
-                && $r->getResponse()->getGeneratedPassword() === null,
-            ));
-
-        $result = $this->subject->handleRequest(
+        $stream = $this->subject->handleRequest(
             new LdapMessageRequest(
                 1,
                 new PasswordModifyRequest(null, '12345', 'newpass'),
@@ -108,10 +94,15 @@ final class ServerPasswordModifyHandlerTest extends TestCase
             $this->userToken,
         );
 
-        self::assertInstanceOf(PasswordModifyOperationResult::class, $result);
+        $response = $this->singleResponse($stream->messages);
+        self::assertInstanceOf(PasswordModifyResponse::class, $response);
+        self::assertNull($response->getGeneratedPassword());
+
+        $outcome = $stream->outcome();
+        self::assertInstanceOf(PasswordModifyOperationResult::class, $outcome);
         self::assertSame(
             OperationOutcome::Succeeded,
-            $result->outcome(),
+            $outcome->outcome(),
         );
     }
 
@@ -121,38 +112,32 @@ final class ServerPasswordModifyHandlerTest extends TestCase
             ->method('get')
             ->willReturn($this->userEntry);
 
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->with(self::callback(
-                fn(LdapMessageResponse $r)
-                => $r->getResponse() instanceof PasswordModifyResponse
-                && strlen((string) $r->getResponse()->getGeneratedPassword()) === 16,
-            ));
-
-        $this->subject->handleRequest(
+        $stream = $this->subject->handleRequest(
             new LdapMessageRequest(
                 1,
                 new PasswordModifyRequest(null, '12345', null),
             ),
             $this->userToken,
         );
+
+        $response = $this->singleResponse($stream->messages);
+        self::assertInstanceOf(PasswordModifyResponse::class, $response);
+        self::assertSame(
+            16,
+            strlen((string) $response->getGeneratedPassword()),
+        );
     }
 
     public function test_anonymous_token_is_rejected_with_unwilling_to_perform(): void
     {
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->with(self::callback(
-                fn(LdapMessageResponse $r)
-                => method_exists($r->getResponse(), 'getResultCode')
-                && $r->getResponse()->getResultCode() === ResultCode::UNWILLING_TO_PERFORM,
-            ));
-
-        $this->subject->handleRequest(
+        $stream = $this->subject->handleRequest(
             new LdapMessageRequest(1, new PasswordModifyRequest()),
             new AnonToken(),
+        );
+
+        self::assertSame(
+            ResultCode::UNWILLING_TO_PERFORM,
+            $this->singleResponse($stream->messages)->getResultCode(),
         );
     }
 
@@ -162,16 +147,7 @@ final class ServerPasswordModifyHandlerTest extends TestCase
             ->method('get')
             ->willReturn($this->userEntry);
 
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->with(self::callback(
-                fn(LdapMessageResponse $r)
-                => method_exists($r->getResponse(), 'getResultCode')
-                && $r->getResponse()->getResultCode() === ResultCode::INVALID_CREDENTIALS,
-            ));
-
-        $result = $this->subject->handleRequest(
+        $stream = $this->subject->handleRequest(
             new LdapMessageRequest(
                 1,
                 new PasswordModifyRequest(null, 'wrongpass', 'newpass'),
@@ -179,10 +155,35 @@ final class ServerPasswordModifyHandlerTest extends TestCase
             $this->userToken,
         );
 
-        self::assertInstanceOf(PasswordModifyOperationResult::class, $result);
+        self::assertSame(
+            ResultCode::INVALID_CREDENTIALS,
+            $this->singleResponse($stream->messages)->getResultCode(),
+        );
+
+        $outcome = $stream->outcome();
+        self::assertInstanceOf(PasswordModifyOperationResult::class, $outcome);
         self::assertSame(
             OperationOutcome::Failed,
-            $result->outcome(),
+            $outcome->outcome(),
         );
+    }
+
+    /**
+     * @param iterable<LdapMessageResponse> $messages
+     */
+    private function singleResponse(iterable $messages): LdapResult
+    {
+        $messages = [...$messages];
+        self::assertCount(
+            1,
+            $messages,
+        );
+        $response = $messages[0]->getResponse();
+        self::assertInstanceOf(
+            LdapResult::class,
+            $response,
+        );
+
+        return $response;
     }
 }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandlerTest.php
@@ -23,7 +23,7 @@ use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Request\ForwardPasswordPolicyStateRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerPasswordPolicyForwardHandler;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
@@ -43,18 +43,16 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
 
     private const DN = 'cn=user,dc=foo,dc=bar';
 
-    private ServerQueue&MockObject $queue;
-
     private WritableLdapBackendInterface&MockObject $backend;
 
     private ServerPasswordPolicyForwardHandler $subject;
 
+    private ResponseStream $lastStream;
+
     protected function setUp(): void
     {
-        $this->queue = $this->createMock(ServerQueue::class);
         $this->backend = $this->createMock(WritableLdapBackendInterface::class);
         $this->subject = new ServerPasswordPolicyForwardHandler(
-            $this->queue,
             $this->backend,
             new PasswordPolicyResolver(
                 $this->backend,
@@ -77,15 +75,16 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
             '2026-05-20 11:59:00',
             new DateTimeZone('UTC'),
         );
-        $this->queue
-            ->expects(self::once())
-            ->method('sendMessage');
 
         $changes = $this->captureComputedChanges(
             new ForwardPasswordPolicyStateRequest(self::DN, 'uuid', [$time]),
             Entry::fromArray(self::DN, ['cn' => ['user']]),
         );
 
+        self::assertCount(
+            1,
+            [...$this->lastStream->messages],
+        );
         self::assertSame(
             'pwdFailureTime',
             $changes[0]->getAttribute()->getName(),
@@ -123,10 +122,6 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
 
     public function test_it_still_acks_and_does_not_write_when_no_policy_applies(): void
     {
-        $this->queue
-            ->expects(self::once())
-            ->method('sendMessage');
-
         $changes = $this->captureComputedChanges(
             new ForwardPasswordPolicyStateRequest(self::DN, 'uuid', [
                 new DateTimeImmutable('2026-05-20 11:59:00', new DateTimeZone('UTC')),
@@ -134,6 +129,10 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
             null,
         );
 
+        self::assertCount(
+            1,
+            [...$this->lastStream->messages],
+        );
         self::assertSame(
             [],
             $changes,
@@ -186,7 +185,7 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
                 }),
             );
 
-        $this->subject->handleRequest(
+        $this->lastStream = $this->subject->handleRequest(
             $this->messageFor($request),
             $this->createMock(TokenInterface::class),
         );

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerRootDseHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerRootDseHandlerTest.php
@@ -23,7 +23,6 @@ use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerRootDseHandler;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
@@ -36,8 +35,6 @@ use PHPUnit\Framework\TestCase;
 
 final class ServerRootDseHandlerTest extends TestCase
 {
-    private ServerQueue&MockObject $mockQueue;
-
     private ServerRootDseHandler $subject;
 
     private TokenInterface&MockObject $mockToken;
@@ -52,7 +49,6 @@ final class ServerRootDseHandlerTest extends TestCase
     {
         $this->options = new ServerOptions();
         $this->mockToken = $this->createMock(TokenInterface::class);
-        $this->mockQueue = $this->createMock(ServerQueue::class);
         $this->mockDseHandler = $this->createMock(RootDseHandlerInterface::class);
         $this->withBackendNamingContexts([]);
     }
@@ -67,11 +63,14 @@ final class ServerRootDseHandlerTest extends TestCase
             (new SearchRequest(Filters::present('objectClass')))->base('')->useBaseScope(),
         );
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with(
-                self::equalTo(new LdapMessageResponse(1, new SearchResultEntry(Entry::create('', [
+        $stream = $this->subject->handleRequest(
+            $search,
+            $this->mockToken,
+        );
+
+        $this->assertEquals(
+            [
+                new LdapMessageResponse(1, new SearchResultEntry(Entry::create('', [
                     'namingContexts' => 'dc=Foo,dc=Bar',
                     'subschemaSubentry' => ['cn=Subschema'],
                     'supportedControl' => [
@@ -96,13 +95,10 @@ final class ServerRootDseHandlerTest extends TestCase
                     ],
                     'supportedLDAPVersion' => ['3'],
                     'vendorName' => 'Foo',
-                ])))),
-                self::equalTo(new LdapMessageResponse(1, new SearchResultDone(0))),
-            );
-
-        $this->subject->handleRequest(
-            $search,
-            $this->mockToken,
+                ]))),
+                new LdapMessageResponse(1, new SearchResultDone(0)),
+            ],
+            [...$stream->messages],
         );
     }
 
@@ -113,32 +109,24 @@ final class ServerRootDseHandlerTest extends TestCase
             (new SearchRequest(Filters::present('objectClass')))->base('')->useBaseScope(),
         );
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with(
-                self::callback(function (LdapMessageResponse $response) {
-                    /** @var SearchResultEntry $result */
-                    $result = $response->getResponse();
-                    $entry = $result->getEntry();
-
-                    return $entry->get('supportedControl')?->has(Control::OID_PAGING) === true
-                        && $entry->get('supportedExtension')?->has(ExtendedRequest::OID_PWD_MODIFY) === true;
-                }),
-                self::anything(),
-            );
-
-        $this->subject->handleRequest(
+        $stream = $this->subject->handleRequest(
             $search,
             $this->mockToken,
         );
+        $messages = [...$stream->messages];
+
+        /** @var SearchResultEntry $result */
+        $result = $messages[0]->getResponse();
+        $entry = $result->getEntry();
+
+        self::assertTrue($entry->get('supportedControl')?->has(Control::OID_PAGING) === true);
+        self::assertTrue($entry->get('supportedExtension')?->has(ExtendedRequest::OID_PWD_MODIFY) === true);
     }
 
     public function test_it_advertises_the_sync_control_when_sync_is_enabled(): void
     {
         $this->subject = new ServerRootDseHandler(
             $this->options,
-            $this->mockQueue,
             $this->mockBackend,
             null,
             true,
@@ -149,23 +137,16 @@ final class ServerRootDseHandlerTest extends TestCase
             (new SearchRequest(Filters::present('objectClass')))->base('')->useBaseScope(),
         );
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with(
-                self::callback(function (LdapMessageResponse $response) {
-                    /** @var SearchResultEntry $result */
-                    $result = $response->getResponse();
-
-                    return $result->getEntry()->get('supportedControl')?->has(Control::OID_SYNC_REQUEST) === true;
-                }),
-                self::anything(),
-            );
-
-        $this->subject->handleRequest(
+        $stream = $this->subject->handleRequest(
             $search,
             $this->mockToken,
         );
+        $messages = [...$stream->messages];
+
+        /** @var SearchResultEntry $result */
+        $result = $messages[0]->getResponse();
+
+        self::assertTrue($result->getEntry()->get('supportedControl')?->has(Control::OID_SYNC_REQUEST) === true);
     }
 
     public function test_it_should_send_a_request_to_the_dispatcher_if_it_implements_a_rootdse_aware_interface(): void
@@ -175,7 +156,6 @@ final class ServerRootDseHandlerTest extends TestCase
 
         $this->subject = new ServerRootDseHandler(
             $this->options,
-            $this->mockQueue,
             $this->mockBackend,
             $this->mockDseHandler,
         );
@@ -224,17 +204,17 @@ final class ServerRootDseHandlerTest extends TestCase
             )
             ->willReturn($handlerRootDse);
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with(
-                new LdapMessageResponse(1, new SearchResultEntry($handlerRootDse)),
-                new LdapMessageResponse(1, new SearchResultDone(0)),
-            );
-
-        $this->subject->handleRequest(
+        $stream = $this->subject->handleRequest(
             $search,
             $this->mockToken,
+        );
+
+        $this->assertEquals(
+            [
+                new LdapMessageResponse(1, new SearchResultEntry($handlerRootDse)),
+                new LdapMessageResponse(1, new SearchResultDone(0)),
+            ],
+            [...$stream->messages],
         );
     }
 
@@ -248,28 +228,25 @@ final class ServerRootDseHandlerTest extends TestCase
             (new SearchRequest(Filters::present('objectClass')))->base('')->useBaseScope(),
         );
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with(
-                self::callback(function (LdapMessageResponse $response) {
-                    /** @var SearchResultEntry $search */
-                    $search = $response->getResponse();
-                    $attribute = $search->getEntry()->get('supportedSaslMechanisms');
-
-                    return $attribute !== null
-                        && $attribute->has(ServerOptions::SASL_PLAIN)
-                        && $attribute->has(ServerOptions::SASL_CRAM_MD5);
-                }),
-                new LdapMessageResponse(
-                    1,
-                    new SearchResultDone(0),
-                ),
-            );
-
-        $this->subject->handleRequest(
+        $stream = $this->subject->handleRequest(
             $search,
             $this->mockToken,
+        );
+        $messages = [...$stream->messages];
+
+        /** @var SearchResultEntry $result */
+        $result = $messages[0]->getResponse();
+        $attribute = $result->getEntry()->get('supportedSaslMechanisms');
+
+        self::assertNotNull($attribute);
+        self::assertTrue($attribute->has(ServerOptions::SASL_PLAIN));
+        self::assertTrue($attribute->has(ServerOptions::SASL_CRAM_MD5));
+        self::assertEquals(
+            new LdapMessageResponse(
+                1,
+                new SearchResultDone(0),
+            ),
+            $messages[1],
         );
     }
 
@@ -286,10 +263,13 @@ final class ServerRootDseHandlerTest extends TestCase
                 ->setAttributesOnly(true),
         );
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with(
+        $stream = $this->subject->handleRequest(
+            $search,
+            $this->mockToken,
+        );
+
+        $this->assertEquals(
+            [
                 new LdapMessageResponse(1, new SearchResultEntry(Entry::create('', [
                     'namingContexts' => [],
                     'subschemaSubentry' => [],
@@ -300,11 +280,8 @@ final class ServerRootDseHandlerTest extends TestCase
                     'vendorName' => [],
                 ]))),
                 new LdapMessageResponse(1, new SearchResultDone(0)),
-            );
-
-        $this->subject->handleRequest(
-            $search,
-            $this->mockToken,
+            ],
+            [...$stream->messages],
         );
     }
 
@@ -315,21 +292,15 @@ final class ServerRootDseHandlerTest extends TestCase
             (new SearchRequest(Filters::present('objectClass')))->base('')->useBaseScope(),
         );
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with(
-                self::callback(function (LdapMessageResponse $response) {
-                    /** @var SearchResultEntry $result */
-                    $result = $response->getResponse();
-                    $attr = $result->getEntry()->get('subschemaSubentry');
+        $stream = $this->subject->handleRequest($search, $this->mockToken);
+        $messages = [...$stream->messages];
 
-                    return $attr !== null && $attr->has('cn=Subschema');
-                }),
-                self::anything(),
-            );
+        /** @var SearchResultEntry $result */
+        $result = $messages[0]->getResponse();
+        $attr = $result->getEntry()->get('subschemaSubentry');
 
-        $this->subject->handleRequest($search, $this->mockToken);
+        self::assertNotNull($attr);
+        self::assertTrue($attr->has('cn=Subschema'));
     }
 
     public function test_it_uses_configured_subschema_entry_dn(): void
@@ -341,21 +312,15 @@ final class ServerRootDseHandlerTest extends TestCase
             (new SearchRequest(Filters::present('objectClass')))->base('')->useBaseScope(),
         );
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with(
-                self::callback(function (LdapMessageResponse $response) {
-                    /** @var SearchResultEntry $result */
-                    $result = $response->getResponse();
-                    $attr = $result->getEntry()->get('subschemaSubentry');
+        $stream = $this->subject->handleRequest($search, $this->mockToken);
+        $messages = [...$stream->messages];
 
-                    return $attr !== null && $attr->has('cn=schema,dc=example,dc=com');
-                }),
-                self::anything(),
-            );
+        /** @var SearchResultEntry $result */
+        $result = $messages[0]->getResponse();
+        $attr = $result->getEntry()->get('subschemaSubentry');
 
-        $this->subject->handleRequest($search, $this->mockToken);
+        self::assertNotNull($attr);
+        self::assertTrue($attr->has('cn=schema,dc=example,dc=com'));
     }
 
     public function test_it_should_only_return_specific_attributes_from_the_RootDSE_if_requested(): void
@@ -376,20 +341,20 @@ final class ServerRootDseHandlerTest extends TestCase
         $entry->changes()->reset();
         $entry->get('namingContexts')?->equals(new Attribute('foo'));
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with(
+        $stream = $this->subject->handleRequest(
+            $search,
+            $this->mockToken,
+        );
+
+        $this->assertEquals(
+            [
                 new LdapMessageResponse(
                     1,
                     new SearchResultEntry($entry),
                 ),
                 new LdapMessageResponse(1, new SearchResultDone(0)),
-            );
-
-        $this->subject->handleRequest(
-            $search,
-            $this->mockToken,
+            ],
+            [...$stream->messages],
         );
     }
 
@@ -408,7 +373,6 @@ final class ServerRootDseHandlerTest extends TestCase
 
         $this->subject = new ServerRootDseHandler(
             $this->options,
-            $this->mockQueue,
             $this->mockBackend,
             null,
         );

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
@@ -29,6 +29,7 @@ use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseWriter;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerSearchHandler;
 use FreeDSx\Ldap\Schema\Schema;
@@ -39,6 +40,7 @@ use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Operation\OperationOutcome;
+use FreeDSx\Ldap\Server\Operation\OperationResult;
 use FreeDSx\Ldap\Server\Operation\SearchOperationResult;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -95,13 +97,7 @@ final class ServerSearchHandlerTest extends TestCase
                 return $this->mockQueue;
             });
 
-        $this->subject = new ServerSearchHandler(
-            queue: $this->mockQueue,
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $this->mockAccessControl,
-            schema: $this->schema,
-        );
+        $this->subject = $this->makeHandler($this->mockAccessControl);
     }
 
     public function test_it_should_send_entries_from_the_backend_to_the_client(): void
@@ -124,9 +120,9 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('evaluate')
             ->willReturn(true);
 
-        $result = $this->subject->handleRequest(
+        $result = $this->drive(
+            $this->subject,
             $search,
-            $this->mockToken,
         );
 
         $this->assertSentMessages([
@@ -157,13 +153,7 @@ final class ServerSearchHandlerTest extends TestCase
         $mockAccessControl = $this->createMock(AccessControlInterface::class);
         $mockAccessControl->method('filterEntry')->willReturn($stripped);
 
-        $subject = new ServerSearchHandler(
-            queue: $this->mockQueue,
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $mockAccessControl,
-            schema: $this->schema,
-        );
+        $subject = $this->makeHandler($mockAccessControl);
 
         $this->mockBackend
             ->method('search')
@@ -173,9 +163,9 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('evaluate')
             ->willReturn(false);
 
-        $subject->handleRequest(
+        $this->drive(
+            $subject,
             $search,
-            $this->mockToken,
         );
 
         $this->assertSentMessages([
@@ -235,7 +225,7 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('evaluate')
             ->willReturn(true);
 
-        $this->subject->handleRequest($search, $this->mockToken);
+        $this->drive($this->subject, $search);
 
         $this->assertSentMessages([
             new LdapMessageResponse(2, new SearchResultEntry($entry1)),
@@ -267,7 +257,7 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('evaluate')
             ->willReturn(true);
 
-        $this->subject->handleRequest($search, $this->mockToken);
+        $this->drive($this->subject, $search);
 
         $this->assertSentMessages([
             new LdapMessageResponse(2, new SearchResultEntry($entry1)),
@@ -296,15 +286,11 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('evaluate')
             ->willReturn(true);
 
-        $subject = new ServerSearchHandler(
-            queue: $this->mockQueue,
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $this->mockAccessControl,
-            schema: $this->schema,
-            limits: new SearchLimits(maxSearchSize: 1),
+        $subject = $this->makeHandler(
+            $this->mockAccessControl,
+            new SearchLimits(maxSearchSize: 1),
         );
-        $subject->handleRequest($search, $this->mockToken);
+        $this->drive($subject, $search);
 
         $this->assertSentMessages([
             new LdapMessageResponse(2, new SearchResultEntry($entry1)),
@@ -332,15 +318,11 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('evaluate')
             ->willReturn(true);
 
-        $subject = new ServerSearchHandler(
-            queue: $this->mockQueue,
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $this->mockAccessControl,
-            schema: $this->schema,
-            limits: new SearchLimits(maxSearchSize: 5),
+        $subject = $this->makeHandler(
+            $this->mockAccessControl,
+            new SearchLimits(maxSearchSize: 5),
         );
-        $subject->handleRequest($search, $this->mockToken);
+        $this->drive($subject, $search);
 
         $this->assertSentMessages([
             new LdapMessageResponse(2, new SearchResultEntry($entry1)),
@@ -368,15 +350,11 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('evaluate')
             ->willReturn(true);
 
-        $subject = new ServerSearchHandler(
-            queue: $this->mockQueue,
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $this->mockAccessControl,
-            schema: $this->schema,
-            limits: new SearchLimits(maxSearchSize: 1),
+        $subject = $this->makeHandler(
+            $this->mockAccessControl,
+            new SearchLimits(maxSearchSize: 1),
         );
-        $subject->handleRequest($search, $this->mockToken);
+        $this->drive($subject, $search);
 
         $this->assertSentMessages([
             new LdapMessageResponse(2, new SearchResultEntry($entry1)),
@@ -396,9 +374,9 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('search')
             ->willReturn(new EntryStream($this->makeGenerator()));
 
-        $this->subject->handleRequest(
+        $this->drive(
+            $this->subject,
             $search,
-            $this->mockToken,
         );
 
         $this->assertSentMessages([
@@ -443,14 +421,8 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('evaluate')
             ->willReturn(true);
 
-        $subject = new ServerSearchHandler(
-            queue: $this->mockQueue,
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $mockAccessControl,
-            schema: $this->schema,
-        );
-        $subject->handleRequest($search, $this->mockToken);
+        $subject = $this->makeHandler($mockAccessControl);
+        $this->drive($subject, $search);
 
         $this->assertSentMessages([
             new LdapMessageResponse(2, new SearchResultEntry($entry2)),
@@ -490,14 +462,8 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('evaluate')
             ->willReturnCallback(static fn(Entry $e): bool => $e === $entry);
 
-        $subject = new ServerSearchHandler(
-            queue: $this->mockQueue,
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $mockAccessControl,
-            schema: $this->schema,
-        );
-        $subject->handleRequest($search, $this->mockToken);
+        $subject = $this->makeHandler($mockAccessControl);
+        $this->drive($subject, $search);
 
         $this->assertSentMessages([
             new LdapMessageResponse(
@@ -533,7 +499,7 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('peekForCancelSignal')
             ->willReturn($abandonSignal);
 
-        $this->subject->handleRequest($search, $this->mockToken);
+        $this->drive($this->subject, $search);
 
         $sentDone = array_filter(
             $this->sentMessages,
@@ -569,7 +535,7 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('peekForCancelSignal')
             ->willReturn($cancelSignal);
 
-        $this->subject->handleRequest($search, $this->mockToken);
+        $this->drive($this->subject, $search);
 
         $nonEntryMessages = array_values(array_filter(
             $this->sentMessages,
@@ -604,9 +570,9 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('search')
             ->willReturn(new EntryStream($this->makeGenerator()));
 
-        $this->subject->handleRequest(
+        $this->drive(
+            $this->subject,
             $search,
-            $this->mockToken,
         );
 
         $this->assertSentMessages([
@@ -629,9 +595,9 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('search')
             ->willReturn(new EntryStream($this->makeGenerator()));
 
-        $this->subject->handleRequest(
+        $this->drive(
+            $this->subject,
             $search,
-            $this->mockToken,
         );
 
         $done = end($this->sentMessages);
@@ -659,9 +625,9 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('search')
             ->willReturn(new EntryStream($this->makeGenerator()));
 
-        $this->subject->handleRequest(
+        $this->drive(
+            $this->subject,
             $search,
-            $this->mockToken,
         );
 
         $done = end($this->sentMessages);
@@ -693,9 +659,9 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('search')
             ->willReturn(new EntryStream($this->makeGenerator()));
 
-        $this->subject->handleRequest(
+        $this->drive(
+            $this->subject,
             $search,
-            $this->mockToken,
         );
 
         $done = end($this->sentMessages);
@@ -722,14 +688,45 @@ final class ServerSearchHandlerTest extends TestCase
             ->method('search')
             ->willReturn(new EntryStream($this->makeGenerator()));
 
-        $this->subject->handleRequest(
+        $this->drive(
+            $this->subject,
             $search,
-            $this->mockToken,
         );
 
         $done = end($this->sentMessages);
         self::assertInstanceOf(LdapMessageResponse::class, $done);
         self::assertNull($done->controls()->get(Control::OID_SORTING_RESPONSE));
+    }
+
+    private function makeHandler(
+        AccessControlInterface $accessControl,
+        ?SearchLimits $limits = null,
+    ): ServerSearchHandler {
+        return new ServerSearchHandler(
+            backend: $this->mockBackend,
+            filterEvaluator: $this->mockFilterEvaluator,
+            accessControl: $accessControl,
+            schema: $this->schema,
+            limits: $limits ?? new SearchLimits(),
+        );
+    }
+
+    /**
+     * Drives the handler's stream through the writer so it flushes and polls for cancellation.
+     */
+    private function drive(
+        ServerSearchHandler $subject,
+        LdapMessageRequest $search,
+    ): OperationResult {
+        $stream = $subject->handleRequest(
+            $search,
+            $this->mockToken,
+        );
+
+        return (new ResponseWriter($this->mockQueue))->write(
+            $stream,
+            $search->getMessageId(),
+        );
     }
 
     private function makeGenerator(Entry ...$entries): Generator

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerStartTlsHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerStartTlsHandlerTest.php
@@ -19,7 +19,7 @@ use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\ConnectionControl;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerStartTlsHandler;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\ServerOptions;
@@ -30,7 +30,7 @@ final class ServerStartTlsHandlerTest extends TestCase
 {
     private ServerStartTlsHandler $subject;
 
-    private ServerQueue&MockObject $mockQueue;
+    private ConnectionControl&MockObject $mockConnection;
 
     private TokenInterface&MockObject $mockToken;
 
@@ -39,12 +39,12 @@ final class ServerStartTlsHandlerTest extends TestCase
     protected function setUp(): void
     {
         $this->mockToken = $this->createMock(TokenInterface::class);
-        $this->mockQueue = $this->createMock(ServerQueue::class);
+        $this->mockConnection = $this->createMock(ConnectionControl::class);
         $this->options = new ServerOptions();
 
         $this->subject = new ServerStartTlsHandler(
             $this->options,
-            $this->mockQueue,
+            $this->mockConnection,
         );
     }
 
@@ -52,78 +52,89 @@ final class ServerStartTlsHandlerTest extends TestCase
     {
         $this->options->setSslCert('foo');
 
-        $this->mockQueue
+        $this->mockConnection
             ->method('isEncrypted')
             ->willReturn(false);
 
-        $this->mockQueue
-            ->method('encrypt')
-            ->willReturnSelf();
+        $startTls = new LdapMessageRequest(1, new ExtendedRequest(ExtendedRequest::OID_START_TLS));
 
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->with(new LdapMessageResponse(
+        $stream = $this->subject->handleRequest(
+            $startTls,
+            $this->mockToken,
+        );
+
+        $this->assertEquals(
+            [new LdapMessageResponse(
                 1,
                 new ExtendedResponse(
                     new LdapResult(0),
                     ExtendedRequest::OID_START_TLS,
                 ),
-            ));
-
-        $startTls = new LdapMessageRequest(1, new ExtendedRequest(ExtendedRequest::OID_START_TLS));
-
-        $this->subject->handleRequest(
-            $startTls,
-            $this->mockToken,
+            )],
+            [...$stream->messages],
         );
+
+        // The socket is only encrypted once the writer runs onComplete, after the SUCCESS is flushed.
+        $this->mockConnection
+            ->expects(self::once())
+            ->method('encrypt')
+            ->willReturnSelf();
+
+        $this->assertNotNull($stream->onComplete);
+        ($stream->onComplete)($this->mockConnection);
     }
 
     public function test_it_should_send_back_an_error_if_the_queue_is_already_encrypted(): void
     {
         $this->options->setSslCert('foo');
 
-        $this->mockQueue
+        $this->mockConnection
             ->method('isEncrypted')
             ->willReturn(true);
 
-        $this->mockQueue
+        $this->mockConnection
             ->expects(self::never())
             ->method('encrypt');
 
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->with(self::equalTo(new LdapMessageResponse(
+        $startTls = new LdapMessageRequest(1, new ExtendedRequest(ExtendedRequest::OID_START_TLS));
+
+        $stream = $this->subject->handleRequest(
+            $startTls,
+            $this->mockToken,
+        );
+
+        $this->assertEquals(
+            [new LdapMessageResponse(
                 1,
                 new ExtendedResponse(
                     new LdapResult(ResultCode::OPERATIONS_ERROR, '', 'The current LDAP session is already encrypted.'),
                     ExtendedRequest::OID_START_TLS,
                 ),
-            )));
-
-        $startTls = new LdapMessageRequest(1, new ExtendedRequest(ExtendedRequest::OID_START_TLS));
-
-        $this->subject->handleRequest(
-            $startTls,
-            $this->mockToken,
+            )],
+            [...$stream->messages],
         );
+        $this->assertNull($stream->onComplete);
     }
 
     public function test_it_should_send_back_an_error_if_encryption_is_not_supported(): void
     {
-        $this->mockQueue
+        $this->mockConnection
             ->method('isEncrypted')
             ->willReturn(false);
 
-        $this->mockQueue
+        $this->mockConnection
             ->expects(self::never())
             ->method('encrypt');
 
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->with(self::equalTo(new LdapMessageResponse(
+        $startTls = new LdapMessageRequest(1, new ExtendedRequest(ExtendedRequest::OID_START_TLS));
+
+        $stream = $this->subject->handleRequest(
+            $startTls,
+            $this->mockToken,
+        );
+
+        $this->assertEquals(
+            [new LdapMessageResponse(
                 1,
                 new ExtendedResponse(
                     new LdapResult(
@@ -133,13 +144,9 @@ final class ServerStartTlsHandlerTest extends TestCase
                     ),
                     ExtendedRequest::OID_START_TLS,
                 ),
-            )));
-
-        $startTls = new LdapMessageRequest(1, new ExtendedRequest(ExtendedRequest::OID_START_TLS));
-
-        $this->subject->handleRequest(
-            $startTls,
-            $this->mockToken,
+            )],
+            [...$stream->messages],
         );
+        $this->assertNull($stream->onComplete);
     }
 }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSubschemaHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSubschemaHandlerTest.php
@@ -20,7 +20,6 @@ use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerSubschemaHandler;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
@@ -31,8 +30,6 @@ use PHPUnit\Framework\TestCase;
 
 final class ServerSubschemaHandlerTest extends TestCase
 {
-    private ServerQueue&MockObject $mockQueue;
-
     private TokenInterface&MockObject $mockToken;
 
     private ServerOptions $options;
@@ -42,56 +39,45 @@ final class ServerSubschemaHandlerTest extends TestCase
     protected function setUp(): void
     {
         $this->options = new ServerOptions();
-        $this->mockQueue = $this->createMock(ServerQueue::class);
         $this->mockToken = $this->createMock(TokenInterface::class);
 
         $this->subject = new ServerSubschemaHandler(
             options: $this->options,
-            queue: $this->mockQueue,
         );
     }
 
     public function test_it_returns_a_stub_subschema_entry(): void
     {
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with(
-                self::callback(function (LdapMessageResponse $response) {
-                    /** @var SearchResultEntry $result */
-                    $result = $response->getResponse();
-                    $entry = $result->getEntry();
+        $stream = $this->subject->handleRequest($this->makeMessage(), $this->mockToken);
+        $messages = [...$stream->messages];
 
-                    return $entry->getDn()->toString() === 'cn=Subschema'
-                        && ($entry->get('objectClass')?->has('subschema') ?? false)
-                        && ($entry->get('cn')?->has('Subschema') ?? false);
-                }),
-                self::equalTo(new LdapMessageResponse(1, new SearchResultDone(ResultCode::SUCCESS))),
-            );
+        /** @var SearchResultEntry $result */
+        $result = $messages[0]->getResponse();
+        $entry = $result->getEntry();
 
-        $this->subject->handleRequest($this->makeMessage(), $this->mockToken);
+        self::assertSame(
+            'cn=Subschema',
+            $entry->getDn()->toString(),
+        );
+        self::assertTrue($entry->get('objectClass')?->has('subschema') ?? false);
+        self::assertTrue($entry->get('cn')?->has('Subschema') ?? false);
+        self::assertEquals(
+            new LdapMessageResponse(1, new SearchResultDone(ResultCode::SUCCESS)),
+            $messages[1],
+        );
     }
 
     public function test_it_uses_the_configured_subschema_entry_dn(): void
     {
         $this->options->setSubschemaEntry(new Dn('cn=schema,dc=example,dc=com'));
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with(
-                self::callback(function (LdapMessageResponse $response) {
-                    /** @var SearchResultEntry $result */
-                    $result = $response->getResponse();
-                    $entry = $result->getEntry();
+        $entry = $this->handleAndCaptureEntry();
 
-                    return $entry->getDn()->toString() === 'cn=schema,dc=example,dc=com'
-                        && ($entry->get('cn')?->has('schema') ?? false);
-                }),
-                self::anything(),
-            );
-
-        $this->subject->handleRequest($this->makeMessage(), $this->mockToken);
+        self::assertSame(
+            'cn=schema,dc=example,dc=com',
+            $entry->getDn()->toString(),
+        );
+        self::assertTrue($entry->get('cn')?->has('schema') ?? false);
     }
 
     public function test_it_returns_non_empty_attribute_types_in_rfc4512_format(): void
@@ -153,26 +139,12 @@ final class ServerSubschemaHandlerTest extends TestCase
 
     private function handleAndCaptureEntry(): Entry
     {
-        $captured = null;
+        $stream = $this->subject->handleRequest($this->makeMessage(), $this->mockToken);
+        $messages = [...$stream->messages];
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with(
-                self::callback(static function (LdapMessageResponse $response) use (&$captured): bool {
-                    /** @var SearchResultEntry $result */
-                    $result = $response->getResponse();
-                    $captured = $result->getEntry();
+        /** @var SearchResultEntry $result */
+        $result = $messages[0]->getResponse();
 
-                    return true;
-                }),
-                self::anything(),
-            );
-
-        $this->subject->handleRequest($this->makeMessage(), $this->mockToken);
-
-        assert($captured instanceof Entry);
-
-        return $captured;
+        return $result->getEntry();
     }
 }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSyncHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSyncHandlerTest.php
@@ -520,7 +520,7 @@ final class ServerSyncHandlerTest extends TestCase
         return $this->subject->handleRequest(
             $this->syncMessage($cookie, $mode, $reloadHint),
             $this->token,
-        );
+        )->outcome();
     }
 
     private function syncMessage(

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerUnbindHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerUnbindHandlerTest.php
@@ -15,37 +15,47 @@ namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Operation\Request\UnbindRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\Queue\ConnectionControl;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerUnbindHandler;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class ServerUnbindHandlerTest extends TestCase
 {
-    private ServerQueue&MockObject $mockQueue;
-
     private ServerUnbindHandler $subject;
 
     protected function setUp(): void
     {
-        $this->mockQueue = $this->createMock(ServerQueue::class);
-
-        $this->subject = new ServerUnbindHandler($this->mockQueue);
+        $this->subject = new ServerUnbindHandler();
     }
 
     public function test_it_should_handle_an_unbind_request(): void
     {
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('close');
-        $this->mockQueue
-            ->expects($this->never())
-            ->method('sendMessage');
-
-        $this->subject->handleRequest(
+        $stream = $this->subject->handleRequest(
             new LdapMessageRequest(1, new UnbindRequest()),
             $this->createMock(TokenInterface::class),
         );
+
+        $this->assertSame(
+            [],
+            [...$stream->messages],
+        );
+        $this->assertNotNull($stream->onComplete);
+    }
+
+    public function test_it_should_close_the_connection_on_completion(): void
+    {
+        $stream = $this->subject->handleRequest(
+            new LdapMessageRequest(1, new UnbindRequest()),
+            $this->createMock(TokenInterface::class),
+        );
+
+        $connection = $this->createMock(ConnectionControl::class);
+        $connection
+            ->expects($this->once())
+            ->method('close');
+
+        $this->assertNotNull($stream->onComplete);
+        ($stream->onComplete)($connection);
     }
 }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerUnsupportedExtendedHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerUnsupportedExtendedHandlerTest.php
@@ -20,7 +20,6 @@ use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerUnsupportedExtendedHandler;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -30,15 +29,12 @@ final class ServerUnsupportedExtendedHandlerTest extends TestCase
 {
     private ServerUnsupportedExtendedHandler $subject;
 
-    private ServerQueue&MockObject $mockQueue;
-
     private TokenInterface&MockObject $mockToken;
 
     protected function setUp(): void
     {
-        $this->mockQueue = $this->createMock(ServerQueue::class);
         $this->mockToken = $this->createMock(TokenInterface::class);
-        $this->subject = new ServerUnsupportedExtendedHandler($this->mockQueue);
+        $this->subject = new ServerUnsupportedExtendedHandler();
     }
 
     public function test_it_returns_protocol_error_with_response_name_echoing_the_request(): void
@@ -49,10 +45,13 @@ final class ServerUnsupportedExtendedHandlerTest extends TestCase
             new ExtendedRequest($oid),
         );
 
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage')
-            ->with(self::equalTo(new LdapMessageResponse(
+        $stream = $this->subject->handleRequest(
+            $request,
+            $this->mockToken,
+        );
+
+        $this->assertEquals(
+            [new LdapMessageResponse(
                 42,
                 new ExtendedResponse(
                     new LdapResult(
@@ -62,11 +61,8 @@ final class ServerUnsupportedExtendedHandlerTest extends TestCase
                     ),
                     $oid,
                 ),
-            )));
-
-        $this->subject->handleRequest(
-            $request,
-            $this->mockToken,
+            )],
+            [...$stream->messages],
         );
     }
 
@@ -78,13 +74,14 @@ final class ServerUnsupportedExtendedHandlerTest extends TestCase
             new Control('1.2.3.4', false),
         );
 
-        $this->mockQueue
-            ->expects(self::once())
-            ->method('sendMessage');
-
-        $this->subject->handleRequest(
+        $stream = $this->subject->handleRequest(
             $request,
             $this->mockToken,
+        );
+
+        $this->assertCount(
+            1,
+            [...$stream->messages],
         );
     }
 }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerWhoAmIHandlerTest.php
@@ -19,43 +19,37 @@ use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
-use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerWhoAmIHandler;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use FreeDSx\Ldap\Server\Token\BindToken;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class ServerWhoAmIHandlerTest extends TestCase
 {
-    private ServerQueue&MockObject $mockQueue;
-
     private ServerWhoAmIHandler $subject;
 
     protected function setUp(): void
     {
-        $this->mockQueue = $this->createMock(ServerQueue::class);
-
-        $this->subject = new ServerWhoAmIHandler($this->mockQueue);
+        $this->subject = new ServerWhoAmIHandler();
     }
 
     public function test_it_should_handle_a_who_am_i_when_there_is_a_token_with_a_DN_name(): void
     {
         $request = new LdapMessageRequest(2, new ExtendedRequest(ExtendedRequest::OID_WHOAMI));
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with($this->equalTo(new LdapMessageResponse(
-                2,
-                new ExtendedResponse(new LdapResult(0), null, 'dn:cn=foo,dc=foo,dc=bar'),
-            )));
-
-        $this->subject->handleRequest(
+        $stream = $this->subject->handleRequest(
             $request,
             BindToken::fromDn(
                 'cn=foo,dc=foo,dc=bar',
             ),
+        );
+
+        $this->assertEquals(
+            [new LdapMessageResponse(
+                2,
+                new ExtendedResponse(new LdapResult(0), null, 'dn:cn=foo,dc=foo,dc=bar'),
+            )],
+            [...$stream->messages],
         );
     }
 
@@ -66,24 +60,24 @@ final class ServerWhoAmIHandlerTest extends TestCase
             new ExtendedRequest(ExtendedRequest::OID_WHOAMI),
         );
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with($this->equalTo(new LdapMessageResponse(
+        $stream = $this->subject->handleRequest(
+            $request,
+            BindToken::fromSasl(
+                'uid=alice',
+                new Dn('cn=Alice,dc=example,dc=com'),
+            ),
+        );
+
+        $this->assertEquals(
+            [new LdapMessageResponse(
                 2,
                 new ExtendedResponse(
                     new LdapResult(0),
                     null,
                     'dn:cn=Alice,dc=example,dc=com',
                 ),
-            )));
-
-        $this->subject->handleRequest(
-            $request,
-            BindToken::fromSasl(
-                'uid=alice',
-                new Dn('cn=Alice,dc=example,dc=com'),
-            ),
+            )],
+            [...$stream->messages],
         );
     }
 
@@ -91,19 +85,19 @@ final class ServerWhoAmIHandlerTest extends TestCase
     {
         $request = new LdapMessageRequest(2, new ExtendedRequest(ExtendedRequest::OID_WHOAMI));
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with($this->equalTo(new LdapMessageResponse(
-                2,
-                new ExtendedResponse(new LdapResult(0), null, 'u:foo@bar.local'),
-            )));
-
-        $this->subject->handleRequest(
+        $stream = $this->subject->handleRequest(
             $request,
             BindToken::fromUsername(
                 'foo@bar.local',
             ),
+        );
+
+        $this->assertEquals(
+            [new LdapMessageResponse(
+                2,
+                new ExtendedResponse(new LdapResult(0), null, 'u:foo@bar.local'),
+            )],
+            [...$stream->messages],
         );
     }
 
@@ -111,24 +105,17 @@ final class ServerWhoAmIHandlerTest extends TestCase
     {
         $request = new LdapMessageRequest(2, new ExtendedRequest(ExtendedRequest::OID_WHOAMI));
 
-        $this->mockQueue
-            ->expects($this->once())
-            ->method('sendMessage')
-            ->with($this->equalTo(new LdapMessageResponse(
-                2,
-                new ExtendedResponse(new LdapResult(0), null, ''),
-            )));
-
-        $this->mockQueue
-            ->method('getMessage')
-            ->willReturn(new LdapMessageRequest(
-                2,
-                new ExtendedRequest(ExtendedRequest::OID_WHOAMI),
-            ));
-
-        $this->subject->handleRequest(
+        $stream = $this->subject->handleRequest(
             $request,
             new AnonToken(),
+        );
+
+        $this->assertEquals(
+            [new LdapMessageResponse(
+                2,
+                new ExtendedResponse(new LdapResult(0), null, ''),
+            )],
+            [...$stream->messages],
         );
     }
 }

--- a/tests/unit/Server/Proxy/ProxyRequestPipelineTest.php
+++ b/tests/unit/Server/Proxy/ProxyRequestPipelineTest.php
@@ -8,6 +8,9 @@ use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseWriter;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerProtocolHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
@@ -32,6 +35,7 @@ final class ProxyRequestPipelineTest extends TestCase
         $this->subject = new ProxyRequestPipeline(
             $this->startTlsHandler,
             $this->forwarder,
+            new ResponseWriter($this->createMock(ServerQueue::class)),
         );
     }
 
@@ -40,7 +44,7 @@ final class ProxyRequestPipelineTest extends TestCase
         $this->startTlsHandler
             ->expects(self::once())
             ->method('handleRequest')
-            ->willReturn(OperationOutcomeResult::succeeded());
+            ->willReturn(ResponseStream::none(OperationOutcomeResult::succeeded()));
         $this->forwarder
             ->expects(self::never())
             ->method('handle');


### PR DESCRIPTION
Currently, all the server handlers use the server queue directly to read / write responses as needed. This is messy and has duplicated logic and made things harder to do in one spot since it's not consolidated. This aims to move the logic into a middleware and have the handlers instead return a stream with a generator so we can pipe through the results in one spot. This way there's only one spot with logic writing to the queue and it simplifies logic in a bunch of spots.

Very messy since all the handlers and all the tests need to be touched to switch all the spots over unfortunately.