### PR TITLE
[1.0.0] Make the bench comparison more generic / test fixes.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
     "test-load": "@php -d xdebug.mode=off -d opcache.enable_cli=1 -d opcache.jit=off tests/bin/ldap-load-test.php --backend=sqlite --runner=pcntl --duration=10 --warmup=2 --clients=8 --output=text",
     "test-load-docker": "tests/profile/load-test.sh",
     "test-load-compare": "@php -d xdebug.mode=off -d opcache.enable_cli=1 -d opcache.jit_buffer_size=128M -d opcache.jit=tracing tests/bin/ldap-bench-compare.php",
+    "compare-ldap": "tests/profile/compare-ldap.sh",
     "profile": "tests/profile/profile.sh",
     "profile-up": "docker compose -f tests/profile/docker-compose.yml up -d --build --wait",
     "profile-down": "docker compose -f tests/profile/docker-compose.yml down",

--- a/tests/integration/ServerTestCase.php
+++ b/tests/integration/ServerTestCase.php
@@ -91,7 +91,7 @@ class ServerTestCase extends LdapTestCase
         $this->client = null;
 
         if ($this->overrideProcess !== null) {
-            $this->overrideProcess->stop(self::SERVER_STOP_TIMEOUT_SECONDS);
+            self::stopProcessTree($this->overrideProcess);
             $this->overrideProcess = null;
         }
 
@@ -125,8 +125,10 @@ class ServerTestCase extends LdapTestCase
 
     protected static function tearDownSharedServer(): void
     {
-        self::$sharedProcess?->stop(self::SERVER_STOP_TIMEOUT_SECONDS);
-        self::$sharedProcess = null;
+        if (self::$sharedProcess !== null) {
+            self::stopProcessTree(self::$sharedProcess);
+            self::$sharedProcess = null;
+        }
     }
 
     /**
@@ -164,10 +166,10 @@ class ServerTestCase extends LdapTestCase
         $this->client = null;
 
         if ($this->overrideProcess !== null) {
-            $this->overrideProcess->stop(self::SERVER_STOP_TIMEOUT_SECONDS);
+            self::stopProcessTree($this->overrideProcess);
             $this->overrideProcess = null;
         } elseif (self::$sharedProcess !== null) {
-            self::$sharedProcess->stop(self::SERVER_STOP_TIMEOUT_SECONDS);
+            self::stopProcessTree(self::$sharedProcess);
             self::$sharedProcess = null;
             $this->needsSharedRestart = true;
         }
@@ -270,6 +272,57 @@ class ServerTestCase extends LdapTestCase
         self::waitForProcess($process, 'server starting...');
 
         self::$sharedProcess = $process;
+    }
+
+    /**
+     * Stops a process and SIGKILLs any descendants, since nested children (provider/upstream) are only cleaned up via
+     * the parent's shutdown function, which does not run on a signal kill.
+     */
+    private static function stopProcessTree(Process $process): void
+    {
+        $pid = $process->getPid();
+        $descendants = $pid !== null
+            ? self::descendantPids($pid)
+            : [];
+
+        $process->stop(self::SERVER_STOP_TIMEOUT_SECONDS);
+
+        foreach ($descendants as $descendant) {
+            if (@posix_kill($descendant, 0)) {
+                @posix_kill($descendant, SIGKILL);
+            }
+        }
+    }
+
+    /**
+     * Walks the process tree below a pid (via pgrep -P) so descendants can be reaped before they are orphaned.
+     *
+     * @return list<int>
+     */
+    private static function descendantPids(int $pid): array
+    {
+        $found = [];
+        $queue = [$pid];
+
+        while ($queue !== []) {
+            $current = array_shift($queue);
+            $children = [];
+            exec(
+                sprintf('pgrep -P %d 2>/dev/null', $current),
+                $children,
+            );
+
+            foreach ($children as $child) {
+                $childPid = (int) trim($child);
+
+                if ($childPid > 0) {
+                    $found[] = $childPid;
+                    $queue[] = $childPid;
+                }
+            }
+        }
+
+        return $found;
     }
 
     private static function waitForProcess(Process $process, string $marker): string

--- a/tests/performance/Compare/BenchCompareCommand.php
+++ b/tests/performance/Compare/BenchCompareCommand.php
@@ -185,11 +185,11 @@ final class BenchCompareCommand extends Command
                 'Disable opcache + tracing JIT on the spawned FreeDSx server (default: enabled).',
             )
             ->addOption(
-                'search-sub-size-limit',
+                'search-size-limit',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Per-request size limit applied to search-sub ops (0 = unlimited)',
-                (string) Config::DEFAULT_SEARCH_SUB_SIZE_LIMIT,
+                'Per-request size limit applied to search-list and search-sub ops (0 = unlimited)',
+                (string) Config::DEFAULT_SEARCH_SIZE_LIMIT,
             )
             ->addOption(
                 'driver-processes',
@@ -306,7 +306,7 @@ final class BenchCompareCommand extends Command
     }
 
     /**
-     * @return array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSubSizeLimit: int, driverProcesses: int}
+     * @return array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSizeLimit: int, driverProcesses: int}
      */
     private function resolveParams(InputInterface $input): array
     {
@@ -336,7 +336,7 @@ final class BenchCompareCommand extends Command
             'rngSeed' => $this->parseInt($input->getOption('rng-seed'), 'rng-seed'),
             'seedEntries' => $this->requireInt($input, 'seed-entries'),
             'jit' => !(bool) $input->getOption('no-jit'),
-            'searchSubSizeLimit' => $this->requireInt($input, 'search-sub-size-limit'),
+            'searchSizeLimit' => $this->requireInt($input, 'search-size-limit'),
             'driverProcesses' => $driverProcesses,
         ];
     }
@@ -374,7 +374,7 @@ final class BenchCompareCommand extends Command
     }
 
     /**
-     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSubSizeLimit: int, driverProcesses: int} $params
+     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSizeLimit: int, driverProcesses: int} $params
      */
     private function runAgainstTarget(
         OutputInterface $output,
@@ -402,7 +402,7 @@ final class BenchCompareCommand extends Command
     }
 
     /**
-     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSubSizeLimit: int, driverProcesses: int} $params
+     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSizeLimit: int, driverProcesses: int} $params
      */
     private function runAgainstFreedsx(
         OutputInterface $output,
@@ -479,12 +479,12 @@ final class BenchCompareCommand extends Command
             baseDn: $config->baseDn,
             writeBase: $config->writeBase,
             jit: $config->jit,
-            searchSubSizeLimit: $config->searchSubSizeLimit,
+            searchSizeLimit: $config->searchSizeLimit,
         );
     }
 
     /**
-     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSubSizeLimit: int, driverProcesses: int} $params
+     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSizeLimit: int, driverProcesses: int} $params
      */
     private function buildTargetConfig(
         InputInterface $input,
@@ -510,12 +510,12 @@ final class BenchCompareCommand extends Command
             baseDn: $bench->benchBaseDn,
             writeBase: $bench->writeBaseDn,
             jit: $params['jit'],
-            searchSubSizeLimit: $params['searchSubSizeLimit'],
+            searchSizeLimit: $params['searchSizeLimit'],
         );
     }
 
     /**
-     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSubSizeLimit: int, driverProcesses: int} $params
+     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSizeLimit: int, driverProcesses: int} $params
      */
     private function buildFreedsxConfig(
         InputInterface $input,
@@ -536,7 +536,7 @@ final class BenchCompareCommand extends Command
             output: 'text',
             seedEntries: $params['seedEntries'],
             jit: $params['jit'],
-            searchSubSizeLimit: $params['searchSubSizeLimit'],
+            searchSizeLimit: $params['searchSizeLimit'],
         );
     }
 

--- a/tests/performance/Compare/BenchCompareCommand.php
+++ b/tests/performance/Compare/BenchCompareCommand.php
@@ -22,31 +22,35 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Tests\Performance\FreeDSx\Ldap\Config;
 use Tests\Performance\FreeDSx\Ldap\Driver;
 use Tests\Performance\FreeDSx\Ldap\Report\Report;
-use Tests\Performance\FreeDSx\Ldap\Server\ServerManager;
 use Tests\Performance\FreeDSx\Ldap\Stats\StatsSnapshot;
 use Tests\Performance\FreeDSx\Ldap\Workload\WorkloadMix;
 use Throwable;
 
-/**
- * Runs the load test against an external LDAP target and FreeDSx (spawned) with
- * identical workload parameters, then prints a side-by-side comparison. Target defaults
- * assume a local OpenLDAP; override `--target-*` to point at another server (389 DS,
- * OpenDJ, ApacheDS, etc). Active Directory is not supported — the seeder uses
- * `inetOrgPerson + extensibleObject`.
- */
 final class BenchCompareCommand extends Command
 {
-    private const DEFAULT_TARGET_BASE_DN = 'dc=example,dc=com';
+    private const DEFAULT_SOURCE_LABEL = 'FreeDSx';
+
+    private const DEFAULT_SOURCE_PORT = 10389;
+
+    private const DEFAULT_SOURCE_BIND_DN = 'cn=user,dc=foo,dc=bar';
+
+    private const DEFAULT_SOURCE_BIND_PASSWORD = '12345';
+
+    private const DEFAULT_SOURCE_BASE_DN = 'dc=foo,dc=bar';
+
+    private const DEFAULT_TARGET_LABEL = 'Target';
+
+    private const DEFAULT_TARGET_PORT = 10390;
 
     private const DEFAULT_TARGET_BIND_DN = 'cn=admin,dc=example,dc=com';
 
     private const DEFAULT_TARGET_BIND_PASSWORD = 'P@ssword12345';
 
-    private const DEFAULT_FREEDSX_PORT = 10389;
+    private const DEFAULT_TARGET_BASE_DN = 'dc=example,dc=com';
 
     protected static $defaultName = 'load-compare';
 
-    protected static $defaultDescription = 'Benchmark FreeDSx vs an external LDAP target under identical workload parameters.';
+    protected static $defaultDescription = 'Benchmark a source LDAP server against a target under identical workload parameters.';
 
     protected function configure(): void
     {
@@ -88,7 +92,7 @@ final class BenchCompareCommand extends Command
                 'seed-entries',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Fixture entries to pre-seed under the write base',
+                'Fixture entries to pre-seed under each side write base',
                 '5000',
             )
             ->addOption(
@@ -98,39 +102,60 @@ final class BenchCompareCommand extends Command
                 'RNG seed for reproducible workloads (applied to both runs)',
             )
             ->addOption(
-                'freedsx-backend',
+                'source-host',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'FreeDSx backend: ' . implode(' | ', Config::BACKENDS),
-                'sqlite',
+                'Source server host',
+                '127.0.0.1',
             )
             ->addOption(
-                'freedsx-runner',
+                'source-port',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'FreeDSx runner: ' . implode(' | ', Config::RUNNERS),
-                'swoole',
+                'Source server port',
+                (string) self::DEFAULT_SOURCE_PORT,
             )
             ->addOption(
-                'freedsx-port',
+                'source-bind-dn',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Port to spawn FreeDSx on',
-                (string) self::DEFAULT_FREEDSX_PORT,
+                'DN to bind to the source for seeding + workload',
+                self::DEFAULT_SOURCE_BIND_DN,
+            )
+            ->addOption(
+                'source-bind-password',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Password paired with --source-bind-dn',
+                self::DEFAULT_SOURCE_BIND_PASSWORD,
+            )
+            ->addOption(
+                'source-base-dn',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Source base DN below which the bench subtree is created',
+                self::DEFAULT_SOURCE_BASE_DN,
+            )
+            ->addOption(
+                'source-label',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Display name for the source server in the report (the project under test)',
+                self::DEFAULT_SOURCE_LABEL,
             )
             ->addOption(
                 'target-host',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'External LDAP target host',
+                'Target server host',
                 '127.0.0.1',
             )
             ->addOption(
                 'target-port',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'External LDAP target port',
-                '389',
+                'Target server port (the bundled bench OpenLDAP publishes 10390; use 389 for a standard slapd)',
+                (string) self::DEFAULT_TARGET_PORT,
             )
             ->addOption(
                 'target-bind-dn',
@@ -154,22 +179,29 @@ final class BenchCompareCommand extends Command
                 self::DEFAULT_TARGET_BASE_DN,
             )
             ->addOption(
+                'target-label',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Display name for the target server in the report (e.g. OpenLDAP)',
+                self::DEFAULT_TARGET_LABEL,
+            )
+            ->addOption(
                 'skip-target',
                 null,
                 InputOption::VALUE_NONE,
-                'Skip the target run (FreeDSx-only)',
+                'Skip the target run (source-only)',
             )
             ->addOption(
-                'skip-freedsx',
+                'skip-source',
                 null,
                 InputOption::VALUE_NONE,
-                'Skip the FreeDSx run (target-only)',
+                'Skip the source run (target-only)',
             )
             ->addOption(
                 'no-cleanup',
                 null,
                 InputOption::VALUE_NONE,
-                'Leave the target bench subtree in place after the run',
+                'Leave the bench subtrees in place after the run',
             )
             ->addOption(
                 'output',
@@ -182,7 +214,7 @@ final class BenchCompareCommand extends Command
                 'no-jit',
                 null,
                 InputOption::VALUE_NONE,
-                'Disable opcache + tracing JIT on the spawned FreeDSx server (default: enabled).',
+                'Disable opcache + tracing JIT on the multi-process driver workers (default: enabled).',
             )
             ->addOption(
                 'search-size-limit',
@@ -190,6 +222,13 @@ final class BenchCompareCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Per-request size limit applied to search-list and search-sub ops (0 = unlimited)',
                 (string) Config::DEFAULT_SEARCH_SIZE_LIMIT,
+            )
+            ->addOption(
+                'search-value',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'cn prefix the subtree searches filter on; a broader value (e.g. "seed-") matches more entries',
+                Config::DEFAULT_SEARCH_VALUE,
             )
             ->addOption(
                 'driver-processes',
@@ -207,10 +246,10 @@ final class BenchCompareCommand extends Command
     ): int {
         $progress = $this->progressChannel($output);
         $skipTarget = (bool) $input->getOption('skip-target');
-        $skipFreedsx = (bool) $input->getOption('skip-freedsx');
+        $skipSource = (bool) $input->getOption('skip-source');
 
-        if ($skipTarget && $skipFreedsx) {
-            $output->writeln('<error>Both --skip-target and --skip-freedsx are set; nothing to run.</error>');
+        if ($skipTarget && $skipSource) {
+            $output->writeln('<error>Both --skip-target and --skip-source are set; nothing to run.</error>');
 
             return Command::INVALID;
         }
@@ -223,90 +262,195 @@ final class BenchCompareCommand extends Command
             return Command::INVALID;
         }
 
-        $targetSnapshot = null;
-        $freedsxSnapshot = null;
+        $targetSide = $this->sideFromOptions($input, 'target');
+        $sourceSide = $this->sideFromOptions($input, 'source');
 
-        $bench = $skipTarget
-            ? null
-            : $this->makeBench($input);
+        $targetSnapshot = null;
+        $sourceSnapshot = null;
+        $benches = [];
 
         try {
-            if ($bench !== null) {
-                $this->seedTarget(
-                    $progress,
-                    $bench,
-                    $params['seedEntries'],
-                );
-
-                $targetSnapshot = $this->runAgainstTarget(
-                    $output,
-                    $progress,
-                    $input,
-                    $bench,
-                    $params,
-                );
-                $this->renderSingleRun(
-                    $output,
-                    'Target',
-                    $targetSnapshot,
-                    $this->buildTargetConfig(
-                        $input,
-                        $bench,
-                        $params,
-                    ),
-                );
+            if (!$skipTarget) {
+                $targetSnapshot = $this->runSide($output, $progress, $targetSide, $params, $benches);
             }
-
-            if (!$skipFreedsx) {
-                $freedsxSnapshot = $this->runAgainstFreedsx(
-                    $output,
-                    $progress,
-                    $input,
-                    $params,
-                );
-                $this->renderSingleRun(
-                    $output,
-                    'FreeDSx',
-                    $freedsxSnapshot,
-                    $this->buildFreedsxConfig(
-                        $input,
-                        $params,
-                    ),
-                );
+            if (!$skipSource) {
+                $sourceSnapshot = $this->runSide($output, $progress, $sourceSide, $params, $benches);
             }
         } catch (Throwable $e) {
             $output->writeln('<error>Benchmark failed: ' . $e->getMessage() . '</error>');
 
             return Command::FAILURE;
         } finally {
-            if ($bench !== null) {
-                if (!$input->getOption('no-cleanup')) {
-                    $progress->writeln(sprintf(
-                        'Cleaning up target bench subtree at %s...',
-                        $bench->benchBaseDn,
-                    ));
-                    try {
-                        $bench->cleanup();
-                    } catch (Throwable $e) {
-                        $progress->writeln('<comment>Cleanup warning: ' . $e->getMessage() . '</comment>');
-                    }
-                }
-                $bench->close();
-            }
+            $this->teardownBenches($progress, $benches, (bool) $input->getOption('no-cleanup'));
         }
 
         $format = $this->requireString($input, 'output');
         (new ComparisonReport(
             target: $targetSnapshot,
-            freedsx: $freedsxSnapshot,
+            source: $sourceSnapshot,
             format: $format,
+            targetLabel: $targetSide->label,
+            sourceLabel: $sourceSide->label,
         ))->render($output);
 
         return Command::SUCCESS;
     }
 
     /**
-     * @return array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSizeLimit: int, driverProcesses: int}
+     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSizeLimit: int, searchValue: string, driverProcesses: int} $params
+     * @param list<TargetBench> $benches
+     */
+    private function runSide(
+        OutputInterface $output,
+        OutputInterface $progress,
+        BenchSide $side,
+        array $params,
+        array &$benches,
+    ): StatsSnapshot {
+        $bench = new TargetBench(
+            host: $side->host,
+            port: $side->port,
+            bindDn: $side->bindDn,
+            bindPassword: $side->bindPassword,
+            rootBaseDn: $side->baseDn,
+        );
+        $benches[] = $bench;
+
+        $this->seedSide(
+            $progress,
+            $side,
+            $bench,
+            $params['seedEntries'],
+        );
+
+        $config = $this->buildConfig(
+            $side,
+            $bench,
+            $params,
+        );
+
+        $progress->writeln(sprintf(
+            'Running workload against %s...',
+            $side->label,
+        ));
+
+        $snapshot = $params['driverProcesses'] === 1
+            ? (new Driver($config))->run($output)
+            : (new MultiDriverCoordinator($params['driverProcesses']))->run(
+                $config,
+                $progress,
+            );
+
+        $this->renderSingleRun(
+            $output,
+            $side->label,
+            $snapshot,
+            $config,
+            sprintf('%s load test', $side->label),
+            true,
+        );
+
+        return $snapshot;
+    }
+
+    private function seedSide(
+        OutputInterface $progress,
+        BenchSide $side,
+        TargetBench $bench,
+        int $seedEntries,
+    ): void {
+        $progress->writeln(sprintf(
+            'Seeding %s bench subtree %s with %d entries (+ cn=alice)...',
+            $side->label,
+            $bench->benchBaseDn,
+            $seedEntries,
+        ));
+
+        $start = microtime(true);
+        $bench->seed($seedEntries);
+        $elapsed = microtime(true) - $start;
+
+        $progress->writeln(sprintf(
+            '%s seed complete in %.1fs.',
+            $side->label,
+            $elapsed,
+        ));
+    }
+
+    /**
+     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSizeLimit: int, searchValue: string, driverProcesses: int} $params
+     */
+    private function buildConfig(
+        BenchSide $side,
+        TargetBench $bench,
+        array $params,
+    ): Config {
+        return new Config(
+            // Backend/runner are FreeDSx-internal knobs; the driver only connects to host:port, so external runs pass
+            // innocuous placeholders that satisfy Config validation without affecting the workload.
+            backend: 'sqlite',
+            runner: 'pcntl',
+            clients: $params['clients'],
+            duration: $params['duration'],
+            ops: $params['ops'],
+            mix: $params['mix'],
+            host: $side->host,
+            port: $side->port,
+            warmup: $params['warmup'],
+            serverMode: 'external',
+            rngSeed: $params['rngSeed'],
+            output: 'text',
+            seedEntries: 0,
+            bindDn: $side->bindDn,
+            bindPassword: $side->bindPassword,
+            baseDn: $bench->benchBaseDn,
+            writeBase: $bench->writeBaseDn,
+            jit: $params['jit'],
+            searchSizeLimit: $params['searchSizeLimit'],
+            searchValue: $params['searchValue'],
+        );
+    }
+
+    /**
+     * @param list<TargetBench> $benches
+     */
+    private function teardownBenches(
+        OutputInterface $progress,
+        array $benches,
+        bool $noCleanup,
+    ): void {
+        foreach ($benches as $bench) {
+            if (!$noCleanup) {
+                $progress->writeln(sprintf(
+                    'Cleaning up bench subtree at %s...',
+                    $bench->benchBaseDn,
+                ));
+                try {
+                    $bench->cleanup();
+                } catch (Throwable $e) {
+                    $progress->writeln('<comment>Cleanup warning: ' . $e->getMessage() . '</comment>');
+                }
+            }
+            $bench->close();
+        }
+    }
+
+    private function sideFromOptions(
+        InputInterface $input,
+        string $prefix,
+    ): BenchSide {
+        return new BenchSide(
+            label: $this->requireString($input, "{$prefix}-label"),
+            host: $this->requireString($input, "{$prefix}-host"),
+            port: $this->requireInt($input, "{$prefix}-port"),
+            bindDn: $this->requireString($input, "{$prefix}-bind-dn"),
+            bindPassword: $this->requireString($input, "{$prefix}-bind-password"),
+            baseDn: $this->requireString($input, "{$prefix}-base-dn"),
+        );
+    }
+
+    /**
+     * @return array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSizeLimit: int, searchValue: string, driverProcesses: int}
      */
     private function resolveParams(InputInterface $input): array
     {
@@ -337,207 +481,9 @@ final class BenchCompareCommand extends Command
             'seedEntries' => $this->requireInt($input, 'seed-entries'),
             'jit' => !(bool) $input->getOption('no-jit'),
             'searchSizeLimit' => $this->requireInt($input, 'search-size-limit'),
+            'searchValue' => $this->requireString($input, 'search-value'),
             'driverProcesses' => $driverProcesses,
         ];
-    }
-
-    private function makeBench(InputInterface $input): TargetBench
-    {
-        return new TargetBench(
-            host: $this->requireString($input, 'target-host'),
-            port: $this->requireInt($input, 'target-port'),
-            bindDn: $this->requireString($input, 'target-bind-dn'),
-            bindPassword: $this->requireString($input, 'target-bind-password'),
-            rootBaseDn: $this->requireString($input, 'target-base-dn'),
-        );
-    }
-
-    private function seedTarget(
-        OutputInterface $progress,
-        TargetBench $bench,
-        int $seedEntries,
-    ): void {
-        $progress->writeln(sprintf(
-            'Seeding target bench subtree %s with %d entries (+ cn=alice)...',
-            $bench->benchBaseDn,
-            $seedEntries,
-        ));
-
-        $start = microtime(true);
-        $bench->seed($seedEntries);
-        $elapsed = microtime(true) - $start;
-
-        $progress->writeln(sprintf(
-            'Target seed complete in %.1fs.',
-            $elapsed,
-        ));
-    }
-
-    /**
-     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSizeLimit: int, driverProcesses: int} $params
-     */
-    private function runAgainstTarget(
-        OutputInterface $output,
-        OutputInterface $progress,
-        InputInterface $input,
-        TargetBench $bench,
-        array $params,
-    ): StatsSnapshot {
-        $progress->writeln('Running workload against target...');
-
-        $config = $this->buildTargetConfig(
-            $input,
-            $bench,
-            $params,
-        );
-
-        if ($params['driverProcesses'] === 1) {
-            return (new Driver($config))->run($output);
-        }
-
-        return (new MultiDriverCoordinator($params['driverProcesses']))->run(
-            $config,
-            $progress,
-        );
-    }
-
-    /**
-     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSizeLimit: int, driverProcesses: int} $params
-     */
-    private function runAgainstFreedsx(
-        OutputInterface $output,
-        OutputInterface $progress,
-        InputInterface $input,
-        array $params,
-    ): StatsSnapshot {
-        $progress->writeln('Running workload against FreeDSx...');
-
-        $config = $this->buildFreedsxConfig(
-            $input,
-            $params,
-        );
-
-        if ($params['driverProcesses'] === 1) {
-            return (new Driver($config))->run($output);
-        }
-
-        return $this->runFreedsxMultiDriver(
-            $config,
-            $params['driverProcesses'],
-            $progress,
-        );
-    }
-
-    /**
-     * Owns the FreeDSx server lifecycle in the parent so all N children connect to a single
-     * spawned instance instead of each trying (and failing) to start their own.
-     */
-    private function runFreedsxMultiDriver(
-        Config $spawnConfig,
-        int $driverProcesses,
-        OutputInterface $progress,
-    ): StatsSnapshot {
-        $progress->writeln(sprintf(
-            'Starting FreeDSx server (parent-owned for %d driver processes)...',
-            $driverProcesses,
-        ));
-
-        $serverManager = new ServerManager($spawnConfig);
-        $serverManager->start();
-        $progress->writeln('Server ready.');
-
-        try {
-            $childConfig = $this->withExternalServer($spawnConfig);
-
-            return (new MultiDriverCoordinator($driverProcesses))->run(
-                $childConfig,
-                $progress,
-            );
-        } finally {
-            $serverManager->stop();
-        }
-    }
-
-    private function withExternalServer(Config $config): Config
-    {
-        return new Config(
-            backend: $config->backend,
-            runner: $config->runner,
-            clients: $config->clients,
-            duration: $config->duration,
-            ops: $config->ops,
-            mix: $config->mix,
-            host: $config->host,
-            port: $config->port,
-            warmup: $config->warmup,
-            serverMode: 'external',
-            rngSeed: $config->rngSeed,
-            output: $config->output,
-            seedEntries: 0,
-            bindDn: $config->bindDn,
-            bindPassword: $config->bindPassword,
-            baseDn: $config->baseDn,
-            writeBase: $config->writeBase,
-            jit: $config->jit,
-            searchSizeLimit: $config->searchSizeLimit,
-        );
-    }
-
-    /**
-     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSizeLimit: int, driverProcesses: int} $params
-     */
-    private function buildTargetConfig(
-        InputInterface $input,
-        TargetBench $bench,
-        array $params,
-    ): Config {
-        return new Config(
-            backend: $this->requireString($input, 'freedsx-backend'),
-            runner: $this->requireString($input, 'freedsx-runner'),
-            clients: $params['clients'],
-            duration: $params['duration'],
-            ops: $params['ops'],
-            mix: $params['mix'],
-            host: $this->requireString($input, 'target-host'),
-            port: $this->requireInt($input, 'target-port'),
-            warmup: $params['warmup'],
-            serverMode: 'external',
-            rngSeed: $params['rngSeed'],
-            output: 'text',
-            seedEntries: 0,
-            bindDn: $this->requireString($input, 'target-bind-dn'),
-            bindPassword: $this->requireString($input, 'target-bind-password'),
-            baseDn: $bench->benchBaseDn,
-            writeBase: $bench->writeBaseDn,
-            jit: $params['jit'],
-            searchSizeLimit: $params['searchSizeLimit'],
-        );
-    }
-
-    /**
-     * @param array{duration: ?int, ops: ?int, mix: string, clients: int, warmup: int, rngSeed: ?int, seedEntries: int, jit: bool, searchSizeLimit: int, driverProcesses: int} $params
-     */
-    private function buildFreedsxConfig(
-        InputInterface $input,
-        array $params,
-    ): Config {
-        return new Config(
-            backend: $this->requireString($input, 'freedsx-backend'),
-            runner: $this->requireString($input, 'freedsx-runner'),
-            clients: $params['clients'],
-            duration: $params['duration'],
-            ops: $params['ops'],
-            mix: $params['mix'],
-            host: '127.0.0.1',
-            port: $this->requireInt($input, 'freedsx-port'),
-            warmup: $params['warmup'],
-            serverMode: 'spawn',
-            rngSeed: $params['rngSeed'],
-            output: 'text',
-            seedEntries: $params['seedEntries'],
-            jit: $params['jit'],
-            searchSizeLimit: $params['searchSizeLimit'],
-        );
     }
 
     private function renderSingleRun(
@@ -545,6 +491,8 @@ final class BenchCompareCommand extends Command
         string $label,
         StatsSnapshot $snapshot,
         Config $config,
+        ?string $subject = null,
+        bool $external = false,
     ): void {
         $output->writeln('');
         $output->writeln(sprintf('--- %s results ---', $label));
@@ -552,6 +500,8 @@ final class BenchCompareCommand extends Command
             $config,
             new WorkloadMix($config->mix),
             $snapshot,
+            $subject,
+            $external,
         ))->render($output);
     }
 

--- a/tests/performance/Compare/BenchSide.php
+++ b/tests/performance/Compare/BenchSide.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Performance\FreeDSx\Ldap\Compare;
+
+/**
+ * One server participating in a comparison run.
+ */
+final readonly class BenchSide
+{
+    public function __construct(
+        public string $label,
+        public string $host,
+        public int    $port,
+        public string $bindDn,
+        public string $bindPassword,
+        public string $baseDn,
+    ) {}
+}

--- a/tests/performance/Compare/ComparisonReport.php
+++ b/tests/performance/Compare/ComparisonReport.php
@@ -18,25 +18,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Tests\Performance\FreeDSx\Ldap\Stats\StatsSnapshot;
 
 /**
- * Side-by-side renderer for an external LDAP target vs FreeDSx benchmark run.
+ * Side-by-side renderer for a target LDAP server vs the source server (FreeDSx by default) benchmark run.
  */
 final class ComparisonReport
 {
-    private const HEADERS = [
-        'Operation',
-        'Target ops/s',
-        'FreeDSx ops/s',
-        'Ratio (FreeDSx/Target)',
-        'Target p99',
-        'FreeDSx p99',
-        'Target err',
-        'FD err',
-    ];
-
     public function __construct(
         private readonly ?StatsSnapshot $target,
-        private readonly ?StatsSnapshot $freedsx,
+        private readonly ?StatsSnapshot $source,
         private readonly string $format,
+        private readonly string $targetLabel = 'Target',
+        private readonly string $sourceLabel = 'FreeDSx',
     ) {}
 
     public function render(OutputInterface $output): void
@@ -50,6 +41,23 @@ final class ComparisonReport
         $this->renderText($output);
     }
 
+    /**
+     * @return list<string>
+     */
+    private function headers(): array
+    {
+        return [
+            'Operation',
+            "{$this->targetLabel} ops/s",
+            "{$this->sourceLabel} ops/s",
+            "Ratio ({$this->sourceLabel}/{$this->targetLabel})",
+            "{$this->targetLabel} p99",
+            "{$this->sourceLabel} p99",
+            "{$this->targetLabel} err",
+            "{$this->sourceLabel} err",
+        ];
+    }
+
     private function renderText(OutputInterface $output): void
     {
         $output->writeln('');
@@ -57,18 +65,18 @@ final class ComparisonReport
         $output->writeln('=======================');
 
         if ($this->target === null) {
-            $output->writeln('Target run was skipped.');
+            $output->writeln(sprintf('%s run was skipped.', $this->targetLabel));
         }
-        if ($this->freedsx === null) {
-            $output->writeln('FreeDSx run was skipped.');
+        if ($this->source === null) {
+            $output->writeln(sprintf('%s run was skipped.', $this->sourceLabel));
         }
 
-        if ($this->target === null || $this->freedsx === null) {
+        if ($this->target === null || $this->source === null) {
             return;
         }
 
         $table = new Table($output);
-        $table->setHeaders(self::HEADERS);
+        $table->setHeaders($this->headers());
 
         foreach ($this->unionOps() as $op) {
             $table->addRow($this->buildRow($op));
@@ -77,24 +85,30 @@ final class ComparisonReport
         $table->render();
 
         $targetTotal = $this->target->overallThroughput();
-        $fdTotal = $this->freedsx->overallThroughput();
+        $sourceTotal = $this->source->overallThroughput();
 
         $output->writeln('');
         $output->writeln(sprintf(
-            'Overall throughput: Target %s ops/s  |  FreeDSx %s ops/s  |  ratio %s',
+            'Overall throughput: %s %s ops/s  |  %s %s ops/s  |  ratio %s',
+            $this->targetLabel,
             number_format($targetTotal, 1),
-            number_format($fdTotal, 1),
-            $this->formatRatio($fdTotal, $targetTotal),
+            $this->sourceLabel,
+            number_format($sourceTotal, 1),
+            $this->formatRatio($sourceTotal, $targetTotal),
         ));
         $output->writeln(sprintf(
-            'Errors: Target %d  |  FreeDSx %d',
+            'Errors: %s %d  |  %s %d',
+            $this->targetLabel,
             $this->target->totalErrors(),
-            $this->freedsx->totalErrors(),
+            $this->sourceLabel,
+            $this->source->totalErrors(),
         ));
         $output->writeln(sprintf(
-            'Elapsed: Target %.1fs  |  FreeDSx %.1fs',
+            'Elapsed: %s %.1fs  |  %s %.1fs',
+            $this->targetLabel,
             $this->target->elapsedSeconds,
-            $this->freedsx->elapsedSeconds,
+            $this->sourceLabel,
+            $this->source->elapsedSeconds,
         ));
     }
 
@@ -104,20 +118,20 @@ final class ComparisonReport
     private function buildRow(string $op): array
     {
         $targetThr = $this->target?->throughput($op) ?? 0.0;
-        $fdThr = $this->freedsx?->throughput($op) ?? 0.0;
+        $sourceThr = $this->source?->throughput($op) ?? 0.0;
 
         $targetStats = $this->target?->latencyStats($op) ?? ['p99' => 0];
-        $fdStats = $this->freedsx?->latencyStats($op) ?? ['p99' => 0];
+        $sourceStats = $this->source?->latencyStats($op) ?? ['p99' => 0];
 
         return [
             $op,
             number_format($targetThr, 2),
-            number_format($fdThr, 2),
-            $this->formatRatio($fdThr, $targetThr),
+            number_format($sourceThr, 2),
+            $this->formatRatio($sourceThr, $targetThr),
             self::formatNanos($targetStats['p99']),
-            self::formatNanos($fdStats['p99']),
+            self::formatNanos($sourceStats['p99']),
             (string) ($this->target?->errorCount($op) ?? 0),
-            (string) ($this->freedsx?->errorCount($op) ?? 0),
+            (string) ($this->source?->errorCount($op) ?? 0),
         ];
     }
 
@@ -128,7 +142,7 @@ final class ComparisonReport
     {
         $ops = array_merge(
             $this->target?->operations() ?? [],
-            $this->freedsx?->operations() ?? [],
+            $this->source?->operations() ?? [],
         );
 
         return array_values(array_unique($ops));
@@ -139,7 +153,7 @@ final class ComparisonReport
         return json_encode(
             [
                 'target' => $this->snapshotToArray($this->target),
-                'freedsx' => $this->snapshotToArray($this->freedsx),
+                'source' => $this->snapshotToArray($this->source),
             ],
             JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
         );

--- a/tests/performance/Compare/MultiDriverCoordinator.php
+++ b/tests/performance/Compare/MultiDriverCoordinator.php
@@ -196,7 +196,7 @@ final class MultiDriverCoordinator
             baseDn: $base->baseDn,
             writeBase: $base->writeBase,
             jit: $base->jit,
-            searchSubSizeLimit: $base->searchSubSizeLimit,
+            searchSizeLimit: $base->searchSizeLimit,
         );
     }
 

--- a/tests/performance/Compare/MultiDriverCoordinator.php
+++ b/tests/performance/Compare/MultiDriverCoordinator.php
@@ -197,6 +197,7 @@ final class MultiDriverCoordinator
             writeBase: $base->writeBase,
             jit: $base->jit,
             searchSizeLimit: $base->searchSizeLimit,
+            searchValue: $base->searchValue,
         );
     }
 

--- a/tests/performance/Compare/TargetBench.php
+++ b/tests/performance/Compare/TargetBench.php
@@ -35,7 +35,7 @@ final class TargetBench
 
     public readonly string $writeBaseDn;
 
-    private readonly LdapClient $client;
+    private LdapClient $client;
 
     private bool $bound = false;
 
@@ -50,14 +50,7 @@ final class TargetBench
     ) {
         $this->benchBaseDn = "ou={$this->benchOu},{$this->rootBaseDn}";
         $this->writeBaseDn = "ou={$this->peopleOu},{$this->benchBaseDn}";
-        $this->client = new LdapClient(
-            (new ClientOptions())
-                ->setServers([$this->host])
-                ->setPort($this->port)
-                ->setTransport('tcp')
-                ->setTimeoutConnect(5)
-                ->setTimeoutRead(30),
-        );
+        $this->client = $this->buildClient();
     }
 
     public function compareDn(): string
@@ -113,7 +106,8 @@ final class TargetBench
 
     public function cleanup(): void
     {
-        $this->bindIfNeeded();
+        // The seed connection may have gone idle and been dropped during the run, so reconnect for a reliable teardown.
+        $this->reconnect();
 
         try {
             $entries = $this->client->search(
@@ -161,6 +155,30 @@ final class TargetBench
         }
 
         $this->bound = false;
+    }
+
+    private function buildClient(): LdapClient
+    {
+        return new LdapClient(
+            (new ClientOptions())
+                ->setServers([$this->host])
+                ->setPort($this->port)
+                ->setTransport('tcp')
+                ->setTimeoutConnect(5)
+                ->setTimeoutRead(30),
+        );
+    }
+
+    private function reconnect(): void
+    {
+        try {
+            $this->client->unbind();
+        } catch (Throwable) {
+        }
+
+        $this->client = $this->buildClient();
+        $this->bound = false;
+        $this->bindIfNeeded();
     }
 
     private function bindIfNeeded(): void

--- a/tests/performance/Config.php
+++ b/tests/performance/Config.php
@@ -66,6 +66,8 @@ final class Config
 
     public const DEFAULT_SEARCH_SIZE_LIMIT = 500;
 
+    public const DEFAULT_SEARCH_VALUE = 'seed-1';
+
     /**
      * A sorted search models a bounded display page typically, so give it a realistic limit.
      */
@@ -96,6 +98,7 @@ final class Config
         public readonly string $writeBase = self::DEFAULT_WRITE_BASE,
         public readonly bool $jit = true,
         public readonly int $searchSizeLimit = self::DEFAULT_SEARCH_SIZE_LIMIT,
+        public readonly string $searchValue = self::DEFAULT_SEARCH_VALUE,
         public readonly int $searchSortSizeLimit = self::DEFAULT_SEARCH_SORT_SIZE_LIMIT,
         public readonly bool $monitor = true,
         public readonly ?string $searchAttributes = null,

--- a/tests/performance/Config.php
+++ b/tests/performance/Config.php
@@ -64,7 +64,7 @@ final class Config
 
     public const DEFAULT_WRITE_BASE = 'ou=people,dc=foo,dc=bar';
 
-    public const DEFAULT_SEARCH_SUB_SIZE_LIMIT = 500;
+    public const DEFAULT_SEARCH_SIZE_LIMIT = 500;
 
     /**
      * A sorted search models a bounded display page typically, so give it a realistic limit.
@@ -95,7 +95,7 @@ final class Config
         public readonly string $baseDn = self::DEFAULT_BASE_DN,
         public readonly string $writeBase = self::DEFAULT_WRITE_BASE,
         public readonly bool $jit = true,
-        public readonly int $searchSubSizeLimit = self::DEFAULT_SEARCH_SUB_SIZE_LIMIT,
+        public readonly int $searchSizeLimit = self::DEFAULT_SEARCH_SIZE_LIMIT,
         public readonly int $searchSortSizeLimit = self::DEFAULT_SEARCH_SORT_SIZE_LIMIT,
         public readonly bool $monitor = true,
         public readonly ?string $searchAttributes = null,
@@ -111,7 +111,7 @@ final class Config
         $this->assertPositive('port', $port);
         $this->assertNonNegative('warmup', $warmup);
         $this->assertNonNegative('seed-entries', $seedEntries);
-        $this->assertNonNegative('search-sub-size-limit', $searchSubSizeLimit);
+        $this->assertNonNegative('search-size-limit', $searchSizeLimit);
         $this->assertNonNegative('search-sort-size-limit', $searchSortSizeLimit);
         $this->assertNonNegative('seed-attributes', $seedAttributes);
         $this->assertNonNegative('max-search-lookthrough', $maxSearchLookthrough);

--- a/tests/performance/LoadTestCommand.php
+++ b/tests/performance/LoadTestCommand.php
@@ -215,6 +215,13 @@ final class LoadTestCommand extends Command
                 (string) Config::DEFAULT_SEARCH_SIZE_LIMIT,
             )
             ->addOption(
+                'search-value',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'cn prefix the subtree searches filter on; a broader value (e.g. "seed-") matches more entries',
+                Config::DEFAULT_SEARCH_VALUE,
+            )
+            ->addOption(
                 'search-sort-size-limit',
                 null,
                 InputOption::VALUE_REQUIRED,
@@ -452,6 +459,7 @@ final class LoadTestCommand extends Command
             // Swoole keeps it. --no-jit forces it off either way.
             jit: !(bool) $input->getOption('no-jit') && $runner !== 'pcntl',
             searchSizeLimit: $this->requireInt($input, 'search-size-limit'),
+            searchValue: $this->requireString($input, 'search-value'),
             searchSortSizeLimit: $this->requireInt($input, 'search-sort-size-limit'),
             monitor: (bool) $input->getOption('monitor'),
             searchAttributes: $this->optionalString($input, 'search-attributes'),

--- a/tests/performance/LoadTestCommand.php
+++ b/tests/performance/LoadTestCommand.php
@@ -208,11 +208,11 @@ final class LoadTestCommand extends Command
                 true,
             )
             ->addOption(
-                'search-sub-size-limit',
+                'search-size-limit',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'Per-request size limit applied to search-sub ops (0 = unlimited)',
-                (string) Config::DEFAULT_SEARCH_SUB_SIZE_LIMIT,
+                'Per-request size limit applied to search-list and search-sub ops (0 = unlimited)',
+                (string) Config::DEFAULT_SEARCH_SIZE_LIMIT,
             )
             ->addOption(
                 'search-sort-size-limit',
@@ -451,7 +451,7 @@ final class LoadTestCommand extends Command
             // The spawned server defaults JIT off for pcntl (tracing JIT can crash forked workers under load)
             // Swoole keeps it. --no-jit forces it off either way.
             jit: !(bool) $input->getOption('no-jit') && $runner !== 'pcntl',
-            searchSubSizeLimit: $this->requireInt($input, 'search-sub-size-limit'),
+            searchSizeLimit: $this->requireInt($input, 'search-size-limit'),
             searchSortSizeLimit: $this->requireInt($input, 'search-sort-size-limit'),
             monitor: (bool) $input->getOption('monitor'),
             searchAttributes: $this->optionalString($input, 'search-attributes'),

--- a/tests/performance/Report/Report.php
+++ b/tests/performance/Report/Report.php
@@ -41,6 +41,8 @@ final class Report
         private readonly Config $config,
         private readonly WorkloadMix $mix,
         private readonly StatsSnapshot $snapshot,
+        private readonly ?string $subject = null,
+        private readonly bool $external = false,
     ) {}
 
     public function render(OutputInterface $output): void
@@ -102,10 +104,23 @@ final class Report
             ? sprintf('%ds', $this->config->duration)
             : sprintf('%d ops/client', $this->config->ops);
 
+        $title = $this->subject ?? 'FreeDSx LDAP load test';
+
         $lines = [
-            'FreeDSx LDAP load test',
-            '======================',
-            sprintf(
+            $title,
+            str_repeat('=', strlen($title)),
+        ];
+
+        // Backend/runner are FreeDSx-internal knobs, so they are omitted when reporting an external (non-FreeDSx) server.
+        $lines[] = $this->external
+            ? sprintf(
+                'Clients: %d   Duration: %s   Warmup: %ds   Elapsed: %.1fs',
+                $this->config->clients,
+                $duration,
+                $this->config->warmup,
+                $this->snapshot->elapsedSeconds,
+            )
+            : sprintf(
                 'Backend: %s (%s runner)   Clients: %d   Duration: %s   Warmup: %ds   Elapsed: %.1fs',
                 $this->config->backend,
                 $this->config->runner,
@@ -113,12 +128,12 @@ final class Report
                 $duration,
                 $this->config->warmup,
                 $this->snapshot->elapsedSeconds,
-            ),
-            sprintf(
-                'Mix: %s',
-                $this->mix->describe(),
-            ),
-        ];
+            );
+
+        $lines[] = sprintf(
+            'Mix: %s',
+            $this->mix->describe(),
+        );
 
         return implode(PHP_EOL, $lines);
     }

--- a/tests/performance/Threshold/CiThresholds.php
+++ b/tests/performance/Threshold/CiThresholds.php
@@ -49,12 +49,12 @@ final class CiThresholds
             'json:swoole' => new ThresholdSet(
                 maxErrors: 0,
                 minThroughput: 600.0,
-                maxP99Ms: 175.0,
+                maxP99Ms: 200.0,
             ),
             'sqlite:pcntl' => new ThresholdSet(
                 maxErrors: 0,
                 minThroughput: 935.0,
-                maxP99Ms: 175.0,
+                maxP99Ms: 200.0,
             ),
             'sqlite:swoole' => new ThresholdSet(
                 maxErrors: 0,

--- a/tests/performance/Workload/Worker.php
+++ b/tests/performance/Workload/Worker.php
@@ -25,6 +25,7 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
 use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Search\Paging;
 use LogicException;
 use Tests\Performance\FreeDSx\Ldap\Config;
 use Tests\Performance\FreeDSx\Ldap\Stats\StatsCollector;
@@ -50,6 +51,11 @@ final class Worker
     private array $ownedDns = [];
 
     private int $addSeq = 0;
+
+    /**
+     * @var ?Paging Active paged search; each search-paged op pulls one page, restarting when the walk is exhausted.
+     */
+    private ?Paging $paging = null;
 
     public function __construct(
         private readonly int $workerId,
@@ -182,6 +188,7 @@ final class Worker
             'search-and' => $this->doSearchAnd($client),
             'search-or' => $this->doSearchOr($client),
             'search-sort' => $this->doSearchSort($client),
+            'search-paged' => $this->doSearchPaged($client),
             'compare' => $this->doCompare($client),
             'add' => $this->doAdd($client),
             'modify' => $this->doModify($client),
@@ -225,10 +232,7 @@ final class Worker
         $request = $this->newSearch($filter)
             ->base($this->config->baseDn)
             ->useSubtreeScope();
-
-        if ($this->config->searchSubSizeLimit > 0) {
-            $request->sizeLimit($this->config->searchSubSizeLimit);
-        }
+        $this->applySearchSizeLimit($request);
 
         $client->search($request);
     }
@@ -238,8 +242,19 @@ final class Worker
         $request = $this->newSearch(Filters::equal('objectClass', 'inetOrgPerson'))
             ->base($this->config->writeBase)
             ->useSingleLevelScope();
+        $this->applySearchSizeLimit($request);
 
         $client->search($request);
+    }
+
+    /**
+     * Applies the shared search size limit so list and sub cap at the same count for an apples-to-apples comparison.
+     */
+    private function applySearchSizeLimit(SearchRequest $request): void
+    {
+        if ($this->config->searchSizeLimit > 0) {
+            $request->sizeLimit($this->config->searchSizeLimit);
+        }
     }
 
     private function doSearchSubstr(LdapClient $client): void
@@ -336,6 +351,37 @@ final class Worker
             $request,
             Controls::sort('sn'),
         );
+    }
+
+    /**
+     * Fetches ONE page of a paged (RFC 2696) subtree search per op, so each sample is a single page's latency; the
+     * page size matches the shared search size limit, making a page directly comparable to a one-shot search.
+     */
+    private function doSearchPaged(LdapClient $client): void
+    {
+        if ($this->paging === null || !$this->paging->hasEntries()) {
+            $filter = $this->config->seedEntries > 0
+                ? Filters::startsWith('cn', 'seed-')
+                : Filters::startsWith('cn', '');
+
+            $this->paging = $client->paging(
+                $this->newSearch($filter)
+                    ->base($this->config->baseDn)
+                    ->useSubtreeScope(),
+                $this->config->searchSizeLimit > 0
+                    ? $this->config->searchSizeLimit
+                    : null,
+            );
+        }
+
+        try {
+            $this->paging->getEntries();
+        } catch (Throwable $e) {
+            // Drop the cursor so the next op starts a fresh walk; re-throw so the outer handler records the outcome.
+            $this->paging = null;
+
+            throw $e;
+        }
     }
 
     /**

--- a/tests/performance/Workload/Worker.php
+++ b/tests/performance/Workload/Worker.php
@@ -68,7 +68,6 @@ final class Worker
         $this->mailDomain = $this->deriveMailDomain($this->config->baseDn);
         $this->fixedReadDns = [
             $this->config->baseDn,
-            $this->config->bindDn,
             $this->config->writeBase,
             $this->compareDn,
         ];
@@ -225,11 +224,7 @@ final class Worker
 
     private function doSearchSub(LdapClient $client): void
     {
-        $filter = $this->config->seedEntries > 0
-            ? Filters::startsWith('cn', 'seed-')
-            : Filters::startsWith('cn', '');
-
-        $request = $this->newSearch($filter)
+        $request = $this->newSearch($this->searchValueFilter())
             ->base($this->config->baseDn)
             ->useSubtreeScope();
         $this->applySearchSizeLimit($request);
@@ -255,6 +250,13 @@ final class Worker
         if ($this->config->searchSizeLimit > 0) {
             $request->sizeLimit($this->config->searchSizeLimit);
         }
+    }
+
+    private function searchValueFilter(): FilterInterface
+    {
+        return $this->config->seedEntries > 0
+            ? Filters::startsWith('cn', $this->config->searchValue)
+            : Filters::startsWith('cn', '');
     }
 
     private function doSearchSubstr(LdapClient $client): void
@@ -335,11 +337,7 @@ final class Worker
      */
     private function doSearchSort(LdapClient $client): void
     {
-        $filter = $this->config->seedEntries > 0
-            ? Filters::startsWith('cn', 'seed-1')
-            : Filters::startsWith('cn', '');
-
-        $request = $this->newSearch($filter)
+        $request = $this->newSearch($this->searchValueFilter())
             ->base($this->config->baseDn)
             ->useSubtreeScope();
 
@@ -360,12 +358,8 @@ final class Worker
     private function doSearchPaged(LdapClient $client): void
     {
         if ($this->paging === null || !$this->paging->hasEntries()) {
-            $filter = $this->config->seedEntries > 0
-                ? Filters::startsWith('cn', 'seed-')
-                : Filters::startsWith('cn', '');
-
             $this->paging = $client->paging(
-                $this->newSearch($filter)
+                $this->newSearch($this->searchValueFilter())
                     ->base($this->config->baseDn)
                     ->useSubtreeScope(),
                 $this->config->searchSizeLimit > 0

--- a/tests/performance/Workload/WorkloadMix.php
+++ b/tests/performance/Workload/WorkloadMix.php
@@ -32,6 +32,7 @@ final class WorkloadMix
         'search-and',
         'search-or',
         'search-sort',
+        'search-paged',
         'compare',
         'add',
         'modify',

--- a/tests/profile/compare-ldap.sh
+++ b/tests/profile/compare-ldap.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# One-command fair LDAP benchmark.
+
+# NOTE: Not storage-parity. Each server uses its own native backend.
+#
+# Usage (from the repo root):
+#
+#   composer compare-ldap -- [--source=freedsx|openldap|opendj] [--target=freedsx|openldap|opendj]
+#       [--seed-entries=2000] [--cpus=4] [--storage=sqlite] [--runner=pcntl] [--mix=default]
+#       [--search-value=seed-1] [--duration=15] [--warmup=3] [--clients=8] [--driver-processes=1] [--keep-up]
+#
+# --storage/--runner apply only to a freedsx side.
+# --search-value is the cn prefix the subtree searches filter on (--search-value=seed- matches all).
+#
+# Examples:
+#
+#   # FreeDSx (sqlite) vs OpenDJ at 25k, with search-sub kept selective on OpenDJ's substring index
+#   composer compare-ldap -- --target=opendj --seed-entries=25000 --search-value=seed-12
+#
+#   # Any-vs-any: neither side is FreeDSx (both seeded over LDAP)
+#   composer compare-ldap -- --source=openldap --target=opendj
+#
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+COMPOSE="tests/profile/docker-compose.yml"
+
+SOURCE=freedsx
+TARGET=openldap
+SEED=2000
+CPUS=4
+STORAGE=sqlite
+RUNNER=pcntl
+MIX=default
+SEARCHVAL=seed-1
+DURATION=15
+WARMUP=3
+CLIENTS=8
+DRIVER_PROCS=1
+KEEP_UP=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --source=*)           SOURCE="${arg#*=}" ;;
+        --target=*)           TARGET="${arg#*=}" ;;
+        --seed-entries=*)     SEED="${arg#*=}" ;;
+        --cpus=*)             CPUS="${arg#*=}" ;;
+        --storage=*)          STORAGE="${arg#*=}" ;;
+        --runner=*)           RUNNER="${arg#*=}" ;;
+        --mix=*)              MIX="${arg#*=}" ;;
+        --search-value=*)     SEARCHVAL="${arg#*=}" ;;
+        --duration=*)         DURATION="${arg#*=}" ;;
+        --warmup=*)           WARMUP="${arg#*=}" ;;
+        --clients=*)          CLIENTS="${arg#*=}" ;;
+        --driver-processes=*) DRIVER_PROCS="${arg#*=}" ;;
+        --keep-up)            KEEP_UP=1 ;;
+        -h|--help)            sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *)                    echo "unknown arg: $arg" >&2; exit 2 ;;
+    esac
+done
+
+# Resolve a service key to its compose service, container, internal LDAP port, admin bind, base DN, display
+# label, and per-service setup hook. Sets ${prefix}_SVC / _CONT / _PORT / _BIND / _PW / _BASE / _LABEL / _SETUP.
+resolve_svc() {
+    local key="$1" p="$2"
+    case "$key" in
+        freedsx)
+            declare -g "${p}_SVC=freedsx-server" "${p}_CONT=freedsx-profile-server" "${p}_PORT=10389" \
+                "${p}_BIND=cn=user,dc=foo,dc=bar" "${p}_PW=12345" "${p}_BASE=dc=foo,dc=bar" \
+                "${p}_LABEL=FreeDSx/$STORAGE" "${p}_SETUP=none" ;;
+        openldap)
+            declare -g "${p}_SVC=openldap" "${p}_CONT=freedsx-profile-openldap" "${p}_PORT=389" \
+                "${p}_BIND=cn=admin,dc=example,dc=com" "${p}_PW=P@ssword12345" "${p}_BASE=dc=example,dc=com" \
+                "${p}_LABEL=OpenLDAP" "${p}_SETUP=none" ;;
+        opendj)
+            declare -g "${p}_SVC=opendj" "${p}_CONT=freedsx-profile-opendj" "${p}_PORT=1389" \
+                "${p}_BIND=cn=Directory Manager" "${p}_PW=P@ssword12345" "${p}_BASE=dc=example,dc=com" \
+                "${p}_LABEL=OpenDJ" "${p}_SETUP=opendj" ;;
+        *) echo "unknown service: $key (expected freedsx, openldap, or opendj)" >&2; exit 2 ;;
+    esac
+}
+
+if [[ "$SOURCE" == "$TARGET" ]]; then
+    echo "--source and --target must differ (got '$SOURCE' for both)" >&2
+    exit 2
+fi
+
+resolve_svc "$SOURCE" SRC
+resolve_svc "$TARGET" TGT
+
+# Resolve the 'default' mix to a portable representative mix (the harness DEFAULT_MIX minus search-sort, which
+# needs server-side sort vanilla slapd does not load; pass a custom --mix with search-sort for servers that support it).
+if [[ "$MIX" == "default" ]]; then
+    MIX="bind=5,search-read=50,search-eq=25,search-sub=10,search-list=5,add=2,modify=2,delete=1"
+fi
+
+# OpenDJ does not create the base entry and defaults are noisy/entry-limited for a benchmark: create the base entry,
+# silence the per-op access log, and raise objectClass's index-entry-limit so search-list (which matches every entry
+# via objectClass) stays indexed past the default 4000. search-sub is kept selective via --search-value.
+setup_opendj() {
+    local bind="$1" pw="$2" base="$3"
+    if ! docker exec freedsx-profile-opendj /opt/opendj/bin/ldapsearch \
+        -h localhost -p 1389 -D "$bind" -w "$pw" -b "$base" -s base "(objectClass=*)" 1.1 >/dev/null 2>&1; then
+        echo "==> creating base entry $base in opendj"
+        local dc="${base#dc=}"; dc="${dc%%,*}"
+        printf 'dn: %s\nobjectClass: top\nobjectClass: domain\ndc: %s\n' "$base" "$dc" \
+            | docker exec -i freedsx-profile-opendj /opt/opendj/bin/ldapmodify -a \
+                -h localhost -p 1389 -D "$bind" -w "$pw"
+    fi
+
+    echo "==> tuning opendj (disable access log; raise objectClass index-entry-limit)"
+    docker exec freedsx-profile-opendj /opt/opendj/bin/dsconfig set-log-publisher-prop \
+        --publisher-name "Json File-Based Access Logger" --set enabled:false \
+        -h localhost -p 4444 -D "$bind" -w "$pw" -X -n >/dev/null 2>&1 \
+    || docker exec freedsx-profile-opendj /opt/opendj/bin/dsconfig set-log-publisher-prop \
+        --publisher-name "File-Based Access Logger" --set enabled:false \
+        -h localhost -p 4444 -D "$bind" -w "$pw" -X -n >/dev/null 2>&1 \
+    || echo "   (access-log tweak skipped)"
+    docker exec freedsx-profile-opendj /opt/opendj/bin/dsconfig set-backend-index-prop \
+        --backend-name userRoot --index-name objectClass --set index-entry-limit:200000 \
+        -h localhost -p 4444 -D "$bind" -w "$pw" -X -n >/dev/null 2>&1 \
+    || echo "   (index-limit tweak skipped)"
+}
+
+echo "==> up $SRC_LABEL ($SRC_SVC) + $TGT_LABEL ($TGT_SVC) (cpus=$CPUS each, seed=$SEED)"
+# freedsx-server self-seeds via SEED_ENTRIES; here the bench seeds it over LDAP like any other side, so it starts empty.
+PROFILE_CPUS="$CPUS" FREEDSX_STORAGE="$STORAGE" FREEDSX_RUNNER="$RUNNER" SEED_ENTRIES=0 \
+    docker compose -f "$COMPOSE" up -d --wait "$SRC_SVC" "$TGT_SVC"
+
+[[ "$SRC_SETUP" == opendj ]] && setup_opendj "$SRC_BIND" "$SRC_PW" "$SRC_BASE"
+[[ "$TGT_SETUP" == opendj ]] && setup_opendj "$TGT_BIND" "$TGT_PW" "$TGT_BASE"
+
+NET=$(docker inspect -f '{{range $k,$_ := .NetworkSettings.Networks}}{{$k}}{{end}}' "$SRC_CONT")
+
+echo "==> running comparison (driver container on '$NET')"
+docker run --rm --network "$NET" -v "$PWD":/app -w /app --entrypoint php \
+    freedsx-profile:latest -d xdebug.mode=off -d opcache.enable_cli=1 -d opcache.jit=off \
+    tests/bin/ldap-bench-compare.php \
+    --source-host="$SRC_SVC" --source-port="$SRC_PORT" --source-bind-dn="$SRC_BIND" --source-bind-password="$SRC_PW" --source-base-dn="$SRC_BASE" --source-label="$SRC_LABEL" \
+    --target-host="$TGT_SVC" --target-port="$TGT_PORT" --target-bind-dn="$TGT_BIND" --target-bind-password="$TGT_PW" --target-base-dn="$TGT_BASE" --target-label="$TGT_LABEL" \
+    --seed-entries="$SEED" --mix="$MIX" --search-value="$SEARCHVAL" --duration="$DURATION" --warmup="$WARMUP" \
+    --clients="$CLIENTS" --driver-processes="$DRIVER_PROCS"
+
+if [[ "$KEEP_UP" -eq 0 ]]; then
+    echo "==> tearing down (pass --keep-up to skip)"
+    docker compose -f "$COMPOSE" down
+fi

--- a/tests/profile/docker-compose.yml
+++ b/tests/profile/docker-compose.yml
@@ -23,6 +23,40 @@ services:
       MYSQL_USER: "root"
       MYSQL_PASSWORD: "root"
 
+  freedsx-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: freedsx-profile:latest
+    container_name: freedsx-profile-server
+    cpus: ${PROFILE_CPUS:-4}
+    ports:
+      - "10389:10389"
+    volumes:
+      - ../..:/app:rw
+    working_dir: /app
+    depends_on:
+      - mysql
+    environment:
+      MYSQL_DSN: "mysql:host=mysql;port=3306;dbname=freedsx"
+      MYSQL_USER: "root"
+      MYSQL_PASSWORD: "root"
+    command:
+      - bash
+      - -lc
+      - >
+        test -f vendor/autoload.php || composer install --no-interaction --no-progress;
+        exec php -d opcache.enable_cli=1 -d opcache.jit_buffer_size=100M -d opcache.jit=function tests/bin/ldap-backend-storage.php
+        --transport=tcp --storage=${FREEDSX_STORAGE:-sqlite} --runner=${FREEDSX_RUNNER:-pcntl}
+        --port=10389 --seed-entries=${SEED_ENTRIES:-25000}
+    # Ready only once seeding finishes and the server listens, so `up --wait` blocks until then.
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/10389'"]
+      interval: 5s
+      timeout: 3s
+      retries: 120
+      start_period: 20s
+
   mysql:
     image: mysql:8.4
     container_name: freedsx-profile-mysql
@@ -42,5 +76,30 @@ services:
       dockerfile: openldap.Dockerfile
     image: freedsx-profile-openldap:latest
     container_name: freedsx-profile-openldap
+    cpus: ${PROFILE_CPUS:-4}
+    ports:
+      - "10390:389"
+    healthcheck:
+      test: ["CMD", "ldapwhoami", "-x", "-H", "ldap://localhost"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
     tmpfs:
       - /var/lib/ldap
+
+  opendj:
+    image: openidentityplatform/opendj:latest
+    container_name: freedsx-profile-opendj
+    cpus: ${PROFILE_CPUS:-4}
+    ports:
+      - "10391:1389"
+    environment:
+      BASE_DN: "dc=example,dc=com"
+      ROOT_USER_DN: "cn=Directory Manager"
+      ROOT_PASSWORD: "P@ssword12345"
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/opendj/bin/ldapsearch -h localhost -p 1389 -D 'cn=Directory Manager' -w 'P@ssword12345' -b '' -s base '(objectClass=*)' 1.1 >/dev/null 2>&1"]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+      start_period: 20s


### PR DESCRIPTION
This makes the bench comparison generic so you can use a source and target. I mostly wanted to see how the performance here compares to other LDAP implementations to see what could still use some attention / where things stand. Currently it only lets you run OpenDJ / OpenLDAP / FreeDSx. 

PHP can't compete with the speed of C + LMDB on sub search / list search, but other ops are basically comparable. We do outpace the speed / throughput of OpenDJ (surprisingly). That's with their default storage though. I didn't try other ones. I may investigate how to configure it with jdbc / something else.