### PR TITLE
[1.0.0] Make storage a config on the server options.

### DIFF
--- a/docs/Server/Access-Control.md
+++ b/docs/Server/Access-Control.md
@@ -109,6 +109,7 @@ use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\AccessControl\Target\Target;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
 
 $server = new LdapServer(
     (new ServerOptions())
@@ -150,7 +151,7 @@ $server = new LdapServer(
                     ),
                 ),
         )
-        ->setStorage(new MyDirectoryStorage())
+        ->setStorageConfig(PdoConfig::forSqlite('/var/lib/myapp/ldap.sqlite'))
 );
 ```
 

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -16,7 +16,7 @@ LDAP Server Configuration
     * [ServerOptions:setAclRules](#setaclrules)
     * [ServerOptions:setAccessControl](#setaccesscontrol)
 * [Backend](#backend)
-    * [ServerOptions:setStorage](#setstorage)
+    * [ServerOptions:setStorageConfig](#setstorageconfig)
     * [ServerOptions:setPasswordAuthenticator](#setpasswordauthenticator)
     * [ServerOptions:setIdentityResolver](#setidentityresolver)
 * [Schema](#schema)
@@ -253,30 +253,29 @@ See [Access Control](Access-Control.md) for control-rule grants.
 ## Backend
 
 The LDAP server handles directory data through `WritableStorageBackend`, which applies LDAP semantics over the
-`EntryStorageInterface` set via `setStorage()`. You can also plug in a custom filter evaluator or a custom RootDSE
-handler.
+storage built from the configured backend config.
 
 ------------------
-#### setStorage
+#### setStorageConfig
 
-The storage backend is configured on `ServerOptions` via `setStorage()` (or `useInMemoryStorage()` for a
-transient in-memory directory). All directory operations (search, authenticate, and optionally write) are
-dispatched to it.
+Storage is configured on `ServerOptions` via `setStorageConfig()` or by passing a config to the `ServerOptions`
+constructor. Choose one of the built-in backend configs: `InMemoryStorageConfig`, `JsonStorageConfig`, or `PdoConfig`
+(SQLite or MySQL). All directory operations (search, authenticate, and optionally write) are dispatched to the
+resulting storage.
 
 ```php
 use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
 use FreeDSx\Ldap\ServerOptions;
 
-$server = new LdapServer((new ServerOptions())->useInMemoryStorage());
+$server = new LdapServer(new ServerOptions(PdoConfig::forSqlite('/var/lib/myapp/ldap.sqlite')));
 ```
 
-For a custom source, pass your own `EntryStorageInterface` implementation to `setStorage()`.
+When no config is given the server uses a transient in-memory backend. That default is for testing only. Supply a
+persistent config such as `PdoConfig::forSqlite()` in production.
 
 The bundled SQLite and MySQL backends create their tables automatically on first connect. For managing that schema
 yourself, see [Database Schema](Database-Schema.md).
-
-**Note**: a non-proxy server started without a configured storage throws at startup rather than silently
-serving an empty directory.
 
 ------------------
 #### setPasswordAuthenticator
@@ -386,7 +385,7 @@ Password Modify requests.
 
 ## Schema
 
-These configure schema validation for `useStorage()` writes. For full documentation, see
+These configure schema validation for storage-backend writes. For full documentation, see
 [Schema Validation](Schema.md).
 
 ------------------
@@ -657,7 +656,8 @@ configure the rest.
 
 A `ServerOptions` setter that puts the server into read-only replica mode against the given `ReplicaConfig`. Client
 writes are refused and a background daemon keeps the local storage in step with the provider.
-`ServerOptions::forReplica($config)` is a shortcut that constructs the options with this already set.
+`ServerOptions::forReplica($replicaConfig, $storageConfig)` is a shortcut that constructs the options with this
+already set, taking the replica config and the backend storage config for the local mirror.
 
 **Default**: `null` (the server is a normal read-write directory).
 

--- a/docs/Server/Database-Schema.md
+++ b/docs/Server/Database-Schema.md
@@ -34,16 +34,14 @@ string in code, `PdoStorage::schemaDdl(new SqliteDialect())` and `PdoStorage::sc
 ## Managing the Schema Yourself
 
 For a managed database you usually want to apply schema changes with your own tooling rather than have the library issue
-DDL on startup. Turn automatic setup off with the `initializeSchema` flag on the storage factory:
+DDL on startup. Turn automatic setup off with the `initializeSchema` flag on the `PdoConfig`, then pass the config to
+`setStorageConfig()` or the `ServerOptions` constructor:
 
 ```php
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactory;
 
-$storage = PdoStorageFactory::forPcntl(
-    PdoConfig::forSqlite('/var/lib/freedsx/directory.sqlite')
-        ->setInitializeSchema(false),
-);
+$storageConfig = PdoConfig::forSqlite('/var/lib/freedsx/directory.sqlite')
+    ->setInitializeSchema(false);
 ```
 
 With it off, the adapter never runs any DDL on connect. Creating and updating the tables is entirely up to you, using

--- a/docs/Server/General-Usage.md
+++ b/docs/Server/General-Usage.md
@@ -61,12 +61,12 @@ use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\LdapServer;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
 use FreeDSx\Ldap\ServerOptions;
 
 $passwordHash = '{SHA}' . base64_encode(sha1('secret', true));
 
-$options = (new ServerOptions())->setStorage(new InMemoryStorage([
+$options = new ServerOptions(InMemoryStorageConfig::withEntries([
     new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example')),
     new Entry(
         new Dn('cn=admin,dc=example,dc=com'),
@@ -91,12 +91,12 @@ searching for an entry where the `uid` attribute matches.
 
 ```php
 use FreeDSx\Ldap\LdapServer;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\JsonStorageConfig;
 use FreeDSx\Ldap\ServerOptions;
 
 $options = (new ServerOptions())
     ->setSaslMechanisms(ServerOptions::SASL_PLAIN)
-    ->setStorage(JsonFileStorage::forPcntl('/var/lib/myapp/ldap.json'));
+    ->setStorageConfig(JsonStorageConfig::forFile('/var/lib/myapp/ldap.json'));
 
 $server = new LdapServer($options);
 $server->run();
@@ -119,7 +119,7 @@ For full control over credential storage, such as delegating to an external user
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\SaslIdentity;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\JsonStorageConfig;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Sasl\Mechanism\MechanismName;
@@ -155,7 +155,7 @@ $options = (new ServerOptions())
         ServerOptions::SASL_PLAIN,
         ServerOptions::SASL_SCRAM_SHA_256,
     )
-    ->setStorage(JsonFileStorage::forPcntl('/var/lib/myapp/ldap.json'))
+    ->setStorageConfig(JsonStorageConfig::forFile('/var/lib/myapp/ldap.json'))
     ->setPasswordAuthenticator(new MyAuthenticator());
 
 $server = new LdapServer($options);
@@ -169,14 +169,15 @@ about the other.
 
 ## Running The Server
 
-In its simplest form you construct the server with storage and call `run()`. A non-proxy server started without
-storage throws at startup rather than silently serving an empty directory.
+In its simplest form you construct the server and call `run()`. `ServerOptions` defaults to a transient in-memory
+backend when no storage config is given. This default is for testing only. In production supply a persistent
+backend config such as `PdoConfig::forSqlite()`.
 
 ```php
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\ServerOptions;
 
-$server = new LdapServer((new ServerOptions())->useInMemoryStorage());
+$server = new LdapServer(new ServerOptions());
 $server->run();
 ```
 
@@ -217,7 +218,7 @@ use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\ServerOptions;
 
 $options = (new ServerOptions())
-    ->setStorage($storage)
+    ->setStorageConfig($storageConfig)
     ->setConfigReloader(new FileConfigReloader('/etc/myapp/ldap.json'));
 
 $server = new LdapServer($options);
@@ -289,38 +290,43 @@ single configured upstream.
 
 ## Providing a Backend
 
-For storage-backed servers, provide an `EntryStorageInterface` implementation via `useStorage()`. FreeDSx LDAP
-wraps it in `WritableStorageBackend`, which handles all LDAP semantics — validation, error codes, scope checking,
-and entry transformation. Your storage implementation handles only raw persistence.
+Configure backend storage via `setStorageConfig()` or pass a config to the `ServerOptions` constructor
+(`new ServerOptions(StorageConfigInterface $config)`). Pick the config that matches your persistence needs: in-memory,
+JSON file, PDO-SQLite, or PDO-MySQL. When no config is given the server uses a transient in-memory backend, which is
+for testing only.
 
 ```php
 use FreeDSx\Ldap\LdapServer;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
 
-$server = new LdapServer((new ServerOptions())->setStorage(new InMemoryStorage($entries)));
+$server = new LdapServer(new ServerOptions(InMemoryStorageConfig::withEntries($entries)));
 $server->run();
 ```
 
-For a custom source that a bundled adapter cannot model, implement `EntryStorageInterface` yourself and pass
-it to `useStorage()`. `WritableStorageBackend` still handles LDAP semantics (validation, error codes, scope
-and DN handling, operational attributes) on top of your storage, so you only implement entry read/write.
+Each config is a value object. The container builds the runner-appropriate storage for the runner set on
+`ServerOptions`, so the same config works under both the PCNTL and Swoole runners.
 
 ```php
 use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
 
-$server = new LdapServer((new ServerOptions())->setStorage(new MyEntryStorage()));
+$server = new LdapServer(new ServerOptions(PdoConfig::forSqlite('/var/lib/myapp/ldap.sqlite')));
 $server->run();
 ```
 
-All client LDAP operations — search, add, delete, modify, rename, compare — are routed to the backend.
-Paging is handled automatically: a PHP generator is stored per connection and resumes it for each page
-request. Your `search()` implementation simply yields entries.
+All client LDAP operations (search, add, delete, modify, rename, compare) are routed to the backend.
+Paging is handled automatically: a PHP generator is stored per connection and resumes it for each page request.
 
 Authentication is a separate concern handled by `PasswordAuthenticatableInterface`. See [Authentication](#authentication).
 
 ### Built-In Storage Implementations
 
-Four storage implementations are included for common use cases. All are used via `useStorage()`.
+Four storage backends are included, each selected via a config object passed to `setStorageConfig()`:
+
+- **SQLite** (`PdoConfig::forSqlite()`): recommended for most deployments. It is the most optimized backend and gives durable persistence with concurrent access.
+- **MySQL** (`PdoConfig::forMysql()`): durable persistence backed by a shared MySQL/MariaDB server.
+- **JsonFileStorage** (`JsonStorageConfig::forFile()`): a single JSON file, useful for small directories.
+- **InMemoryStorage** (`InMemoryStorageConfig::withEntries()`): non-persistent, ideal for testing or read-only PCNTL data seeded before `run()`.
 
 #### InMemoryStorage
 
@@ -334,19 +340,19 @@ An in-memory, array-backed storage implementation. Suitable for:
 > Under the PCNTL runner, `InMemoryStorage` is **not safe for multi-client write workloads**. Each forked child receives
 > its own copy of the store at fork time. Written data is not propagated.
 >
-> Use `JsonFileStorage` or a `PdoStorage` (via `PdoStorageFactory` with a SQLite/MySQL `PdoConfig`) if you need write behavior and use PCNTL.
+> Use `JsonStorageConfig` or a SQLite/MySQL `PdoConfig` if you need write behavior under the PCNTL runner.
 
 ```php
 use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\LdapServer;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
 use FreeDSx\Ldap\ServerOptions;
 
 $passwordHash = '{SHA}' . base64_encode(sha1('secret', true));
 
-$options = (new ServerOptions())->setStorage(new InMemoryStorage([
+$options = new ServerOptions(InMemoryStorageConfig::withEntries([
     new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example')),
     new Entry(
         new Dn('cn=admin,dc=example,dc=com'),
@@ -364,19 +370,16 @@ $server->run();
 A file-backed storage implementation that persists the directory as a JSON file. Safe for PCNTL (write operations are
 serialised with `flock(LOCK_EX)` and the in-memory read cache is invalidated via `filemtime` checks).
 
-Use the named constructor that matches your server runner:
+Pass a `JsonStorageConfig::forFile()` to the `ServerOptions` constructor. The container selects the PCNTL
+implementation (`flock()` serialised writes) or the Swoole implementation (coroutine Channel mutex, non-blocking file
+I/O) to match the configured runner:
 
 ```php
 use FreeDSx\Ldap\LdapServer;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\JsonStorageConfig;
 use FreeDSx\Ldap\ServerOptions;
 
-// PCNTL runner — uses flock() to serialise writes across forked processes
-$server = new LdapServer((new ServerOptions())->setStorage(JsonFileStorage::forPcntl('/var/lib/myapp/ldap.json')));
-$server->run();
-
-// Swoole runner — uses a coroutine Channel mutex and non-blocking file I/O
-$server = new LdapServer((new ServerOptions())->setStorage(JsonFileStorage::forSwoole('/var/lib/myapp/ldap.json')));
+$server = new LdapServer(new ServerOptions(JsonStorageConfig::forFile('/var/lib/myapp/ldap.json')));
 $server->run();
 ```
 
@@ -402,56 +405,38 @@ use cases that need durable persistence across restarts with support for concurr
 - **PCNTL**: a single shared PDO connection is inherited by all forked child processes. SQLite WAL mode handles concurrent access at the OS level.
 - **Swoole**: each coroutine gets its own PDO connection to avoid blocking.
 
-Build a `PdoConfig::forSqlite()` and pass it to the `PdoStorageFactory` method that matches your server runner:
+Pass a `PdoConfig::forSqlite()` to the `ServerOptions` constructor. The container builds the shared-connection
+(PCNTL) or per-coroutine (Swoole) storage to match the configured runner, both using WAL journal mode:
 
 ```php
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactory;
 use FreeDSx\Ldap\ServerOptions;
 
-// PCNTL runner — WAL journal mode, shared connection
-$server = new LdapServer((new ServerOptions())->setStorage(
-    PdoStorageFactory::forPcntl(PdoConfig::forSqlite('/var/lib/myapp/ldap.sqlite'))
-));
-$server->run();
-
-// Swoole runner — WAL journal mode, per-coroutine connection
-$server = new LdapServer((new ServerOptions())->setStorage(
-    PdoStorageFactory::forSwoole(PdoConfig::forSqlite('/var/lib/myapp/ldap.sqlite'))
-));
+$server = new LdapServer(new ServerOptions(PdoConfig::forSqlite('/var/lib/myapp/ldap.sqlite')));
 $server->run();
 ```
 
 Use `:memory:` as the path to run a non-persistent, in-process SQLite database (useful for testing):
 
 ```php
-$server = new LdapServer((new ServerOptions())->setStorage(
-    PdoStorageFactory::forPcntl(PdoConfig::forSqlite(':memory:'))
-));
+$server = new LdapServer(new ServerOptions(PdoConfig::forSqlite(':memory:')));
 ```
 
 #### MySQL
 
 A MySQL/MariaDB-backed `PdoStorage`. Requires MySQL 8.0+ or MariaDB 10.6+.
 
-Build a `PdoConfig::forMysql()` and pass it to the `PdoStorageFactory` method that matches your server runner:
+Pass a `PdoConfig::forMysql()` to the `ServerOptions` constructor. The container builds the shared-connection (PCNTL)
+or per-coroutine (Swoole) storage to match the configured runner:
 
 ```php
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactory;
 use FreeDSx\Ldap\ServerOptions;
 
-// PCNTL runner — shared connection across forked processes
-$server = new LdapServer((new ServerOptions())->setStorage(
-    PdoStorageFactory::forPcntl(PdoConfig::forMysql('mysql:host=localhost;dbname=ldap', 'user', 'secret'))
-));
-$server->run();
-
-// Swoole runner — per-coroutine connection
-$server = new LdapServer((new ServerOptions())->setStorage(
-    PdoStorageFactory::forSwoole(PdoConfig::forMysql('mysql:host=localhost;dbname=ldap', 'user', 'secret'))
+$server = new LdapServer(new ServerOptions(
+    PdoConfig::forMysql('mysql:host=localhost;dbname=ldap', 'user', 'secret'),
 ));
 $server->run();
 ```
@@ -468,7 +453,6 @@ extension, then tune the rest with the setters. Your dialect's `createFilterTran
 
 ```php
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactory;
 
 $config = PdoConfig::forDriver(
     new MyPostgresDialect(),
@@ -478,9 +462,10 @@ $config = PdoConfig::forDriver(
     ->setUsername('user')
     ->setPassword('secret')
     ->setSessionStatements(["SET client_encoding = 'UTF8'"]);
-
-$storage = PdoStorageFactory::forPcntl($config);
 ```
+
+`PdoConfig` implements `StorageConfigInterface`, so pass `$config` to `setStorageConfig()` or the `ServerOptions`
+constructor like any other backend config.
 
 ## LDIF Data
 
@@ -492,19 +477,19 @@ other source (database, remote URL, gzip stream, etc.). LDIF output uses the par
 ### Seeding Initial Entries
 
 `LdapServer::seed()` bulk-imports RFC 2849 LDIF content records into the storage configured via
-`ServerOptions::setStorage()` in one atomic transaction, with schema validation and operational-attribute stamping
-(`createTimestamp`, `entryUUID`, etc.) applied. Use it to populate a persistent storage backend before `$server->run()`.
+`ServerOptions::setStorageConfig()` in one atomic transaction, with schema validation and operational-attribute
+stamping (`createTimestamp`, `entryUUID`, etc.) applied. Use it to populate a persistent storage backend before
+`$server->run()`.
 
 ```php
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Ldif\Loader\FileLdifLoader;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactory;
 use FreeDSx\Ldap\ServerOptions;
 
 $server = new LdapServer(
-    (new ServerOptions())->setStorage(PdoStorageFactory::forPcntl(PdoConfig::forSqlite('/var/lib/myapp/ldap.sqlite'))),
+    new ServerOptions(PdoConfig::forSqlite('/var/lib/myapp/ldap.sqlite')),
 );
 $server->seed(
     new FileLdifLoader('/etc/myapp/initial-data.ldif'),
@@ -514,14 +499,14 @@ $server->seed(
 $server->run();
 ```
 
-The optional second argument is the creator DN, stamped as `creatorsName`/`modifiersName` on each imported entry —
-defaults to the empty (anonymous) DN.
+The optional second argument is the creator DN, stamped as `creatorsName`/`modifiersName` on each imported entry.
+It defaults to the empty (anonymous) DN.
 
 `seed()` accepts only content records (entries without `changetype:`) and requires depth-first input (parents first,
 then children entries). LDIF produced by `dump()` is already in this order. The operation itself is an upsert that overwrites.
 
-For Swoole factories (`::forSwoole()`), call `seed()` inside `Swoole\Coroutine\run()` so the adapter's
-coroutine-scoped connection is available during import.
+When using the Swoole runner (`setRunner(RunnerMode::Swoole)`), call `seed()` inside `Swoole\Coroutine\run()` so the
+storage adapter's per-coroutine connection is available during import.
 
 ### Replaying LDIF Changelogs
 
@@ -551,7 +536,7 @@ use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Ldif\Loader\FileLdifLoader;
 use FreeDSx\Ldap\ServerOptions;
 
-$server = new LdapServer((new ServerOptions())->setStorage($storage));
+$server = new LdapServer(new ServerOptions($storageConfig));
 $server->seed(new FileLdifLoader('/etc/myapp/initial-data.ldif'))
     ->applyChanges(new FileLdifLoader('/etc/myapp/changes-today.ldif'))
     ->run();
@@ -571,11 +556,10 @@ entries exactly as they were.
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Ldif\Output\FileLdifOutput;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactory;
 use FreeDSx\Ldap\ServerOptions;
 
 $server = new LdapServer(
-    (new ServerOptions())->setStorage(PdoStorageFactory::forPcntl(PdoConfig::forSqlite('/var/lib/myapp/ldap.sqlite'))),
+    new ServerOptions(PdoConfig::forSqlite('/var/lib/myapp/ldap.sqlite')),
 );
 $server->dump(new FileLdifOutput('/var/backups/ldap-snapshot.ldif'));
 ```

--- a/docs/Server/Replication.md
+++ b/docs/Server/Replication.md
@@ -32,7 +32,6 @@ use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\AccessControl\Target\Target;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactory;
 use FreeDSx\Ldap\ServerOptions;
 
 // The one sync-specific grant: the privileged sync control, over the base to sync.
@@ -45,12 +44,11 @@ $syncGrant = ControlRule::allow(
 // Add that grant to your directory's AclRules (see the Access Control page for the rest).
 $aclRules = $myAclRules->withControlRules($syncGrant);
 
-// A storage that is visible across connections (see Storage and Runner Requirements below).
-$storage = PdoStorageFactory::forPcntl(PdoConfig::forSqlite('/var/lib/freedsx/directory.sqlite'));
+// A storage config that is visible across connections (see Storage and Runner Requirements below).
+$storageConfig = PdoConfig::forSqlite('/var/lib/freedsx/directory.sqlite');
 
-$options = (new ServerOptions())
+$options = (new ServerOptions($storageConfig))
     ->setSyncEnabled(true)
-    ->setStorage($storage)
     ->setAclRules($aclRules);
 
 $server = new LdapServer($options);
@@ -177,7 +175,6 @@ use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\ReplicaConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactory;
 use FreeDSx\Ldap\Sync\Consumer\Checkpoint\FileReplicationCheckpoint;
 use FreeDSx\Ldap\ServerOptions;
 
@@ -196,8 +193,10 @@ $replicaConfig = new ReplicaConfig(
 // How the replica authenticates to the provider (a simple bind here; use Operations::bindSasl() for SASL/EXTERNAL).
 $replicaConfig->setBind(Operations::bind('cn=replica,dc=example,dc=com', 'secret'));
 
-$options = ServerOptions::forReplica($replicaConfig)
-    ->setStorage(PdoStorageFactory::forPcntl(PdoConfig::forSqlite('/var/lib/freedsx/replica.sqlite')));
+$options = ServerOptions::forReplica(
+    $replicaConfig,
+    PdoConfig::forSqlite('/var/lib/freedsx/replica.sqlite'),
+);
 
 (new LdapServer($options))->run();
 ```

--- a/docs/Server/Schema.md
+++ b/docs/Server/Schema.md
@@ -12,8 +12,8 @@ Schema Validation
 * [Operational Attributes](#operational-attributes)
 * [String Matching and Internationalization (RFC 4518)](#string-matching-and-internationalization-rfc-4518)
 
-Calling `LdapServer::useStorage()` automatically enables schema validation using the built-in RFC 4519
-schema in `Strict` mode.
+Configuring backend storage automatically enables schema validation using the built-in RFC 4519 schema in
+`Strict` mode.
 
 ## Default Behavior
 
@@ -21,7 +21,7 @@ schema in `Strict` mode.
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\ServerOptions;
 
-$server = new LdapServer((new ServerOptions())->useInMemoryStorage());
+$server = new LdapServer(new ServerOptions());
 ```
 
 ## What Gets Validated
@@ -90,13 +90,11 @@ otherwise make unmodifiable.
 ```php
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\ServerOptions;
 
 $server = new LdapServer(
     (new ServerOptions())
         ->setSchemaValidationMode(SchemaValidationMode::Lenient)
-        ->setStorage(new InMemoryStorage())
 );
 ```
 
@@ -143,9 +141,9 @@ $options = (new ServerOptions())->setSchema($schema);
 
 ## Operational Attributes
 
-`useStorage()` automatically populates and maintains server-managed operational attributes on every write. Clients
-cannot modify these — they are flagged `NO-USER-MODIFICATION` in the schema and client attempts are rejected with
-`constraintViolation`.
+The storage backend automatically populates and maintains server-managed operational attributes on every write.
+Clients cannot modify these. They are flagged `NO-USER-MODIFICATION` in the schema and client attempts are rejected
+with `constraintViolation`.
 
 **Set on `add`:**
 

--- a/src/FreeDSx/Ldap/Container/CoreServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/CoreServerContainerProvider.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Container;
 
 use Closure;
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
@@ -21,6 +22,12 @@ use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\ProxyOptions;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactory;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\JsonStorageConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluator;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
@@ -81,6 +88,7 @@ final class CoreServerContainerProvider implements ContainerProviderInterface
             SocketServerFactory::class => $this->makeSocketServerFactory(...),
             HandlerFactoryInterface::class => $this->makeHandlerFactory(...),
             FilterEvaluatorInterface::class => $this->makeFilterEvaluator(...),
+            EntryStorageInterface::class => $this->makeStorage(...),
             WritableStorageBackend::class => $this->makeBackend(...),
             ServerProtocolFactory::class => $this->makeServerProtocolFactory(...),
             ServerProtocolFactoryInterface::class => $this->makeServerProtocolFactoryInterface(...),
@@ -121,7 +129,7 @@ final class CoreServerContainerProvider implements ContainerProviderInterface
      */
     private function makeSleeper(Container $container): SleeperInterface
     {
-        return $container->get(ServerOptions::class)->getUseSwooleRunner()
+        return $container->get(ServerOptions::class)->getRunner() === RunnerMode::Swoole
             ? new CoroutineSleeper()
             : new BlockingSleeper();
     }
@@ -145,30 +153,56 @@ final class CoreServerContainerProvider implements ContainerProviderInterface
     private function backendOrFail(Container $container): WritableStorageBackend
     {
         return $this->backendOrNull($container)
-            ?? throw new RuntimeException('No storage is configured; set ServerOptions::setStorage().');
+            ?? throw new RuntimeException('No storage is configured; set ServerOptions::setStorageConfig().');
     }
 
     /**
-     * The configured backend, or null when no storage is set (the proxy path has none).
+     * The assembled backend, or null on the proxy path which serves no local directory.
      */
     private function backendOrNull(Container $container): ?WritableStorageBackend
     {
-        return $container->get(ServerOptions::class)->getStorage() !== null
-            ? $container->get(WritableStorageBackend::class)
-            : null;
+        return $container->has(ProxyOptions::class)
+            ? null
+            : $container->get(WritableStorageBackend::class);
     }
 
     /**
-     * Assemble the writable backend from the configured storage; only invoked when storage is set.
+     * Build the runner-appropriate storage backend from the configured StorageConfigInterface.
+     */
+    private function makeStorage(Container $container): EntryStorageInterface
+    {
+        $options = $container->get(ServerOptions::class);
+        $config = $options->getStorageConfig();
+        $swoole = $options->getRunner() === RunnerMode::Swoole;
+
+        return match (true) {
+            $config instanceof PdoConfig => $swoole
+                ? PdoStorageFactory::forSwoole($config)
+                : PdoStorageFactory::forPcntl($config),
+            $config instanceof JsonStorageConfig => $swoole
+                ? JsonFileStorage::forSwoole(
+                    $config->path(),
+                    logger: $config->logger(),
+                )
+                : JsonFileStorage::forPcntl(
+                    $config->path(),
+                    logger: $config->logger(),
+                ),
+            $config instanceof InMemoryStorageConfig => new InMemoryStorage($config->entries()),
+            default => throw new RuntimeException(sprintf(
+                'Unsupported storage config "%s".',
+                $config::class,
+            )),
+        };
+    }
+
+    /**
+     * Assemble the writable backend from the container-built storage; only invoked when storage is configured.
      */
     private function makeBackend(Container $container): WritableStorageBackend
     {
         $options = $container->get(ServerOptions::class);
-        $storage = $options->getStorage();
-
-        if ($storage === null) {
-            throw new RuntimeException('No storage is configured; set ServerOptions::setStorage().');
-        }
+        $storage = $container->get(EntryStorageInterface::class);
 
         $schema = $options->getSchemaValidationMode() !== SchemaValidationMode::Off
             ? $options->getSchema()
@@ -240,7 +274,7 @@ final class CoreServerContainerProvider implements ContainerProviderInterface
         $protocolFactoryProvider = $this->makeProtocolFactoryProvider($container);
         $metricsRecorder = $container->get(MetricsRecorderInterface::class);
 
-        if ($options->getUseSwooleRunner()) {
+        if ($options->getRunner() === RunnerMode::Swoole) {
             return new SwooleServerRunner(
                 serverProtocolFactory: $protocolFactoryProvider($options),
                 options: $options,
@@ -287,7 +321,7 @@ final class CoreServerContainerProvider implements ContainerProviderInterface
         return RetentionSweeper::isSweepable(
             $policy,
             $journal,
-            $options->getUseSwooleRunner(),
+            $options->getRunner() === RunnerMode::Swoole,
         )
             ? $policy
             : null;
@@ -436,11 +470,12 @@ final class CoreServerContainerProvider implements ContainerProviderInterface
     ): ?LdapReplica {
         $options = $container->get(ServerOptions::class);
         $config = $options->getReplicaConfig();
-        $storage = $options->getStorage();
 
-        if ($config === null || $storage === null) {
+        if ($config === null) {
             return null;
         }
+
+        $storage = $container->get(EntryStorageInterface::class);
 
         // Pair reconciliation with forwarding: the store drops forwarded state once the primary's entry replicates back.
         $passwordStateStore = $options->isPasswordPolicyEnabled()
@@ -532,7 +567,7 @@ final class CoreServerContainerProvider implements ContainerProviderInterface
     {
         $options = $container->get(ServerOptions::class);
 
-        if (!$options->getUseSwooleRunner()) {
+        if ($options->getRunner() !== RunnerMode::Swoole) {
             return new FileSnapshotProvider($options->getMonitorSnapshotPath());
         }
 
@@ -549,8 +584,10 @@ final class CoreServerContainerProvider implements ContainerProviderInterface
         $proxyOptions = $container->has(ProxyOptions::class)
             ? $container->get(ProxyOptions::class)
             : null;
-        // Carry the backend across reloads so a SIGHUP does not drop the configured storage.
+        // Carry the backend and its storage across reloads so a SIGHUP does not drop or rebuild the configured storage;
+        // sharing the exact instance keeps the backend, replica daemon, and replica ppolicy store on one storage.
         $backend = $this->backendOrNull($container);
+        $storage = $backend?->getStorage();
 
         // Share the metrics state across reloads so SIGHUP does not reset the counters or detach cn=monitor. The rollup
         // coordinator is shared so a reloaded middleware streams to the same channel the (persistent) runner bound.

--- a/src/FreeDSx/Ldap/Container/HandlerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/HandlerContainerProvider.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Container;
 
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\Protocol\Factory\HandlerContext;
 use FreeDSx\Ldap\Protocol\Factory\HandlerId;
@@ -179,7 +180,7 @@ final class HandlerContainerProvider implements ContainerProviderInterface
             );
             // Persist can only deliver writes made on other connections: a single process (Swoole)
             // shares them in memory, otherwise the journal itself must be cross-process.
-            $persistSupported = $options->getUseSwooleRunner()
+            $persistSupported = $options->getRunner() === RunnerMode::Swoole
                 || $journal->sharesAcrossProcesses();
         }
 

--- a/src/FreeDSx/Ldap/Container/PasswordPolicyContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/PasswordPolicyContainerProvider.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Container;
 
 use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\ReplicaPasswordStateStoreProviderInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\Clock\ClockInterface;
@@ -80,7 +81,7 @@ final class PasswordPolicyContainerProvider implements ContainerProviderInterfac
      */
     private function makeReplicaPasswordStateStore(Container $container): ReplicaPasswordStateStoreInterface
     {
-        $storage = $container->get(ServerOptions::class)->getStorage();
+        $storage = $container->get(EntryStorageInterface::class);
 
         return $storage instanceof ReplicaPasswordStateStoreProviderInterface
             ? $storage->replicaPasswordStateStore()

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap;
 
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
@@ -26,7 +27,7 @@ use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\BackendAwareInterface;
 use FreeDSx\Ldap\Server\AccessControl\PrivilegedBypassAccessControl;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\StorageType;
 use FreeDSx\Ldap\Server\Backend\Storage\Export\DirectoryDumper;
 use FreeDSx\Ldap\Server\Backend\Storage\Export\DumpOptions;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
@@ -90,13 +91,13 @@ class LdapServer
     }
 
     /**
-     * Bulk-loads LDIF content records into the storage configured via {@see useStorage()} as one atomic batch.
+     * Bulk-loads LDIF content records into the configured storage as one atomic batch.
      *
      * Use {@see applyChanges()} instead to replay a changelog (modify/delete/rename) through the live write path.
      *
      * @param Dn $creatorDn DN recorded as creatorsName/modifiersName on imported entries; defaults to the anonymous (empty) DN.
      * @throws LdifParseException when the LDIF cannot be parsed
-     * @throws RuntimeException when no storage backend is configured (or the loader fails to load)
+     * @throws RuntimeException on a proxy server, which serves no local directory
      * @throws InvalidArgumentException when the creator DN is malformed or an entry's parent is missing
      * @throws OperationException when an entry violates the schema and validation mode is strict
      */
@@ -104,11 +105,7 @@ class LdapServer
         LdifLoaderInterface $loader,
         Dn $creatorDn = new Dn(''),
     ): self {
-        $backend = $this->backend();
-
-        if ($backend === null) {
-            throw new RuntimeException('seed() requires storage configured via ServerOptions::setStorage().');
-        }
+        $backend = $this->requireLocalBackend('seed()');
 
         (new LdapImporter(
             $backend->getStorage(),
@@ -126,16 +123,12 @@ class LdapServer
      * Use {@see seed()} instead for bulk initial provisioning of content records straight to storage.
      *
      * @throws LdifParseException when the LDIF cannot be parsed
-     * @throws RuntimeException when no backend is configured
+     * @throws RuntimeException on a proxy server, which serves no local directory
      * @throws OperationException when a write fails (no such entry, schema violation, etc.)
      */
     public function applyChanges(LdifLoaderInterface $loader): self
     {
-        $backend = $this->backend();
-
-        if ($backend === null) {
-            throw new RuntimeException('applyChanges() requires storage configured via ServerOptions::setStorage().');
-        }
+        $backend = $this->requireLocalBackend('applyChanges()');
 
         (new WriteRequestReplayer($backend))
             ->apply((new LdifParser())->parse($loader));
@@ -149,17 +142,13 @@ class LdapServer
      * Symmetric with {@see seed()}: the produced LDIF re-seeds the directory verbatim, including operational
      * attributes.
      *
-     * @throws RuntimeException when no storage backend is configured
+     * @throws RuntimeException on a proxy server, which serves no local directory
      */
     public function dump(
         LdifOutputInterface $output,
         DumpOptions $options = new DumpOptions(),
     ): self {
-        $backend = $this->backend();
-
-        if ($backend === null) {
-            throw new RuntimeException('dump() requires storage configured via ServerOptions::setStorage().');
-        }
+        $backend = $this->requireLocalBackend('dump()');
 
         $output->write((new DirectoryDumper(
             $backend,
@@ -191,23 +180,11 @@ class LdapServer
 
     private function init(): void
     {
-        $this->requireBackendUnlessProxy();
         $this->requireSharedStorageForForkingReplica();
         // Wrap once so a privileged manager token bypasses whichever policy resolved, and inject the backend into it.
         $this->options->setAccessControl($this->injectBackendIfNeeded(
             new PrivilegedBypassAccessControl($this->resolveAccessControl()),
         ));
-    }
-
-    private function requireBackendUnlessProxy(): void
-    {
-        if ($this->options->getStorage() !== null || $this->container->has(ProxyOptions::class)) {
-            return;
-        }
-
-        throw new RuntimeException(
-            'No storage is configured. Set ServerOptions::setStorage() (or useInMemoryStorage()) before running.',
-        );
     }
 
     /**
@@ -216,11 +193,11 @@ class LdapServer
      */
     private function requireSharedStorageForForkingReplica(): void
     {
-        if ($this->options->getReplicaConfig() === null || $this->options->getUseSwooleRunner()) {
+        if ($this->options->getReplicaConfig() === null || $this->options->getRunner() === RunnerMode::Swoole) {
             return;
         }
 
-        if (!$this->options->getStorage() instanceof InMemoryStorage) {
+        if ($this->options->getStorageConfig()->type() !== StorageType::InMemory) {
             return;
         }
 
@@ -231,13 +208,27 @@ class LdapServer
     }
 
     /**
-     * The assembled storage backend from the container, or null when no storage is configured.
+     * The assembled storage backend from the container, or null on the proxy path which serves no local directory.
      */
     private function backend(): ?WritableStorageBackend
     {
-        return $this->options->getStorage() === null
+        return $this->container->has(ProxyOptions::class)
             ? null
             : $this->container->get(WritableStorageBackend::class);
+    }
+
+    /**
+     * The local directory backend for seed/applyChanges/dump; a proxy server has none.
+     *
+     * @throws RuntimeException on a proxy server
+     */
+    private function requireLocalBackend(string $operation): WritableStorageBackend
+    {
+        return $this->backend()
+            ?? throw new RuntimeException(sprintf(
+                '%s is not available on a proxy server, which serves no local directory.',
+                $operation,
+            ));
     }
 
     private function resolveAccessControl(): AccessControlInterface

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerMonitorHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerMonitorHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
@@ -133,7 +134,7 @@ class ServerMonitorHandler implements ServerProtocolHandlerInterface
             return $runner instanceof CoroutineServerRunnerInterface;
         }
 
-        return $this->options->getUseSwooleRunner();
+        return $this->options->getRunner() === RunnerMode::Swoole;
     }
 
     /**
@@ -189,7 +190,7 @@ class ServerMonitorHandler implements ServerProtocolHandlerInterface
             return $runner::class;
         }
 
-        return $this->options->getUseSwooleRunner()
+        return $this->options->getRunner() === RunnerMode::Swoole
             ? SwooleServerRunner::class
             : PcntlServerRunner::class;
     }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
@@ -28,6 +28,8 @@ use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 /**
  * Array-backed storage; safe under Swoole or as a pre-seeded read-only fixture under PCNTL (child writes are not shared).
  *
+ * @internal built from InMemoryStorageConfig via ServerOptions::setStorageConfig()
+ *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 final class InMemoryStorage implements EntryStorageInterface, ChangeJournalingInterface

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonFileStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonFileStorage.php
@@ -36,11 +36,11 @@ use Psr\Log\NullLogger;
 use Throwable;
 
 /**
- * JSON-file storage; use forPcntl() / forSwoole() to pick a locking strategy. Reads are lock-free; writes go through atomic() which loads, mutates, and rewrites the file under lock.
+ * JSON-file storage; the container picks forPcntl()/forSwoole() locking from JsonStorageConfig. Reads are lock-free; writes go through atomic() which loads, mutates, and rewrites the file under lock.
  *
  * File format: { "cn=x,dc=y": { "dn": "cn=x,dc=y", "attributes": { "cn": ["x"] } } }
  *
- * @api
+ * @internal built from JsonStorageConfig via ServerOptions::setStorageConfig()
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoConfig.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoConfig.php
@@ -19,6 +19,8 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SqliteDialect;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SubstringIndex\Fts5SubstringIndex;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SubstringIndex\SubstringIndexInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SubstringIndex\TrigramSubstringIndex;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\StorageConfigInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\StorageType;
 use PDO;
 use SensitiveParameter;
 
@@ -29,7 +31,7 @@ use SensitiveParameter;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final class PdoConfig
+final class PdoConfig implements StorageConfigInterface
 {
     /**
      * @param array<int, mixed> $pdoOptions
@@ -247,5 +249,10 @@ final class PdoConfig
         $this->substringIndex = $substringIndex;
 
         return $this;
+    }
+
+    public function type(): StorageType
+    {
+        return StorageType::Pdo;
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoStorageFactory.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoStorageFactory.php
@@ -24,7 +24,7 @@ use PDO;
 /**
  * Builds a PdoStorage from a PdoConfig, selecting the runner: forPcntl() (shared) or forSwoole() (per-coroutine).
  *
- * @api
+ * @internal the container builds storage from PdoConfig via ServerOptions::setStorageConfig()
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -50,9 +50,11 @@ use PDOStatement;
 use Throwable;
 
 /**
- * PDO-backed storage; build one with PdoStorageFactory::forPcntl()/forSwoole() from a PdoConfig::forSqlite()/forMysql().
+ * PDO-backed storage; the container builds it from a PdoConfig set via ServerOptions::setStorageConfig().
  *
  * When injecting a pre-built PDO, wrap it in SharedPdoConnectionProvider and call PdoStorage::initialize($pdo, $dialect) first.
+ *
+ * @internal
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Config/InMemoryStorageConfig.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Config/InMemoryStorageConfig.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Config;
+
+use FreeDSx\Ldap\Entry\Entry;
+
+/**
+ * Backs the server with a transient in-memory directory, optionally pre-seeded with entries.
+ *
+ * @api
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class InMemoryStorageConfig implements StorageConfigInterface
+{
+    /**
+     * @param Entry[] $entries
+     */
+    private function __construct(private array $entries) {}
+
+    /**
+     * @param Entry[] $entries pre-populated into the store
+     */
+    public static function withEntries(array $entries = []): self
+    {
+        return new self($entries);
+    }
+
+    /**
+     * @return Entry[]
+     */
+    public function entries(): array
+    {
+        return $this->entries;
+    }
+
+    public function type(): StorageType
+    {
+        return StorageType::InMemory;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Config/JsonStorageConfig.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Config/JsonStorageConfig.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Config;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Backs the server with a JSON file; the container picks the runner-appropriate locking strategy.
+ *
+ * @api
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class JsonStorageConfig implements StorageConfigInterface
+{
+    private function __construct(
+        private string $path,
+        private ?LoggerInterface $logger,
+    ) {}
+
+    public static function forFile(
+        string $path,
+        ?LoggerInterface $logger = null,
+    ): self {
+        return new self(
+            $path,
+            $logger,
+        );
+    }
+
+    public function path(): string
+    {
+        return $this->path;
+    }
+
+    public function logger(): ?LoggerInterface
+    {
+        return $this->logger;
+    }
+
+    public function type(): StorageType
+    {
+        return StorageType::Json;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Config/StorageConfigInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Config/StorageConfigInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Config;
+
+/**
+ * Configures the storage backend for the server; pass one to ServerOptions::setStorage().
+ *
+ * @api
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface StorageConfigInterface
+{
+    /**
+     * The storage backend this config selects.
+     */
+    public function type(): StorageType;
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Config/StorageType.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Config/StorageType.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Config;
+
+/**
+ * The built-in storage backend a StorageConfigInterface selects.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+enum StorageType
+{
+    case Pdo;
+
+    case Json;
+
+    case InMemory;
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStorageInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStorageInterface.php
@@ -20,6 +20,8 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Support\DefaultHasChildrenTrait;
 /**
  * Raw persistence contract; LDAP semantics live in WritableStorageBackend. Dn parameters are always normalised (lowercased).
  *
+ * @internal
+ *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 interface EntryStorageInterface

--- a/src/FreeDSx/Ldap/Server/ServerRunner/RunnerMode.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/RunnerMode.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\ServerRunner;
+
+/**
+ * The process model the server runs under, selecting the runner and runner-appropriate collaborators.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+enum RunnerMode
+{
+    case Pcntl;
+
+    case Swoole;
+}

--- a/src/FreeDSx/Ldap/Server/SocketServerFactory.php
+++ b/src/FreeDSx/Ldap/Server/SocketServerFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server;
 
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\SocketServer;
@@ -41,7 +42,7 @@ class SocketServerFactory
             $this->removeExistingSocketIfNeeded($resource);
         }
 
-        $writeTimeoutEnforcer = $this->options->getUseSwooleRunner()
+        $writeTimeoutEnforcer = $this->options->getRunner() === RunnerMode::Swoole
             ? new SwooleTimerEnforcer()
             : new BlockingSelectEnforcer();
 

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -16,7 +16,6 @@ namespace FreeDSx\Ldap;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Entry\Dn;
-use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Schema\PasswordPolicySchemaProvider;
 use FreeDSx\Ldap\Schema\Schema;
@@ -30,8 +29,8 @@ use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashScheme;
 use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\DefaultPasswordQualityChecker;
 use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\PasswordQualityCheckerInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
-use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\StorageConfigInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\AclRules;
@@ -43,6 +42,7 @@ use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
 use FreeDSx\Ldap\Server\Metrics\Recorder\NullMetricsRecorder;
 use FreeDSx\Ldap\Server\SearchLimit\SearchLimitRules;
 use FreeDSx\Ldap\Server\SearchLimits;
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
 use FreeDSx\Ldap\Server\TlsVersion;
 use Psr\Log\LoggerInterface;
@@ -154,7 +154,7 @@ final class ServerOptions
 
     private ?string $dseVendorVersion = null;
 
-    private ?EntryStorageInterface $storage = null;
+    private StorageConfigInterface $storageConfig;
 
     private ?PasswordAuthenticatableInterface $passwordAuthenticator = null;
 
@@ -210,7 +210,7 @@ final class ServerOptions
 
     private ?ServerRunnerInterface $serverRunner = null;
 
-    private bool $useSwooleRunner = false;
+    private RunnerMode $runner = RunnerMode::Pcntl;
 
     private bool $monitorEnabled = false;
 
@@ -250,6 +250,14 @@ final class ServerOptions
      * @var string[]
      */
     private array $saslMechanisms = [];
+
+    /**
+     * @param ?StorageConfigInterface $storageConfig Storage backend; a transient in-memory directory when omitted.
+     */
+    public function __construct(?StorageConfigInterface $storageConfig = null)
+    {
+        $this->storageConfig = $storageConfig ?? InMemoryStorageConfig::withEntries();
+    }
 
     public function getIp(): string
     {
@@ -515,26 +523,14 @@ final class ServerOptions
         return $this;
     }
 
-    public function getStorage(): ?EntryStorageInterface
+    public function getStorageConfig(): StorageConfigInterface
     {
-        return $this->storage;
+        return $this->storageConfig;
     }
 
-    public function setStorage(?EntryStorageInterface $storage): self
+    public function setStorageConfig(StorageConfigInterface $storageConfig): self
     {
-        $this->storage = $storage;
-
-        return $this;
-    }
-
-    /**
-     * Back the server with a transient in-memory directory.
-     *
-     * @param Entry[] $entries
-     */
-    public function useInMemoryStorage(array $entries = []): self
-    {
-        $this->storage = new InMemoryStorage($entries);
+        $this->storageConfig = $storageConfig;
 
         return $this;
     }
@@ -842,9 +838,9 @@ final class ServerOptions
         return $this->serverRunner;
     }
 
-    public function setUseSwooleRunner(bool $use): self
+    public function setRunner(RunnerMode $runner): self
     {
-        $this->useSwooleRunner = $use;
+        $this->runner = $runner;
 
         return $this;
     }
@@ -904,10 +900,14 @@ final class ServerOptions
 
     /**
      * Named constructor for a read-only replica that mirrors an upstream primary over RFC 4533.
+     *
+     * @param StorageConfigInterface $storageConfig Persistent storage for the replica.
      */
-    public static function forReplica(ReplicaConfig $replicaConfig): self
-    {
-        return (new self())->setReplicaConfig($replicaConfig);
+    public static function forReplica(
+        ReplicaConfig $replicaConfig,
+        StorageConfigInterface $storageConfig,
+    ): self {
+        return (new self($storageConfig))->setReplicaConfig($replicaConfig);
     }
 
     public function getReplicaConfig(): ?ReplicaConfig
@@ -1088,9 +1088,9 @@ final class ServerOptions
         return $this;
     }
 
-    public function getUseSwooleRunner(): bool
+    public function getRunner(): RunnerMode
     {
-        return $this->useSwooleRunner;
+        return $this->runner;
     }
 
     public function getOnServerReady(): ?Closure

--- a/tests/integration/Ldif/LdapDumpServerTest.php
+++ b/tests/integration/Ldif/LdapDumpServerTest.php
@@ -14,12 +14,13 @@ declare(strict_types=1);
 namespace Tests\Integration\FreeDSx\Ldap\Ldif;
 
 use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Ldap\Ldif\LdifChanges;
 use FreeDSx\Ldap\Ldif\Loader\FileLdifLoader;
 use FreeDSx\Ldap\Ldif\Loader\StringLdifLoader;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
 
 final class LdapDumpServerTest extends ServerTestCase
@@ -109,9 +110,13 @@ final class LdapDumpServerTest extends ServerTestCase
 
     public function test_a_fresh_server_seeded_from_the_dump_reconstructs_the_directory(): void
     {
-        $storage = new InMemoryStorage();
-        (new LdapServer((new ServerOptions())->setStorage($storage)))
-            ->seed(new StringLdifLoader((string) file_get_contents(self::$dumpPath)));
+        $options = new ServerOptions();
+        $container = Container::forServer($options);
+        (new LdapServer(
+            $options,
+            $container,
+        ))->seed(new StringLdifLoader((string) file_get_contents(self::$dumpPath)));
+        $storage = $container->get(EntryStorageInterface::class);
 
         $alice = $storage->find(new Dn('cn=alice,dc=foo,dc=bar'));
         self::assertNotNull($alice);

--- a/tests/support/LdapAclCommand.php
+++ b/tests/support/LdapAclCommand.php
@@ -14,7 +14,7 @@ use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\AccessControl\Target\Target;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
 use FreeDSx\Ldap\ServerOptions;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -139,7 +139,7 @@ class LdapAclCommand extends Command
                 ),
         );
 
-        $server->getOptions()->setStorage(new InMemoryStorage($entries));
+        $server->getOptions()->setStorageConfig(InMemoryStorageConfig::withEntries($entries));
         $server->run();
 
         return Command::SUCCESS;

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Support\FreeDSx\Ldap;
 
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
+use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
@@ -13,10 +15,10 @@ use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\AccessControl\Target\Target;
 use FreeDSx\Ldap\Server\Backend\Auth\ManagerIdentity;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactory;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\JsonStorageConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
 use FreeDSx\Ldap\Schema\NisSchemaProvider;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
@@ -273,10 +275,8 @@ final class LdapBackendStorageCommand extends Command
             ));
         }
 
-        $server = new LdapServer($serverOptions);
-
         if ($storage === 'memory') {
-            $server->getOptions()->setStorage(new InMemoryStorage($entries));
+            $config = InMemoryStorageConfig::withEntries($entries);
         } elseif ($storage === 'json') {
             $filePath = sys_get_temp_dir() . '/ldap_test_backend_storage.json';
 
@@ -284,19 +284,7 @@ final class LdapBackendStorageCommand extends Command
                 unlink($filePath);
             }
 
-            $adapter = $runner === 'swoole'
-                ? JsonFileStorage::forSwoole($filePath)
-                : JsonFileStorage::forPcntl($filePath);
-
-            $importer = new LdapImporter($adapter);
-
-            if ($runner === 'swoole') {
-                \Swoole\Coroutine\run(fn() => $importer->importEntries($entries));
-            } else {
-                $importer->importEntries($entries);
-            }
-
-            $server->getOptions()->setStorage($adapter);
+            $config = JsonStorageConfig::forFile($filePath);
         } elseif ($storage === 'sqlite') {
             $dbPath = sys_get_temp_dir() . '/ldap_test_backend_storage.sqlite';
 
@@ -306,19 +294,7 @@ final class LdapBackendStorageCommand extends Command
                 }
             }
 
-            $adapter = $runner === 'swoole'
-                ? PdoStorageFactory::forSwoole(PdoConfig::forSqlite($dbPath))
-                : PdoStorageFactory::forPcntl(PdoConfig::forSqlite($dbPath));
-
-            $importer = new LdapImporter($adapter);
-
-            if ($runner === 'swoole') {
-                \Swoole\Coroutine\run(fn() => $importer->importEntries($entries));
-            } else {
-                $importer->importEntries($entries);
-            }
-
-            $server->getOptions()->setStorage($adapter);
+            $config = PdoConfig::forSqlite($dbPath);
         } else {
             $dsn = getenv('MYSQL_DSN') ?: 'mysql:host=127.0.0.1;port=3306;dbname=freedsx';
             $user = getenv('MYSQL_USER') ?: 'root';
@@ -336,23 +312,28 @@ final class LdapBackendStorageCommand extends Command
             $cleanup->exec('DROP TABLE IF EXISTS entries');
             unset($cleanup);
 
-            $adapter = $runner === 'swoole'
-                ? PdoStorageFactory::forSwoole(PdoConfig::forMysql($dsn, $user, $password))
-                : PdoStorageFactory::forPcntl(PdoConfig::forMysql($dsn, $user, $password));
+            $config = PdoConfig::forMysql($dsn, $user, $password);
+        }
 
-            $importer = new LdapImporter($adapter);
+        $serverOptions
+            ->setStorageConfig($config)
+            ->setRunner($runner === 'swoole' ? RunnerMode::Swoole : RunnerMode::Pcntl);
+
+        $container = Container::forServer($serverOptions);
+        $server = new LdapServer(
+            $serverOptions,
+            $container,
+        );
+
+        // The in-memory config carries its seed entries; other backends get a raw import (no schema validation).
+        if ($storage !== 'memory') {
+            $importer = new LdapImporter($container->get(EntryStorageInterface::class));
 
             if ($runner === 'swoole') {
                 \Swoole\Coroutine\run(fn() => $importer->importEntries($entries));
             } else {
                 $importer->importEntries($entries);
             }
-
-            $server->getOptions()->setStorage($adapter);
-        }
-
-        if ($runner === 'swoole') {
-            $server->getOptions()->setUseSwooleRunner(true);
         }
 
         $server->run();

--- a/tests/support/LdapPasswordPolicyCommand.php
+++ b/tests/support/LdapPasswordPolicyCommand.php
@@ -9,7 +9,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\ServerOptions;
 use Symfony\Component\Console\Command\Command;
@@ -85,7 +85,7 @@ final class LdapPasswordPolicyCommand extends Command
                 ->setSaslMechanisms(ServerOptions::SASL_PLAIN)
                 ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL)),
         );
-        $server->getOptions()->setStorage(new InMemoryStorage($entries));
+        $server->getOptions()->setStorageConfig(InMemoryStorageConfig::withEntries($entries));
         $server->run();
 
         return Command::SUCCESS;

--- a/tests/support/LdapReplicaCommand.php
+++ b/tests/support/LdapReplicaCommand.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Support\FreeDSx\Ldap;
 
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\ReplicaConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactory;
-use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\JsonStorageConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\StorageConfigInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
 use FreeDSx\Ldap\ServerOptions;
@@ -88,11 +88,13 @@ final class LdapReplicaCommand extends Command
         ));
 
         $server = new LdapServer(
-            ServerOptions::forReplica($replicaConfig)
+            ServerOptions::forReplica(
+                $replicaConfig,
+                $this->createReplicaStorageConfig($storageType),
+            )
                 ->setPort($port)
                 ->setTransport($transport)
-                ->setUseSwooleRunner($runner === 'swoole')
-                ->setStorage($this->createReplicaStorage($storageType, $runner))
+                ->setRunner($runner === 'swoole' ? RunnerMode::Swoole : RunnerMode::Pcntl)
                 ->setPasswordPolicy(new PasswordPolicy(
                     lockout: new PasswordLockoutRules(
                         enabled: true,
@@ -150,12 +152,8 @@ final class LdapReplicaCommand extends Command
         return $provider;
     }
 
-    private function createReplicaStorage(
-        string $storageType,
-        string $runner,
-    ): EntryStorageInterface {
-        $swoole = $runner === 'swoole';
-
+    private function createReplicaStorageConfig(string $storageType): StorageConfigInterface
+    {
         if ($storageType === 'json') {
             $filePath = sys_get_temp_dir() . '/ldap_replica.json';
 
@@ -163,9 +161,7 @@ final class LdapReplicaCommand extends Command
                 unlink($filePath);
             }
 
-            return $swoole
-                ? JsonFileStorage::forSwoole($filePath)
-                : JsonFileStorage::forPcntl($filePath);
+            return JsonStorageConfig::forFile($filePath);
         }
 
         $dbPath = sys_get_temp_dir() . '/ldap_replica.sqlite';
@@ -176,8 +172,6 @@ final class LdapReplicaCommand extends Command
             }
         }
 
-        return $swoole
-            ? PdoStorageFactory::forSwoole(PdoConfig::forSqlite($dbPath))
-            : PdoStorageFactory::forPcntl(PdoConfig::forSqlite($dbPath));
+        return PdoConfig::forSqlite($dbPath);
     }
 }

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Support\FreeDSx\Ldap;
 
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
+use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\LdapServer;
@@ -18,13 +20,13 @@ use FreeDSx\Ldap\Server\AccessControl\Target\Target;
 use FreeDSx\Ldap\Server\Backend\Auth\ManagerIdentity;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\Server\SearchLimit\SearchLimitRule;
 use FreeDSx\Ldap\Server\SearchLimit\SearchLimitRules;
 use FreeDSx\Ldap\Server\SearchLimits;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactory;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\JsonStorageConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\StorageConfigInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
 use FreeDSx\Ldap\ServerOptions;
@@ -249,16 +251,14 @@ final class LdapServerCommand extends Command
             );
         }
 
-        $storage = $this->createStorage($storageType, $runner);
-
-        $options = (new ServerOptions())
+        $options = (new ServerOptions($this->createStorageConfig($storageType)))
             ->setPort($port)
             ->setTransport($transport)
             ->setUnixSocket(sys_get_temp_dir() . '/ldap.socket')
             ->setSslCert(self::SSL_CERT)
             ->setSslCertKey(self::SSL_KEY)
             ->setUseSsl($useSsl)
-            ->setUseSwooleRunner($runner === 'swoole')
+            ->setRunner($runner === 'swoole' ? RunnerMode::Swoole : RunnerMode::Pcntl)
             ->setAllowAnonymous($allowAnonymous)
             ->setSocketAcceptTimeout(0.1)
             ->setMaxSearchLookthrough((int) $this->getStringOption($input, 'max-search-lookthrough'))
@@ -282,7 +282,13 @@ final class LdapServerCommand extends Command
             $options->setConfigReloader(new FileFlagConfigReloader($reloadFlagFile));
         }
 
-        $server = new LdapServer($options);
+        $container = Container::forServer($options);
+        $server = new LdapServer(
+            $options,
+            $container,
+        );
+        // Raw import (no schema validation) so tests can seed synthetic fixtures such as the paging `foo` attribute.
+        $storage = $container->get(EntryStorageInterface::class);
 
         if ($sasl) {
             $options->setSaslMechanisms(
@@ -350,8 +356,6 @@ final class LdapServerCommand extends Command
             ));
         }
 
-        $server->getOptions()->setStorage($storage);
-
         $loadData = function () use ($server, $storage, $seedFile, $entries, $changesFile, $dumpFile): void {
             if ($seedFile !== '') {
                 $server->seed(new FileLdifLoader($seedFile));
@@ -379,12 +383,8 @@ final class LdapServerCommand extends Command
         return Command::SUCCESS;
     }
 
-    private function createStorage(
-        string $storageType,
-        string $runner,
-    ): EntryStorageInterface {
-        $swoole = $runner === 'swoole';
-
+    private function createStorageConfig(string $storageType): StorageConfigInterface
+    {
         if ($storageType === 'json') {
             $filePath = sys_get_temp_dir() . '/ldap_test_server.json';
 
@@ -392,9 +392,7 @@ final class LdapServerCommand extends Command
                 unlink($filePath);
             }
 
-            return $swoole
-                ? JsonFileStorage::forSwoole($filePath)
-                : JsonFileStorage::forPcntl($filePath);
+            return JsonStorageConfig::forFile($filePath);
         }
 
         if ($storageType === 'sqlite') {
@@ -406,9 +404,7 @@ final class LdapServerCommand extends Command
                 }
             }
 
-            return $swoole
-                ? PdoStorageFactory::forSwoole(PdoConfig::forSqlite($dbPath))
-                : PdoStorageFactory::forPcntl(PdoConfig::forSqlite($dbPath));
+            return PdoConfig::forSqlite($dbPath);
         }
 
         if ($storageType === 'mysql') {
@@ -427,12 +423,10 @@ final class LdapServerCommand extends Command
             $cleanup->exec('DROP TABLE IF EXISTS entries');
             unset($cleanup);
 
-            return $swoole
-                ? PdoStorageFactory::forSwoole(PdoConfig::forMysql($dsn, $user, $password))
-                : PdoStorageFactory::forPcntl(PdoConfig::forMysql($dsn, $user, $password));
+            return PdoConfig::forMysql($dsn, $user, $password);
         }
 
-        return new InMemoryStorage();
+        return InMemoryStorageConfig::withEntries();
     }
 
     /**

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap;
 
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Protocol\ClientProtocolHandler;
@@ -23,6 +24,13 @@ use FreeDSx\Ldap\Protocol\Factory\ProtocolHandlerFactoryMap;
 use FreeDSx\Ldap\Protocol\Queue\Response\MetricsResponseInterceptor;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\AssertionEvaluator;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\JsonFileStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\PdoStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\JsonStorageConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
@@ -58,7 +66,7 @@ class ContainerTest extends TestCase
     {
         parent::setUp();
 
-        $this->subject = Container::forServer((new ServerOptions())->useInMemoryStorage());
+        $this->subject = Container::forServer(new ServerOptions());
     }
 
     public function test_it_assembles_the_backend_from_the_configured_storage(): void
@@ -66,6 +74,50 @@ class ContainerTest extends TestCase
         self::assertInstanceOf(
             WritableStorageBackend::class,
             $this->subject->get(HandlerFactoryInterface::class)->makeBackend(),
+        );
+    }
+
+    public function test_it_builds_in_memory_storage_from_an_in_memory_config(): void
+    {
+        $container = Container::forServer(
+            new ServerOptions(InMemoryStorageConfig::withEntries()),
+        );
+
+        self::assertInstanceOf(
+            InMemoryStorage::class,
+            $container->get(EntryStorageInterface::class),
+        );
+    }
+
+    public function test_it_builds_a_json_backend_from_a_json_config(): void
+    {
+        $container = Container::forServer(
+            new ServerOptions(JsonStorageConfig::forFile(sys_get_temp_dir() . '/freedsx_container_test.json')),
+        );
+
+        self::assertInstanceOf(
+            JsonFileStorage::class,
+            $container->get(EntryStorageInterface::class),
+        );
+    }
+
+    public function test_it_builds_a_pdo_backend_from_a_pdo_config(): void
+    {
+        $container = Container::forServer(
+            new ServerOptions(PdoConfig::forSqlite(':memory:')),
+        );
+
+        self::assertInstanceOf(
+            PdoStorage::class,
+            $container->get(EntryStorageInterface::class),
+        );
+    }
+
+    public function test_the_storage_is_a_shared_singleton(): void
+    {
+        self::assertSame(
+            $this->subject->get(EntryStorageInterface::class),
+            $this->subject->get(EntryStorageInterface::class),
         );
     }
 
@@ -194,7 +246,7 @@ class ContainerTest extends TestCase
         $container = $this->containerFor(
             (new ServerOptions())
                 ->setMonitorEnabled(true)
-                ->setUseSwooleRunner(true),
+                ->setRunner(RunnerMode::Swoole),
         );
 
         self::assertSame(
@@ -234,7 +286,7 @@ class ContainerTest extends TestCase
         }
 
         $container = $this->containerFor(
-            $this->journalingOptions()->setUseSwooleRunner(true),
+            $this->journalingOptions()->setRunner(RunnerMode::Swoole),
         );
 
         self::assertInstanceOf(
@@ -264,6 +316,6 @@ class ContainerTest extends TestCase
 
     private function containerFor(ServerOptions $options): Container
     {
-        return Container::forServer($options->useInMemoryStorage());
+        return Container::forServer($options);
     }
 }

--- a/tests/unit/LdapServerTest.php
+++ b/tests/unit/LdapServerTest.php
@@ -13,14 +13,16 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap;
 
+use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Ldif\Loader\StringLdifLoader;
 use FreeDSx\Ldap\Ldif\Output\StringLdifOutput;
 use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Export\DumpOptions;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\ReplicaConfig;
 use FreeDSx\Ldap\ProxyOptions;
@@ -48,6 +50,8 @@ class LdapServerTest extends TestCase
 
     private ServerOptions $options;
 
+    private Container $container;
+
     private ServerRunnerInterface&MockObject $mockServerRunner;
 
     protected function setUp(): void
@@ -58,7 +62,11 @@ class LdapServerTest extends TestCase
             ->setPort(33389)
             ->setServerRunner($this->mockServerRunner);
 
-        $this->subject = new LdapServer($this->options);
+        $this->container = Container::forServer($this->options);
+        $this->subject = new LdapServer(
+            $this->options,
+            $this->container,
+        );
     }
 
     public function test_it_should_run_the_server(): void
@@ -67,14 +75,6 @@ class LdapServerTest extends TestCase
             ->expects(self::once())
             ->method('run');
 
-        $this->options->useInMemoryStorage();
-        $this->subject->run();
-    }
-
-    public function test_run_throws_when_no_storage_is_configured(): void
-    {
-        $this->expectException(RuntimeException::class);
-
         $this->subject->run();
     }
 
@@ -82,7 +82,7 @@ class LdapServerTest extends TestCase
     {
         $this->options
             ->setReplicaConfig(new ReplicaConfig(new ClientOptions()))
-            ->useInMemoryStorage();
+            ->setStorageConfig(InMemoryStorageConfig::withEntries());
 
         $this->expectException(RuntimeException::class);
 
@@ -127,7 +127,6 @@ class LdapServerTest extends TestCase
 
         $this->options->setSaslMechanisms(ServerOptions::SASL_PLAIN);
 
-        $this->options->useInMemoryStorage();
         $this->subject->run();
 
         $this->expectNotToPerformAssertions();
@@ -149,13 +148,10 @@ class LdapServerTest extends TestCase
 
     public function test_it_should_seed_entries_into_the_configured_storage(): void
     {
-        $storage = new InMemoryStorage();
-        $this->options->setStorage($storage);
-
         $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
 
-        self::assertNotNull($storage->find(new Dn('dc=example,dc=com')));
-        $foo = $storage->find(new Dn('cn=foo,dc=example,dc=com'));
+        self::assertNotNull($this->storage()->find(new Dn('dc=example,dc=com')));
+        $foo = $this->storage()->find(new Dn('cn=foo,dc=example,dc=com'));
         self::assertNotNull($foo);
         self::assertSame(
             ['Bar'],
@@ -165,12 +161,9 @@ class LdapServerTest extends TestCase
 
     public function test_it_should_stamp_operational_attributes_on_seeded_entries(): void
     {
-        $storage = new InMemoryStorage();
-        $this->options->setStorage($storage);
-
         $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
 
-        $foo = $storage->find(new Dn('cn=foo,dc=example,dc=com'));
+        $foo = $this->storage()->find(new Dn('cn=foo,dc=example,dc=com'));
 
         self::assertNotNull($foo);
         self::assertMatchesRegularExpression(
@@ -189,9 +182,6 @@ class LdapServerTest extends TestCase
 
     public function test_it_should_record_the_creator_dn_when_seeding(): void
     {
-        $storage = new InMemoryStorage();
-        $this->options->setStorage($storage);
-
         $this->subject->seed(
             new StringLdifLoader(self::SEED_LDIF),
             new Dn('cn=Importer,dc=example,dc=com'),
@@ -199,22 +189,22 @@ class LdapServerTest extends TestCase
 
         self::assertSame(
             'cn=Importer,dc=example,dc=com',
-            $storage->find(new Dn('cn=foo,dc=example,dc=com'))?->get('creatorsName')?->getValues()[0],
+            $this->storage()->find(new Dn('cn=foo,dc=example,dc=com'))?->get('creatorsName')?->getValues()[0],
         );
     }
 
-    public function test_it_should_throw_when_seeding_without_a_storage_backend(): void
+    public function test_it_should_throw_when_seeding_on_a_proxy_server(): void
     {
-        $this->expectException(RuntimeException::class);
+        $proxy = LdapServer::makeProxy(new ProxyOptions(new ClientOptions(['localhost'])));
 
-        $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('not available on a proxy server');
+
+        $proxy->seed(new StringLdifLoader(self::SEED_LDIF));
     }
 
     public function test_it_should_reject_seeding_when_the_ldif_contains_change_records(): void
     {
-        $storage = new InMemoryStorage();
-        $this->options->setStorage($storage);
-
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('only accepts content records');
 
@@ -223,8 +213,6 @@ class LdapServerTest extends TestCase
 
     public function test_it_should_apply_modify_changes_against_the_seeded_storage(): void
     {
-        $storage = new InMemoryStorage();
-        $this->options->setStorage($storage);
         $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
 
         $this->subject->applyChanges(new StringLdifLoader(
@@ -233,43 +221,43 @@ class LdapServerTest extends TestCase
 
         self::assertSame(
             ['Updated'],
-            $storage->find(new Dn('cn=foo,dc=example,dc=com'))?->get('sn')?->getValues(),
+            $this->storage()->find(new Dn('cn=foo,dc=example,dc=com'))?->get('sn')?->getValues(),
         );
     }
 
     public function test_it_should_apply_a_delete_change_against_the_seeded_storage(): void
     {
-        $storage = new InMemoryStorage();
-        $this->options->setStorage($storage);
         $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
 
         $this->subject->applyChanges(new StringLdifLoader(
             "dn: cn=foo,dc=example,dc=com\nchangetype: delete\n",
         ));
 
-        self::assertNull($storage->find(new Dn('cn=foo,dc=example,dc=com')));
+        self::assertNull($this->storage()->find(new Dn('cn=foo,dc=example,dc=com')));
     }
 
-    public function test_it_should_throw_when_applying_changes_without_a_backend(): void
+    public function test_it_should_throw_when_applying_changes_on_a_proxy_server(): void
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('requires storage configured');
+        $proxy = LdapServer::makeProxy(new ProxyOptions(new ClientOptions(['localhost'])));
 
-        $this->subject->applyChanges(new StringLdifLoader("dn: cn=x,dc=x\nchangetype: delete\n"));
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('not available on a proxy server');
+
+        $proxy->applyChanges(new StringLdifLoader("dn: cn=x,dc=x\nchangetype: delete\n"));
     }
 
-    public function test_it_should_throw_when_dumping_without_a_storage_backend(): void
+    public function test_it_should_throw_when_dumping_on_a_proxy_server(): void
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('requires storage configured');
+        $proxy = LdapServer::makeProxy(new ProxyOptions(new ClientOptions(['localhost'])));
 
-        $this->subject->dump(new StringLdifOutput());
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('not available on a proxy server');
+
+        $proxy->dump(new StringLdifOutput());
     }
 
     public function test_it_should_dump_seeded_entries_to_the_given_output(): void
     {
-        $storage = new InMemoryStorage();
-        $this->options->setStorage($storage);
         $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
 
         $output = new StringLdifOutput();
@@ -295,11 +283,9 @@ class LdapServerTest extends TestCase
 
     public function test_dump_seed_round_trip_preserves_entryUUID_and_create_timestamp(): void
     {
-        $storage = new InMemoryStorage();
-        $this->options->setStorage($storage);
         $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
 
-        $originalFoo = $storage->find(new Dn('cn=foo,dc=example,dc=com'));
+        $originalFoo = $this->storage()->find(new Dn('cn=foo,dc=example,dc=com'));
         self::assertNotNull($originalFoo);
         $originalUuid = $originalFoo->get('entryUUID')?->firstValue();
         $originalTimestamp = $originalFoo->get('createTimestamp')?->firstValue();
@@ -312,11 +298,15 @@ class LdapServerTest extends TestCase
             (new DumpOptions())->setBaseDn(new Dn('dc=example,dc=com')),
         );
 
-        $restoredStorage = new InMemoryStorage();
-        (new LdapServer((new ServerOptions())->setStorage($restoredStorage)))
-            ->seed(new StringLdifLoader($output->getLdif()));
+        $restoreOptions = new ServerOptions();
+        $restoreContainer = Container::forServer($restoreOptions);
+        (new LdapServer(
+            $restoreOptions,
+            $restoreContainer,
+        ))->seed(new StringLdifLoader($output->getLdif()));
 
-        $restoredFoo = $restoredStorage->find(new Dn('cn=foo,dc=example,dc=com'));
+        $restoredFoo = $restoreContainer->get(EntryStorageInterface::class)
+            ->find(new Dn('cn=foo,dc=example,dc=com'));
         self::assertNotNull($restoredFoo);
         self::assertSame(
             $originalUuid,
@@ -330,8 +320,6 @@ class LdapServerTest extends TestCase
 
     public function test_it_should_apply_the_dump_options_filter(): void
     {
-        $storage = new InMemoryStorage();
-        $this->options->setStorage($storage);
         $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
 
         $output = new StringLdifOutput();
@@ -350,5 +338,13 @@ class LdapServerTest extends TestCase
             'dn: dc=example,dc=com',
             $output->getLdif(),
         );
+    }
+
+    /**
+     * The container-built storage the server operates on.
+     */
+    private function storage(): EntryStorageInterface
+    {
+        return $this->container->get(EntryStorageInterface::class);
     }
 }

--- a/tests/unit/Protocol/Factory/ProtocolHandlerProviderTest.php
+++ b/tests/unit/Protocol/Factory/ProtocolHandlerProviderTest.php
@@ -50,7 +50,7 @@ final class ProtocolHandlerProviderTest extends TestCase
 
     protected function setUp(): void
     {
-        $container = Container::forServer((new ServerOptions())->useInMemoryStorage());
+        $container = Container::forServer(new ServerOptions());
 
         $this->subject = new ProtocolHandlerProvider(
             routeResolver: $container->get(ServerProtocolHandlerFactory::class),
@@ -200,7 +200,7 @@ final class ProtocolHandlerProviderTest extends TestCase
     #[DataProvider('handlerIdProvider')]
     public function test_every_route_has_a_registered_factory(HandlerId $handlerId): void
     {
-        $container = Container::forServer((new ServerOptions())->useInMemoryStorage());
+        $container = Container::forServer(new ServerOptions());
 
         self::assertInstanceOf(
             ServerProtocolHandlerInterface::class,

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerMonitorHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerMonitorHandlerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
@@ -304,7 +305,7 @@ final class ServerMonitorHandlerTest extends TestCase
         $this->metrics->operationStarted(OperationType::Search);
 
         $subject = new ServerMonitorHandler(
-            options: (new ServerOptions())->setUseSwooleRunner(true),
+            options: (new ServerOptions())->setRunner(RunnerMode::Swoole),
             snapshots: $this->metrics,
         );
 

--- a/tests/unit/Server/Backend/Storage/Config/InMemoryStorageConfigTest.php
+++ b/tests/unit/Server/Backend/Storage/Config/InMemoryStorageConfigTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Config;
+
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\StorageType;
+use PHPUnit\Framework\TestCase;
+
+final class InMemoryStorageConfigTest extends TestCase
+{
+    public function test_its_type_is_in_memory(): void
+    {
+        self::assertSame(
+            StorageType::InMemory,
+            InMemoryStorageConfig::withEntries()->type(),
+        );
+    }
+
+    public function test_it_defaults_to_no_entries(): void
+    {
+        self::assertSame(
+            [],
+            InMemoryStorageConfig::withEntries()->entries(),
+        );
+    }
+
+    public function test_it_carries_the_given_entries(): void
+    {
+        $entries = [Entry::fromArray('dc=example,dc=com')];
+
+        self::assertSame(
+            $entries,
+            InMemoryStorageConfig::withEntries($entries)->entries(),
+        );
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Config/JsonStorageConfigTest.php
+++ b/tests/unit/Server/Backend/Storage/Config/JsonStorageConfigTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Config;
+
+use FreeDSx\Ldap\Server\Backend\Storage\Config\JsonStorageConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\StorageType;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class JsonStorageConfigTest extends TestCase
+{
+    public function test_its_type_is_json(): void
+    {
+        self::assertSame(
+            StorageType::Json,
+            JsonStorageConfig::forFile('/tmp/ldap.json')->type(),
+        );
+    }
+
+    public function test_it_carries_the_file_path(): void
+    {
+        self::assertSame(
+            '/tmp/ldap.json',
+            JsonStorageConfig::forFile('/tmp/ldap.json')->path(),
+        );
+    }
+
+    public function test_it_has_no_logger_by_default(): void
+    {
+        self::assertNull(JsonStorageConfig::forFile('/tmp/ldap.json')->logger());
+    }
+
+    public function test_it_carries_the_given_logger(): void
+    {
+        $logger = new NullLogger();
+
+        self::assertSame(
+            $logger,
+            JsonStorageConfig::forFile(
+                '/tmp/ldap.json',
+                $logger,
+            )->logger(),
+        );
+    }
+}

--- a/tests/unit/Server/ConnectionHandlerBuilderTest.php
+++ b/tests/unit/Server/ConnectionHandlerBuilderTest.php
@@ -50,7 +50,7 @@ final class ConnectionHandlerBuilderTest extends TestCase
 
     private function builderFor(ServerOptions $options): ConnectionHandlerBuilderInterface
     {
-        return Container::forServer($options->useInMemoryStorage())
+        return Container::forServer($options)
             ->get(ConnectionHandlerBuilderInterface::class);
     }
 }

--- a/tests/unit/Server/SocketServerFactoryTest.php
+++ b/tests/unit/Server/SocketServerFactoryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Server;
 
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Ldap\Server\TlsVersion;
 use FreeDSx\Ldap\ServerOptions;
@@ -89,7 +90,7 @@ final class SocketServerFactoryTest extends TestCase
             (new ServerOptions())
                 ->setPort(3392)
                 ->setWriteTimeout(45)
-                ->setUseSwooleRunner(true),
+                ->setRunner(RunnerMode::Swoole),
             $this->mockLogger,
         );
 

--- a/tests/unit/ServerOptionsTest.php
+++ b/tests/unit/ServerOptionsTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap;
 
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
@@ -25,7 +26,8 @@ use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Sasl\External\ExternalCredentialMapperInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
 use FreeDSx\Ldap\Server\Metrics\Recorder\InMemoryMetricsRecorder;
@@ -61,7 +63,10 @@ final class ServerOptionsTest extends TestCase
     public function test_for_replica_configures_a_read_only_replica(): void
     {
         $config = new ReplicaConfig(new ClientOptions());
-        $options = ServerOptions::forReplica($config);
+        $options = ServerOptions::forReplica(
+            $config,
+            PdoConfig::forSqlite(':memory:'),
+        );
 
         self::assertTrue($options->isReadOnly());
         self::assertSame(
@@ -590,30 +595,33 @@ final class ServerOptionsTest extends TestCase
         );
     }
 
-    public function test_storage_is_null_by_default(): void
+    public function test_storage_defaults_to_an_in_memory_config(): void
     {
-        self::assertNull($this->subject->getStorage());
-    }
-
-    public function test_it_can_set_storage(): void
-    {
-        $storage = new InMemoryStorage();
-
-        $this->subject->setStorage($storage);
-
-        self::assertSame(
-            $storage,
-            $this->subject->getStorage(),
+        self::assertInstanceOf(
+            InMemoryStorageConfig::class,
+            $this->subject->getStorageConfig(),
         );
     }
 
-    public function test_use_in_memory_storage_configures_an_in_memory_directory(): void
+    public function test_it_can_set_a_storage_config(): void
     {
-        $this->subject->useInMemoryStorage();
+        $config = PdoConfig::forSqlite(':memory:');
 
-        self::assertInstanceOf(
-            InMemoryStorage::class,
-            $this->subject->getStorage(),
+        $this->subject->setStorageConfig($config);
+
+        self::assertSame(
+            $config,
+            $this->subject->getStorageConfig(),
+        );
+    }
+
+    public function test_it_can_be_constructed_with_a_storage_config(): void
+    {
+        $config = PdoConfig::forSqlite(':memory:');
+
+        self::assertSame(
+            $config,
+            (new ServerOptions($config))->getStorageConfig(),
         );
     }
 
@@ -668,16 +676,22 @@ final class ServerOptionsTest extends TestCase
         );
     }
 
-    public function test_swoole_runner_is_disabled_by_default(): void
+    public function test_the_runner_defaults_to_pcntl(): void
     {
-        self::assertFalse($this->subject->getUseSwooleRunner());
+        self::assertSame(
+            RunnerMode::Pcntl,
+            $this->subject->getRunner(),
+        );
     }
 
-    public function test_it_can_enable_swoole_runner(): void
+    public function test_it_can_set_the_runner(): void
     {
-        $this->subject->setUseSwooleRunner(true);
+        $this->subject->setRunner(RunnerMode::Swoole);
 
-        self::assertTrue($this->subject->getUseSwooleRunner());
+        self::assertSame(
+            RunnerMode::Swoole,
+            $this->subject->getRunner(),
+        );
     }
 
     public function test_socket_accept_timeout_defaults_to_half_second(): void


### PR DESCRIPTION
This moves the runner mode and storage config to server options. So constructing the storage directly is now owned by the container. This removes some of the friction for dependency injection for other pieces (like journaling). I will be following up to remove some of the interfaces that got built up around this.

This also means that storage is no longer a custom entry point. There's just too much someone can get wrong trying to implement it. So I will maintain a set list of storage types going forward and the users of this library can decide what they want to use. PDO will fit just about any use case. The other are niche / specific anyway. I'd rather have one well optimized storage. Though it is nice for it to remain pluggable to some extent.