### PR TITLE
[1.0.0] Move the proxy server into its own class / options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ CHANGELOG
 * Add the ability to run the LDAP server / client over a UNIX socket.
 * Add the ability to run the LDAP server over an SSL / TLS only socket.
 * Add the ability for the server to handle client paging requests via a handler.
-* Add a helper factory method for creating a proxy LDAP server.
+* Add a dedicated `LdapProxyServer` for creating a forwarding proxy.
 * The LDAP server handlers can now be set as a class instance in addition to the class FQCN string.
 * When setting the options on the LdapClient you can now choose to force a disconnect at the same time.
 * The criticality for paging can now be set using the "isCritical" method.

--- a/UPGRADE-1.0.md
+++ b/UPGRADE-1.0.md
@@ -96,8 +96,9 @@ $ldap = new LdapServer(
 
 ## Constructing a Proxy Server
 
-When instantiating an `LdapServer` instance with `LdapServer::makeProxy()`, options are now an options object instead
-of an associative array.
+A proxy is now a dedicated `LdapProxyServer` constructed with a single `ProxyOptions` object, instead of
+`LdapServer::makeProxy()` with associative arrays. `ProxyOptions` carries the proxy's own listener config
+(`ProxyServerOptions`) and the upstream `ClientOptions`.
 
 **Before**:
 
@@ -122,22 +123,22 @@ $server = LdapServer::makeProxy(
 **After**:
 
 ```php
-use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\ClientOptions;
-use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\LdapProxyServer;
+use FreeDSx\Ldap\ProxyOptions;
+use FreeDSx\Ldap\ProxyServerOptions;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
 
-$server = LdapServer::makeProxy(
-    // The LDAP server to proxy connections to...
-    'ldap.example.com',
-    // Any additional LdapClient options for the proxy...
-    (new ClientOptions)
-        // Perhaps the server to proxy is on some non-standard port?
-        ->setPort(3389)
-    ,
-    // Any additional LdapServer options. In this case, also run this server over port 3389
-    (new ServerOptions)
-        ->setPort(3389)
-);
+$server = new LdapProxyServer(new ProxyOptions(
+    // The proxy's own listener (its port, downstream TLS, etc.).
+    serverOptions: new ProxyServerOptions(
+        (new NetworkConfig())->setPort(3389),
+    ),
+    // The upstream LDAP server to forward connections to.
+    clientOptions: (new ClientOptions())
+        ->setServers(['ldap.example.com'])
+        ->setPort(3389),
+));
 ```
 
 ## Using a Custom ServerRunner
@@ -431,21 +432,5 @@ attribute of the RootDSE is populated automatically when a backend is configured
 
 ### Proxy server
 
-`ProxyRequestHandler` has been replaced by `ProxyBackend`. Extend it and provide an `LdapClient` instance:
-
-```php
-use FreeDSx\Ldap\ClientOptions;
-use FreeDSx\Ldap\LdapServer;
-use FreeDSx\Ldap\Server\RequestHandler\ProxyBackend;
-
-$server = (new LdapServer())
-    ->useBackend(new ProxyBackend(
-        (new ClientOptions)->setServers(['ldap.example.com'])
-    ));
-```
-
-Or use the convenience factory (unchanged from 0.x):
-
-```php
-$server = LdapServer::makeProxy('ldap.example.com');
-```
+A forwarding proxy is now its own `LdapProxyServer` constructed from a `ProxyOptions` object. See
+[Constructing a Proxy Server](#constructing-a-proxy-server) above.

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -2,16 +2,28 @@ LDAP Server Configuration
 ================
 
 * [General Options](#general-options)
-    * [ServerOptions:setIp](#setip)
-    * [ServerOptions:setPort](#setport)
-    * [ServerOptions:setUnixSocket](#setunixsocket)
-    * [ServerOptions:setTransport](#settransport)
     * [ServerOptions:setLogger](#setlogger)
     * [ServerOptions:setEventLogPolicy](#seteventlogpolicy)
-    * [ServerOptions:setIdleTimeout](#setidletimeout)
     * [ServerOptions:setRequireAuthentication](#setrequireauthentication)
     * [ServerOptions:setAllowAnonymous](#setallowanonymous)
-    * [ServerOptions:setSocketAcceptTimeout](#setsocketaccepttimeout)
+* [Network Configuration](#network-configuration)
+    * [NetworkConfig:setIp](#setip)
+    * [NetworkConfig:setPort](#setport)
+    * [NetworkConfig:setUnixSocket](#setunixsocket)
+    * [NetworkConfig:setTransport](#settransport)
+    * [NetworkConfig:setIdleTimeout](#setidletimeout)
+    * [NetworkConfig:setWriteTimeout](#setwritetimeout)
+    * [NetworkConfig:setSocketAcceptTimeout](#setsocketaccepttimeout)
+    * [TLS](#tls)
+        * [NetworkConfig:setUseSsl](#setusessl)
+        * [NetworkConfig:setSslCert](#setsslcert)
+        * [NetworkConfig:setSslCertKey](#setsslcertkey)
+        * [NetworkConfig:setSslCertPassphrase](#setsslcertpassphrase)
+        * [NetworkConfig:setMinTlsVersion](#setmintlsversion)
+        * [NetworkConfig:setSslCiphers](#setsslciphers)
+        * [NetworkConfig:setSslValidateCert](#setsslvalidatecert)
+        * [NetworkConfig:setSslAllowSelfSigned](#setsslallowselfsigned)
+        * [NetworkConfig:setSslCaCert](#setsslcacert)
 * [Access Control](#access-control)
     * [ServerOptions:setAclRules](#setaclrules)
     * [ServerOptions:setAccessControl](#setaccesscontrol)
@@ -26,15 +38,6 @@ LDAP Server Configuration
     * [ServerOptions:setDseAltServer](#setdsealtserver)
     * [ServerOptions:setDseVendorName](#setdsevendorname)
     * [ServerOptions:setDseVendorVersion](#setdsevendorversion)
-* [SSL and TLS Options](#ssl-and-tls-options)
-    * [ServerOptions:setSslCert](#setsslcert)
-    * [ServerOptions:setSslCertKey](#setsslcertkey)
-    * [ServerOptions:setSslCertPassphrase](#setsslcertpassphrase)
-    * [ServerOptions:setMinTlsVersion](#setmintlsversion)
-    * [ServerOptions:setSslCiphers](#setsslciphers)
-    * [ServerOptions:setSslValidateCert](#setsslvalidatecert)
-    * [ServerOptions:setSslAllowSelfSigned](#setsslallowselfsigned)
-    * [ServerOptions:setSslCaCert](#setsslcacert)
 * [Search Limits](#search-limits)
     * [ServerOptions:setMaxSearchSize](#setmaxsearchsize)
     * [ServerOptions:setMaxSearchTimeLimit](#setmaxsearchtimelimit)
@@ -62,10 +65,10 @@ on construction:
 ```php
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
 
-$options = (new ServerOptions)
-  ->setDseAltServer('dc2.local')
-  ->setPort(33389);
+$options = (new ServerOptions(network: NetworkConfig::withPort(33389)))
+  ->setDseAltServer('dc2.local');
 
 $ldap = new LdapServer($options);
 ```
@@ -73,42 +76,6 @@ $ldap = new LdapServer($options);
 The following documents these various configuration options and how they impact the server.
 
 ## General Options
-
-------------------
-#### setIp
-
-The IP address to bind and listen to while the server is running. By default it will bind to `0.0.0.0`, which will listen
-on all IP addresses of the machine.
-
-**Default**: `0.0.0.0`
-
-------------------
-#### setPort
-
-The port to bind to and accept client connections on. By default this is port 389. Since this port is underneath the
-first 1024 ports, it will require administrative access when running the server. You can change this to something higher
-than 1024 instead if needed.
-
-**Default**: `389`
-
-------------------
-#### setUnixSocket
-
-When using `unix` as the transport type, this is the full path to the socket file the client must interact with.
-
-**Default**: `/var/run/ldap.socket`
-
-------------------
-#### setTransport
-
-The transport mechanism for the server to use. Use either:
-
-* `tcp`
-* `unix`
-
-If using `unix` for the transport you can change set the `unix_socket` to a file path representing the unix socket the clients must connect to.
-
-**Default**: `tcp`
 
 ------------------
 #### setLogger
@@ -150,6 +117,83 @@ the policy API.
 **Default**: `EventLogPolicy::default()`
 
 ------------------
+#### setRequireAuthentication
+
+Whether authentication (bind) should be required before an operation is allowed.
+
+**Note**: Certain LDAP operations implicitly do not require authentication: StartTLS, RootDSE requests, WhoAmI
+
+**Default**: `true`
+
+------------------
+#### setAllowAnonymous
+
+Whether anonymous binds should be allowed.
+
+**Default**: `false`
+
+## Network Configuration
+
+The listen socket, timeouts, and TLS settings live on `FreeDSx\Ldap\Server\Config\NetworkConfig`, not on
+`ServerOptions`. Reach it either by passing a `NetworkConfig` as the second constructor argument (the storage config is
+first), or through `getNetworkConfig()` on an existing options instance. `ProxyServerOptions` exposes the same
+`getNetworkConfig()` accessor and `new ProxyServerOptions(NetworkConfig)` constructor.
+
+```php
+use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
+
+// On construction, as the second argument.
+$options = new ServerOptions(
+    network: (new NetworkConfig())
+        ->setPort(636)
+        ->setUseSsl(true),
+);
+
+// Or on an existing options instance.
+$options->getNetworkConfig()->setPort(636);
+```
+
+`NetworkConfig::withPort(int $port): self` is a shortcut for the common port-only case:
+`new ServerOptions(network: NetworkConfig::withPort(10389))`.
+
+------------------
+#### setIp
+
+The IP address to bind and listen to while the server is running. By default it will bind to `0.0.0.0`, which will listen
+on all IP addresses of the machine.
+
+**Default**: `0.0.0.0`
+
+------------------
+#### setPort
+
+The port to bind to and accept client connections on. By default this is port 389. Since this port is underneath the
+first 1024 ports, it will require administrative access when running the server. You can change this to something higher
+than 1024 instead if needed.
+
+**Default**: `389`
+
+------------------
+#### setUnixSocket
+
+When using `unix` as the transport type, this is the full path to the socket file the client must interact with.
+
+**Default**: `/var/run/ldap.socket`
+
+------------------
+#### setTransport
+
+The transport mechanism for the server to use. Use either:
+
+* `tcp`
+* `unix`
+
+If using `unix` for the transport you can change set the `unix_socket` to a file path representing the unix socket the clients must connect to.
+
+**Default**: `tcp`
+
+------------------
 #### setIdleTimeout
 
 Consider an idle client to timeout after this period of time (in seconds) and disconnect their LDAP session. If set to
@@ -166,22 +210,6 @@ Set to `0` to disable.
 **Default**: `600`
 
 ------------------
-#### setRequireAuthentication
-
-Whether authentication (bind) should be required before an operation is allowed.
-
-**Note**: Certain LDAP operations implicitly do not require authentication: StartTLS, RootDSE requests, WhoAmI
-
-**Default**: `true`
-
-------------------
-#### setAllowAnonymous
-
-Whether anonymous binds should be allowed.
-
-**Default**: `false`
-
-------------------
 #### setSocketAcceptTimeout
 
 The number of seconds (fractional) to wait for a new client connection before re-checking server state. Lower values
@@ -190,6 +218,102 @@ in the accept loop.
 
 **Default**: `0.5`
 
+### TLS
+
+The StartTLS and LDAPS settings below are also part of `NetworkConfig`. Configure them on the network config passed to
+the `ServerOptions` constructor, or via `getNetworkConfig()`.
+
+```php
+use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
+
+$options = new ServerOptions(
+    network: (new NetworkConfig())
+        ->setUseSsl(true)
+        ->setSslCert('/path/to/cert.pem')
+        ->setSslCertKey('/path/to/key.pem'),
+);
+```
+
+------------------
+#### setUseSsl
+
+If set to true, and the transport is `tcp`, the server will use an SSL stream to bind to the IP address. This forces clients
+to use an encrypted stream only for communication to the server.
+
+**Note**: LDAP over SSL, commonly referred to as LDAPS, is not an official LDAP standard. Support is dependent on the client / server specific implementations.
+
+**Default**: `false`
+
+------------------
+#### setSslCert
+
+The server certificate to use for clients issuing StartTLS commands to encrypt their TCP session.
+
+**Note**: If no certificate is provided clients will be unable to issue a StartTLS operation.
+
+**Default**: `(null)`
+
+------------------
+#### setSslCertKey
+
+The server certificate private key. This can also be bundled with the certificate in the `NetworkConfig::setSslCert` option.
+
+**Default**: `(null)`
+
+------------------
+#### setSslCertPassphrase
+
+The passphrase needed for the server certificate's private key.
+
+**Default**: `(null)`
+
+------------------
+#### setMinTlsVersion
+
+The minimum TLS protocol version the server will negotiate for StartTLS and LDAPS sessions. Provide a
+`FreeDSx\Ldap\Server\TlsVersion` case (`Tls1_0`, `Tls1_1`, `Tls1_2`, `Tls1_3`); the server accepts that version and any
+higher one. The default rejects the deprecated TLS 1.0 and 1.1 (RFC 8996); lower it explicitly only for legacy clients.
+
+```php
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
+use FreeDSx\Ldap\Server\TlsVersion;
+
+$network = (new NetworkConfig())
+    ->setMinTlsVersion(TlsVersion::Tls1_3);
+```
+
+**Default**: `TlsVersion::Tls1_2`
+
+------------------
+#### setSslCiphers
+
+The OpenSSL cipher list (in OpenSSL cipher-string format) offered during the TLS handshake.
+
+**Default**: `DEFAULT`
+
+------------------
+#### setSslValidateCert
+
+Whether the server requires and verifies a client certificate (mutual TLS). When enabled, provide the trust anchors via
+`setSslCaCert` so client certificates can be validated.
+
+**Default**: `false`
+
+------------------
+#### setSslAllowSelfSigned
+
+Whether a self-signed client certificate is accepted when `setSslValidateCert` is enabled. `null` leaves the underlying
+default (not allowed).
+
+**Default**: `(null)`
+
+------------------
+#### setSslCaCert
+
+Path to a CA certificate bundle used to verify client certificates when `setSslValidateCert` is enabled.
+
+**Default**: `(null)`
 
 ## Access Control
 
@@ -431,88 +555,6 @@ The vendorName attribute for the RootDSE.
 #### setDseVendorVersion
 
 The vendorVersion attribute for the RootDSE.
-
-**Default**: `(null)`
-
-## SSL and TLS Options
-
-------------------
-#### setSslCert
-
-The server certificate to use for clients issuing StartTLS commands to encrypt their TCP session.
-
-**Note**: If no certificate is provided clients will be unable to issue a StartTLS operation.
-
-**Default**: `(null)`
-
-------------------
-#### setSslCertKey
-
-The server certificate private key. This can also be bundled with the certificate in the `ServerOptions::setSslCert` option.
-
-**Default**: `(null)`
-
-------------------
-#### setSslCertPassphrase
-
-The passphrase needed for the server certificate's private key.
-
-**Default**: `(null)`
-
-------------------
-#### setUseSsl
-
-If set to true, and the transport is `tcp`, the server will use an SSL stream to bind to the IP address. This forces clients
-to use an encrypted stream only for communication to the server.
-
-**Note**: LDAP over SSL, commonly referred to as LDAPS, is not an official LDAP standard. Support is dependent on the client / server specific implementations.
-
-**Default**: `false`
-
-------------------
-#### setMinTlsVersion
-
-The minimum TLS protocol version the server will negotiate for StartTLS and LDAPS sessions. Provide a
-`FreeDSx\Ldap\Server\TlsVersion` case (`Tls1_0`, `Tls1_1`, `Tls1_2`, `Tls1_3`); the server accepts that version and any
-higher one. The default rejects the deprecated TLS 1.0 and 1.1 (RFC 8996); lower it explicitly only for legacy clients.
-
-```php
-use FreeDSx\Ldap\ServerOptions;
-use FreeDSx\Ldap\Server\TlsVersion;
-
-$options = (new ServerOptions())
-    ->setMinTlsVersion(TlsVersion::Tls1_3);
-```
-
-**Default**: `TlsVersion::Tls1_2`
-
-------------------
-#### setSslCiphers
-
-The OpenSSL cipher list (in OpenSSL cipher-string format) offered during the TLS handshake.
-
-**Default**: `DEFAULT`
-
-------------------
-#### setSslValidateCert
-
-Whether the server requires and verifies a client certificate (mutual TLS). When enabled, provide the trust anchors via
-`setSslCaCert` so client certificates can be validated.
-
-**Default**: `false`
-
-------------------
-#### setSslAllowSelfSigned
-
-Whether a self-signed client certificate is accepted when `setSslValidateCert` is enabled. `null` leaves the underlying
-default (not allowed).
-
-**Default**: `(null)`
-
-------------------
-#### setSslCaCert
-
-Path to a CA certificate bundle used to verify client certificates when `setSslValidateCert` is enabled.
 
 **Default**: `(null)`
 

--- a/docs/Server/General-Usage.md
+++ b/docs/Server/General-Usage.md
@@ -249,41 +249,42 @@ reload is discarded rather than taking the server down.
 
 ## Creating a Proxy Server
 
-The server can act as a transparent proxy to an upstream LDAP server via `LdapServer::makeProxy()`.
+The server can act as a transparent proxy to an upstream LDAP server via a dedicated `LdapProxyServer`.
 
 **Note**: Each client connection gets its own upstream connection. Requests (with their controls) are relayed upstream and
 the responses (with their controls) relayed back. So the upstream is the authority. Works on all server runners.
 
 ```php
 use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\LdapProxyServer;
 use FreeDSx\Ldap\ProxyOptions;
-use FreeDSx\Ldap\ServerOptions;
-use FreeDSx\Ldap\LdapServer;
-
-// The upstream connection: servers + TLS live on the ClientOptions.
-$proxyOptions = new ProxyOptions(
-    (new ClientOptions())
-        ->setServers(['ldap.example.com'])
-        // Upstream TLS: LDAPS here, or $proxyOptions->setUseStartTls(true) for StartTLS.
-        ->setUseSsl(true),
-);
+use FreeDSx\Ldap\ProxyServerOptions;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
 
 // The proxy's own listener: port/transport + downstream TLS cert.
-$serverOptions = (new ServerOptions())
-    ->setPort(3389)
-    ->setSslCert('/path/to/cert.pem')
-    ->setSslCertKey('/path/to/key.pem');
-
-$server = LdapServer::makeProxy(
-    $proxyOptions,
-    $serverOptions,
+$serverOptions = new ProxyServerOptions(
+    (new NetworkConfig())
+        ->setPort(3389)
+        ->setSslCert('/path/to/cert.pem')
+        ->setSslCertKey('/path/to/key.pem'),
 );
+
+// The upstream connection: servers + TLS live on the ClientOptions.
+$clientOptions = (new ClientOptions())
+    ->setServers(['ldap.example.com'])
+    // Upstream TLS: LDAPS here, or useStartTls: true for StartTLS.
+    ->setUseSsl(true);
+
+$server = new LdapProxyServer(new ProxyOptions(
+    serverOptions: $serverOptions,
+    clientOptions: $clientOptions,
+));
 $server->run();
 ```
 
 TLS terminates at each hop: configure the **upstream** hop on the `ClientOptions` (LDAPS via `setUseSsl`,
-or `ProxyOptions::setUseStartTls(true)`), and the **downstream** hop on the `ServerOptions` (LDAPS, or a
-client StartTLS upgrade using the configured server cert).
+or `ProxyOptions` `useStartTls: true`), and the **downstream** hop on the `ProxyServerOptions` network config
+(LDAPS, or a client StartTLS upgrade using the configured server cert).
 
 **Note**: only simple and anonymous binds are proxied (SASL is not), and every request is forwarded to the
 single configured upstream.
@@ -720,7 +721,7 @@ as `vendorName` come from `ServerOptions`. The entry always advertises:
 - `supportedExtension`: WhoAmI (RFC 4532), Password Modify (RFC 3062), and StartTLS (RFC 4511) if an SSL certificate is configured
 - `supportedLDAPVersion`: `3`
 
-A `makeProxy()` server forwards RootDSE requests to the upstream automatically.
+A proxy server forwards RootDSE requests to the upstream automatically.
 
 ## SASL Authentication
 
@@ -814,7 +815,8 @@ Adding the generated certs and keys on construction:
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Ldap\LdapServer;
 
-$options = (new ServerOptions)
+$options = new ServerOptions();
+$options->getNetworkConfig()
     # The key can also be bundled in this cert
     ->setSslCert('/path/to/cert.pem')
     # The key for the cert. Not needed if bundled above.

--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap;
 
-use FreeDSx\Ldap\Container\ClientContainerProvider;
-use FreeDSx\Ldap\Container\ConnectionGraphContainerProvider;
-use FreeDSx\Ldap\Container\ContainerProviderInterface;
-use FreeDSx\Ldap\Container\CoreServerContainerProvider;
-use FreeDSx\Ldap\Container\HandlerContainerProvider;
-use FreeDSx\Ldap\Container\PasswordPolicyContainerProvider;
+use FreeDSx\Ldap\Container\ContainerReloadFactory;
+use FreeDSx\Ldap\Container\Provider\ClientContainerProvider;
+use FreeDSx\Ldap\Container\Provider\ConnectionGraphContainerProvider;
+use FreeDSx\Ldap\Container\Provider\ContainerProviderInterface;
+use FreeDSx\Ldap\Container\Provider\DirectoryServerContainerProvider;
+use FreeDSx\Ldap\Container\Provider\HandlerContainerProvider;
+use FreeDSx\Ldap\Container\Provider\PasswordPolicyContainerProvider;
+use FreeDSx\Ldap\Container\Provider\ProxyServerContainerProvider;
+use FreeDSx\Ldap\Container\Provider\ServerListenerContainerProvider;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
@@ -88,20 +91,43 @@ class Container
         ServerOptions $options,
         array $sharedInstances = [],
     ): self {
-        return new self([ServerOptions::class => $options] + $sharedInstances);
+        return new self([
+            ServerListenerOptionsInterface::class => $options,
+            ServerOptions::class => $options,
+            ContainerReloadFactory::class => new ContainerReloadFactory(
+                static fn(ServerListenerOptionsInterface $reloaded, array $shared): self => self::forServer(
+                    $reloaded instanceof ServerOptions
+                        ? $reloaded
+                        : throw new RuntimeException('A directory server can only reload into ServerOptions.'),
+                    $shared,
+                ),
+            ),
+        ] + $sharedInstances);
     }
 
     /**
      * @param array<class-string, object> $sharedInstances services carried into this generation (e.g. across a reload).
      */
     public static function forProxy(
-        ServerOptions $options,
-        ProxyOptions $proxyOptions,
+        ProxyOptions $options,
         array $sharedInstances = [],
     ): self {
         return new self([
-            ServerOptions::class => $options,
-            ProxyOptions::class => $proxyOptions,
+            ServerListenerOptionsInterface::class => $options->getServerOptions(),
+            ProxyServerOptions::class => $options->getServerOptions(),
+            ProxyOptions::class => $options,
+            ContainerReloadFactory::class => new ContainerReloadFactory(
+                static fn(ServerListenerOptionsInterface $reloaded, array $shared): self => self::forProxy(
+                    new ProxyOptions(
+                        $reloaded instanceof ProxyServerOptions
+                            ? $reloaded
+                            : throw new RuntimeException('A proxy server can only reload into ProxyServerOptions.'),
+                        $options->getClientOptions(),
+                        $options->getUseStartTls(),
+                    ),
+                    $shared,
+                ),
+            ),
         ] + $sharedInstances);
     }
 
@@ -139,16 +165,7 @@ class Container
     }
 
     /**
-     * @param class-string $className
-     */
-    public function has(string $className): bool
-    {
-        return isset($this->instances[$className])
-            || isset($this->instanceFactory[$className]);
-    }
-
-    /**
-     * The providers whose factories apply to the seeded options (client and/or server).
+     * The providers whose factories apply to the seeded options (client, directory server, or proxy server).
      *
      * @return ContainerProviderInterface[]
      */
@@ -161,10 +178,16 @@ class Container
         }
 
         if (isset($this->instances[ServerOptions::class])) {
-            $providers[] = new CoreServerContainerProvider();
+            $providers[] = new ServerListenerContainerProvider();
+            $providers[] = new DirectoryServerContainerProvider();
             $providers[] = new PasswordPolicyContainerProvider();
             $providers[] = new ConnectionGraphContainerProvider();
             $providers[] = new HandlerContainerProvider();
+        }
+
+        if (isset($this->instances[ProxyOptions::class])) {
+            $providers[] = new ServerListenerContainerProvider();
+            $providers[] = new ProxyServerContainerProvider();
         }
 
         return $providers;

--- a/src/FreeDSx/Ldap/Container/ContainerReloadFactory.php
+++ b/src/FreeDSx/Ldap/Container/ContainerReloadFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Container;
+
+use Closure;
+use FreeDSx\Ldap\Container;
+use FreeDSx\Ldap\ServerListenerOptionsInterface;
+
+/**
+ * Rebuilds a container of the same server type from reloaded options, captured at seed time so the shared listener
+ * provider never branches on server type.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class ContainerReloadFactory
+{
+    /**
+     * @param Closure(ServerListenerOptionsInterface, array<class-string, object>): Container $rebuild
+     */
+    public function __construct(
+        private readonly Closure $rebuild,
+    ) {}
+
+    /**
+     * @param array<class-string, object> $sharedInstances
+     */
+    public function rebuild(
+        ServerListenerOptionsInterface $options,
+        array $sharedInstances,
+    ): Container {
+        return ($this->rebuild)(
+            $options,
+            $sharedInstances,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Container/Contributor/DirectoryListenerContributor.php
+++ b/src/FreeDSx/Ldap/Container/Contributor/DirectoryListenerContributor.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Container\Contributor;
+
+use FreeDSx\Ldap\Server\Backend\ResettableInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+
+/**
+ * A directory server's contribution: its backend is reset per fork and carried, with its storage, across a reload.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class DirectoryListenerContributor implements ListenerContributorInterface
+{
+    /**
+     * @param array<class-string, object> $reloadInstances
+     */
+    public function __construct(
+        private readonly WritableStorageBackend $backend,
+        private readonly array $reloadInstances,
+    ) {}
+
+    public function forkResettable(): ResettableInterface
+    {
+        return $this->backend;
+    }
+
+    public function reloadInstances(): array
+    {
+        return $this->reloadInstances;
+    }
+}

--- a/src/FreeDSx/Ldap/Container/Contributor/ListenerContributorInterface.php
+++ b/src/FreeDSx/Ldap/Container/Contributor/ListenerContributorInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Container\Contributor;
+
+use FreeDSx\Ldap\Server\Backend\ResettableInterface;
+
+/**
+ * Server-type-specific pieces the shared listener provider cannot derive itself: a per-fork resettable and the live
+ * services to carry across a reload; a proxy contributes neither.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface ListenerContributorInterface
+{
+    /**
+     * The service the forking runner resets in each child, or null when the server type has nothing to reset.
+     */
+    public function forkResettable(): ?ResettableInterface;
+
+    /**
+     * Live services to seed into the reloaded container so their state survives the reload.
+     *
+     * @return array<class-string, object>
+     */
+    public function reloadInstances(): array;
+}

--- a/src/FreeDSx/Ldap/Container/Contributor/ProxyListenerContributor.php
+++ b/src/FreeDSx/Ldap/Container/Contributor/ProxyListenerContributor.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Container\Contributor;
+
+use FreeDSx\Ldap\Server\Backend\ResettableInterface;
+
+/**
+ * A proxy serves no local directory, so it has nothing to reset per fork and carries nothing across a reload.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class ProxyListenerContributor implements ListenerContributorInterface
+{
+    public function forkResettable(): ?ResettableInterface
+    {
+        return null;
+    }
+
+    public function reloadInstances(): array
+    {
+        return [];
+    }
+}

--- a/src/FreeDSx/Ldap/Container/Provider/ClientContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/ClientContainerProvider.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap\Container;
+namespace FreeDSx\Ldap\Container\Provider;
 
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Container;

--- a/src/FreeDSx/Ldap/Container/Provider/ConnectionGraphContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/ConnectionGraphContainerProvider.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap\Container;
+namespace FreeDSx\Ldap\Container\Provider;
 
 use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;

--- a/src/FreeDSx/Ldap/Container/Provider/ContainerProviderInterface.php
+++ b/src/FreeDSx/Ldap/Container/Provider/ContainerProviderInterface.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap\Container;
+namespace FreeDSx\Ldap\Container\Provider;
 
 use FreeDSx\Ldap\Container;
 

--- a/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
@@ -11,15 +11,13 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap\Container;
+namespace FreeDSx\Ldap\Container\Provider;
 
-use Closure;
-use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Container;
+use FreeDSx\Ldap\Container\Contributor\DirectoryListenerContributor;
+use FreeDSx\Ldap\Container\Contributor\ListenerContributorInterface;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
-use FreeDSx\Ldap\Protocol\ServerAuthorization;
-use FreeDSx\Ldap\ProxyOptions;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
@@ -45,127 +43,60 @@ use FreeDSx\Ldap\Server\Clock\SystemClock;
 use FreeDSx\Ldap\Server\ConnectionHandlerBuilderInterface;
 use FreeDSx\Ldap\Server\HandlerFactoryInterface;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
-use FreeDSx\Ldap\Server\Metrics\File\FileSnapshotProvider;
-use FreeDSx\Ldap\Server\Metrics\File\FileSnapshotWriter;
-use FreeDSx\Ldap\Server\Metrics\File\SnapshotPublisher;
-use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
-use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
-use FreeDSx\Ldap\Server\Metrics\Recorder\InMemoryMetricsRecorder;
-use FreeDSx\Ldap\Server\Metrics\Recorder\MetricsRecorderChain;
-use FreeDSx\Ldap\Server\Metrics\Recorder\NullMetricsRecorder;
-use FreeDSx\Ldap\Server\Metrics\Rollup\OperationRollupCoordinator;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\LdapClientForwardStateSender;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\PasswordPolicyForwardWorker;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
+use FreeDSx\Ldap\Server\Process\BackgroundTask\BackgroundTasksInterface;
 use FreeDSx\Ldap\Server\Process\BackgroundTask\LongLivedTask;
 use FreeDSx\Ldap\Server\Process\BackgroundTask\PcntlBackgroundTasks;
 use FreeDSx\Ldap\Server\Process\BackgroundTask\PeriodicTask;
 use FreeDSx\Ldap\Server\Process\BackgroundTask\SwooleBackgroundTasks;
 use FreeDSx\Ldap\Server\Process\Signals\PcntlShutdownSignals;
-use FreeDSx\Ldap\Server\Proxy\ProxyProtocolFactory;
 use FreeDSx\Ldap\Server\RequestHandler\HandlerFactory;
 use FreeDSx\Ldap\Server\ServerProtocolFactory;
 use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
-use FreeDSx\Ldap\Server\ServerRunner\PcntlServerRunner;
-use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
-use FreeDSx\Ldap\Server\ServerRunner\SwooleServerRunner;
-use FreeDSx\Ldap\Server\SocketServerFactory;
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Ldap\Sync\Consumer\LdapReplica;
 use FreeDSx\Ldap\Sync\Consumer\PrimaryConnectionFactory;
 use Psr\Log\NullLogger;
 
 /**
- * Registers the core server services: sockets, backend, protocol factory, runner, metrics, and clock.
+ * Registers the local-directory services.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final class CoreServerContainerProvider implements ContainerProviderInterface
+final class DirectoryServerContainerProvider implements ContainerProviderInterface
 {
     public function factories(): array
     {
         return [
-            SocketServerFactory::class => $this->makeSocketServerFactory(...),
             HandlerFactoryInterface::class => $this->makeHandlerFactory(...),
             FilterEvaluatorInterface::class => $this->makeFilterEvaluator(...),
             EntryStorageInterface::class => $this->makeStorage(...),
             PdoBackendBuilder::class => $this->makePdoBackendBuilder(...),
             WritableStorageBackend::class => $this->makeBackend(...),
             ServerProtocolFactory::class => $this->makeServerProtocolFactory(...),
-            ServerProtocolFactoryInterface::class => $this->makeServerProtocolFactoryInterface(...),
-            ServerRunnerInterface::class => $this->makeServerRunner(...),
-            ServerAuthorization::class => $this->makeServerAuthorizer(...),
+            ServerProtocolFactoryInterface::class => static fn(Container $c): ServerProtocolFactoryInterface => $c->get(ServerProtocolFactory::class),
+            ServerProtocolHandlerFactory::class => $this->makeServerProtocolHandlerFactory(...),
             ClockInterface::class => static fn(): ClockInterface => new SystemClock(),
             SleeperInterface::class => $this->makeSleeper(...),
-            ServerProtocolHandlerFactory::class => $this->makeServerProtocolHandlerFactory(...),
-            InMemoryMetricsRecorder::class => static fn(): InMemoryMetricsRecorder => new InMemoryMetricsRecorder(),
-            MetricsRecorderInterface::class => $this->makeMetricsRecorder(...),
-            MetricsSnapshotProvider::class => $this->makeMetricsSnapshotProvider(...),
-            OperationRollupCoordinator::class => $this->makeOperationRollupCoordinator(...),
+            BackgroundTasksInterface::class => $this->makeBackgroundTasks(...),
+            ListenerContributorInterface::class => $this->makeListenerContributor(...),
         ];
-    }
-
-    private function makeSocketServerFactory(Container $container): SocketServerFactory
-    {
-        $serverOptions = $container->get(ServerOptions::class);
-
-        return new SocketServerFactory(
-            $serverOptions->getNetworkConfig(),
-            $serverOptions->getRunner(),
-            $serverOptions->getLogger(),
-        );
-    }
-
-    private function makeServerAuthorizer(Container $container): ServerAuthorization
-    {
-        return new ServerAuthorization($container->get(ServerOptions::class));
-    }
-
-    private function makeServerProtocolHandlerFactory(Container $container): ServerProtocolHandlerFactory
-    {
-        return new ServerProtocolHandlerFactory($container->get(ServerOptions::class));
-    }
-
-    /**
-     * The runner-appropriate sleeper: a coroutine-aware sleeper under Swoole, else a blocking one.
-     */
-    private function makeSleeper(Container $container): SleeperInterface
-    {
-        return $container->get(ServerOptions::class)->getRunner() === RunnerMode::Swoole
-            ? new CoroutineSleeper()
-            : new BlockingSleeper();
     }
 
     private function makeHandlerFactory(Container $container): HandlerFactory
     {
         return new HandlerFactory(
             $container->get(ServerOptions::class),
-            $this->backendOrFail($container),
+            $container->get(WritableStorageBackend::class),
         );
     }
 
     private function makeFilterEvaluator(Container $container): FilterEvaluator
     {
         return new FilterEvaluator($container->get(ServerOptions::class)->getSchema());
-    }
-
-    /**
-     * The configured backend; only reached on the non-proxy path, where LdapServer's startup check guarantees one.
-     */
-    private function backendOrFail(Container $container): WritableStorageBackend
-    {
-        return $this->backendOrNull($container)
-            ?? throw new RuntimeException('No storage is configured; set ServerOptions::setStorageConfig().');
-    }
-
-    /**
-     * The assembled backend, or null on the proxy path which serves no local directory.
-     */
-    private function backendOrNull(Container $container): ?WritableStorageBackend
-    {
-        return $container->has(ProxyOptions::class)
-            ? null
-            : $container->get(WritableStorageBackend::class);
     }
 
     /**
@@ -197,7 +128,7 @@ final class CoreServerContainerProvider implements ContainerProviderInterface
     }
 
     /**
-     * The PDO backend assembly (storage + replica password-state store on one connection)
+     * The PDO backend assembly (storage + replica password-state store on one connection).
      */
     private function makePdoBackendBuilder(Container $container): PdoBackendBuilder
     {
@@ -214,9 +145,6 @@ final class CoreServerContainerProvider implements ContainerProviderInterface
         );
     }
 
-    /**
-     * Assemble the writable backend from the container-built storage; only invoked when storage is configured.
-     */
     private function makeBackend(Container $container): WritableStorageBackend
     {
         $options = $container->get(ServerOptions::class);
@@ -274,45 +202,45 @@ final class CoreServerContainerProvider implements ContainerProviderInterface
         return new ServerProtocolFactory($container->get(ConnectionHandlerBuilderInterface::class));
     }
 
-    private function makeServerProtocolFactoryInterface(Container $container): ServerProtocolFactoryInterface
+    private function makeServerProtocolHandlerFactory(Container $container): ServerProtocolHandlerFactory
     {
-        if ($container->has(ProxyOptions::class)) {
-            return new ProxyProtocolFactory(
-                $container->get(ServerOptions::class),
-                $container->get(ProxyOptions::class),
-            );
-        }
-
-        return $container->get(ServerProtocolFactory::class);
+        return new ServerProtocolHandlerFactory($container->get(ServerOptions::class));
     }
 
-    private function makeServerRunner(Container $container): ServerRunnerInterface
+    /**
+     * The runner-appropriate sleeper: a coroutine-aware sleeper under Swoole, else a blocking one.
+     */
+    private function makeSleeper(Container $container): SleeperInterface
     {
-        $options = $container->get(ServerOptions::class);
-        $protocolFactoryProvider = $this->makeProtocolFactoryProvider($container);
-        $metricsRecorder = $container->get(MetricsRecorderInterface::class);
+        return $container->get(ServerOptions::class)->getRunner() === RunnerMode::Swoole
+            ? new CoroutineSleeper()
+            : new BlockingSleeper();
+    }
 
-        if ($options->getRunner() === RunnerMode::Swoole) {
-            return new SwooleServerRunner(
-                serverProtocolFactory: $protocolFactoryProvider($options),
-                options: $options,
-                socketServerFactory: $container->get(SocketServerFactory::class),
-                protocolFactoryProvider: $protocolFactoryProvider,
-                metricsRecorder: $metricsRecorder,
-                backgroundTasks: $this->makeSwooleBackgroundTasks($container),
-            );
+    private function makeBackgroundTasks(Container $container): BackgroundTasksInterface
+    {
+        return $container->get(ServerOptions::class)->getRunner() === RunnerMode::Swoole
+            ? $this->makeSwooleBackgroundTasks($container)
+            : $this->makePcntlBackgroundTasks($container);
+    }
+
+    private function makeListenerContributor(Container $container): ListenerContributorInterface
+    {
+        $backend = $container->get(WritableStorageBackend::class);
+
+        $instances = [
+            WritableStorageBackend::class => $backend,
+            EntryStorageInterface::class => $backend->getStorage(),
+        ];
+
+        // On the PDO path, share the builder so the reloaded replica store stays on the storage's connection.
+        if ($container->get(ServerOptions::class)->getStorageConfig() instanceof PdoConfig) {
+            $instances[PdoBackendBuilder::class] = $container->get(PdoBackendBuilder::class);
         }
 
-        return new PcntlServerRunner(
-            serverProtocolFactory: $protocolFactoryProvider($options),
-            options: $options,
-            socketServerFactory: $container->get(SocketServerFactory::class),
-            protocolFactoryProvider: $protocolFactoryProvider,
-            metricsRecorder: $metricsRecorder,
-            snapshotPublisher: $this->makeSnapshotPublisher($container),
-            operationRollup: $this->makeOperationRollup($container),
-            backend: $this->backendOrNull($container),
-            backgroundTasks: $this->makePcntlBackgroundTasks($container),
+        return new DirectoryListenerContributor(
+            $backend,
+            $instances,
         );
     }
 
@@ -322,13 +250,12 @@ final class CoreServerContainerProvider implements ContainerProviderInterface
     private function journalRetentionPolicyIfSweepable(Container $container): ?RetentionPolicy
     {
         $options = $container->get(ServerOptions::class);
-        $backend = $this->backendOrNull($container);
 
-        if ($backend === null || !$options->isSyncEnabled()) {
+        if (!$options->isSyncEnabled()) {
             return null;
         }
 
-        $journal = $backend->changeJournal();
+        $journal = $container->get(WritableStorageBackend::class)->changeJournal();
 
         if ($journal === null) {
             return null;
@@ -354,7 +281,7 @@ final class CoreServerContainerProvider implements ContainerProviderInterface
         }
 
         // Safe to resolve now: a non-null policy means sync is enabled and the journal is configured.
-        $journal = $this->backendOrNull($container)?->changeJournal();
+        $journal = $container->get(WritableStorageBackend::class)->changeJournal();
 
         if ($journal === null) {
             return null;
@@ -514,158 +441,5 @@ final class CoreServerContainerProvider implements ContainerProviderInterface
                 $options->getLogger(),
                 passwordStateStore: $passwordStateStore,
             );
-    }
-
-    /**
-     * The child-to-parent operation rollup for the forking runner, over the shared in-memory recorder; built only when
-     * cn=monitor is enabled.
-     */
-    private function makeOperationRollup(Container $container): ?OperationRollupCoordinator
-    {
-        if (!$container->get(ServerOptions::class)->isMonitorEnabled()) {
-            return null;
-        }
-
-        return $container->get(OperationRollupCoordinator::class);
-    }
-
-    private function makeOperationRollupCoordinator(Container $container): OperationRollupCoordinator
-    {
-        return new OperationRollupCoordinator($container->get(InMemoryMetricsRecorder::class));
-    }
-
-    /**
-     * The PCNTL parent publishes connection metrics to a file for forked children (serving cn=monitor) to read; built
-     * only when cn=monitor is enabled.
-     */
-    private function makeSnapshotPublisher(Container $container): ?SnapshotPublisher
-    {
-        $options = $container->get(ServerOptions::class);
-
-        if (!$options->isMonitorEnabled()) {
-            return null;
-        }
-
-        return new SnapshotPublisher(
-            $container->get(InMemoryMetricsRecorder::class),
-            new FileSnapshotWriter($options->getMonitorSnapshotPath()),
-        );
-    }
-
-    /**
-     * The process metrics recorder: an in-memory recorder when cn=monitor is enabled (chained with a user recorder if
-     * set), otherwise just the user recorder (a no-op by default).
-     */
-    private function makeMetricsRecorder(Container $container): MetricsRecorderInterface
-    {
-        $options = $container->get(ServerOptions::class);
-        $userRecorder = $options->getMetricsRecorder();
-
-        if (!$options->isMonitorEnabled()) {
-            return $userRecorder;
-        }
-
-        $inMemory = $container->get(InMemoryMetricsRecorder::class);
-
-        if ($userRecorder instanceof NullMetricsRecorder) {
-            return $inMemory;
-        }
-
-        return new MetricsRecorderChain(
-            $inMemory,
-            $userRecorder,
-        );
-    }
-
-    /**
-     * The snapshot source for cn=monitor: the live in-memory recorder under Swoole, or the parent-published file under
-     * the forking PCNTL runner.
-     */
-    private function makeMetricsSnapshotProvider(Container $container): MetricsSnapshotProvider
-    {
-        $options = $container->get(ServerOptions::class);
-
-        if ($options->getRunner() !== RunnerMode::Swoole) {
-            return new FileSnapshotProvider($options->getMonitorSnapshotPath());
-        }
-
-        return $container->get(InMemoryMetricsRecorder::class);
-    }
-
-    /**
-     * Builds a protocol factory from a (possibly reloaded) set of options via a fresh container.
-     *
-     * @return Closure(ServerOptions): ServerProtocolFactoryInterface
-     */
-    private function makeProtocolFactoryProvider(Container $container): Closure
-    {
-        $proxyOptions = $container->has(ProxyOptions::class)
-            ? $container->get(ProxyOptions::class)
-            : null;
-        $sharedInstances = $this->reloadSharedInstances($container);
-
-        return static function (ServerOptions $options) use (
-            $proxyOptions,
-            $sharedInstances,
-        ): ServerProtocolFactoryInterface {
-            $container = $proxyOptions !== null
-                ? Container::forProxy(
-                    $options,
-                    $proxyOptions,
-                    $sharedInstances,
-                )
-                : Container::forServer(
-                    $options,
-                    $sharedInstances,
-                );
-
-            return $container->get(ServerProtocolFactoryInterface::class);
-        };
-    }
-
-    /**
-     * Services carried verbatim across a SIGHUP reload so their live state survives into the fresh container.
-     *
-     * @return array<class-string, object>
-     */
-    private function reloadSharedInstances(Container $container): array
-    {
-        $shared = [
-            MetricsRecorderInterface::class => $container->get(MetricsRecorderInterface::class),
-            MetricsSnapshotProvider::class => $container->get(MetricsSnapshotProvider::class),
-            InMemoryMetricsRecorder::class => $container->get(InMemoryMetricsRecorder::class),
-        ];
-
-        $operationRollup = $this->makeOperationRollup($container);
-        if ($operationRollup !== null) {
-            $shared[OperationRollupCoordinator::class] = $operationRollup;
-        }
-
-        return $shared + $this->reloadStorageInstances($container);
-    }
-
-    /**
-     * The storage services to carry across a reload (empty on the proxy path, which has no local directory).
-     *
-     * @return array<class-string, object>
-     */
-    private function reloadStorageInstances(Container $container): array
-    {
-        $backend = $this->backendOrNull($container);
-        if ($backend === null) {
-            return [];
-        }
-
-        $shared = [
-            WritableStorageBackend::class => $backend,
-            EntryStorageInterface::class => $backend->getStorage(),
-        ];
-
-        // On the PDO path, share the builder so the reloaded replica store stays on the storage's connection.
-        if ($container->get(ServerOptions::class)->getStorageConfig() instanceof PdoConfig) {
-            $shared[PdoBackendBuilder::class] = $container->get(PdoBackendBuilder::class);
-        }
-
-        return $shared;
     }
 }

--- a/src/FreeDSx/Ldap/Container/Provider/HandlerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/HandlerContainerProvider.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap\Container;
+namespace FreeDSx\Ldap\Container\Provider;
 
 use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Container;

--- a/src/FreeDSx/Ldap/Container/Provider/PasswordPolicyContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/PasswordPolicyContainerProvider.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap\Container;
+namespace FreeDSx\Ldap\Container\Provider;
 
 use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;

--- a/src/FreeDSx/Ldap/Container/Provider/ProxyServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/ProxyServerContainerProvider.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Container\Provider;
+
+use FreeDSx\Ldap\Container;
+use FreeDSx\Ldap\Container\Contributor\ListenerContributorInterface;
+use FreeDSx\Ldap\Container\Contributor\ProxyListenerContributor;
+use FreeDSx\Ldap\ProxyOptions;
+use FreeDSx\Ldap\ProxyServerOptions;
+use FreeDSx\Ldap\Server\Process\BackgroundTask\BackgroundTasksInterface;
+use FreeDSx\Ldap\Server\Process\BackgroundTask\PcntlBackgroundTasks;
+use FreeDSx\Ldap\Server\Process\BackgroundTask\SwooleBackgroundTasks;
+use FreeDSx\Ldap\Server\Proxy\ProxyProtocolFactory;
+use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
+
+/**
+ * Registers the forwarding-proxy services.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class ProxyServerContainerProvider implements ContainerProviderInterface
+{
+    public function factories(): array
+    {
+        return [
+            ServerProtocolFactoryInterface::class => static fn(Container $c): ServerProtocolFactoryInterface => new ProxyProtocolFactory($c->get(ProxyOptions::class)),
+            BackgroundTasksInterface::class => $this->makeBackgroundTasks(...),
+            ListenerContributorInterface::class => static fn(): ListenerContributorInterface => new ProxyListenerContributor(),
+        ];
+    }
+
+    private function makeBackgroundTasks(Container $container): BackgroundTasksInterface
+    {
+        $options = $container->get(ProxyServerOptions::class);
+
+        if ($options->getRunner() === RunnerMode::Swoole) {
+            return new SwooleBackgroundTasks(
+                [],
+                [],
+                $options->getLogger(),
+            );
+        }
+
+        return new PcntlBackgroundTasks(
+            periodicTasks: [],
+            longLivedTasks: [],
+            logger: $options->getLogger(),
+            gracefulStopSeconds: $options->getNetworkConfig()->getShutdownTimeout(),
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Container/Provider/ServerListenerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/ServerListenerContainerProvider.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Container\Provider;
+
+use Closure;
+use FreeDSx\Ldap\Container;
+use FreeDSx\Ldap\Container\ContainerReloadFactory;
+use FreeDSx\Ldap\Container\Contributor\ListenerContributorInterface;
+use FreeDSx\Ldap\Protocol\ServerAuthorization;
+use FreeDSx\Ldap\Server\Metrics\File\FileSnapshotProvider;
+use FreeDSx\Ldap\Server\Metrics\File\FileSnapshotWriter;
+use FreeDSx\Ldap\Server\Metrics\File\SnapshotPublisher;
+use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
+use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
+use FreeDSx\Ldap\Server\Metrics\Recorder\InMemoryMetricsRecorder;
+use FreeDSx\Ldap\Server\Metrics\Recorder\MetricsRecorderChain;
+use FreeDSx\Ldap\Server\Metrics\Recorder\NullMetricsRecorder;
+use FreeDSx\Ldap\Server\Metrics\Rollup\OperationRollupCoordinator;
+use FreeDSx\Ldap\Server\Process\BackgroundTask\BackgroundTasksInterface;
+use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
+use FreeDSx\Ldap\Server\ServerRunner\PcntlServerRunner;
+use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
+use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
+use FreeDSx\Ldap\Server\ServerRunner\SwooleServerRunner;
+use FreeDSx\Ldap\Server\SocketServerFactory;
+use FreeDSx\Ldap\ServerListenerOptionsInterface;
+
+/**
+ * Registers the listener services shared by every server type: the socket, runner, reload, authorization, and metrics.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class ServerListenerContainerProvider implements ContainerProviderInterface
+{
+    public function factories(): array
+    {
+        return [
+            SocketServerFactory::class => $this->makeSocketServerFactory(...),
+            ServerAuthorization::class => $this->makeServerAuthorizer(...),
+            ServerRunnerInterface::class => $this->makeServerRunner(...),
+            InMemoryMetricsRecorder::class => static fn(): InMemoryMetricsRecorder => new InMemoryMetricsRecorder(),
+            MetricsRecorderInterface::class => $this->makeMetricsRecorder(...),
+            MetricsSnapshotProvider::class => $this->makeMetricsSnapshotProvider(...),
+            OperationRollupCoordinator::class => $this->makeOperationRollupCoordinator(...),
+        ];
+    }
+
+    private function makeSocketServerFactory(Container $container): SocketServerFactory
+    {
+        $options = $container->get(ServerListenerOptionsInterface::class);
+
+        return new SocketServerFactory(
+            $options->getNetworkConfig(),
+            $options->getRunner(),
+            $options->getLogger(),
+        );
+    }
+
+    private function makeServerAuthorizer(Container $container): ServerAuthorization
+    {
+        return new ServerAuthorization($container->get(ServerListenerOptionsInterface::class));
+    }
+
+    private function makeServerRunner(Container $container): ServerRunnerInterface
+    {
+        $options = $container->get(ServerListenerOptionsInterface::class);
+        $protocolFactoryProvider = $this->makeProtocolFactoryProvider($container);
+        $metricsRecorder = $container->get(MetricsRecorderInterface::class);
+
+        if ($options->getRunner() === RunnerMode::Swoole) {
+            return new SwooleServerRunner(
+                serverProtocolFactory: $protocolFactoryProvider($options),
+                options: $options,
+                socketServerFactory: $container->get(SocketServerFactory::class),
+                protocolFactoryProvider: $protocolFactoryProvider,
+                metricsRecorder: $metricsRecorder,
+                backgroundTasks: $container->get(BackgroundTasksInterface::class),
+            );
+        }
+
+        return new PcntlServerRunner(
+            serverProtocolFactory: $protocolFactoryProvider($options),
+            options: $options,
+            socketServerFactory: $container->get(SocketServerFactory::class),
+            protocolFactoryProvider: $protocolFactoryProvider,
+            metricsRecorder: $metricsRecorder,
+            snapshotPublisher: $this->makeSnapshotPublisher($container),
+            operationRollup: $this->makeOperationRollup($container),
+            resettable: $container->get(ListenerContributorInterface::class)->forkResettable(),
+            backgroundTasks: $container->get(BackgroundTasksInterface::class),
+        );
+    }
+
+    /**
+     * Builds a protocol factory from a (possibly reloaded) set of options via a freshly assembled container.
+     *
+     * @return Closure(ServerListenerOptionsInterface): ServerProtocolFactoryInterface
+     */
+    private function makeProtocolFactoryProvider(Container $container): Closure
+    {
+        $rebuild = $container->get(ContainerReloadFactory::class);
+        $shared = $this->reloadSharedInstances($container);
+
+        return static fn(ServerListenerOptionsInterface $options): ServerProtocolFactoryInterface => $rebuild
+            ->rebuild($options, $shared)
+            ->get(ServerProtocolFactoryInterface::class);
+    }
+
+    /**
+     * Services carried verbatim across a SIGHUP reload so their live state survives into the fresh container.
+     *
+     * @return array<class-string, object>
+     */
+    private function reloadSharedInstances(Container $container): array
+    {
+        $shared = [
+            MetricsRecorderInterface::class => $container->get(MetricsRecorderInterface::class),
+            MetricsSnapshotProvider::class => $container->get(MetricsSnapshotProvider::class),
+            InMemoryMetricsRecorder::class => $container->get(InMemoryMetricsRecorder::class),
+        ];
+
+        $operationRollup = $this->makeOperationRollup($container);
+        if ($operationRollup !== null) {
+            $shared[OperationRollupCoordinator::class] = $operationRollup;
+        }
+
+        return $shared + $container->get(ListenerContributorInterface::class)->reloadInstances();
+    }
+
+    /**
+     * The child-to-parent operation rollup for the forking runner; built only when cn=monitor is enabled.
+     */
+    private function makeOperationRollup(Container $container): ?OperationRollupCoordinator
+    {
+        if (!$container->get(ServerListenerOptionsInterface::class)->isMonitorEnabled()) {
+            return null;
+        }
+
+        return $container->get(OperationRollupCoordinator::class);
+    }
+
+    private function makeOperationRollupCoordinator(Container $container): OperationRollupCoordinator
+    {
+        return new OperationRollupCoordinator($container->get(InMemoryMetricsRecorder::class));
+    }
+
+    /**
+     * The PCNTL parent publishes connection metrics to a file for forked children (serving cn=monitor); built only when
+     * cn=monitor is enabled.
+     */
+    private function makeSnapshotPublisher(Container $container): ?SnapshotPublisher
+    {
+        $options = $container->get(ServerListenerOptionsInterface::class);
+
+        if (!$options->isMonitorEnabled()) {
+            return null;
+        }
+
+        return new SnapshotPublisher(
+            $container->get(InMemoryMetricsRecorder::class),
+            new FileSnapshotWriter($options->getMonitorSnapshotPath()),
+        );
+    }
+
+    /**
+     * The process metrics recorder: an in-memory recorder when cn=monitor is enabled (chained with a user recorder if
+     * set), otherwise just the user recorder (a no-op by default).
+     */
+    private function makeMetricsRecorder(Container $container): MetricsRecorderInterface
+    {
+        $options = $container->get(ServerListenerOptionsInterface::class);
+        $userRecorder = $options->getMetricsRecorder();
+
+        if (!$options->isMonitorEnabled()) {
+            return $userRecorder;
+        }
+
+        $inMemory = $container->get(InMemoryMetricsRecorder::class);
+
+        if ($userRecorder instanceof NullMetricsRecorder) {
+            return $inMemory;
+        }
+
+        return new MetricsRecorderChain(
+            $inMemory,
+            $userRecorder,
+        );
+    }
+
+    /**
+     * The snapshot source for cn=monitor: the live in-memory recorder under Swoole, or the parent-published file under
+     * the forking PCNTL runner.
+     */
+    private function makeMetricsSnapshotProvider(Container $container): MetricsSnapshotProvider
+    {
+        $options = $container->get(ServerListenerOptionsInterface::class);
+
+        if ($options->getRunner() !== RunnerMode::Swoole) {
+            return new FileSnapshotProvider($options->getMonitorSnapshotPath());
+        }
+
+        return $container->get(InMemoryMetricsRecorder::class);
+    }
+}

--- a/src/FreeDSx/Ldap/LdapProxyServer.php
+++ b/src/FreeDSx/Ldap/LdapProxyServer.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap;
+
+use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
+use FreeDSx\Socket\Exception\ConnectionException;
+
+/**
+ * An LDAP server that forwards client requests to an upstream server.
+ *
+ * @api
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class LdapProxyServer
+{
+    private readonly Container $container;
+
+    public function __construct(
+        private readonly ProxyOptions $options,
+        ?Container $container = null,
+    ) {
+        $this->container = $container ?? Container::forProxy($this->options);
+    }
+
+    /**
+     * Runs the proxy server. Binds the socket and starts accepting client connections.
+     *
+     * @throws ConnectionException
+     */
+    public function run(): void
+    {
+        $this->container->get(ServerRunnerInterface::class)->run();
+    }
+
+    public function getOptions(): ProxyOptions
+    {
+        return $this->options;
+    }
+}

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -97,7 +97,7 @@ class LdapServer
      *
      * @param Dn $creatorDn DN recorded as creatorsName/modifiersName on imported entries; defaults to the anonymous (empty) DN.
      * @throws LdifParseException when the LDIF cannot be parsed
-     * @throws RuntimeException on a proxy server, which serves no local directory
+     * @throws RuntimeException when the LDIF contains a non-add change record
      * @throws InvalidArgumentException when the creator DN is malformed or an entry's parent is missing
      * @throws OperationException when an entry violates the schema and validation mode is strict
      */
@@ -105,7 +105,7 @@ class LdapServer
         LdifLoaderInterface $loader,
         Dn $creatorDn = new Dn(''),
     ): self {
-        $backend = $this->requireLocalBackend('seed()');
+        $backend = $this->backend();
 
         (new LdapImporter(
             $backend->getStorage(),
@@ -123,12 +123,11 @@ class LdapServer
      * Use {@see seed()} instead for bulk initial provisioning of content records straight to storage.
      *
      * @throws LdifParseException when the LDIF cannot be parsed
-     * @throws RuntimeException on a proxy server, which serves no local directory
      * @throws OperationException when a write fails (no such entry, schema violation, etc.)
      */
     public function applyChanges(LdifLoaderInterface $loader): self
     {
-        $backend = $this->requireLocalBackend('applyChanges()');
+        $backend = $this->backend();
 
         (new WriteRequestReplayer($backend))
             ->apply((new LdifParser())->parse($loader));
@@ -141,14 +140,12 @@ class LdapServer
      *
      * Symmetric with {@see seed()}: the produced LDIF re-seeds the directory verbatim, including operational
      * attributes.
-     *
-     * @throws RuntimeException on a proxy server, which serves no local directory
      */
     public function dump(
         LdifOutputInterface $output,
         DumpOptions $options = new DumpOptions(),
     ): self {
-        $backend = $this->requireLocalBackend('dump()');
+        $backend = $this->backend();
 
         $output->write((new DirectoryDumper(
             $backend,
@@ -157,25 +154,6 @@ class LdapServer
         ))->dump($options));
 
         return $this;
-    }
-
-    /**
-     * Convenience method for generating an LDAP server instance that forwards client requests to an upstream server.
-     *
-     * @param ProxyOptions $proxyOptions The upstream connection (set servers/TLS on its ClientOptions).
-     * @param ServerOptions $serverOptions Server options for the proxy's own listener (ip/port/transport, downstream TLS).
-     */
-    public static function makeProxy(
-        ProxyOptions $proxyOptions,
-        ServerOptions $serverOptions = new ServerOptions(),
-    ): LdapServer {
-        return new LdapServer(
-            $serverOptions,
-            Container::forProxy(
-                $serverOptions,
-                $proxyOptions,
-            ),
-        );
     }
 
     private function init(): void
@@ -208,27 +186,11 @@ class LdapServer
     }
 
     /**
-     * The assembled storage backend from the container, or null on the proxy path which serves no local directory.
+     * The assembled storage backend from the container.
      */
-    private function backend(): ?WritableStorageBackend
+    private function backend(): WritableStorageBackend
     {
-        return $this->container->has(ProxyOptions::class)
-            ? null
-            : $this->container->get(WritableStorageBackend::class);
-    }
-
-    /**
-     * The local directory backend for seed/applyChanges/dump; a proxy server has none.
-     *
-     * @throws RuntimeException on a proxy server
-     */
-    private function requireLocalBackend(string $operation): WritableStorageBackend
-    {
-        return $this->backend()
-            ?? throw new RuntimeException(sprintf(
-                '%s is not available on a proxy server, which serves no local directory.',
-                $operation,
-            ));
+        return $this->container->get(WritableStorageBackend::class);
     }
 
     private function resolveAccessControl(): AccessControlInterface
@@ -242,10 +204,8 @@ class LdapServer
 
     private function injectBackendIfNeeded(AccessControlInterface $acl): AccessControlInterface
     {
-        $backend = $this->backend();
-
-        if ($backend !== null && $acl instanceof BackendAwareInterface) {
-            $acl->setBackend($backend);
+        if ($acl instanceof BackendAwareInterface) {
+            $acl->setBackend($this->backend());
         }
 
         return $acl;

--- a/src/FreeDSx/Ldap/ProxyOptions.php
+++ b/src/FreeDSx/Ldap/ProxyOptions.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap;
 
 /**
- * Options for a forwarding proxy server.
+ * The complete configuration for a forwarding proxy server: its own listener config plus the upstream connection.
  *
  * @api
  *
@@ -23,9 +23,18 @@ namespace FreeDSx\Ldap;
 final class ProxyOptions
 {
     public function __construct(
+        private ProxyServerOptions $serverOptions,
         private ClientOptions $clientOptions = new ClientOptions(),
         private bool $useStartTls = false,
     ) {}
+
+    /**
+     * The proxy's own server config (listener, TLS, auth-gating).
+     */
+    public function getServerOptions(): ProxyServerOptions
+    {
+        return $this->serverOptions;
+    }
 
     /**
      * The client options used for the upstream connection (servers, TLS, timeouts).

--- a/src/FreeDSx/Ldap/ProxyServerOptions.php
+++ b/src/FreeDSx/Ldap/ProxyServerOptions.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap;
+
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
+
+/**
+ * The forwarding proxy's own server config (its listener, TLS, auth-gating, logging, runner), separate from the upstream
+ * connection held on ProxyOptions.
+ *
+ * @api
+ */
+final class ProxyServerOptions implements ServerListenerOptionsInterface
+{
+    use ServerListenerOptionsTrait;
+
+    public function __construct(?NetworkConfig $network = null)
+    {
+        $this->network = $network ?? new NetworkConfig();
+    }
+
+    /**
+     * A proxy performs simple and anonymous binds only; SASL is never advertised.
+     *
+     * @return string[]
+     */
+    public function getSaslMechanisms(): array
+    {
+        return [];
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyProtocolFactory.php
@@ -41,10 +41,13 @@ final class ProxyProtocolFactory implements ServerProtocolFactoryInterface
 {
     use ServerConnectionScaffoldingTrait;
 
+    private readonly ServerListenerOptionsInterface $options;
+
     public function __construct(
-        private readonly ServerListenerOptionsInterface $options,
         private readonly ProxyOptions $proxyOptions,
-    ) {}
+    ) {
+        $this->options = $proxyOptions->getServerOptions();
+    }
 
     public function make(
         Socket $socket,

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -16,7 +16,7 @@ namespace FreeDSx\Ldap\Server\ServerRunner;
 use FreeDSx\Asn1\Exception\EncoderException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\ResettableInterface;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Metrics\File\SnapshotPublisher;
 use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
@@ -92,7 +92,7 @@ class PcntlServerRunner implements ServerRunnerInterface
         private readonly MetricsRecorderInterface $metricsRecorder = new NullMetricsRecorder(),
         private readonly ?SnapshotPublisher $snapshotPublisher = null,
         private readonly ?OperationRollupCoordinator $operationRollup = null,
-        private readonly ?WritableStorageBackend $backend = null,
+        private readonly ?ResettableInterface $resettable = null,
         BackgroundTasksInterface $backgroundTasks = new PcntlBackgroundTasks(
             periodicTasks: [],
             longLivedTasks: [],
@@ -489,7 +489,7 @@ class PcntlServerRunner implements ServerRunnerInterface
         $context = ['pid' => $pid];
         $this->isMainProcess = false;
 
-        $this->backend?->reset();
+        $this->resettable?->reset();
 
         $serverProtocolHandler = $this->serverProtocolFactory->make(
             $socket,
@@ -524,7 +524,7 @@ class PcntlServerRunner implements ServerRunnerInterface
 
     /**
      * Prepare a freshly forked background-task child: drop the inherited server socket, channels and signal
-     * handlers, then reset the backend for a fresh connection.
+     * handlers, then reset inherited per-connection state.
      */
     private function enterChild(): void
     {
@@ -544,7 +544,7 @@ class PcntlServerRunner implements ServerRunnerInterface
             SIG_IGN,
         );
 
-        $this->backend?->reset();
+        $this->resettable?->reset();
     }
 
     /**

--- a/tests/bin/ldap-proxy.php
+++ b/tests/bin/ldap-proxy.php
@@ -3,10 +3,10 @@
 declare(strict_types=1);
 
 use FreeDSx\Ldap\ClientOptions;
-use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\LdapProxyServer;
 use FreeDSx\Ldap\ProxyOptions;
+use FreeDSx\Ldap\ProxyServerOptions;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
-use FreeDSx\Ldap\ServerOptions;
 use Symfony\Component\Process\Process;
 
 require __DIR__ . '/../../vendor/autoload.php';
@@ -34,21 +34,19 @@ while ($upstream->isRunning()) {
 
 register_shutdown_function(static fn() => $upstream->stop());
 
-$server = LdapServer::makeProxy(
-    new ProxyOptions(
-        (new ClientOptions())
-            ->setServers(['127.0.0.1'])
-            ->setPort(10390)
-            ->setUseSsl(true)
-            ->setSslValidateCert(false)
-            ->setSslAllowSelfSigned(true),
-    ),
-    (new ServerOptions(network: (new NetworkConfig())
+$server = new LdapProxyServer(new ProxyOptions(
+    serverOptions: (new ProxyServerOptions((new NetworkConfig())
         ->setPort(10389)
         ->setSslCert(__DIR__ . '/../resources/cert/slapd.crt')
         ->setSslCertKey(__DIR__ . '/../resources/cert/slapd.key')
         ->setSocketAcceptTimeout(0.1)))
         ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL)),
-);
+    clientOptions: (new ClientOptions())
+        ->setServers(['127.0.0.1'])
+        ->setPort(10390)
+        ->setUseSsl(true)
+        ->setSslValidateCert(false)
+        ->setSslAllowSelfSigned(true),
+));
 
 $server->run();

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -53,7 +53,11 @@ use FreeDSx\Ldap\Server\PasswordPolicy\Guard\BindStrategy\PasswordPolicyBindStra
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\InMemoryReplicaPasswordStateStore;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
 use FreeDSx\Ldap\Server\SearchLimit\SearchLimitResolver;
+use FreeDSx\Ldap\ProxyOptions;
+use FreeDSx\Ldap\ProxyServerOptions;
+use FreeDSx\Ldap\Server\Proxy\ProxyProtocolFactory;
 use FreeDSx\Ldap\Server\ServerProtocolFactory;
+use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
 use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Ldap\ServerOptions;
@@ -141,6 +145,16 @@ class ContainerTest extends TestCase
         self::assertInstanceOf(
             InMemoryReplicaPasswordStateStore::class,
             $this->subject->get(ReplicaPasswordStateStoreInterface::class),
+        );
+    }
+
+    public function test_a_proxy_container_uses_the_proxy_protocol_factory(): void
+    {
+        $container = Container::forProxy(new ProxyOptions(new ProxyServerOptions()));
+
+        self::assertInstanceOf(
+            ProxyProtocolFactory::class,
+            $container->get(ServerProtocolFactoryInterface::class),
         );
     }
 

--- a/tests/unit/LdapProxyServerTest.php
+++ b/tests/unit/LdapProxyServerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap;
+
+use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\Container;
+use FreeDSx\Ldap\LdapProxyServer;
+use FreeDSx\Ldap\ProxyOptions;
+use FreeDSx\Ldap\ProxyServerOptions;
+use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class LdapProxyServerTest extends TestCase
+{
+    private ProxyOptions $options;
+
+    private ServerRunnerInterface&MockObject $mockServerRunner;
+
+    private LdapProxyServer $subject;
+
+    protected function setUp(): void
+    {
+        $this->options = new ProxyOptions(
+            new ProxyServerOptions(),
+            new ClientOptions(['localhost']),
+        );
+        $this->mockServerRunner = $this->createMock(ServerRunnerInterface::class);
+        $this->subject = new LdapProxyServer(
+            $this->options,
+            Container::forProxy(
+                $this->options,
+                [ServerRunnerInterface::class => $this->mockServerRunner],
+            ),
+        );
+    }
+
+    public function test_it_exposes_its_options(): void
+    {
+        self::assertSame(
+            $this->options,
+            $this->subject->getOptions(),
+        );
+    }
+
+    public function test_it_runs_the_server_via_the_container_runner(): void
+    {
+        $this->mockServerRunner
+            ->expects(self::once())
+            ->method('run');
+
+        $this->subject->run();
+    }
+}

--- a/tests/unit/LdapServerTest.php
+++ b/tests/unit/LdapServerTest.php
@@ -26,7 +26,6 @@ use FreeDSx\Ldap\Server\Backend\Storage\Export\DumpOptions;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\ReplicaConfig;
-use FreeDSx\Ldap\ProxyOptions;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
 use FreeDSx\Ldap\ServerOptions;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -100,20 +99,6 @@ class LdapServerTest extends TestCase
         $this->expectNotToPerformAssertions();
     }
 
-    public function test_it_should_make_a_proxy_server(): void
-    {
-        $serverOptions = new ServerOptions();
-        $server = LdapServer::makeProxy(
-            new ProxyOptions(new ClientOptions(['localhost'])),
-            $serverOptions,
-        );
-
-        self::assertSame(
-            $serverOptions,
-            $server->getOptions(),
-        );
-    }
-
     public function test_it_should_seed_entries_into_the_configured_storage(): void
     {
         $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
@@ -161,16 +146,6 @@ class LdapServerTest extends TestCase
         );
     }
 
-    public function test_it_should_throw_when_seeding_on_a_proxy_server(): void
-    {
-        $proxy = LdapServer::makeProxy(new ProxyOptions(new ClientOptions(['localhost'])));
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('not available on a proxy server');
-
-        $proxy->seed(new StringLdifLoader(self::SEED_LDIF));
-    }
-
     public function test_it_should_reject_seeding_when_the_ldif_contains_change_records(): void
     {
         $this->expectException(RuntimeException::class);
@@ -202,26 +177,6 @@ class LdapServerTest extends TestCase
         ));
 
         self::assertNull($this->storage()->find(new Dn('cn=foo,dc=example,dc=com')));
-    }
-
-    public function test_it_should_throw_when_applying_changes_on_a_proxy_server(): void
-    {
-        $proxy = LdapServer::makeProxy(new ProxyOptions(new ClientOptions(['localhost'])));
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('not available on a proxy server');
-
-        $proxy->applyChanges(new StringLdifLoader("dn: cn=x,dc=x\nchangetype: delete\n"));
-    }
-
-    public function test_it_should_throw_when_dumping_on_a_proxy_server(): void
-    {
-        $proxy = LdapServer::makeProxy(new ProxyOptions(new ClientOptions(['localhost'])));
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('not available on a proxy server');
-
-        $proxy->dump(new StringLdifOutput());
     }
 
     public function test_it_should_dump_seeded_entries_to_the_given_output(): void

--- a/tests/unit/ProxyOptionsTest.php
+++ b/tests/unit/ProxyOptionsTest.php
@@ -6,29 +6,40 @@ namespace Tests\Unit\FreeDSx\Ldap;
 
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\ProxyOptions;
+use FreeDSx\Ldap\ProxyServerOptions;
 use PHPUnit\Framework\TestCase;
 
 final class ProxyOptionsTest extends TestCase
 {
+    public function test_it_exposes_the_server_options(): void
+    {
+        $serverOptions = new ProxyServerOptions();
+
+        self::assertSame(
+            $serverOptions,
+            (new ProxyOptions($serverOptions))->getServerOptions(),
+        );
+    }
+
     public function test_it_exposes_the_client_options(): void
     {
         $clientOptions = new ClientOptions(['127.0.0.1']);
 
         self::assertSame(
             $clientOptions,
-            (new ProxyOptions($clientOptions))->getClientOptions(),
+            (new ProxyOptions(new ProxyServerOptions(), $clientOptions))->getClientOptions(),
         );
     }
 
     public function test_it_does_not_use_start_tls_by_default(): void
     {
-        self::assertFalse((new ProxyOptions())->getUseStartTls());
+        self::assertFalse((new ProxyOptions(new ProxyServerOptions()))->getUseStartTls());
     }
 
     public function test_it_can_enable_upstream_start_tls(): void
     {
         self::assertTrue(
-            (new ProxyOptions())->setUseStartTls(true)->getUseStartTls(),
+            (new ProxyOptions(new ProxyServerOptions()))->setUseStartTls(true)->getUseStartTls(),
         );
     }
 }


### PR DESCRIPTION
This removes the proxy server from the LDAP server class and removes the various backend checking happening in the server and the container for it. Updating all the docs for the network config split / proxy options.