### PR TITLE
[1.0.0] Decompose the network config from the ServerOptions.

### DIFF
--- a/src/FreeDSx/Ldap/Container/CoreServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/CoreServerContainerProvider.php
@@ -110,8 +110,9 @@ final class CoreServerContainerProvider implements ContainerProviderInterface
         $serverOptions = $container->get(ServerOptions::class);
 
         return new SocketServerFactory(
-            options: $serverOptions,
-            logger: $serverOptions->getLogger(),
+            $serverOptions->getNetworkConfig(),
+            $serverOptions->getRunner(),
+            $serverOptions->getLogger(),
         );
     }
 
@@ -447,7 +448,7 @@ final class CoreServerContainerProvider implements ContainerProviderInterface
             periodicTasks: $periodicTasks,
             longLivedTasks: $longLivedTasks,
             logger: $options->getLogger(),
-            gracefulStopSeconds: $options->getShutdownTimeout(),
+            gracefulStopSeconds: $options->getNetworkConfig()->getShutdownTimeout(),
         );
     }
 

--- a/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/ExternalMechanismOptionsBuilder.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/Sasl/OptionsBuilder/ExternalMechanismOptionsBuilder.php
@@ -101,14 +101,14 @@ final class ExternalMechanismOptionsBuilder implements MechanismOptionsBuilderIn
     private function assertSecureChannel(): void
     {
         // LDAPS connections are encrypted from accept (the StartTLS-only isEncrypted flag is not set for them).
-        if (!$this->options->isUseSsl() && !$this->queue->isEncrypted()) {
+        if (!$this->options->getNetworkConfig()->isUseSsl() && !$this->queue->isEncrypted()) {
             throw new OperationException(
                 'SASL EXTERNAL requires a TLS-protected connection.',
                 ResultCode::CONFIDENTIALITY_REQUIRED,
             );
         }
 
-        if (!$this->options->isSslValidateCert()) {
+        if (!$this->options->getNetworkConfig()->isSslValidateCert()) {
             throw new OperationException(
                 'SASL EXTERNAL requires client certificate validation to be enabled.',
                 ResultCode::INAPPROPRIATE_AUTHENTICATION,

--- a/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
@@ -24,7 +24,7 @@ use FreeDSx\Ldap\Operation\Request\UnbindRequest;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
-use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\ServerListenerOptionsInterface;
 
 /**
  * Abstracts out some of the server authorization logic.
@@ -34,7 +34,7 @@ use FreeDSx\Ldap\ServerOptions;
 class ServerAuthorization
 {
     public function __construct(
-        private readonly ServerOptions $options,
+        private readonly ServerListenerOptionsInterface $options,
         private TokenInterface $token = new AnonToken(),
     ) {}
 

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerMonitorHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerMonitorHandler.php
@@ -93,7 +93,7 @@ class ServerMonitorHandler implements ServerProtocolHandlerInterface
             'connectionsIdleTimeouts' => [(string) $connections->idleTimeouts],
             'connectionsRequestSizeExceeded' => [(string) $connections->requestSizeExceeded],
             'connectionsProtocolErrors' => [(string) $connections->protocolErrors],
-            'connectionsMax' => [(string) $this->options->getMaxConnections()],
+            'connectionsMax' => [(string) $this->options->getNetworkConfig()->getMaxConnections()],
             'operationsCompleted' => [(string) $operations->total()],
             'operationsFailed' => [(string) $operations->totalErrors()],
             'operationsByType' => $this->formatCounts($operations->counts),

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
@@ -96,7 +96,7 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
                 ExtendedRequest::OID_PPOLICY_STATE_FORWARD,
             );
         }
-        if ($this->options->getSslCert()) {
+        if ($this->options->getNetworkConfig()->getSslCert()) {
             $entry->add(
                 'supportedExtension',
                 ExtendedRequest::OID_START_TLS,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
@@ -25,7 +25,7 @@ use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
-use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\ServerListenerOptionsInterface;
 
 use function extension_loaded;
 
@@ -39,7 +39,7 @@ class ServerStartTlsHandler implements ServerProtocolHandlerInterface
     private static ?bool $hasOpenssl = null;
 
     public function __construct(
-        private readonly ServerOptions $options,
+        private readonly ServerListenerOptionsInterface $options,
         private readonly ConnectionControl $connection,
         private readonly EventLogger $eventLogger = new EventLogger(null),
     ) {
@@ -53,7 +53,7 @@ class ServerStartTlsHandler implements ServerProtocolHandlerInterface
         TokenInterface $token,
     ): ResponseStream {
         # RFC 4511 §4.14.2: return unavailable (not protocolError) when the server cannot negotiate TLS.
-        if ($this->options->getSslCert() === null || !self::$hasOpenssl) {
+        if ($this->options->getNetworkConfig()->getSslCert() === null || !self::$hasOpenssl) {
             return $this->failure(
                 $message,
                 ResultCode::UNAVAILABLE,

--- a/src/FreeDSx/Ldap/Server/Config/NetworkConfig.php
+++ b/src/FreeDSx/Ldap/Server/Config/NetworkConfig.php
@@ -1,0 +1,313 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Config;
+
+use FreeDSx\Ldap\Server\TlsVersion;
+
+/**
+ * The listener socket and TLS settings a server binds and accepts connections with.
+ *
+ * @api
+ */
+final class NetworkConfig
+{
+    private string $ip = '0.0.0.0';
+
+    private int $port = 389;
+
+    private string $unixSocket = '/var/run/ldap.socket';
+
+    private string $transport = 'tcp';
+
+    private int $idleTimeout = 600;
+
+    /**
+     * Disconnect a client whose response send makes no progress for this many seconds (a stalled reader).
+     */
+    private int $writeTimeout = 600;
+
+    /**
+     * Seconds (fractional) to wait for a new client connection before re-checking server state.
+     */
+    private float $socketAcceptTimeout = 0.5;
+
+    /**
+     * Seconds to wait for active connections to close gracefully before forcing them closed on shutdown.
+     */
+    private int $shutdownTimeout = 15;
+
+    /**
+     * The largest incoming request PDU accepted, in bytes (5 MiB); 0 disables the limit.
+     */
+    private int $maxRequestSize = 5_242_880;
+
+    /**
+     * The maximum number of concurrent connections the server will accept; zero (the default) means no limit.
+     */
+    private int $maxConnections = 0;
+
+    private bool $useSsl = false;
+
+    private ?string $sslCert = null;
+
+    private ?string $sslCertKey = null;
+
+    private ?string $sslCertPassphrase = null;
+
+    private TlsVersion $minTlsVersion = TlsVersion::Tls1_2;
+
+    private string $sslCiphers = 'DEFAULT';
+
+    private bool $sslValidateCert = false;
+
+    private ?bool $sslAllowSelfSigned = null;
+
+    private ?string $sslCaCert = null;
+
+    /**
+     * Convenience constructor for the common case of only choosing the listening port.
+     */
+    public static function withPort(int $port): self
+    {
+        return (new self())->setPort($port);
+    }
+
+    public function getIp(): string
+    {
+        return $this->ip;
+    }
+
+    public function setIp(string $ip): self
+    {
+        $this->ip = $ip;
+
+        return $this;
+    }
+
+    public function getPort(): int
+    {
+        return $this->port;
+    }
+
+    public function setPort(int $port): self
+    {
+        $this->port = $port;
+
+        return $this;
+    }
+
+    public function getUnixSocket(): string
+    {
+        return $this->unixSocket;
+    }
+
+    public function setUnixSocket(string $unixSocket): self
+    {
+        $this->unixSocket = $unixSocket;
+
+        return $this;
+    }
+
+    public function getTransport(): string
+    {
+        return $this->transport;
+    }
+
+    public function setTransport(string $transport): self
+    {
+        $this->transport = $transport;
+
+        return $this;
+    }
+
+    public function getIdleTimeout(): int
+    {
+        return $this->idleTimeout;
+    }
+
+    public function setIdleTimeout(int $idleTimeout): self
+    {
+        $this->idleTimeout = $idleTimeout;
+
+        return $this;
+    }
+
+    public function getWriteTimeout(): int
+    {
+        return $this->writeTimeout;
+    }
+
+    public function setWriteTimeout(int $writeTimeout): self
+    {
+        $this->writeTimeout = $writeTimeout;
+
+        return $this;
+    }
+
+    public function getSocketAcceptTimeout(): float
+    {
+        return $this->socketAcceptTimeout;
+    }
+
+    public function setSocketAcceptTimeout(float $socketAcceptTimeout): self
+    {
+        $this->socketAcceptTimeout = $socketAcceptTimeout;
+
+        return $this;
+    }
+
+    public function getShutdownTimeout(): int
+    {
+        return $this->shutdownTimeout;
+    }
+
+    public function setShutdownTimeout(int $shutdownTimeout): self
+    {
+        $this->shutdownTimeout = $shutdownTimeout;
+
+        return $this;
+    }
+
+    public function getMaxRequestSize(): int
+    {
+        return $this->maxRequestSize;
+    }
+
+    public function setMaxRequestSize(int $maxRequestSize): self
+    {
+        $this->maxRequestSize = $maxRequestSize;
+
+        return $this;
+    }
+
+    public function getMaxConnections(): int
+    {
+        return $this->maxConnections;
+    }
+
+    public function setMaxConnections(int $maxConnections): self
+    {
+        $this->maxConnections = $maxConnections;
+
+        return $this;
+    }
+
+    public function isUseSsl(): bool
+    {
+        return $this->useSsl;
+    }
+
+    public function setUseSsl(bool $useSsl): self
+    {
+        $this->useSsl = $useSsl;
+
+        return $this;
+    }
+
+    public function getSslCert(): ?string
+    {
+        return $this->sslCert;
+    }
+
+    public function setSslCert(?string $sslCert): self
+    {
+        $this->sslCert = $sslCert;
+
+        return $this;
+    }
+
+    public function getSslCertKey(): ?string
+    {
+        return $this->sslCertKey;
+    }
+
+    public function setSslCertKey(?string $sslCertKey): self
+    {
+        $this->sslCertKey = $sslCertKey;
+
+        return $this;
+    }
+
+    public function getSslCertPassphrase(): ?string
+    {
+        return $this->sslCertPassphrase;
+    }
+
+    public function setSslCertPassphrase(?string $sslCertPassphrase): self
+    {
+        $this->sslCertPassphrase = $sslCertPassphrase;
+
+        return $this;
+    }
+
+    public function getMinTlsVersion(): TlsVersion
+    {
+        return $this->minTlsVersion;
+    }
+
+    public function setMinTlsVersion(TlsVersion $minTlsVersion): self
+    {
+        $this->minTlsVersion = $minTlsVersion;
+
+        return $this;
+    }
+
+    public function getSslCiphers(): string
+    {
+        return $this->sslCiphers;
+    }
+
+    public function setSslCiphers(string $sslCiphers): self
+    {
+        $this->sslCiphers = $sslCiphers;
+
+        return $this;
+    }
+
+    public function isSslValidateCert(): bool
+    {
+        return $this->sslValidateCert;
+    }
+
+    public function setSslValidateCert(bool $sslValidateCert): self
+    {
+        $this->sslValidateCert = $sslValidateCert;
+
+        return $this;
+    }
+
+    public function getSslAllowSelfSigned(): ?bool
+    {
+        return $this->sslAllowSelfSigned;
+    }
+
+    public function setSslAllowSelfSigned(?bool $sslAllowSelfSigned): self
+    {
+        $this->sslAllowSelfSigned = $sslAllowSelfSigned;
+
+        return $this;
+    }
+
+    public function getSslCaCert(): ?string
+    {
+        return $this->sslCaCert;
+    }
+
+    public function setSslCaCert(?string $sslCaCert): self
+    {
+        $this->sslCaCert = $sslCaCert;
+
+        return $this;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Configuration/ReloadCoordinator.php
+++ b/src/FreeDSx/Ldap/Server/Configuration/ReloadCoordinator.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Server\Configuration;
 
 use Closure;
 use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
+use FreeDSx\Ldap\ServerListenerOptionsInterface;
 use FreeDSx\Ldap\ServerOptions;
 use Psr\Log\LogLevel;
 use Throwable;
@@ -29,14 +30,24 @@ final class ReloadCoordinator
     /**
      * Returns the options and factory to adopt for new connections, or null on a no-op (no reloader) or failure.
      *
-     * @param Closure(ServerOptions): ServerProtocolFactoryInterface $protocolFactoryProvider
+     * @param Closure(ServerListenerOptionsInterface): ServerProtocolFactoryInterface $protocolFactoryProvider
      * @param array<string, mixed> $context
      */
     public function reload(
-        ServerOptions $current,
+        ServerListenerOptionsInterface $current,
         Closure $protocolFactoryProvider,
         array $context = [],
     ): ?ReloadResult {
+        if (!$current instanceof ServerOptions) {
+            $current->getLogger()?->log(
+                LogLevel::INFO,
+                'Received a reload signal, but the current server type does not support reloading. Ignoring.',
+                $context,
+            );
+
+            return null;
+        }
+
         $reloader = $current->getConfigReloader();
 
         if ($reloader === null) {

--- a/src/FreeDSx/Ldap/Server/Configuration/ReloadResult.php
+++ b/src/FreeDSx/Ldap/Server/Configuration/ReloadResult.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Configuration;
 
 use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
-use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\ServerListenerOptionsInterface;
 
 /**
  * The configuration a runner should adopt for new connections after a successful reload.
@@ -24,7 +24,7 @@ use FreeDSx\Ldap\ServerOptions;
 final readonly class ReloadResult
 {
     public function __construct(
-        public ServerOptions $options,
+        public ServerListenerOptionsInterface $options,
         public ServerProtocolFactoryInterface $protocolFactory,
     ) {}
 }

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyProtocolFactory.php
@@ -29,7 +29,7 @@ use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareChain;
 use FreeDSx\Ldap\Server\Middleware\RequestValidationMiddleware;
 use FreeDSx\Ldap\Server\ServerConnectionScaffoldingTrait;
 use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
-use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\ServerListenerOptionsInterface;
 use FreeDSx\Socket\Socket;
 
 /**
@@ -42,7 +42,7 @@ final class ProxyProtocolFactory implements ServerProtocolFactoryInterface
     use ServerConnectionScaffoldingTrait;
 
     public function __construct(
-        private readonly ServerOptions $options,
+        private readonly ServerListenerOptionsInterface $options,
         private readonly ProxyOptions $proxyOptions,
     ) {}
 
@@ -103,7 +103,7 @@ final class ProxyProtocolFactory implements ServerProtocolFactoryInterface
         );
     }
 
-    protected function serverOptions(): ServerOptions
+    protected function serverOptions(): ServerListenerOptionsInterface
     {
         return $this->options;
     }

--- a/src/FreeDSx/Ldap/Server/ServerConnectionScaffoldingTrait.php
+++ b/src/FreeDSx/Ldap/Server/ServerConnectionScaffoldingTrait.php
@@ -20,7 +20,7 @@ use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
 use FreeDSx\Ldap\Server\Metrics\Recorder\NullMetricsRecorder;
-use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\ServerListenerOptionsInterface;
 use FreeDSx\Socket\Socket;
 
 /**
@@ -30,7 +30,7 @@ use FreeDSx\Socket\Socket;
  */
 trait ServerConnectionScaffoldingTrait
 {
-    abstract protected function serverOptions(): ServerOptions;
+    abstract protected function serverOptions(): ServerListenerOptionsInterface;
 
     /**
      * @param ResponseInterceptor[] $interceptors applied to every outgoing response, in order.
@@ -42,7 +42,7 @@ trait ServerConnectionScaffoldingTrait
     ): ServerQueue {
         return new ServerQueue(
             $socket,
-            maxReceiveSize: $this->serverOptions()->getMaxRequestSize(),
+            maxReceiveSize: $this->serverOptions()->getNetworkConfig()->getMaxRequestSize(),
             interceptors: $interceptors,
             metricsRecorder: $metricsRecorder,
         );

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -31,7 +31,7 @@ use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
 use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Socket\Socket;
 use FreeDSx\Socket\SocketServer;
-use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\ServerListenerOptionsInterface;
 use Closure;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -86,7 +86,7 @@ class PcntlServerRunner implements ServerRunnerInterface
      */
     public function __construct(
         ServerProtocolFactoryInterface $serverProtocolFactory,
-        ServerOptions $options,
+        ServerListenerOptionsInterface $options,
         private readonly SocketServerFactory $socketServerFactory,
         Closure $protocolFactoryProvider,
         private readonly MetricsRecorderInterface $metricsRecorder = new NullMetricsRecorder(),
@@ -268,7 +268,7 @@ class PcntlServerRunner implements ServerRunnerInterface
 
         do {
             $this->backgroundTasks->tick();
-            $socket = $this->server->accept($this->options->getSocketAcceptTimeout());
+            $socket = $this->server->accept($this->options->getNetworkConfig()->getSocketAcceptTimeout());
 
             if ($this->isShuttingDown) {
                 if ($socket) {
@@ -286,7 +286,7 @@ class PcntlServerRunner implements ServerRunnerInterface
                 continue;
             }
 
-            $maxConnections = $this->options->getMaxConnections();
+            $maxConnections = $this->options->getNetworkConfig()->getMaxConnections();
             if ($maxConnections > 0 && count($this->childProcesses) >= $maxConnections) {
                 $this->logConnectionLimitReached($this->defaultContext);
                 $this->metricsRecorder->connectionObserved(ConnectionObservation::Rejected);
@@ -417,7 +417,7 @@ class PcntlServerRunner implements ServerRunnerInterface
         $waitTime = 0;
         while (!empty($this->childProcesses)) {
             // If we reach the shutdown timeout, attempt to force end them and then stop.
-            if ($waitTime >= $this->options->getShutdownTimeout()) {
+            if ($waitTime >= $this->options->getNetworkConfig()->getShutdownTimeout()) {
                 $this->forceEndChildProcesses();
 
                 break;

--- a/src/FreeDSx/Ldap/Server/ServerRunner/ReloadsConfigurationTrait.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/ReloadsConfigurationTrait.php
@@ -16,7 +16,7 @@ namespace FreeDSx\Ldap\Server\ServerRunner;
 use Closure;
 use FreeDSx\Ldap\Server\Configuration\ReloadCoordinator;
 use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
-use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\ServerListenerOptionsInterface;
 
 /**
  * Holds a runner's live configuration and adopts a reloaded one when the ReloadCoordinator produces it.
@@ -25,12 +25,12 @@ use FreeDSx\Ldap\ServerOptions;
  */
 trait ReloadsConfigurationTrait
 {
-    private ServerOptions $options;
+    private ServerListenerOptionsInterface $options;
 
     private ServerProtocolFactoryInterface $serverProtocolFactory;
 
     /**
-     * @var Closure(ServerOptions): ServerProtocolFactoryInterface
+     * @var Closure(ServerListenerOptionsInterface): ServerProtocolFactoryInterface
      */
     private Closure $protocolFactoryProvider;
 

--- a/src/FreeDSx/Ldap/Server/ServerRunner/SwooleServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/SwooleServerRunner.php
@@ -23,7 +23,7 @@ use FreeDSx\Ldap\Server\Process\BackgroundTask\BackgroundTasksInterface;
 use FreeDSx\Ldap\Server\Process\BackgroundTask\SwooleBackgroundTasks;
 use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
 use FreeDSx\Ldap\Server\SocketServerFactory;
-use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\ServerListenerOptionsInterface;
 use FreeDSx\Socket\Socket;
 use FreeDSx\Socket\SocketServer;
 use Closure;
@@ -81,7 +81,7 @@ class SwooleServerRunner implements CoroutineServerRunnerInterface
 
     public function __construct(
         ServerProtocolFactoryInterface $serverProtocolFactory,
-        ServerOptions $options,
+        ServerListenerOptionsInterface $options,
         private readonly SocketServerFactory $socketServerFactory,
         Closure $protocolFactoryProvider,
         private readonly MetricsRecorderInterface $metricsRecorder = new NullMetricsRecorder(),
@@ -171,7 +171,7 @@ class SwooleServerRunner implements CoroutineServerRunnerInterface
                 return;
             }
 
-            $allClosed = $this->waitGroup->wait((float) $this->options->getShutdownTimeout());
+            $allClosed = $this->waitGroup->wait((float) $this->options->getNetworkConfig()->getShutdownTimeout());
 
             if ($allClosed) {
                 return;
@@ -195,7 +195,7 @@ class SwooleServerRunner implements CoroutineServerRunnerInterface
             $this->backgroundTasks->tick();
 
             try {
-                $socket = $this->server->accept($this->options->getSocketAcceptTimeout());
+                $socket = $this->server->accept($this->options->getNetworkConfig()->getSocketAcceptTimeout());
             } catch (Throwable $e) {
                 $this->logAcceptError($e);
 
@@ -206,7 +206,7 @@ class SwooleServerRunner implements CoroutineServerRunnerInterface
                 continue;
             }
 
-            $maxConnections = $this->options->getMaxConnections();
+            $maxConnections = $this->options->getNetworkConfig()->getMaxConnections();
             if ($maxConnections > 0 && count($this->activeSockets) >= $maxConnections) {
                 $this->logConnectionLimitReached(['max_connections' => $maxConnections]);
                 $this->metricsRecorder->connectionObserved(ConnectionObservation::Rejected);

--- a/src/FreeDSx/Ldap/Server/SocketServerFactory.php
+++ b/src/FreeDSx/Ldap/Server/SocketServerFactory.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server;
 
-use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Exception\RuntimeException;
-use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Socket\SocketServer;
 use FreeDSx\Socket\SocketServerOptions;
 use FreeDSx\Socket\Timeout\BlockingSelectEnforcer;
@@ -27,45 +27,46 @@ use Psr\Log\LogLevel;
 class SocketServerFactory
 {
     public function __construct(
-        private readonly ServerOptions $options,
+        private readonly NetworkConfig $network,
+        private readonly RunnerMode $runner,
         private readonly ?LoggerInterface $logger,
     ) {}
 
     public function makeAndBind(): SocketServer
     {
-        $isUnixSocket = $this->options->getTransport() === 'unix';
+        $isUnixSocket = $this->network->getTransport() === 'unix';
         $resource = $isUnixSocket
-            ? $this->options->getUnixSocket()
-            : $this->options->getIp();
+            ? $this->network->getUnixSocket()
+            : $this->network->getIp();
 
         if ($isUnixSocket) {
             $this->removeExistingSocketIfNeeded($resource);
         }
 
-        $writeTimeoutEnforcer = $this->options->getRunner() === RunnerMode::Swoole
+        $writeTimeoutEnforcer = $this->runner === RunnerMode::Swoole
             ? new SwooleTimerEnforcer()
             : new BlockingSelectEnforcer();
 
         $socketServerOptions = (new SocketServerOptions())
-            ->setTransport(Transport::from($this->options->getTransport()))
-            ->setIdleTimeout($this->options->getIdleTimeout())
-            ->setWriteTimeout($this->options->getWriteTimeout())
+            ->setTransport(Transport::from($this->network->getTransport()))
+            ->setIdleTimeout($this->network->getIdleTimeout())
+            ->setWriteTimeout($this->network->getWriteTimeout())
             ->setWriteTimeoutEnforcer($writeTimeoutEnforcer)
-            ->setUseSsl($this->options->isUseSsl())
-            ->setSslCert($this->options->getSslCert())
-            ->setSslCertKey($this->options->getSslCertKey())
-            ->setSslCertPassphrase($this->options->getSslCertPassphrase())
-            ->setSslCryptoMethod($this->options->getMinTlsVersion()->toServerCryptoMethod())
-            ->setSslCiphers($this->options->getSslCiphers())
-            ->setSslValidateCert($this->options->isSslValidateCert())
-            ->setSslAllowSelfSigned($this->options->getSslAllowSelfSigned())
-            ->setSslCaCert($this->options->getSslCaCert());
+            ->setUseSsl($this->network->isUseSsl())
+            ->setSslCert($this->network->getSslCert())
+            ->setSslCertKey($this->network->getSslCertKey())
+            ->setSslCertPassphrase($this->network->getSslCertPassphrase())
+            ->setSslCryptoMethod($this->network->getMinTlsVersion()->toServerCryptoMethod())
+            ->setSslCiphers($this->network->getSslCiphers())
+            ->setSslValidateCert($this->network->isSslValidateCert())
+            ->setSslAllowSelfSigned($this->network->getSslAllowSelfSigned())
+            ->setSslCaCert($this->network->getSslCaCert());
 
         return SocketServer::bind(
             $resource,
             $isUnixSocket
                 ? null
-                : $this->options->getPort(),
+                : $this->network->getPort(),
             $socketServerOptions,
         );
     }

--- a/src/FreeDSx/Ldap/ServerListenerOptionsInterface.php
+++ b/src/FreeDSx/Ldap/ServerListenerOptionsInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap;
+
+use Closure;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
+use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
+use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The config a server needs to accept connections (network/TLS, auth-gating, logging, runner, metrics), shared by
+ * ServerOptions and ProxyServerOptions.
+ *
+ * @api
+ */
+interface ServerListenerOptionsInterface
+{
+    public function getNetworkConfig(): NetworkConfig;
+
+    public function isRequireAuthentication(): bool;
+
+    public function isAllowAnonymous(): bool;
+
+    /**
+     * @return string[]
+     */
+    public function getSaslMechanisms(): array;
+
+    public function getLogger(): ?LoggerInterface;
+
+    public function getEventLogPolicy(): EventLogPolicy;
+
+    public function getRunner(): RunnerMode;
+
+    public function isMonitorEnabled(): bool;
+
+    public function getMonitorSnapshotPath(): string;
+
+    public function getMetricsRecorder(): MetricsRecorderInterface;
+
+    public function getOnServerReady(): ?Closure;
+}

--- a/src/FreeDSx/Ldap/ServerListenerOptionsTrait.php
+++ b/src/FreeDSx/Ldap/ServerListenerOptionsTrait.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap;
+
+use Closure;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
+use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
+use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
+use FreeDSx\Ldap\Server\Metrics\Recorder\NullMetricsRecorder;
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The listener config (network/TLS, auth-gating, logging, runner, metrics) shared by ServerOptions and
+ * ProxyServerOptions; using classes initialize $network in their constructor.
+ */
+trait ServerListenerOptionsTrait
+{
+    private NetworkConfig $network;
+
+    private bool $requireAuthentication = true;
+
+    private bool $allowAnonymous = false;
+
+    private ?LoggerInterface $logger = null;
+
+    private ?EventLogPolicy $eventLogPolicy = null;
+
+    private RunnerMode $runner = RunnerMode::Pcntl;
+
+    private bool $monitorEnabled = false;
+
+    private ?string $monitorSnapshotPath = null;
+
+    private ?MetricsRecorderInterface $metricsRecorder = null;
+
+    private ?Closure $onServerReady = null;
+
+    public function getNetworkConfig(): NetworkConfig
+    {
+        return $this->network;
+    }
+
+    public function setNetworkConfig(NetworkConfig $network): self
+    {
+        $this->network = $network;
+
+        return $this;
+    }
+
+    public function isRequireAuthentication(): bool
+    {
+        return $this->requireAuthentication;
+    }
+
+    public function setRequireAuthentication(bool $requireAuthentication): self
+    {
+        $this->requireAuthentication = $requireAuthentication;
+
+        return $this;
+    }
+
+    public function isAllowAnonymous(): bool
+    {
+        return $this->allowAnonymous;
+    }
+
+    public function setAllowAnonymous(bool $allowAnonymous): self
+    {
+        $this->allowAnonymous = $allowAnonymous;
+
+        return $this;
+    }
+
+    public function getLogger(): ?LoggerInterface
+    {
+        return $this->logger;
+    }
+
+    public function setLogger(?LoggerInterface $logger): self
+    {
+        $this->logger = $logger;
+
+        return $this;
+    }
+
+    public function getEventLogPolicy(): EventLogPolicy
+    {
+        return $this->eventLogPolicy ??= EventLogPolicy::default();
+    }
+
+    /**
+     * @api
+     */
+    public function setEventLogPolicy(EventLogPolicy $policy): self
+    {
+        $this->eventLogPolicy = $policy;
+
+        return $this;
+    }
+
+    public function setRunner(RunnerMode $runner): self
+    {
+        $this->runner = $runner;
+
+        return $this;
+    }
+
+    public function getRunner(): RunnerMode
+    {
+        return $this->runner;
+    }
+
+    public function isMonitorEnabled(): bool
+    {
+        return $this->monitorEnabled;
+    }
+
+    public function setMonitorEnabled(bool $monitorEnabled): self
+    {
+        $this->monitorEnabled = $monitorEnabled;
+
+        return $this;
+    }
+
+    /**
+     * The configured cn=monitor snapshot path, or a per-port default under the system temp directory.
+     */
+    public function getMonitorSnapshotPath(): string
+    {
+        return $this->monitorSnapshotPath
+            ?? sys_get_temp_dir() . '/freedsx_ldap_monitor_' . $this->network->getPort() . '.json';
+    }
+
+    public function setMonitorSnapshotPath(?string $monitorSnapshotPath): self
+    {
+        $this->monitorSnapshotPath = $monitorSnapshotPath;
+
+        return $this;
+    }
+
+    public function getMetricsRecorder(): MetricsRecorderInterface
+    {
+        return $this->metricsRecorder ??= new NullMetricsRecorder();
+    }
+
+    public function setMetricsRecorder(MetricsRecorderInterface $metricsRecorder): self
+    {
+        $this->metricsRecorder = $metricsRecorder;
+
+        return $this;
+    }
+
+    public function getOnServerReady(): ?Closure
+    {
+        return $this->onServerReady;
+    }
+
+    public function setOnServerReady(?Closure $onServerReady): self
+    {
+        $this->onServerReady = $onServerReady;
+
+        return $this;
+    }
+}

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -36,23 +36,19 @@ use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\AclRules;
 use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
 use FreeDSx\Ldap\Server\AccessControl\Subject\SubjectMatcherInterface;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\Server\Configuration\ConfigReloaderInterface;
-use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
-use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
-use FreeDSx\Ldap\Server\Metrics\Recorder\NullMetricsRecorder;
 use FreeDSx\Ldap\Server\SearchLimit\SearchLimitRules;
 use FreeDSx\Ldap\Server\SearchLimits;
-use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
-use FreeDSx\Ldap\Server\TlsVersion;
-use Psr\Log\LoggerInterface;
-use Closure;
 
 /**
  * @api
  */
-final class ServerOptions
+final class ServerOptions implements ServerListenerOptionsInterface
 {
+    use ServerListenerOptionsTrait;
+
     public const SASL_PLAIN = 'PLAIN';
 
     public const SASL_CRAM_MD5 = 'CRAM-MD5';
@@ -103,48 +99,6 @@ final class ServerOptions
         self::SASL_SCRAM_SHA3_512,
         self::SASL_SCRAM_SHA3_512_PLUS,
     ];
-
-    private string $ip = '0.0.0.0';
-
-    private int $port = 389;
-
-    private string $unixSocket = '/var/run/ldap.socket';
-
-    private string $transport = 'tcp';
-
-    private int $idleTimeout = 600;
-
-    /**
-     * Disconnect a client whose response send makes no progress for this many seconds (a stalled reader).
-     */
-    private int $writeTimeout = 600;
-
-    /**
-     * The largest incoming request PDU accepted, in bytes (5 MiB); 0 disables the limit.
-     */
-    private int $maxRequestSize = 5_242_880;
-
-    private bool $requireAuthentication = true;
-
-    private bool $allowAnonymous = false;
-
-    private bool $useSsl = false;
-
-    private ?string $sslCert = null;
-
-    private ?string $sslCertKey = null;
-
-    private ?string $sslCertPassphrase = null;
-
-    private TlsVersion $minTlsVersion = TlsVersion::Tls1_2;
-
-    private string $sslCiphers = 'DEFAULT';
-
-    private bool $sslValidateCert = false;
-
-    private ?bool $sslAllowSelfSigned = null;
-
-    private ?string $sslCaCert = null;
 
     private ?string $dseAltServer = null;
 
@@ -204,27 +158,13 @@ final class ServerOptions
 
     private ?PasswordQualityCheckerInterface $passwordQualityChecker = null;
 
-    private ?LoggerInterface $logger = null;
-
-    private ?EventLogPolicy $eventLogPolicy = null;
-
     private ?ServerRunnerInterface $serverRunner = null;
-
-    private RunnerMode $runner = RunnerMode::Pcntl;
-
-    private bool $monitorEnabled = false;
 
     private bool $syncEnabled = false;
 
     private ?ChangeJournalConfig $changeJournalConfig = null;
 
     private ?ReplicaConfig $replicaConfig = null;
-
-    private ?string $monitorSnapshotPath = null;
-
-    private ?MetricsRecorderInterface $metricsRecorder = null;
-
-    private int $maxConnections = 0;
 
     private int $maxSearchSize = 1000;
 
@@ -238,13 +178,7 @@ final class ServerOptions
 
     private ?SearchLimitRules $searchLimitRules = null;
 
-    private ?Closure $onServerReady = null;
-
     private ?ConfigReloaderInterface $configReloader = null;
-
-    private int $shutdownTimeout = 15;
-
-    private float $socketAcceptTimeout = 0.5;
 
     /**
      * @var string[]
@@ -253,226 +187,14 @@ final class ServerOptions
 
     /**
      * @param ?StorageConfigInterface $storageConfig Storage backend; a transient in-memory directory when omitted.
+     * @param ?NetworkConfig $network Listener and TLS settings; defaults to a plaintext listener on 0.0.0.0:389.
      */
-    public function __construct(?StorageConfigInterface $storageConfig = null)
-    {
+    public function __construct(
+        ?StorageConfigInterface $storageConfig = null,
+        ?NetworkConfig $network = null,
+    ) {
         $this->storageConfig = $storageConfig ?? InMemoryStorageConfig::withEntries();
-    }
-
-    public function getIp(): string
-    {
-        return $this->ip;
-    }
-
-    public function setIp(string $ip): self
-    {
-        $this->ip = $ip;
-
-        return $this;
-    }
-
-    public function getPort(): int
-    {
-        return $this->port;
-    }
-
-    public function setPort(int $port): self
-    {
-        $this->port = $port;
-
-        return $this;
-    }
-
-    public function getUnixSocket(): string
-    {
-        return $this->unixSocket;
-    }
-
-    public function setUnixSocket(string $unixSocket): self
-    {
-        $this->unixSocket = $unixSocket;
-
-        return $this;
-    }
-
-    public function getTransport(): string
-    {
-        return $this->transport;
-    }
-
-    public function setTransport(string $transport): self
-    {
-        $this->transport = $transport;
-
-        return $this;
-    }
-
-    public function getIdleTimeout(): int
-    {
-        return $this->idleTimeout;
-    }
-
-    public function setIdleTimeout(int $idleTimeout): self
-    {
-        $this->idleTimeout = $idleTimeout;
-
-        return $this;
-    }
-
-    public function getWriteTimeout(): int
-    {
-        return $this->writeTimeout;
-    }
-
-    public function setWriteTimeout(int $writeTimeout): self
-    {
-        $this->writeTimeout = $writeTimeout;
-
-        return $this;
-    }
-
-    public function getMaxRequestSize(): int
-    {
-        return $this->maxRequestSize;
-    }
-
-    public function setMaxRequestSize(int $maxRequestSize): self
-    {
-        $this->maxRequestSize = $maxRequestSize;
-
-        return $this;
-    }
-
-    public function isRequireAuthentication(): bool
-    {
-        return $this->requireAuthentication;
-    }
-
-    public function setRequireAuthentication(bool $requireAuthentication): self
-    {
-        $this->requireAuthentication = $requireAuthentication;
-
-        return $this;
-    }
-
-    public function isAllowAnonymous(): bool
-    {
-        return $this->allowAnonymous;
-    }
-
-    public function setAllowAnonymous(bool $allowAnonymous): self
-    {
-        $this->allowAnonymous = $allowAnonymous;
-
-        return $this;
-    }
-
-    public function isUseSsl(): bool
-    {
-        return $this->useSsl;
-    }
-
-    public function setUseSsl(bool $useSsl): self
-    {
-        $this->useSsl = $useSsl;
-
-        return $this;
-    }
-
-    public function getSslCertKey(): ?string
-    {
-        return $this->sslCertKey;
-    }
-
-    public function setSslCertKey(?string $sslCertKey): self
-    {
-        $this->sslCertKey = $sslCertKey;
-
-        return $this;
-    }
-
-    public function getSslCert(): ?string
-    {
-        return $this->sslCert;
-    }
-
-    public function setSslCert(?string $sslCert): self
-    {
-        $this->sslCert = $sslCert;
-
-        return $this;
-    }
-
-    public function getSslCertPassphrase(): ?string
-    {
-        return $this->sslCertPassphrase;
-    }
-
-    public function setSslCertPassphrase(?string $sslCertPassphrase): self
-    {
-        $this->sslCertPassphrase = $sslCertPassphrase;
-
-        return $this;
-    }
-
-    public function getMinTlsVersion(): TlsVersion
-    {
-        return $this->minTlsVersion;
-    }
-
-    public function setMinTlsVersion(TlsVersion $minTlsVersion): self
-    {
-        $this->minTlsVersion = $minTlsVersion;
-
-        return $this;
-    }
-
-    public function getSslCiphers(): string
-    {
-        return $this->sslCiphers;
-    }
-
-    public function setSslCiphers(string $sslCiphers): self
-    {
-        $this->sslCiphers = $sslCiphers;
-
-        return $this;
-    }
-
-    public function isSslValidateCert(): bool
-    {
-        return $this->sslValidateCert;
-    }
-
-    public function setSslValidateCert(bool $sslValidateCert): self
-    {
-        $this->sslValidateCert = $sslValidateCert;
-
-        return $this;
-    }
-
-    public function getSslAllowSelfSigned(): ?bool
-    {
-        return $this->sslAllowSelfSigned;
-    }
-
-    public function setSslAllowSelfSigned(?bool $sslAllowSelfSigned): self
-    {
-        $this->sslAllowSelfSigned = $sslAllowSelfSigned;
-
-        return $this;
-    }
-
-    public function getSslCaCert(): ?string
-    {
-        return $this->sslCaCert;
-    }
-
-    public function setSslCaCert(?string $sslCaCert): self
-    {
-        $this->sslCaCert = $sslCaCert;
-
-        return $this;
+        $this->network = $network ?? new NetworkConfig();
     }
 
     public function getDseAltServer(): ?string
@@ -777,30 +499,6 @@ final class ServerOptions
         return $this;
     }
 
-    public function getLogger(): ?LoggerInterface
-    {
-        return $this->logger;
-    }
-
-    public function setLogger(?LoggerInterface $logger): self
-    {
-        $this->logger = $logger;
-
-        return $this;
-    }
-
-    public function getEventLogPolicy(): EventLogPolicy
-    {
-        return $this->eventLogPolicy ??= EventLogPolicy::default();
-    }
-
-    public function setEventLogPolicy(EventLogPolicy $policy): self
-    {
-        $this->eventLogPolicy = $policy;
-
-        return $this;
-    }
-
     /**
      * @return string[]
      */
@@ -836,42 +534,6 @@ final class ServerOptions
     public function getServerRunner(): ?ServerRunnerInterface
     {
         return $this->serverRunner;
-    }
-
-    public function setRunner(RunnerMode $runner): self
-    {
-        $this->runner = $runner;
-
-        return $this;
-    }
-
-    /**
-     * The maximum number of concurrent connections the server will accept.
-     *
-     * Zero (the default) means no limit.
-     */
-    public function getMaxConnections(): int
-    {
-        return $this->maxConnections;
-    }
-
-    public function setMaxConnections(int $maxConnections): self
-    {
-        $this->maxConnections = $maxConnections;
-
-        return $this;
-    }
-
-    public function isMonitorEnabled(): bool
-    {
-        return $this->monitorEnabled;
-    }
-
-    public function setMonitorEnabled(bool $monitorEnabled): self
-    {
-        $this->monitorEnabled = $monitorEnabled;
-
-        return $this;
     }
 
     public function isSyncEnabled(): bool
@@ -928,34 +590,6 @@ final class ServerOptions
     public function isReadOnly(): bool
     {
         return $this->replicaConfig !== null;
-    }
-
-    /**
-     * The configured cn=monitor snapshot path, or a per-port default under the system temp directory.
-     */
-    public function getMonitorSnapshotPath(): string
-    {
-        return $this->monitorSnapshotPath
-            ?? sys_get_temp_dir() . '/freedsx_ldap_monitor_' . $this->port . '.json';
-    }
-
-    public function setMonitorSnapshotPath(?string $monitorSnapshotPath): self
-    {
-        $this->monitorSnapshotPath = $monitorSnapshotPath;
-
-        return $this;
-    }
-
-    public function getMetricsRecorder(): MetricsRecorderInterface
-    {
-        return $this->metricsRecorder ??= new NullMetricsRecorder();
-    }
-
-    public function setMetricsRecorder(MetricsRecorderInterface $metricsRecorder): self
-    {
-        $this->metricsRecorder = $metricsRecorder;
-
-        return $this;
     }
 
     /**
@@ -1058,53 +692,6 @@ final class ServerOptions
         );
     }
 
-    /**
-     * Seconds to wait for active connections to close gracefully before forcing them closed on shutdown.
-     */
-    public function getShutdownTimeout(): int
-    {
-        return $this->shutdownTimeout;
-    }
-
-    public function setShutdownTimeout(int $shutdownTimeout): self
-    {
-        $this->shutdownTimeout = $shutdownTimeout;
-
-        return $this;
-    }
-
-    /**
-     * Seconds (fractional) to wait for a new client connection before re-checking server state.
-     */
-    public function getSocketAcceptTimeout(): float
-    {
-        return $this->socketAcceptTimeout;
-    }
-
-    public function setSocketAcceptTimeout(float $socketAcceptTimeout): self
-    {
-        $this->socketAcceptTimeout = $socketAcceptTimeout;
-
-        return $this;
-    }
-
-    public function getRunner(): RunnerMode
-    {
-        return $this->runner;
-    }
-
-    public function getOnServerReady(): ?Closure
-    {
-        return $this->onServerReady;
-    }
-
-    public function setOnServerReady(?Closure $onServerReady): self
-    {
-        $this->onServerReady = $onServerReady;
-
-        return $this;
-    }
-
     public function getConfigReloader(): ?ConfigReloaderInterface
     {
         return $this->configReloader;
@@ -1115,37 +702,5 @@ final class ServerOptions
         $this->configReloader = $configReloader;
 
         return $this;
-    }
-
-    /**
-     * @return array{ip: string, port: int, unix_socket: string, transport: string, idle_timeout: int, require_authentication: bool, allow_anonymous: bool, logger: ?LoggerInterface, use_ssl: bool, ssl_cert: ?string, ssl_cert_key: ?string, ssl_cert_passphrase: ?string, min_tls_version: string, ssl_ciphers: string, ssl_validate_cert: bool, ssl_allow_self_signed: ?bool, ssl_ca_cert: ?string, monitor_enabled: bool, monitor_snapshot_path: ?string, dse_alt_server: ?string, dse_vendor_name: string, dse_vendor_version: ?string, sasl_mechanisms: string[]}
-     */
-    public function toArray(): array
-    {
-        return [
-            'ip' => $this->getIp(),
-            'port' => $this->getPort(),
-            'unix_socket' => $this->getUnixSocket(),
-            'transport' => $this->getTransport(),
-            'idle_timeout' => $this->getIdleTimeout(),
-            'require_authentication' => $this->isRequireAuthentication(),
-            'allow_anonymous' => $this->isAllowAnonymous(),
-            'logger' => $this->getLogger(),
-            'use_ssl' => $this->isUseSsl(),
-            'ssl_cert' => $this->getSslCert(),
-            'ssl_cert_key' => $this->getSslCertKey(),
-            'ssl_cert_passphrase' => $this->getSslCertPassphrase(),
-            'min_tls_version' => $this->getMinTlsVersion()->value,
-            'ssl_ciphers' => $this->getSslCiphers(),
-            'ssl_validate_cert' => $this->isSslValidateCert(),
-            'ssl_allow_self_signed' => $this->getSslAllowSelfSigned(),
-            'ssl_ca_cert' => $this->getSslCaCert(),
-            'monitor_enabled' => $this->isMonitorEnabled(),
-            'monitor_snapshot_path' => $this->monitorSnapshotPath,
-            'dse_alt_server' => $this->getDseAltServer(),
-            'dse_vendor_name' => $this->getDseVendorName(),
-            'dse_vendor_version' => $this->getDseVendorVersion(),
-            'sasl_mechanisms' => $this->getSaslMechanisms(),
-        ];
     }
 }

--- a/tests/bin/ldap-proxy.php
+++ b/tests/bin/ldap-proxy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\ProxyOptions;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\ServerOptions;
 use Symfony\Component\Process\Process;
 
@@ -42,11 +43,11 @@ $server = LdapServer::makeProxy(
             ->setSslValidateCert(false)
             ->setSslAllowSelfSigned(true),
     ),
-    (new ServerOptions())
+    (new ServerOptions(network: (new NetworkConfig())
         ->setPort(10389)
         ->setSslCert(__DIR__ . '/../resources/cert/slapd.crt')
         ->setSslCertKey(__DIR__ . '/../resources/cert/slapd.key')
-        ->setSocketAcceptTimeout(0.1)
+        ->setSocketAcceptTimeout(0.1)))
         ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL)),
 );
 

--- a/tests/support/LdapAclCommand.php
+++ b/tests/support/LdapAclCommand.php
@@ -15,6 +15,7 @@ use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\AccessControl\Target\Target;
 use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\ServerOptions;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -89,11 +90,13 @@ class LdapAclCommand extends Command
             ),
         ];
 
+        $network = (new NetworkConfig())
+            ->setPort(10389)
+            ->setTransport($transport)
+            ->setSocketAcceptTimeout(0.1);
+
         $server = new LdapServer(
-            (new ServerOptions())
-                ->setPort(10389)
-                ->setTransport($transport)
-                ->setSocketAcceptTimeout(0.1)
+            (new ServerOptions(network: $network))
                 ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL))
                 ->setAclRules(
                     (AclRules::fromEmpty())

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
 use FreeDSx\Ldap\Schema\NisSchemaProvider;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Schema\StandardSchemaProvider;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\ServerOptions;
 use PDO;
 use Symfony\Component\Console\Command\Command;
@@ -232,10 +233,12 @@ final class LdapBackendStorageCommand extends Command
             );
         }
 
-        $serverOptions = (new ServerOptions())
+        $network = (new NetworkConfig())
             ->setPort($port)
             ->setTransport($transport)
-            ->setSocketAcceptTimeout(0.1)
+            ->setSocketAcceptTimeout(0.1);
+
+        $serverOptions = (new ServerOptions(network: $network))
             ->setSchemaValidationMode($validationMode)
             ->setSchema(StandardSchemaProvider::buildCore()->merge(NisSchemaProvider::build()))
             ->setMonitorEnabled((bool) $input->getOption('monitor'))

--- a/tests/support/LdapPasswordPolicyCommand.php
+++ b/tests/support/LdapPasswordPolicyCommand.php
@@ -10,6 +10,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
 use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\ServerOptions;
 use Symfony\Component\Console\Command\Command;
@@ -76,11 +77,13 @@ final class LdapPasswordPolicyCommand extends Command
             ),
         ];
 
+        $network = (new NetworkConfig())
+            ->setPort($port)
+            ->setTransport($transport)
+            ->setSocketAcceptTimeout(0.1);
+
         $server = new LdapServer(
-            (new ServerOptions())
-                ->setPort($port)
-                ->setTransport($transport)
-                ->setSocketAcceptTimeout(0.1)
+            (new ServerOptions(network: $network))
                 ->setPasswordPolicy(new PasswordPolicy())
                 ->setSaslMechanisms(ServerOptions::SASL_PLAIN)
                 ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL)),

--- a/tests/support/LdapReplicaCommand.php
+++ b/tests/support/LdapReplicaCommand.php
@@ -12,6 +12,7 @@ use FreeDSx\Ldap\ReplicaConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Config\JsonStorageConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Config\StorageConfigInterface;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
 use FreeDSx\Ldap\ServerOptions;
@@ -87,13 +88,18 @@ final class LdapReplicaCommand extends Command
             '12345',
         ));
 
+        $network = (new NetworkConfig())
+            ->setPort($port)
+            ->setTransport($transport)
+            ->setSocketAcceptTimeout(0.1)
+            ->setShutdownTimeout(0);
+
         $server = new LdapServer(
             ServerOptions::forReplica(
                 $replicaConfig,
                 $this->createReplicaStorageConfig($storageType),
             )
-                ->setPort($port)
-                ->setTransport($transport)
+                ->setNetworkConfig($network)
                 ->setRunner($runner === 'swoole' ? RunnerMode::Swoole : RunnerMode::Pcntl)
                 ->setPasswordPolicy(new PasswordPolicy(
                     lockout: new PasswordLockoutRules(
@@ -101,8 +107,6 @@ final class LdapReplicaCommand extends Command
                         maxFailure: 2,
                     ),
                 ))
-                ->setSocketAcceptTimeout(0.1)
-                ->setShutdownTimeout(0)
                 ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL)),
         );
 

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -29,6 +29,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Config\JsonStorageConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Config\StorageConfigInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\ServerOptions;
 use Tests\Support\FreeDSx\Ldap\Server\Configuration\FileFlagConfigReloader;
 use PDO;
@@ -251,20 +252,22 @@ final class LdapServerCommand extends Command
             );
         }
 
-        $options = (new ServerOptions($this->createStorageConfig($storageType)))
+        $network = (new NetworkConfig())
             ->setPort($port)
             ->setTransport($transport)
             ->setUnixSocket(sys_get_temp_dir() . '/ldap.socket')
             ->setSslCert(self::SSL_CERT)
             ->setSslCertKey(self::SSL_KEY)
             ->setUseSsl($useSsl)
+            ->setSocketAcceptTimeout(0.1)
+            ->setShutdownTimeout(0);
+
+        $options = (new ServerOptions($this->createStorageConfig($storageType), $network))
             ->setRunner($runner === 'swoole' ? RunnerMode::Swoole : RunnerMode::Pcntl)
             ->setAllowAnonymous($allowAnonymous)
-            ->setSocketAcceptTimeout(0.1)
             ->setMaxSearchLookthrough((int) $this->getStringOption($input, 'max-search-lookthrough'))
             ->setMaxSearchPagedLookthrough((int) $this->getStringOption($input, 'max-search-paged-lookthrough'))
             ->setSyncEnabled(true)
-            ->setShutdownTimeout(0)
             ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL));
 
         $authenticatedLookthrough = (int) $this->getStringOption($input, 'authenticated-lookthrough');
@@ -299,10 +302,10 @@ final class LdapServerCommand extends Command
         }
 
         if ($external) {
-            $options
+            $options->getNetworkConfig()
                 ->setSslValidateCert(true)
-                ->setSslCaCert(self::EXTERNAL_CA_CERT)
-                ->setSaslMechanisms(ServerOptions::SASL_EXTERNAL);
+                ->setSslCaCert(self::EXTERNAL_CA_CERT);
+            $options->setSaslMechanisms(ServerOptions::SASL_EXTERNAL);
         }
 
         if ($external && $input->getOption('external-allow-proxy') === true) {

--- a/tests/unit/LdapServerTest.php
+++ b/tests/unit/LdapServerTest.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Export\DumpOptions;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\ReplicaConfig;
 use FreeDSx\Ldap\ProxyOptions;
@@ -58,8 +59,7 @@ class LdapServerTest extends TestCase
     {
         $this->mockServerRunner = $this->createMock(ServerRunnerInterface::class);
 
-        $this->options = (new ServerOptions())
-            ->setPort(33389)
+        $this->options = (new ServerOptions(network: NetworkConfig::withPort(33389)))
             ->setServerRunner($this->mockServerRunner);
 
         $this->container = Container::forServer($this->options);
@@ -87,38 +87,6 @@ class LdapServerTest extends TestCase
         $this->expectException(RuntimeException::class);
 
         $this->subject->run();
-    }
-
-    public function test_it_should_get_the_default_options(): void
-    {
-        self::assertEquals(
-            [
-                'ip' => '0.0.0.0',
-                'port' => 33389,
-                'unix_socket' => '/var/run/ldap.socket',
-                'transport' => 'tcp',
-                'idle_timeout' => 600,
-                'require_authentication' => true,
-                'allow_anonymous' => false,
-                'logger' => null,
-                'use_ssl' => false,
-                'ssl_cert' => null,
-                'ssl_cert_key' => null,
-                'ssl_cert_passphrase' => null,
-                'min_tls_version' => '1.2',
-                'ssl_ciphers' => 'DEFAULT',
-                'ssl_validate_cert' => false,
-                'ssl_allow_self_signed' => null,
-                'ssl_ca_cert' => null,
-                'monitor_enabled' => false,
-                'monitor_snapshot_path' => null,
-                'dse_alt_server' => null,
-                'dse_vendor_name' => 'FreeDSx',
-                'dse_vendor_version' => null,
-                'sasl_mechanisms' => [],
-            ],
-            $this->subject->getOptions()->toArray(),
-        );
     }
 
     public function test_it_does_not_throw_for_sasl_mechanisms_without_a_sasl_backend(): void

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/ExternalMechanismOptionsBuilderTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/ExternalMechanismOptionsBuilderTest.php
@@ -27,6 +27,7 @@ use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\Server\Sasl\External\ExternalCredentialMapperInterface;
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Sasl\Mechanism\MechanismName;
@@ -160,7 +161,7 @@ final class ExternalMechanismOptionsBuilderTest extends TestCase
 
         return new ExternalMechanismOptionsBuilder(
             $queue,
-            (new ServerOptions())->setSslValidateCert($validateCert),
+            new ServerOptions(network: (new NetworkConfig())->setSslValidateCert($validateCert)),
             $mapper,
             $this->authzIdResolver,
         );

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerStartTlsHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerStartTlsHandlerTest.php
@@ -50,7 +50,7 @@ final class ServerStartTlsHandlerTest extends TestCase
 
     public function test_it_should_handle_a_start_tls_request(): void
     {
-        $this->options->setSslCert('foo');
+        $this->options->getNetworkConfig()->setSslCert('foo');
 
         $this->mockConnection
             ->method('isEncrypted')
@@ -86,7 +86,7 @@ final class ServerStartTlsHandlerTest extends TestCase
 
     public function test_it_should_send_back_an_error_if_the_queue_is_already_encrypted(): void
     {
-        $this->options->setSslCert('foo');
+        $this->options->getNetworkConfig()->setSslCert('foo');
 
         $this->mockConnection
             ->method('isEncrypted')

--- a/tests/unit/Server/Config/NetworkConfigTest.php
+++ b/tests/unit/Server/Config/NetworkConfigTest.php
@@ -1,0 +1,335 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Config;
+
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
+use FreeDSx\Ldap\Server\TlsVersion;
+use PHPUnit\Framework\TestCase;
+
+final class NetworkConfigTest extends TestCase
+{
+    private NetworkConfig $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new NetworkConfig();
+    }
+
+    public function test_with_port_sets_only_the_port(): void
+    {
+        $config = NetworkConfig::withPort(33389);
+
+        self::assertSame(
+            33389,
+            $config->getPort(),
+        );
+    }
+
+    public function test_max_connections_defaults_to_zero(): void
+    {
+        self::assertSame(0, $this->subject->getMaxConnections());
+    }
+
+    public function test_it_can_set_max_connections(): void
+    {
+        $this->subject->setMaxConnections(500);
+
+        self::assertSame(500, $this->subject->getMaxConnections());
+    }
+
+    public function test_max_request_size_defaults_to_five_mib(): void
+    {
+        self::assertSame(
+            5_242_880,
+            $this->subject->getMaxRequestSize(),
+        );
+    }
+
+    public function test_it_can_set_max_request_size(): void
+    {
+        $this->subject->setMaxRequestSize(1_048_576);
+
+        self::assertSame(
+            1_048_576,
+            $this->subject->getMaxRequestSize(),
+        );
+    }
+
+    public function test_shutdown_timeout_defaults_to_fifteen_seconds(): void
+    {
+        self::assertSame(15, $this->subject->getShutdownTimeout());
+    }
+
+    public function test_it_can_set_shutdown_timeout(): void
+    {
+        $this->subject->setShutdownTimeout(30);
+
+        self::assertSame(30, $this->subject->getShutdownTimeout());
+    }
+
+    public function test_ip_defaults_to_all_interfaces(): void
+    {
+        self::assertSame(
+            '0.0.0.0',
+            $this->subject->getIp(),
+        );
+    }
+
+    public function test_it_can_set_ip(): void
+    {
+        $this->subject->setIp('127.0.0.1');
+
+        self::assertSame(
+            '127.0.0.1',
+            $this->subject->getIp(),
+        );
+    }
+
+    public function test_port_defaults_to_389(): void
+    {
+        self::assertSame(
+            389,
+            $this->subject->getPort(),
+        );
+    }
+
+    public function test_it_can_set_port(): void
+    {
+        $this->subject->setPort(33389);
+
+        self::assertSame(
+            33389,
+            $this->subject->getPort(),
+        );
+    }
+
+    public function test_transport_defaults_to_tcp(): void
+    {
+        self::assertSame(
+            'tcp',
+            $this->subject->getTransport(),
+        );
+    }
+
+    public function test_it_can_set_transport(): void
+    {
+        $this->subject->setTransport('unix');
+
+        self::assertSame(
+            'unix',
+            $this->subject->getTransport(),
+        );
+    }
+
+    public function test_unix_socket_has_a_default(): void
+    {
+        self::assertSame(
+            '/var/run/ldap.socket',
+            $this->subject->getUnixSocket(),
+        );
+    }
+
+    public function test_it_can_set_unix_socket(): void
+    {
+        $this->subject->setUnixSocket('/tmp/ldap.sock');
+
+        self::assertSame('/tmp/ldap.sock', $this->subject->getUnixSocket());
+    }
+
+    public function test_idle_timeout_defaults_to_600(): void
+    {
+        self::assertSame(
+            600,
+            $this->subject->getIdleTimeout(),
+        );
+    }
+
+    public function test_it_can_set_idle_timeout(): void
+    {
+        $this->subject->setIdleTimeout(120);
+
+        self::assertSame(
+            120,
+            $this->subject->getIdleTimeout(),
+        );
+    }
+
+    public function test_write_timeout_defaults_to_600(): void
+    {
+        self::assertSame(
+            600,
+            $this->subject->getWriteTimeout(),
+        );
+    }
+
+    public function test_it_can_set_write_timeout(): void
+    {
+        $this->subject->setWriteTimeout(0);
+
+        self::assertSame(
+            0,
+            $this->subject->getWriteTimeout(),
+        );
+    }
+
+    public function test_ssl_is_disabled_by_default(): void
+    {
+        self::assertFalse($this->subject->isUseSsl());
+    }
+
+    public function test_it_can_enable_ssl(): void
+    {
+        $this->subject->setUseSsl(true);
+
+        self::assertTrue($this->subject->isUseSsl());
+    }
+
+    public function test_ssl_cert_is_null_by_default(): void
+    {
+        self::assertNull($this->subject->getSslCert());
+    }
+
+    public function test_it_can_set_ssl_cert(): void
+    {
+        $this->subject->setSslCert('/path/to/cert.pem');
+
+        self::assertSame(
+            '/path/to/cert.pem',
+            $this->subject->getSslCert(),
+        );
+    }
+
+    public function test_ssl_cert_key_is_null_by_default(): void
+    {
+        self::assertNull($this->subject->getSslCertKey());
+    }
+
+    public function test_it_can_set_ssl_cert_key(): void
+    {
+        $this->subject->setSslCertKey('/path/to/key.pem');
+
+        self::assertSame(
+            '/path/to/key.pem',
+            $this->subject->getSslCertKey(),
+        );
+    }
+
+    public function test_ssl_cert_passphrase_is_null_by_default(): void
+    {
+        self::assertNull($this->subject->getSslCertPassphrase());
+    }
+
+    public function test_it_can_set_ssl_cert_passphrase(): void
+    {
+        $this->subject->setSslCertPassphrase('secret');
+
+        self::assertSame(
+            'secret',
+            $this->subject->getSslCertPassphrase(),
+        );
+    }
+
+    public function test_min_tls_version_defaults_to_1_2(): void
+    {
+        self::assertSame(
+            TlsVersion::Tls1_2,
+            $this->subject->getMinTlsVersion(),
+        );
+    }
+
+    public function test_it_can_set_min_tls_version(): void
+    {
+        $this->subject->setMinTlsVersion(TlsVersion::Tls1_3);
+
+        self::assertSame(
+            TlsVersion::Tls1_3,
+            $this->subject->getMinTlsVersion(),
+        );
+    }
+
+    public function test_ssl_ciphers_default_to_default(): void
+    {
+        self::assertSame(
+            'DEFAULT',
+            $this->subject->getSslCiphers(),
+        );
+    }
+
+    public function test_it_can_set_ssl_ciphers(): void
+    {
+        $this->subject->setSslCiphers('ECDHE-RSA-AES128-GCM-SHA256');
+
+        self::assertSame(
+            'ECDHE-RSA-AES128-GCM-SHA256',
+            $this->subject->getSslCiphers(),
+        );
+    }
+
+    public function test_ssl_validate_cert_is_disabled_by_default(): void
+    {
+        self::assertFalse($this->subject->isSslValidateCert());
+    }
+
+    public function test_it_can_enable_ssl_validate_cert(): void
+    {
+        $this->subject->setSslValidateCert(true);
+
+        self::assertTrue($this->subject->isSslValidateCert());
+    }
+
+    public function test_ssl_allow_self_signed_is_null_by_default(): void
+    {
+        self::assertNull($this->subject->getSslAllowSelfSigned());
+    }
+
+    public function test_it_can_set_ssl_allow_self_signed(): void
+    {
+        $this->subject->setSslAllowSelfSigned(true);
+
+        self::assertTrue($this->subject->getSslAllowSelfSigned());
+    }
+
+    public function test_ssl_ca_cert_is_null_by_default(): void
+    {
+        self::assertNull($this->subject->getSslCaCert());
+    }
+
+    public function test_it_can_set_ssl_ca_cert(): void
+    {
+        $this->subject->setSslCaCert('/path/to/ca.pem');
+
+        self::assertSame(
+            '/path/to/ca.pem',
+            $this->subject->getSslCaCert(),
+        );
+    }
+
+    public function test_socket_accept_timeout_defaults_to_half_second(): void
+    {
+        self::assertSame(
+            0.5,
+            $this->subject->getSocketAcceptTimeout(),
+        );
+    }
+
+    public function test_it_can_set_socket_accept_timeout(): void
+    {
+        $this->subject->setSocketAcceptTimeout(1.0);
+
+        self::assertSame(
+            1.0,
+            $this->subject->getSocketAcceptTimeout(),
+        );
+    }
+}

--- a/tests/unit/Server/Configuration/ReloadCoordinatorTest.php
+++ b/tests/unit/Server/Configuration/ReloadCoordinatorTest.php
@@ -15,7 +15,9 @@ namespace Tests\Unit\FreeDSx\Ldap\Server\Configuration;
 
 use FreeDSx\Ldap\Server\Configuration\ConfigReloaderInterface;
 use FreeDSx\Ldap\Server\Configuration\ReloadCoordinator;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
+use FreeDSx\Ldap\ServerListenerOptionsInterface;
 use FreeDSx\Ldap\ServerOptions;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -36,7 +38,7 @@ final class ReloadCoordinatorTest extends TestCase
 
     public function test_reload_returns_the_new_options_and_a_factory_rebuilt_from_them(): void
     {
-        $newOptions = (new ServerOptions())->setMaxConnections(123);
+        $newOptions = new ServerOptions(network: (new NetworkConfig())->setMaxConnections(123));
         $reloader = $this->createMock(ConfigReloaderInterface::class);
         $reloader
             ->expects(self::once())
@@ -46,7 +48,7 @@ final class ReloadCoordinatorTest extends TestCase
         $rebuiltFrom = null;
         $result = $this->subject->reload(
             (new ServerOptions())->setConfigReloader($reloader),
-            function (ServerOptions $options) use (&$rebuiltFrom): ServerProtocolFactoryInterface {
+            function (ServerListenerOptionsInterface $options) use (&$rebuiltFrom): ServerProtocolFactoryInterface {
                 $rebuiltFrom = $options;
 
                 return $this->reloadedFactory;
@@ -82,7 +84,7 @@ final class ReloadCoordinatorTest extends TestCase
 
         $result = $this->subject->reload(
             (new ServerOptions())->setLogger($logger),
-            fn(ServerOptions $options) => $this->reloadedFactory,
+            fn(ServerListenerOptionsInterface $options) => $this->reloadedFactory,
         );
 
         self::assertNull($result);
@@ -109,7 +111,7 @@ final class ReloadCoordinatorTest extends TestCase
             (new ServerOptions())
                 ->setLogger($logger)
                 ->setConfigReloader($reloader),
-            fn(ServerOptions $options) => $this->reloadedFactory,
+            fn(ServerListenerOptionsInterface $options) => $this->reloadedFactory,
         );
 
         self::assertNull($result);

--- a/tests/unit/Server/SocketServerFactoryTest.php
+++ b/tests/unit/Server/SocketServerFactoryTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Server;
 
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Ldap\Server\TlsVersion;
-use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Socket\Timeout\BlockingSelectEnforcer;
 use FreeDSx\Socket\Timeout\SwooleTimerEnforcer;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -45,8 +45,8 @@ final class SocketServerFactoryTest extends TestCase
         $this->mockLogger = $this->createMock(LoggerInterface::class);
 
         $this->subject = new SocketServerFactory(
-            (new ServerOptions())
-                ->setPort(3390),
+            NetworkConfig::withPort(3390),
+            RunnerMode::Pcntl,
             $this->mockLogger,
         );
     }
@@ -66,9 +66,10 @@ final class SocketServerFactoryTest extends TestCase
     public function test_it_uses_the_blocking_select_enforcer_for_the_pcntl_runner(): void
     {
         $subject = new SocketServerFactory(
-            (new ServerOptions())
+            (new NetworkConfig())
                 ->setPort(3391)
                 ->setWriteTimeout(45),
+            RunnerMode::Pcntl,
             $this->mockLogger,
         );
 
@@ -87,10 +88,10 @@ final class SocketServerFactoryTest extends TestCase
     public function test_it_uses_the_swoole_timer_enforcer_for_the_swoole_runner(): void
     {
         $subject = new SocketServerFactory(
-            (new ServerOptions())
+            (new NetworkConfig())
                 ->setPort(3392)
-                ->setWriteTimeout(45)
-                ->setRunner(RunnerMode::Swoole),
+                ->setWriteTimeout(45),
+            RunnerMode::Swoole,
             $this->mockLogger,
         );
 
@@ -109,13 +110,14 @@ final class SocketServerFactoryTest extends TestCase
     public function test_it_flows_the_tls_settings_to_the_socket_server(): void
     {
         $subject = new SocketServerFactory(
-            (new ServerOptions())
+            (new NetworkConfig())
                 ->setPort(3393)
                 ->setMinTlsVersion(TlsVersion::Tls1_3)
                 ->setSslCiphers('ECDHE-RSA-AES128-GCM-SHA256')
                 ->setSslValidateCert(true)
                 ->setSslAllowSelfSigned(true)
                 ->setSslCaCert('/path/to/ca.pem'),
+            RunnerMode::Pcntl,
             $this->mockLogger,
         );
 
@@ -145,9 +147,10 @@ final class SocketServerFactoryTest extends TestCase
         self::expectNotToPerformAssertions();
 
         $this->subject = new SocketServerFactory(
-            (new ServerOptions())
+            (new NetworkConfig())
                 ->setUnixSocket($this->tmpUnixSocketFilePath)
                 ->setTransport('unix'),
+            RunnerMode::Pcntl,
             $this->mockLogger,
         );
 

--- a/tests/unit/ServerOptionsTest.php
+++ b/tests/unit/ServerOptionsTest.php
@@ -38,7 +38,6 @@ use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\SearchLimit\SearchLimitRule;
 use FreeDSx\Ldap\Server\SearchLimit\SearchLimitRules;
 use FreeDSx\Ldap\Server\SearchLimits;
-use FreeDSx\Ldap\Server\TlsVersion;
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\ReplicaConfig;
 use FreeDSx\Ldap\ServerOptions;
@@ -148,18 +147,6 @@ final class ServerOptionsTest extends TestCase
         $this->subject->setSaslMechanisms(ServerOptions::SASL_PLAIN, 'GSSAPI');
     }
 
-    public function test_max_connections_defaults_to_zero(): void
-    {
-        self::assertSame(0, $this->subject->getMaxConnections());
-    }
-
-    public function test_it_can_set_max_connections(): void
-    {
-        $this->subject->setMaxConnections(500);
-
-        self::assertSame(500, $this->subject->getMaxConnections());
-    }
-
     public function test_monitor_is_disabled_by_default(): void
     {
         self::assertFalse($this->subject->isMonitorEnabled());
@@ -239,123 +226,6 @@ final class ServerOptionsTest extends TestCase
         );
     }
 
-    public function test_shutdown_timeout_defaults_to_fifteen_seconds(): void
-    {
-        self::assertSame(15, $this->subject->getShutdownTimeout());
-    }
-
-    public function test_it_can_set_shutdown_timeout(): void
-    {
-        $this->subject->setShutdownTimeout(30);
-
-        self::assertSame(30, $this->subject->getShutdownTimeout());
-    }
-
-    public function test_ip_defaults_to_all_interfaces(): void
-    {
-        self::assertSame(
-            '0.0.0.0',
-            $this->subject->getIp(),
-        );
-    }
-
-    public function test_it_can_set_ip(): void
-    {
-        $this->subject->setIp('127.0.0.1');
-
-        self::assertSame(
-            '127.0.0.1',
-            $this->subject->getIp(),
-        );
-    }
-
-    public function test_port_defaults_to_389(): void
-    {
-        self::assertSame(
-            389,
-            $this->subject->getPort(),
-        );
-    }
-
-    public function test_it_can_set_port(): void
-    {
-        $this->subject->setPort(33389);
-
-        self::assertSame(
-            33389,
-            $this->subject->getPort(),
-        );
-    }
-
-    public function test_transport_defaults_to_tcp(): void
-    {
-        self::assertSame(
-            'tcp',
-            $this->subject->getTransport(),
-        );
-    }
-
-    public function test_it_can_set_transport(): void
-    {
-        $this->subject->setTransport('unix');
-
-        self::assertSame(
-            'unix',
-            $this->subject->getTransport(),
-        );
-    }
-
-    public function test_unix_socket_has_a_default(): void
-    {
-        self::assertSame(
-            '/var/run/ldap.socket',
-            $this->subject->getUnixSocket(),
-        );
-    }
-
-    public function test_it_can_set_unix_socket(): void
-    {
-        $this->subject->setUnixSocket('/tmp/ldap.sock');
-
-        self::assertSame('/tmp/ldap.sock', $this->subject->getUnixSocket());
-    }
-
-    public function test_idle_timeout_defaults_to_600(): void
-    {
-        self::assertSame(
-            600,
-            $this->subject->getIdleTimeout(),
-        );
-    }
-
-    public function test_it_can_set_idle_timeout(): void
-    {
-        $this->subject->setIdleTimeout(120);
-
-        self::assertSame(
-            120,
-            $this->subject->getIdleTimeout(),
-        );
-    }
-
-    public function test_write_timeout_defaults_to_600(): void
-    {
-        self::assertSame(
-            600,
-            $this->subject->getWriteTimeout(),
-        );
-    }
-
-    public function test_it_can_set_write_timeout(): void
-    {
-        $this->subject->setWriteTimeout(0);
-
-        self::assertSame(
-            0,
-            $this->subject->getWriteTimeout(),
-        );
-    }
-
     public function test_require_authentication_defaults_to_true(): void
     {
         self::assertTrue($this->subject->isRequireAuthentication());
@@ -378,138 +248,6 @@ final class ServerOptionsTest extends TestCase
         $this->subject->setAllowAnonymous(true);
 
         self::assertTrue($this->subject->isAllowAnonymous());
-    }
-
-    public function test_ssl_is_disabled_by_default(): void
-    {
-        self::assertFalse($this->subject->isUseSsl());
-    }
-
-    public function test_it_can_enable_ssl(): void
-    {
-        $this->subject->setUseSsl(true);
-
-        self::assertTrue($this->subject->isUseSsl());
-    }
-
-    public function test_ssl_cert_is_null_by_default(): void
-    {
-        self::assertNull($this->subject->getSslCert());
-    }
-
-    public function test_it_can_set_ssl_cert(): void
-    {
-        $this->subject->setSslCert('/path/to/cert.pem');
-
-        self::assertSame(
-            '/path/to/cert.pem',
-            $this->subject->getSslCert(),
-        );
-    }
-
-    public function test_ssl_cert_key_is_null_by_default(): void
-    {
-        self::assertNull($this->subject->getSslCertKey());
-    }
-
-    public function test_it_can_set_ssl_cert_key(): void
-    {
-        $this->subject->setSslCertKey('/path/to/key.pem');
-
-        self::assertSame(
-            '/path/to/key.pem',
-            $this->subject->getSslCertKey(),
-        );
-    }
-
-    public function test_ssl_cert_passphrase_is_null_by_default(): void
-    {
-        self::assertNull($this->subject->getSslCertPassphrase());
-    }
-
-    public function test_it_can_set_ssl_cert_passphrase(): void
-    {
-        $this->subject->setSslCertPassphrase('secret');
-
-        self::assertSame(
-            'secret',
-            $this->subject->getSslCertPassphrase(),
-        );
-    }
-
-    public function test_min_tls_version_defaults_to_1_2(): void
-    {
-        self::assertSame(
-            TlsVersion::Tls1_2,
-            $this->subject->getMinTlsVersion(),
-        );
-    }
-
-    public function test_it_can_set_min_tls_version(): void
-    {
-        $this->subject->setMinTlsVersion(TlsVersion::Tls1_3);
-
-        self::assertSame(
-            TlsVersion::Tls1_3,
-            $this->subject->getMinTlsVersion(),
-        );
-    }
-
-    public function test_ssl_ciphers_default_to_default(): void
-    {
-        self::assertSame(
-            'DEFAULT',
-            $this->subject->getSslCiphers(),
-        );
-    }
-
-    public function test_it_can_set_ssl_ciphers(): void
-    {
-        $this->subject->setSslCiphers('ECDHE-RSA-AES128-GCM-SHA256');
-
-        self::assertSame(
-            'ECDHE-RSA-AES128-GCM-SHA256',
-            $this->subject->getSslCiphers(),
-        );
-    }
-
-    public function test_ssl_validate_cert_is_disabled_by_default(): void
-    {
-        self::assertFalse($this->subject->isSslValidateCert());
-    }
-
-    public function test_it_can_enable_ssl_validate_cert(): void
-    {
-        $this->subject->setSslValidateCert(true);
-
-        self::assertTrue($this->subject->isSslValidateCert());
-    }
-
-    public function test_ssl_allow_self_signed_is_null_by_default(): void
-    {
-        self::assertNull($this->subject->getSslAllowSelfSigned());
-    }
-
-    public function test_it_can_set_ssl_allow_self_signed(): void
-    {
-        $this->subject->setSslAllowSelfSigned(true);
-
-        self::assertTrue($this->subject->getSslAllowSelfSigned());
-    }
-
-    public function test_ssl_ca_cert_is_null_by_default(): void
-    {
-        self::assertNull($this->subject->getSslCaCert());
-    }
-
-    public function test_it_can_set_ssl_ca_cert(): void
-    {
-        $this->subject->setSslCaCert('/path/to/ca.pem');
-
-        self::assertSame(
-            '/path/to/ca.pem',
-            $this->subject->getSslCaCert(),
-        );
     }
 
     public function test_dse_alt_server_is_null_by_default(): void
@@ -691,24 +429,6 @@ final class ServerOptionsTest extends TestCase
         self::assertSame(
             RunnerMode::Swoole,
             $this->subject->getRunner(),
-        );
-    }
-
-    public function test_socket_accept_timeout_defaults_to_half_second(): void
-    {
-        self::assertSame(
-            0.5,
-            $this->subject->getSocketAcceptTimeout(),
-        );
-    }
-
-    public function test_it_can_set_socket_accept_timeout(): void
-    {
-        $this->subject->setSocketAcceptTimeout(1.0);
-
-        self::assertSame(
-            1.0,
-            $this->subject->getSocketAcceptTimeout(),
         );
     }
 


### PR DESCRIPTION
This will be re-used as I split the proxy out of the main LdapServer. This consolidates the shared usages into a trait and a DTO. Shared pieces between the two will use an interface instead of the main options object. Or they will receive the network config DTO.