### PR TITLE
[1.0.0] Optimize server side sort on sqlite / mysql

### DIFF
--- a/resources/schema/sqlite/baseline.sql
+++ b/resources/schema/sqlite/baseline.sql
@@ -17,7 +17,8 @@ CREATE TABLE IF NOT EXISTS entry_attribute_values (
 
 CREATE INDEX IF NOT EXISTS idx_eav_attr_value ON entry_attribute_values (attr_name_lower, value_lower);
 
-CREATE INDEX IF NOT EXISTS idx_eav_entry ON entry_attribute_values (entry_lc_dn);
+-- Covering (entry_lc_dn leads): entry-scoped lookups plus index-only sort MIN() and correlated EXISTS.
+CREATE INDEX IF NOT EXISTS idx_eav_entry ON entry_attribute_values (entry_lc_dn, attr_name_lower, value_lower);
 
 CREATE TABLE IF NOT EXISTS ldap_change_journal (
     seq          INTEGER NOT NULL PRIMARY KEY,

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
@@ -139,24 +139,48 @@ trait PdoDialectTrait
         return 'INSERT INTO entry_attribute_values (entry_lc_dn, attr_name_lower, value_lower, value_original) VALUES ';
     }
 
-    public function sortKeyClause(
-        string $attributeLower,
-        string $direction,
-    ): SortClause {
-        $expr = <<<SQL
-            (SELECT MIN(eav.value_lower)
-             FROM entry_attribute_values eav
-             WHERE eav.entry_lc_dn = LOWER(dn)
-               AND eav.attr_name_lower = ?)
+    public function sortedQuery(
+        string $baseSql,
+        array $baseParams,
+        array $sortKeys,
+    ): SortedQuery {
+        $projections = [];
+        $orderTerms = [];
+        $sortParams = [];
+
+        // MySQL/MariaDB lack NULLS FIRST/LAST and would re-run the correlated subquery per ORDER BY term; project the
+        // key once into a derived table, then order by the materialised column (single evaluation per candidate).
+        foreach ($sortKeys as $index => $sortKey) {
+            $alias = '__sk' . $index;
+            $projections[] = <<<SQL
+                (SELECT MIN(eav.value_lower)
+                 FROM entry_attribute_values eav
+                 WHERE eav.entry_lc_dn = LOWER(__base.dn)
+                   AND eav.attr_name_lower = ?) AS {$alias}
+                SQL;
+            $orderTerms[] = "{$alias} IS NULL {$sortKey->direction}, {$alias} {$sortKey->direction}";
+            $sortParams[] = $sortKey->attributeLower;
+        }
+
+        $projection = implode(",\n", $projections);
+        $order = implode(', ', $orderTerms);
+        $sql = <<<SQL
+            SELECT dn, attributes FROM (
+                SELECT __base.dn, __base.attributes,
+                {$projection}
+                FROM ({$baseSql}) __base
+            ) __keyed
+            ORDER BY {$order}
             SQL;
 
-        // MySQL/MariaDB lack NULLS FIRST/LAST...emulate via an "IS NULL" ordering prefix.
-        return new SortClause(
-            $expr . ' IS NULL ' . $direction . ', ' . $expr . ' ' . $direction,
-            [
-                $attributeLower,
-                $attributeLower,
-            ],
+        // The projected subqueries precede the nested base query textually.
+        // So their params bind first.
+        return new SortedQuery(
+            $sql,
+            array_merge(
+                $sortParams,
+                $baseParams,
+            ),
         );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoEntryDialectInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoEntryDialectInterface.php
@@ -109,10 +109,14 @@ interface PdoEntryDialectInterface
     public function maxDnLength(): ?int;
 
     /**
-     * Returns the ORDER BY term and bound params for one sort key, with NULL/missing values ordered per RFC 2891 §2.2.
+     * Rewrites the base entry query with an ORDER BY for the sort keys, NULL/missing values ordered per RFC 2891 §2.2.
+     *
+     * @param list<string> $baseParams
+     * @param list<SortKeySpec> $sortKeys
      */
-    public function sortKeyClause(
-        string $attributeLower,
-        string $direction,
-    ): SortClause;
+    public function sortedQuery(
+        string $baseSql,
+        array $baseParams,
+        array $sortKeys,
+    ): SortedQuery;
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SortKeySpec.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SortKeySpec.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
+
+/**
+ * One resolved sort key: the lowercased attribute and its SQL direction.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class SortKeySpec
+{
+    public function __construct(
+        public string $attributeLower,
+        public string $direction,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SortedQuery.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SortedQuery.php
@@ -14,11 +14,11 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
 
 /**
- * ORDER BY term for one sort key plus its bound parameters.
+ * A base entry query rewritten with an ORDER BY, plus its parameters in bind order.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final readonly class SortClause
+final readonly class SortedQuery
 {
     /**
      * @param list<string> $params

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SqliteDialect.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SqliteDialect.php
@@ -74,23 +74,35 @@ final class SqliteDialect implements PdoDialectInterface
         return null;
     }
 
-    public function sortKeyClause(
-        string $attributeLower,
-        string $direction,
-    ): SortClause {
-        // RFC 2891 §2.2: NULL is the largest value, so missing entries sort last (ASC) or first (DESC).
-        $nulls = $direction === 'ASC'
-            ? 'NULLS LAST'
-            : 'NULLS FIRST';
+    public function sortedQuery(
+        string $baseSql,
+        array $baseParams,
+        array $sortKeys,
+    ): SortedQuery {
+        $terms = [];
+        $sortParams = [];
 
-        return new SortClause(
-            <<<SQL
+        // RFC 2891 §2.2: NULL is the largest value, so missing entries sort last (ASC) or first (DESC). Native
+        // NULLS ordering evaluates the correlated subquery once, so the base query needs no wrapping.
+        foreach ($sortKeys as $sortKey) {
+            $nulls = $sortKey->direction === 'ASC'
+                ? 'NULLS LAST'
+                : 'NULLS FIRST';
+            $terms[] = <<<SQL
                 (SELECT MIN(eav.value_lower)
                  FROM entry_attribute_values eav
                  WHERE eav.entry_lc_dn = LOWER(dn)
-                   AND eav.attr_name_lower = ?) $direction $nulls
-            SQL,
-            [$attributeLower],
+                   AND eav.attr_name_lower = ?) {$sortKey->direction} {$nulls}
+                SQL;
+            $sortParams[] = $sortKey->attributeLower;
+        }
+
+        return new SortedQuery(
+            $baseSql . ' ORDER BY ' . implode(', ', $terms),
+            array_merge(
+                $baseParams,
+                $sortParams,
+            ),
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilder.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo;
 
 use FreeDSx\Ldap\Control\Sorting\SortKey;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SortKeySpec;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterResult;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterUtility;
 
@@ -58,7 +59,7 @@ final readonly class PdoListQueryBuilder
         };
 
         if ($sortKeys !== []) {
-            $query = $this->appendSortClause(
+            $query = $this->applySort(
                 $query,
                 $sortKeys,
             );
@@ -218,28 +219,27 @@ final readonly class PdoListQueryBuilder
     /**
      * @param SortKey[] $sortKeys
      */
-    private function appendSortClause(
+    private function applySort(
         SqlQuery $query,
         array $sortKeys,
     ): SqlQuery {
-        $clauses = [];
-        $params = [];
-
-        foreach ($sortKeys as $sortKey) {
-            $clause = $this->dialect->sortKeyClause(
+        $specs = array_values(array_map(
+            static fn(SortKey $sortKey): SortKeySpec => new SortKeySpec(
                 strtolower($sortKey->getAttribute()),
                 $sortKey->getUseReverseOrder() ? 'DESC' : 'ASC',
-            );
-            $clauses[] = $clause->sql;
-            $params = array_merge(
-                $params,
-                $clause->params,
-            );
-        }
+            ),
+            $sortKeys,
+        ));
 
-        return $query->appending(
-            ' ORDER BY ' . implode(', ', $clauses),
-            $params,
+        $sorted = $this->dialect->sortedQuery(
+            $query->sql,
+            $query->params,
+            $specs,
+        );
+
+        return new SqlQuery(
+            $sorted->sql,
+            $sorted->params,
         );
     }
 }

--- a/tests/performance/Config.php
+++ b/tests/performance/Config.php
@@ -67,6 +67,11 @@ final class Config
     public const DEFAULT_SEARCH_SUB_SIZE_LIMIT = 500;
 
     /**
+     * A sorted search models a bounded display page typically, so give it a realistic limit.
+     */
+    public const DEFAULT_SEARCH_SORT_SIZE_LIMIT = 50;
+
+    /**
      * Mirrors the realistic ServerOptions default so load tests run bounded rather than with lookthrough disabled.
      */
     public const DEFAULT_MAX_SEARCH_LOOKTHROUGH = 5000;
@@ -91,6 +96,7 @@ final class Config
         public readonly string $writeBase = self::DEFAULT_WRITE_BASE,
         public readonly bool $jit = true,
         public readonly int $searchSubSizeLimit = self::DEFAULT_SEARCH_SUB_SIZE_LIMIT,
+        public readonly int $searchSortSizeLimit = self::DEFAULT_SEARCH_SORT_SIZE_LIMIT,
         public readonly bool $monitor = true,
         public readonly ?string $searchAttributes = null,
         public readonly bool $attributesOnly = false,
@@ -106,6 +112,7 @@ final class Config
         $this->assertNonNegative('warmup', $warmup);
         $this->assertNonNegative('seed-entries', $seedEntries);
         $this->assertNonNegative('search-sub-size-limit', $searchSubSizeLimit);
+        $this->assertNonNegative('search-sort-size-limit', $searchSortSizeLimit);
         $this->assertNonNegative('seed-attributes', $seedAttributes);
         $this->assertNonNegative('max-search-lookthrough', $maxSearchLookthrough);
 

--- a/tests/performance/Config.php
+++ b/tests/performance/Config.php
@@ -54,7 +54,7 @@ final class Config
         'json',
     ];
 
-    public const DEFAULT_MIX = 'bind=5,search-read=50,search-eq=25,search-sub=10,search-list=5,add=2,modify=2,delete=1';
+    public const DEFAULT_MIX = 'bind=5,search-read=50,search-eq=25,search-sub=10,search-list=5,search-sort=3,add=2,modify=2,delete=1';
 
     public const DEFAULT_BIND_DN = 'cn=user,dc=foo,dc=bar';
 

--- a/tests/performance/LoadTestCommand.php
+++ b/tests/performance/LoadTestCommand.php
@@ -215,6 +215,13 @@ final class LoadTestCommand extends Command
                 (string) Config::DEFAULT_SEARCH_SUB_SIZE_LIMIT,
             )
             ->addOption(
+                'search-sort-size-limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Per-request size limit applied to search-sort ops (0 = unlimited)',
+                (string) Config::DEFAULT_SEARCH_SORT_SIZE_LIMIT,
+            )
+            ->addOption(
                 'search-attributes',
                 null,
                 InputOption::VALUE_REQUIRED,
@@ -445,6 +452,7 @@ final class LoadTestCommand extends Command
             // Swoole keeps it. --no-jit forces it off either way.
             jit: !(bool) $input->getOption('no-jit') && $runner !== 'pcntl',
             searchSubSizeLimit: $this->requireInt($input, 'search-sub-size-limit'),
+            searchSortSizeLimit: $this->requireInt($input, 'search-sort-size-limit'),
             monitor: (bool) $input->getOption('monitor'),
             searchAttributes: $this->optionalString($input, 'search-attributes'),
             attributesOnly: (bool) $input->getOption('attributes-only'),

--- a/tests/performance/Threshold/CiThresholds.php
+++ b/tests/performance/Threshold/CiThresholds.php
@@ -65,11 +65,14 @@ final class CiThresholds
                 maxErrors: 0,
                 minThroughput: 720.0,
                 maxP99Ms: 200.0,
+                // Server-sides sort file-sorts + materializes per query, so it's going to be slower.
+                perOpMaxP99Ms: ['search-sort' => 250.0],
             ),
             'mysql:swoole' => new ThresholdSet(
                 maxErrors: 0,
                 minThroughput: 720.0,
                 maxP99Ms: 200.0,
+                perOpMaxP99Ms: ['search-sort' => 250.0],
             ),
             default => throw new InvalidArgumentException(sprintf(
                 'Unknown CI profile "%s". Known: %s.',

--- a/tests/performance/Threshold/ThresholdEvaluator.php
+++ b/tests/performance/Threshold/ThresholdEvaluator.php
@@ -47,10 +47,11 @@ final class ThresholdEvaluator
             );
         }
 
-        if ($thresholds->maxP99Ms !== null) {
+        if ($thresholds->maxP99Ms !== null || $thresholds->perOpMaxP99Ms !== []) {
             $gates[] = $this->evaluateMaxP99(
                 $snapshot,
                 $thresholds->maxP99Ms,
+                $thresholds->perOpMaxP99Ms,
             );
         }
 
@@ -122,32 +123,48 @@ final class ThresholdEvaluator
     }
 
     /**
+     * Gates each op against its own ceiling (per-op override, else the global), reporting the op nearest its limit.
+     *
+     * @param array<string, float> $perOpMaxMs
+     *
      * @return array{gate: string, passed: bool, expected: string, actual: string}
      */
     private function evaluateMaxP99(
         StatsSnapshot $snapshot,
-        float $maxMs,
+        ?float $globalMaxMs,
+        array $perOpMaxMs,
     ): array {
         $worstOp = null;
-        $worstP99Ns = 0;
+        $worstRatio = 0.0;
+        $worstP99Ms = 0.0;
+        $worstCeilingMs = 0.0;
 
         foreach ($snapshot->operations() as $op) {
-            $p99 = $snapshot->latencyStats($op)['p99'];
+            $ceilingMs = $perOpMaxMs[$op] ?? $globalMaxMs;
 
-            if ($p99 <= $worstP99Ns) {
+            if ($ceilingMs === null) {
                 continue;
             }
 
-            $worstP99Ns = $p99;
-            $worstOp = $op;
-        }
+            $p99Ms = $snapshot->latencyStats($op)['p99'] / 1_000_000;
+            $ratio = $p99Ms / $ceilingMs;
 
-        $worstP99Ms = $worstP99Ns / 1_000_000;
+            if ($ratio <= $worstRatio) {
+                continue;
+            }
+
+            $worstRatio = $ratio;
+            $worstOp = $op;
+            $worstP99Ms = $p99Ms;
+            $worstCeilingMs = $ceilingMs;
+        }
 
         return [
             'gate' => 'max-p99-ms',
-            'passed' => $worstP99Ms <= $maxMs,
-            'expected' => sprintf('<= %.2f ms', $maxMs),
+            'passed' => $worstOp === null || $worstP99Ms <= $worstCeilingMs,
+            'expected' => $worstOp !== null
+                ? sprintf('<= %.2f ms (%s)', $worstCeilingMs, $worstOp)
+                : 'no gated ops',
             'actual' => $worstOp !== null
                 ? sprintf('%.2f ms (%s)', $worstP99Ms, $worstOp)
                 : 'no data',

--- a/tests/performance/Threshold/ThresholdSet.php
+++ b/tests/performance/Threshold/ThresholdSet.php
@@ -18,11 +18,15 @@ namespace Tests\Performance\FreeDSx\Ldap\Threshold;
  */
 final class ThresholdSet
 {
+    /**
+     * @param array<string, float> $perOpMaxP99Ms per-op p99 ceilings (ms) that override maxP99Ms for the named op
+     */
     public function __construct(
         public readonly ?float $maxErrorRate = null,
         public readonly ?int $maxErrors = null,
         public readonly ?float $minThroughput = null,
         public readonly ?float $maxP99Ms = null,
+        public readonly array $perOpMaxP99Ms = [],
     ) {}
 
     public function isEmpty(): bool
@@ -30,7 +34,8 @@ final class ThresholdSet
         return $this->maxErrorRate === null
             && $this->maxErrors === null
             && $this->minThroughput === null
-            && $this->maxP99Ms === null;
+            && $this->maxP99Ms === null
+            && $this->perOpMaxP99Ms === [];
     }
 
     /**
@@ -43,6 +48,10 @@ final class ThresholdSet
             maxErrors: $overrides->maxErrors ?? $this->maxErrors,
             minThroughput: $overrides->minThroughput ?? $this->minThroughput,
             maxP99Ms: $overrides->maxP99Ms ?? $this->maxP99Ms,
+            perOpMaxP99Ms: array_merge(
+                $this->perOpMaxP99Ms,
+                $overrides->perOpMaxP99Ms,
+            ),
         );
     }
 }

--- a/tests/performance/Workload/Worker.php
+++ b/tests/performance/Workload/Worker.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Performance\FreeDSx\Ldap\Workload;
 
 use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\Controls;
 use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Entry;
@@ -180,6 +181,7 @@ final class Worker
             'search-list' => $this->doSearchList($client),
             'search-and' => $this->doSearchAnd($client),
             'search-or' => $this->doSearchOr($client),
+            'search-sort' => $this->doSearchSort($client),
             'compare' => $this->doCompare($client),
             'add' => $this->doAdd($client),
             'modify' => $this->doModify($client),
@@ -310,6 +312,23 @@ final class Worker
             $this->newSearch($filter)
                 ->base($this->config->baseDn)
                 ->useSubtreeScope(),
+        );
+    }
+
+    /**
+     * Subtree search with a server-side sort; the sort key is resolved per candidate from the sidecar.
+     */
+    private function doSearchSort(LdapClient $client): void
+    {
+        $filter = $this->config->seedEntries > 0
+            ? Filters::startsWith('cn', 'seed-')
+            : Filters::startsWith('cn', '');
+
+        $client->search(
+            $this->newSearch($filter)
+                ->base($this->config->baseDn)
+                ->useSubtreeScope(),
+            Controls::sort('sn'),
         );
     }
 

--- a/tests/performance/Workload/Worker.php
+++ b/tests/performance/Workload/Worker.php
@@ -316,18 +316,24 @@ final class Worker
     }
 
     /**
-     * Subtree search with a server-side sort; the sort key is resolved per candidate from the sidecar.
+     * Server-side sort over a selective subset (a realistic sorted search filters first), size-limited to a display page.
      */
     private function doSearchSort(LdapClient $client): void
     {
         $filter = $this->config->seedEntries > 0
-            ? Filters::startsWith('cn', 'seed-')
+            ? Filters::startsWith('cn', 'seed-1')
             : Filters::startsWith('cn', '');
 
+        $request = $this->newSearch($filter)
+            ->base($this->config->baseDn)
+            ->useSubtreeScope();
+
+        if ($this->config->searchSortSizeLimit > 0) {
+            $request->sizeLimit($this->config->searchSortSizeLimit);
+        }
+
         $client->search(
-            $this->newSearch($filter)
-                ->base($this->config->baseDn)
-                ->useSubtreeScope(),
+            $request,
             Controls::sort('sn'),
         );
     }

--- a/tests/performance/Workload/WorkloadMix.php
+++ b/tests/performance/Workload/WorkloadMix.php
@@ -31,6 +31,7 @@ final class WorkloadMix
         'search-list',
         'search-and',
         'search-or',
+        'search-sort',
         'compare',
         'add',
         'modify',

--- a/tests/unit/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilderTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilderTest.php
@@ -58,7 +58,7 @@ final class PdoListQueryBuilderTest extends TestCase
         self::assertSame(['cn'], $params);
     }
 
-    public function test_mysql_ascending_emulates_nulls_last_with_two_params(): void
+    public function test_mysql_ascending_projects_the_key_once_and_orders_nulls_last(): void
     {
         [$sql, $params] = $this->rootQuery(
             new PdoListQueryBuilder(new MysqlDialect()),
@@ -66,11 +66,12 @@ final class PdoListQueryBuilderTest extends TestCase
             SortKey::ascending('cn'),
         );
 
-        self::assertStringContainsString('IS NULL ASC', $sql);
-        self::assertSame(['cn', 'cn'], $params);
+        self::assertStringContainsString('AS __sk0', $sql);
+        self::assertStringContainsString('ORDER BY __sk0 IS NULL ASC, __sk0 ASC', $sql);
+        self::assertSame(['cn'], $params);
     }
 
-    public function test_mysql_descending_emulates_nulls_first_with_two_params(): void
+    public function test_mysql_descending_projects_the_key_once_and_orders_nulls_first(): void
     {
         [$sql, $params] = $this->rootQuery(
             new PdoListQueryBuilder(new MysqlDialect()),
@@ -78,21 +79,41 @@ final class PdoListQueryBuilderTest extends TestCase
             SortKey::descending('cn'),
         );
 
-        self::assertStringContainsString('IS NULL DESC', $sql);
-        self::assertSame(['cn', 'cn'], $params);
+        self::assertStringContainsString('ORDER BY __sk0 IS NULL DESC, __sk0 DESC', $sql);
+        self::assertSame(['cn'], $params);
     }
 
-    public function test_mysql_multi_key_preserves_param_order(): void
+    public function test_mysql_multi_key_projects_each_key_and_orders_in_sequence(): void
     {
-        [, $params] = $this->rootQuery(
+        [$sql, $params] = $this->rootQuery(
             new PdoListQueryBuilder(new MysqlDialect()),
             null,
             SortKey::ascending('sn'),
             SortKey::descending('cn'),
         );
 
+        self::assertStringContainsString(
+            'ORDER BY __sk0 IS NULL ASC, __sk0 ASC, __sk1 IS NULL DESC, __sk1 DESC',
+            $sql,
+        );
         self::assertSame(
-            ['sn', 'sn', 'cn', 'cn'],
+            ['sn', 'cn'],
+            $params,
+        );
+    }
+
+    public function test_mysql_sort_params_bind_before_the_base_query_params(): void
+    {
+        [$sql, $params] = $this->rootQuery(
+            new PdoListQueryBuilder(new MysqlDialect()),
+            new SqlFilterResult('eav.value_lower = ?', ['smith']),
+            SortKey::ascending('sn'),
+        );
+
+        // The projected sort key precedes the nested base query, so its param binds first.
+        self::assertStringContainsString('FROM (', $sql);
+        self::assertSame(
+            ['sn', 'smith'],
             $params,
         );
     }


### PR DESCRIPTION
Two things related to sorting here:

1. Add an index to speed up server side sorting on sqlite. Without this index, sorting on a larger directory can be verrrry slow on sqlite. 
2. Fix MySQL server-side sort to evaluate the sort key once per row instead of twice. This meant actual dialect / query changes.

Server side sort in general isn't super performant. But this at least makes it more usable than it was. Also added search-sort to the CI load test default mix so it's easier to spot these issues.