### PR TITLE
[1.0.0] Optimize PDO subentry deletes and trigram reindexing.

### DIFF
--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
@@ -126,6 +126,19 @@ trait PdoDialectTrait
         SQL;
     }
 
+    public function queryDeleteIn(int $count): string
+    {
+        $markers = implode(
+            ', ',
+            array_fill(0, $count, '?'),
+        );
+
+        return <<<SQL
+            DELETE FROM entries
+            WHERE lc_dn IN ($markers)
+        SQL;
+    }
+
     public function querySidecarDelete(): string
     {
         return <<<SQL

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
@@ -147,6 +147,20 @@ trait PdoDialectTrait
         SQL;
     }
 
+    public function querySidecarDeleteNames(int $count): string
+    {
+        $markers = implode(
+            ', ',
+            array_fill(0, $count, '?'),
+        );
+
+        return <<<SQL
+            DELETE FROM entry_attribute_values
+            WHERE entry_lc_dn = ?
+              AND attr_name_lower IN ($markers)
+        SQL;
+    }
+
     public function querySidecarInsertPrefix(): string
     {
         return 'INSERT INTO entry_attribute_values (entry_lc_dn, attr_name_lower, value_lower, value_original) VALUES ';

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoEntryDialectInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoEntryDialectInterface.php
@@ -104,6 +104,11 @@ interface PdoEntryDialectInterface
     public function querySidecarDelete(): string;
 
     /**
+     * The same restricted to $count attribute names. Parameters: [entry_lc_dn, attr_name_lower, ...]
+     */
+    public function querySidecarDeleteNames(int $count): string;
+
+    /**
      * INSERT prefix for the sidecar; caller appends `(?, ?, ?, ?)` tuples for (entry_lc_dn, attr_name_lower, value_lower, value_original).
      */
     public function querySidecarInsertPrefix(): string;

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoEntryDialectInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoEntryDialectInterface.php
@@ -94,6 +94,11 @@ interface PdoEntryDialectInterface
     public function queryDelete(): string;
 
     /**
+     * `DELETE FROM entries WHERE lc_dn IN (?, ...)` with $count markers. Parameters: [lc_dn, ...]
+     */
+    public function queryDeleteIn(int $count): string;
+
+    /**
      * `DELETE FROM entry_attribute_values WHERE entry_lc_dn = ?`. Parameters: [entry_lc_dn]
      */
     public function querySidecarDelete(): string;

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
@@ -86,6 +86,13 @@ final class InMemoryStorage implements EntryStorageInterface, ChangeJournalingIn
         unset($this->entries[$dn->normalize()->toString()]);
     }
 
+    public function removeAll(array $dns): void
+    {
+        foreach ($dns as $dn) {
+            $this->remove($dn);
+        }
+    }
+
     public function atomic(callable $operation): void
     {
         $operation($this);

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
@@ -76,8 +76,10 @@ final class InMemoryStorage implements EntryStorageInterface, ChangeJournalingIn
         );
     }
 
-    public function store(Entry $entry): void
-    {
+    public function store(
+        Entry $entry,
+        bool $rebuildIndexes = false,
+    ): void {
         $this->entries[$entry->getDn()->normalize()->toString()] = $entry;
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonFileStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonFileStorage.php
@@ -108,8 +108,10 @@ final class JsonFileStorage implements EntryStorageInterface, ChangeJournalingIn
         );
     }
 
-    public function store(Entry $entry): void
-    {
+    public function store(
+        Entry $entry,
+        bool $rebuildIndexes = false,
+    ): void {
         $this->withMutation(function (string $contents) use ($entry): string {
             $data = $this->decodeContents($contents);
             $data[$entry->getDn()->normalize()->toString()] = $this->entryToArray($entry);

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonFileStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonFileStorage.php
@@ -128,6 +128,16 @@ final class JsonFileStorage implements EntryStorageInterface, ChangeJournalingIn
         });
     }
 
+    /**
+     * One mutation for the whole set, rather than rewriting the file once per DN.
+     */
+    public function removeAll(array $dns): void
+    {
+        $this->atomic(static function (EntryStorageInterface $storage) use ($dns): void {
+            $storage->removeAll($dns);
+        });
+    }
+
     public function atomic(callable $operation): void
     {
         $buffer = $this->newBuffer([]);

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/EntryIndexWriter.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/EntryIndexWriter.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo;
+
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Schema\Text;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoEntryDialectInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Statement\PdoStatementPool;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterUtility;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SubstringIndex\SubstringIndexInterface;
+
+/**
+ * Keeps an entry's secondary indexes, the attribute-value sidecar and any substring index, in step with its row.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class EntryIndexWriter
+{
+    public function __construct(
+        private PdoEntryDialectInterface $dialect,
+        private PdoStatementPool $statements,
+        private ?SubstringIndexInterface $substringIndex = null,
+    ) {}
+
+    /**
+     * Replace every index row for the entry, for a new entry or an explicit rebuild.
+     */
+    public function rewrite(
+        string $lcDn,
+        Entry $entry,
+    ): void {
+        $this->statements->execute(
+            $this->dialect->querySidecarDelete(),
+            [$lcDn],
+        );
+        $this->insertRows($lcDn, $entry);
+        $this->maintainSubstringIndex($lcDn, $entry);
+    }
+
+    /**
+     * Touch only the index rows of attributes whose values differ from those of the currently stored entry.
+     */
+    public function update(
+        string $lcDn,
+        Entry $entry,
+        Entry $current,
+    ): void {
+        $changed = $this->changedNames($entry, $current);
+        if ($changed === []) {
+            return;
+        }
+
+        $this->statements->execute(
+            $this->dialect->querySidecarDeleteNames(count($changed)),
+            [$lcDn, ...$changed],
+        );
+        $this->insertRows(
+            $lcDn,
+            $entry,
+            array_fill_keys($changed, true),
+        );
+
+        // A substring index keys off its own attribute set, so it only needs redoing when one of those changed.
+        if (!$this->indexCovers($changed)) {
+            return;
+        }
+
+        $this->maintainSubstringIndex($lcDn, $entry);
+    }
+
+    /**
+     * Lowercased names whose value set differs between the two entries, in either direction.
+     *
+     * @return list<string>
+     */
+    private function changedNames(
+        Entry $entry,
+        Entry $current,
+    ): array {
+        $next = $this->valuesByName($entry);
+        $previous = $this->valuesByName($current);
+
+        $changed = [];
+        foreach ($next as $name => $values) {
+            if (($previous[$name] ?? null) !== $values) {
+                $changed[] = $name;
+            }
+        }
+
+        foreach ($previous as $name => $values) {
+            if (!isset($next[$name])) {
+                $changed[] = $name;
+            }
+        }
+
+        return $changed;
+    }
+
+    /**
+     * Attribute values keyed by lowercased name and sorted, so ordering alone never reads as a change.
+     *
+     * @return array<string, list<string>>
+     */
+    private function valuesByName(Entry $entry): array
+    {
+        $byName = [];
+
+        foreach ($entry->getAttributes() as $attribute) {
+            $values = array_values($attribute->getValues());
+            sort($values);
+            $byName[strtolower($attribute->getName())] = $values;
+        }
+
+        return $byName;
+    }
+
+    /**
+     * @param list<string> $changed
+     */
+    private function indexCovers(array $changed): bool
+    {
+        if ($this->substringIndex === null) {
+            return false;
+        }
+
+        foreach ($changed as $name) {
+            if ($this->substringIndex->indexes($name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function maintainSubstringIndex(
+        string $lcDn,
+        Entry $entry,
+    ): void {
+        $this->substringIndex?->maintain(
+            $lcDn,
+            $entry,
+            function (string $sql, array $params): void {
+                $this->statements->execute(
+                    $sql,
+                    $params,
+                );
+            },
+        );
+    }
+
+    /**
+     * @param array<string, true>|null $only Lowercased attribute names to write, or null for every attribute.
+     */
+    private function insertRows(
+        string $lcDn,
+        Entry $entry,
+        ?array $only = null,
+    ): void {
+        $rows = $this->buildRows($lcDn, $entry, $only);
+        if ($rows === []) {
+            return;
+        }
+
+        $placeholders = implode(
+            ', ',
+            array_fill(0, count($rows), '(?, ?, ?, ?)'),
+        );
+        $params = [];
+        foreach ($rows as $row) {
+            $params[] = $row[0];
+            $params[] = $row[1];
+            $params[] = $row[2];
+            $params[] = $row[3];
+        }
+
+        $this->statements->execute(
+            $this->dialect->querySidecarInsertPrefix() . $placeholders,
+            $params,
+        );
+    }
+
+    /**
+     * @param array<string, true>|null $only
+     *
+     * @return list<array{string, string, string, string}> (entry_lc_dn, attr_name_lower, value_lower, value_original)
+     */
+    private function buildRows(
+        string $lcDn,
+        Entry $entry,
+        ?array $only,
+    ): array {
+        $rows = [];
+
+        foreach ($entry->getAttributes() as $attribute) {
+            $attrNameLower = strtolower($attribute->getName());
+            if ($only !== null && !isset($only[$attrNameLower])) {
+                continue;
+            }
+
+            foreach ($attribute->getValues() as $value) {
+                $rows[] = [
+                    $lcDn,
+                    $attrNameLower,
+                    $this->valueLower($value),
+                    $value,
+                ];
+            }
+        }
+
+        return $rows;
+    }
+
+    private function valueLower(string $value): string
+    {
+        if (!Text::isUtf8($value)) {
+            return '';
+        }
+
+        return mb_substr(
+            mb_strtolower($value, 'UTF-8'),
+            0,
+            SqlFilterUtility::MAX_INDEXED_VALUE_CHARS,
+            'UTF-8',
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoStorageFactory.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoStorageFactory.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\CoroutinePdoConnectionProvider;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\PdoConnectionProviderInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\SharedPdoConnectionProvider;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Statement\PdoStatementPool;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\PdoStorage;
 use PDO;
 
@@ -56,11 +57,19 @@ final class PdoStorageFactory
         PdoConfig $config,
         PdoConnectionProviderInterface $provider,
     ): PdoStorage {
+        // Storage and its index writer share one statement pool, so both draw from the same connection and cache.
+        $statements = new PdoStatementPool($provider);
+
         return new PdoStorage(
             $provider,
             $config->getDialect()->createFilterTranslator($config->getSubstringIndex()),
             $config->getDialect(),
-            $config->getSubstringIndex(),
+            $statements,
+            new EntryIndexWriter(
+                $config->getDialect(),
+                $statements,
+                $config->getSubstringIndex(),
+            ),
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -69,6 +69,11 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
      */
     private const COMPOSED_DRIVER_PROBE_LIMIT = 128;
 
+    /**
+     * DNs per batched delete, well inside the placeholder limits of every supported driver.
+     */
+    private const DELETE_BATCH_SIZE = 500;
+
     private readonly PdoListQueryBuilder $queryBuilder;
 
     private readonly PdoTransactor $transactor;
@@ -260,6 +265,22 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
             $this->dialect->queryDelete(),
             [$dn->normalize()->toString()],
         );
+    }
+
+    /**
+     * Chunked so the placeholder count stays inside driver limits and full chunks share one prepared statement.
+     */
+    public function removeAll(array $dns): void
+    {
+        foreach (array_chunk($dns, self::DELETE_BATCH_SIZE) as $chunk) {
+            $this->statements->execute(
+                $this->dialect->queryDeleteIn(count($chunk)),
+                array_map(
+                    static fn(Dn $dn): string => $dn->normalize()->toString(),
+                    $chunk,
+                ),
+            );
+        }
     }
 
     public function hasChildren(Dn $dn): bool

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -17,9 +17,9 @@ use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\RuntimeException;
-use FreeDSx\Ldap\Schema\Text;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\PdoConnectionProviderInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\EntryIndexWriter;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query\PdoListQueryBuilder;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\PdoTransactor;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Statement\PdoStatementPool;
@@ -35,7 +35,6 @@ use FreeDSx\Ldap\Server\Backend\Storage\Journal\PdoChangeJournal;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\DnTooLongException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\FilterTranslatorInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterUtility;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SubstringIndex\SubstringIndexInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock\RowLockableInterface;
@@ -80,15 +79,18 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
 
     private readonly PdoStatementPool $statements;
 
+    private readonly EntryIndexWriter $indexes;
+
     /**
      * @param ?PdoStatementPool $statements Must draw from $provider; defaults to a pool of its own over that connection.
+     * @param ?EntryIndexWriter $indexes Must share $statements; defaults to one with no substring index attached.
      */
     public function __construct(
         private readonly PdoConnectionProviderInterface $provider,
         private readonly FilterTranslatorInterface $translator,
         private readonly PdoDialectInterface $dialect,
-        private readonly ?SubstringIndexInterface $substringIndex = null,
         ?PdoStatementPool $statements = null,
+        ?EntryIndexWriter $indexes = null,
     ) {
         if (!extension_loaded('mbstring')) {
             throw new RuntimeException(
@@ -102,6 +104,10 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
             $dialect,
         );
         $this->statements = $statements ?? new PdoStatementPool($provider);
+        $this->indexes = $indexes ?? new EntryIndexWriter(
+            $dialect,
+            $this->statements,
+        );
     }
 
     public function reset(): void
@@ -219,8 +225,10 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
         );
     }
 
-    public function store(Entry $entry): void
-    {
+    public function store(
+        Entry $entry,
+        bool $rebuildIndexes = false,
+    ): void {
         $normDn = $entry->getDn()->normalize();
         $dnString = $entry->getDn()->toString();
 
@@ -228,7 +236,13 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
 
         $lcDn = $normDn->toString();
 
-        $this->atomic(function () use ($entry, $lcDn, $dnString, $normDn): void {
+        $this->atomic(function () use ($entry, $lcDn, $dnString, $normDn, $rebuildIndexes): void {
+            // Read the row we are about to overwrite under its write lock, so the diff is against what is actually
+            // stored; a second writer then repairs whatever the first left behind instead of drifting from it.
+            $current = $rebuildIndexes
+                ? null
+                : $this->currentForDiff($normDn);
+
             $this->statements->execute($this->dialect->queryUpsert(), [
                 $lcDn,
                 $dnString,
@@ -236,25 +250,16 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
                 $this->encodeAttributes($entry),
             ]);
 
-            $this->statements->execute(
-                $this->dialect->querySidecarDelete(),
-                [$lcDn],
-            );
+            if ($current === null) {
+                $this->indexes->rewrite($lcDn, $entry);
 
-            $this->insertSidecarRows(
+                return;
+            }
+
+            $this->indexes->update(
                 $lcDn,
                 $entry,
-            );
-
-            $this->substringIndex?->maintain(
-                $lcDn,
-                $entry,
-                function (string $sql, array $params): void {
-                    $this->statements->execute(
-                        $sql,
-                        $params,
-                    );
-                },
+                $current,
             );
         });
     }
@@ -439,71 +444,18 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
         }
     }
 
-    private function insertSidecarRows(
-        string $lcDn,
-        Entry $entry,
-    ): void {
-        $rows = $this->buildSidecarRows($lcDn, $entry);
-        if ($rows === []) {
-            return;
-        }
-
-        $tuple = '(?, ?, ?, ?)';
-        $placeholders = implode(
-            ', ',
-            array_fill(0, count($rows), $tuple),
-        );
-        $params = [];
-        foreach ($rows as $row) {
-            $params[] = $row[0];
-            $params[] = $row[1];
-            $params[] = $row[2];
-            $params[] = $row[3];
-        }
-
-        $this->statements->execute(
-            $this->dialect->querySidecarInsertPrefix() . $placeholders,
-            $params,
-        );
-    }
-
     /**
-     * @return list<array{string, string, string, string}> (entry_lc_dn, attr_name_lower, value_lower, value_original)
+     * The stored entry, locked for the rest of this transaction, or null when there is nothing to diff against.
      */
-    private function buildSidecarRows(
-        string $lcDn,
-        Entry $entry,
-    ): array {
-        $rows = [];
-
-        foreach ($entry->getAttributes() as $attribute) {
-            $attrNameLower = strtolower($attribute->getName());
-
-            foreach ($attribute->getValues() as $value) {
-                $rows[] = [
-                    $lcDn,
-                    $attrNameLower,
-                    $this->buildSidecarValueLower($value),
-                    $value,
-                ];
-            }
-        }
-
-        return $rows;
-    }
-
-    private function buildSidecarValueLower(string $value): string
+    private function currentForDiff(Dn $normDn): ?Entry
     {
-        if (!Text::isUtf8($value)) {
-            return '';
-        }
-
-        return mb_substr(
-            mb_strtolower($value, 'UTF-8'),
-            0,
-            SqlFilterUtility::MAX_INDEXED_VALUE_CHARS,
-            'UTF-8',
+        $this->dialect->lockRowForWrite(
+            $this->transactor->pdo(),
+            'entries',
+            $normDn->toString(),
         );
+
+        return $this->find($normDn);
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SubstringIndex/Fts5SubstringIndex.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SubstringIndex/Fts5SubstringIndex.php
@@ -140,6 +140,11 @@ final class Fts5SubstringIndex implements SubstringIndexInterface
         ];
     }
 
+    public function indexes(string $attributeLower): bool
+    {
+        return isset($this->attributes[$attributeLower]);
+    }
+
     public function maintain(
         string $lcDn,
         Entry $entry,

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SubstringIndex/SubstringIndexInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SubstringIndex/SubstringIndexInterface.php
@@ -32,6 +32,11 @@ interface SubstringIndexInterface
     public function schemaStatements(PdoDialectInterface $dialect): array;
 
     /**
+     * Whether this strategy indexes the attribute, so a write can skip re-indexing when none of its own changed.
+     */
+    public function indexes(string $attributeLower): bool;
+
+    /**
      * Re-index one entry, running each write through the executor inside the caller's transaction.
      *
      * @param callable(string $sql, list<string> $params): void $execute

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SubstringIndex/SubstringIndexReindexer.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SubstringIndex/SubstringIndexReindexer.php
@@ -44,7 +44,10 @@ final readonly class SubstringIndexReindexer
                     continue;
                 }
 
-                $this->storage->store($entry);
+                $this->storage->store(
+                    $entry,
+                    rebuildIndexes: true,
+                );
             }
         });
     }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SubstringIndex/TrigramSubstringIndex.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SubstringIndex/TrigramSubstringIndex.php
@@ -84,6 +84,11 @@ final class TrigramSubstringIndex implements SubstringIndexInterface
         return $dialect->schemaStatementsNamed(self::SCHEMA_NAME);
     }
 
+    public function indexes(string $attributeLower): bool
+    {
+        return isset($this->attributes[$attributeLower]);
+    }
+
     public function maintain(
         string $lcDn,
         Entry $entry,

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/JsonEntryBuffer.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/JsonEntryBuffer.php
@@ -87,6 +87,13 @@ final class JsonEntryBuffer implements EntryStorageInterface, ChangeAppenderInte
         unset($this->data[$dn->toString()]);
     }
 
+    public function removeAll(array $dns): void
+    {
+        foreach ($dns as $dn) {
+            $this->remove($dn);
+        }
+    }
+
     public function atomic(callable $operation): void
     {
         $operation($this);

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/JsonEntryBuffer.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/JsonEntryBuffer.php
@@ -77,8 +77,10 @@ final class JsonEntryBuffer implements EntryStorageInterface, ChangeAppenderInte
         return new EntryStream($this->generateEntries($options));
     }
 
-    public function store(Entry $entry): void
-    {
+    public function store(
+        Entry $entry,
+        bool $rebuildIndexes = false,
+    ): void {
         $this->data[$entry->getDn()->normalize()->toString()] = ($this->fromEntry)($entry);
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/WriteSerializingStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/WriteSerializingStorage.php
@@ -60,26 +60,22 @@ final readonly class WriteSerializingStorage implements EntryStorageInterface, R
 
     public function store(Entry $entry): void
     {
-        $writes = $this->writes;
-        $this->queue->run(static function () use ($writes, $entry): void {
-            $writes->store($entry);
-        });
+        $this->queue->run(fn() => $this->writes->store($entry));
     }
 
     public function remove(Dn $dn): void
     {
-        $writes = $this->writes;
-        $this->queue->run(static function () use ($writes, $dn): void {
-            $writes->remove($dn);
-        });
+        $this->queue->run(fn() => $this->writes->remove($dn));
+    }
+
+    public function removeAll(array $dns): void
+    {
+        $this->queue->run(fn() => $this->writes->removeAll($dns));
     }
 
     public function atomic(callable $operation): void
     {
-        $writes = $this->writes;
-        $this->queue->run(static function () use ($writes, $operation): void {
-            $writes->atomic($operation);
-        });
+        $this->queue->run(fn() => $this->writes->atomic($operation));
     }
 
     public function namingContexts(): array

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/WriteSerializingStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/WriteSerializingStorage.php
@@ -58,9 +58,14 @@ final readonly class WriteSerializingStorage implements EntryStorageInterface, R
         return $this->reads->list($options);
     }
 
-    public function store(Entry $entry): void
-    {
-        $this->queue->run(fn() => $this->writes->store($entry));
+    public function store(
+        Entry $entry,
+        bool $rebuildIndexes = false,
+    ): void {
+        $this->queue->run(fn() => $this->writes->store(
+            $entry,
+            $rebuildIndexes,
+        ));
     }
 
     public function remove(Dn $dn): void

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStorageInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStorageInterface.php
@@ -57,6 +57,13 @@ interface EntryStorageInterface
     public function remove(Dn $dn): void;
 
     /**
+     * Remove every given entry, ignoring any that are already gone.
+     *
+     * @param list<Dn> $dns
+     */
+    public function removeAll(array $dns): void;
+
+    /**
      * Execute $operation as an atomic read-modify-write cycle; implementations must hold an exclusive lock or transaction.
      *
      * @param callable(EntryStorageInterface): void $operation

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStorageInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStorageInterface.php
@@ -49,7 +49,13 @@ interface EntryStorageInterface
     /**
      * Persist the entry keyed by its normalised DN, replacing any existing entry at the same DN.
      */
-    public function store(Entry $entry): void;
+    /**
+     * @param bool $rebuildIndexes Rewrite every secondary-index row rather than only those whose values changed.
+     */
+    public function store(
+        Entry $entry,
+        bool $rebuildIndexes = false,
+    ): void;
 
     /**
      * Remove the entry for the given normalised DN. A no-op if the entry does not exist.

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/LdapImporter.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/LdapImporter.php
@@ -68,7 +68,10 @@ final readonly class LdapImporter
                     $entry,
                     $this->creatorDn->toString(),
                 );
-                $storage->store($entry);
+                $storage->store(
+                    $entry,
+                    rebuildIndexes: true,
+                );
             }
         });
     }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
@@ -56,16 +56,21 @@ final class StorageListOptions
     /**
      * Match-all options for internal callers (e.g. hasChildren) and tests that do not need a meaningful filter.
      */
+    /**
+     * @param list<string>|null $attributes Lowercase base attribute names to materialize, or null for all.
+     */
     public static function matchAll(
         Dn $baseDn,
         bool $subtree,
         int $timeLimit = 0,
+        ?array $attributes = null,
     ): self {
         return new self(
             baseDn: $baseDn,
             subtree: $subtree,
             filter: new AndFilter(),
             timeLimit: $timeLimit,
+            attributes: $attributes,
         );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -370,19 +370,15 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
 
         foreach (array_chunk($dns, self::SUBTREE_DELETE_BATCH_SIZE) as $batch) {
             $this->writeAtomic(function (EntryStorageInterface $storage) use ($batch, $context): void {
-                foreach ($batch as $dn) {
-                    $entry = $this->changeRecorder !== null
-                        ? $storage->find($dn)
-                        : null;
-                    $storage->remove($dn);
+                $preImages = $this->preImagesFor($storage, $batch);
+                $storage->removeAll($batch);
 
-                    if ($entry !== null) {
-                        $this->changeRecorder->recordDelete(
-                            $storage,
-                            $entry,
-                            $context,
-                        );
-                    }
+                foreach ($preImages as $entry) {
+                    $this->changeRecorder?->recordDelete(
+                        $storage,
+                        $entry,
+                        $context,
+                    );
                 }
             });
         }
@@ -489,6 +485,32 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
                 $context,
             );
         });
+    }
+
+    /**
+     * Entries the journal needs a pre-image of, read before they are removed; none when nothing is journaling.
+     *
+     * @param list<Dn> $batch
+     *
+     * @return list<Entry>
+     */
+    private function preImagesFor(
+        EntryStorageInterface $storage,
+        array $batch,
+    ): array {
+        if ($this->changeRecorder === null) {
+            return [];
+        }
+
+        $entries = [];
+        foreach ($batch as $dn) {
+            $entry = $storage->find($dn);
+            if ($entry !== null) {
+                $entries[] = $entry;
+            }
+        }
+
+        return $entries;
     }
 
     /**
@@ -646,7 +668,13 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
     private function collectSubtreeDnsDeepestFirst(Dn $base): array
     {
         $dns = [];
-        foreach ($this->storage->list(StorageListOptions::matchAll($base, subtree: true))->entries as $entry) {
+        $options = StorageListOptions::matchAll(
+            $base,
+            subtree: true,
+            attributes: [],
+        );
+
+        foreach ($this->storage->list($options)->entries as $entry) {
             $dns[] = $entry->getDn()->normalize();
         }
         usort(

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -294,7 +294,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
                 $command->entry,
                 $context,
             );
-            $storage->store($command->entry);
+            $storage->store(
+                $command->entry,
+                rebuildIndexes: true,
+            );
             $this->changeRecorder?->recordAdd(
                 $storage,
                 $command->entry,
@@ -477,7 +480,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
                 $context,
             );
             $storage->remove($normOld);
-            $storage->store($newEntry);
+            $storage->store(
+                $newEntry,
+                rebuildIndexes: true,
+            );
             $this->changeRecorder?->recordModRdn(
                 $storage,
                 $newEntry,

--- a/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
@@ -184,6 +184,47 @@ final class PdoStorageTest extends TestCase
         );
     }
 
+    public function test_remove_all_deletes_every_given_entry_and_ignores_missing_ones(): void
+    {
+        foreach (range(1, 3) as $i) {
+            $this->storage->store(new Entry(
+                new Dn("cn=e{$i},dc=example,dc=com"),
+                new Attribute('cn', "e{$i}"),
+            ));
+        }
+
+        $this->storage->removeAll([
+            (new Dn('cn=e1,dc=example,dc=com'))->normalize(),
+            (new Dn('cn=gone,dc=example,dc=com'))->normalize(),
+            (new Dn('cn=e3,dc=example,dc=com'))->normalize(),
+        ]);
+
+        self::assertFalse($this->storage->exists(new Dn('cn=e1,dc=example,dc=com')));
+        self::assertTrue($this->storage->exists(new Dn('cn=e2,dc=example,dc=com')));
+        self::assertFalse($this->storage->exists(new Dn('cn=e3,dc=example,dc=com')));
+    }
+
+    public function test_remove_all_spans_more_entries_than_one_batch(): void
+    {
+        $dns = [];
+        $this->storage->atomic(function () use (&$dns): void {
+            foreach (range(1, 1200) as $i) {
+                $dn = new Dn("cn=b{$i},dc=example,dc=com");
+                $this->storage->store(new Entry(
+                    $dn,
+                    new Attribute('cn', "b{$i}"),
+                ));
+                $dns[] = $dn->normalize();
+            }
+        });
+
+        $this->storage->removeAll($dns);
+
+        self::assertFalse($this->storage->exists(new Dn('cn=b1,dc=example,dc=com')));
+        self::assertFalse($this->storage->exists(new Dn('cn=b600,dc=example,dc=com')));
+        self::assertFalse($this->storage->exists(new Dn('cn=b1200,dc=example,dc=com')));
+    }
+
     public function test_initialize_creates_the_baseline_schema(): void
     {
         $pdo = new PDO('sqlite::memory:');

--- a/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
@@ -31,7 +31,9 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqliteFilterTranslator
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SubstringIndex\TrigramSubstringIndex;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\SharedPdoConnectionProvider;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\FilterTranslatorInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\EntryIndexWriter;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Statement\PdoStatementPool;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactory;
 use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
@@ -225,6 +227,62 @@ final class PdoStorageTest extends TestCase
         self::assertFalse($this->storage->exists(new Dn('cn=b1200,dc=example,dc=com')));
     }
 
+    public function test_a_modified_value_stops_matching_its_old_value_and_starts_matching_the_new(): void
+    {
+        $dn = new Dn('cn=drift,dc=example,dc=com');
+        $this->storage->store(new Entry(
+            $dn,
+            new Attribute('cn', 'drift'),
+            new Attribute('sn', 'before'),
+            new Attribute('description', 'untouched'),
+        ));
+
+        $this->storage->store(new Entry(
+            $dn,
+            new Attribute('cn', 'drift'),
+            new Attribute('sn', 'after'),
+            new Attribute('description', 'untouched'),
+        ));
+
+        self::assertSame(
+            [],
+            $this->dnsMatching(Filters::equal('sn', 'before')),
+        );
+        self::assertSame(
+            ['cn=drift,dc=example,dc=com'],
+            $this->dnsMatching(Filters::equal('sn', 'after')),
+        );
+        // An attribute nobody touched must survive the partial rewrite.
+        self::assertSame(
+            ['cn=drift,dc=example,dc=com'],
+            $this->dnsMatching(Filters::equal('description', 'untouched')),
+        );
+    }
+
+    public function test_a_removed_attribute_stops_matching_after_a_modify(): void
+    {
+        $dn = new Dn('cn=shrink,dc=example,dc=com');
+        $this->storage->store(new Entry(
+            $dn,
+            new Attribute('cn', 'shrink'),
+            new Attribute('sn', 'gone'),
+        ));
+
+        $this->storage->store(new Entry(
+            $dn,
+            new Attribute('cn', 'shrink'),
+        ));
+
+        self::assertSame(
+            [],
+            $this->dnsMatching(Filters::equal('sn', 'gone')),
+        );
+        self::assertSame(
+            [],
+            $this->dnsMatching(Filters::present('sn')),
+        );
+    }
+
     public function test_initialize_creates_the_baseline_schema(): void
     {
         $pdo = new PDO('sqlite::memory:');
@@ -305,14 +363,21 @@ final class PdoStorageTest extends TestCase
             $index,
         );
 
+        $provider = new SharedPdoConnectionProvider(
+            $pdo,
+            fn(): PDO => $pdo,
+        );
+        $statements = new PdoStatementPool($provider);
         $storage = new PdoStorage(
-            new SharedPdoConnectionProvider(
-                $pdo,
-                fn(): PDO => $pdo,
-            ),
+            $provider,
             new SqliteFilterTranslator(),
             new SqliteDialect(),
-            $index,
+            $statements,
+            new EntryIndexWriter(
+                new SqliteDialect(),
+                $statements,
+                $index,
+            ),
         );
         $storage->store(new Entry(
             new Dn('cn=Smith,dc=example,dc=com'),
@@ -1340,6 +1405,25 @@ final class PdoStorageTest extends TestCase
         }
 
         return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function dnsMatching(FilterInterface $filter): array
+    {
+        $entries = $this->storage->list(new StorageListOptions(
+            baseDn: new Dn('dc=example,dc=com'),
+            subtree: true,
+            filter: $filter,
+        ))->entries;
+
+        $dns = [];
+        foreach ($entries as $entry) {
+            $dns[] = $entry->getDn()->toString();
+        }
+
+        return $dns;
     }
 
     /**

--- a/tests/unit/Server/Backend/Storage/Adapter/SubstringIndex/Fts5SubstringIndexTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/SubstringIndex/Fts5SubstringIndexTest.php
@@ -19,6 +19,8 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SqliteDialect;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\SharedPdoConnectionProvider;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\EntryIndexWriter;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Statement\PdoStatementPool;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\PdoStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SubstringIndex\Fts5SubstringIndex;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
@@ -88,14 +90,21 @@ final class Fts5SubstringIndexTest extends TestCase
             $index,
         );
 
+        $provider = new SharedPdoConnectionProvider(
+            $pdo,
+            fn(): PDO => $pdo,
+        );
+        $statements = new PdoStatementPool($provider);
         $storage = new PdoStorage(
-            new SharedPdoConnectionProvider(
-                $pdo,
-                fn(): PDO => $pdo,
-            ),
+            $provider,
             (new SqliteDialect())->createFilterTranslator($index),
             new SqliteDialect(),
-            $index,
+            $statements,
+            new EntryIndexWriter(
+                new SqliteDialect(),
+                $statements,
+                $index,
+            ),
         );
 
         $storage->store(new Entry(

--- a/tests/unit/Server/Backend/Storage/Adapter/SubstringIndex/SubstringIndexReindexerTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/SubstringIndex/SubstringIndexReindexerTest.php
@@ -18,6 +18,8 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SqliteDialect;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\SharedPdoConnectionProvider;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\EntryIndexWriter;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Statement\PdoStatementPool;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\PdoStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SubstringIndex\SubstringIndexReindexer;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SubstringIndex\TrigramSubstringIndex;
@@ -42,14 +44,21 @@ final class SubstringIndexReindexerTest extends TestCase
             $index,
         );
 
+        $provider = new SharedPdoConnectionProvider(
+            $this->pdo,
+            fn(): PDO => $this->pdo,
+        );
+        $statements = new PdoStatementPool($provider);
         $this->storage = new PdoStorage(
-            new SharedPdoConnectionProvider(
-                $this->pdo,
-                fn(): PDO => $this->pdo,
-            ),
+            $provider,
             (new SqliteDialect())->createFilterTranslator($index),
             new SqliteDialect(),
-            $index,
+            $statements,
+            new EntryIndexWriter(
+                new SqliteDialect(),
+                $statements,
+                $index,
+            ),
         );
 
         $this->dn = new Dn('cn=Smith,dc=example,dc=com');

--- a/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
@@ -1842,6 +1842,44 @@ final class WritableStorageBackendTest extends TestCase
         );
     }
 
+    public function test_delete_subtree_journals_every_entry_with_its_pre_image(): void
+    {
+        [$backend, $journal] = $this->journalingBackend();
+        foreach ([
+            new Entry(new Dn('ou=people,dc=example,dc=com'), new Attribute('ou', 'people')),
+            new Entry(new Dn('cn=alice,ou=people,dc=example,dc=com'), new Attribute('cn', 'alice')),
+            new Entry(new Dn('cn=bob,ou=people,dc=example,dc=com'), new Attribute('cn', 'bob')),
+        ] as $entry) {
+            $backend->add(
+                new AddCommand($entry),
+                $this->context(),
+            );
+        }
+
+        $backend->deleteSubtree(
+            new DeleteCommand(new Dn('ou=people,dc=example,dc=com')),
+            $this->context(),
+            static function (Dn $dn): void {},
+        );
+
+        $deletes = array_values(array_filter(
+            iterator_to_array($journal->read()),
+            static fn(ChangeRecord $record): bool => $record->change->changeType === ChangeType::Delete,
+        ));
+
+        self::assertSame(
+            [
+                'cn=alice,ou=people,dc=example,dc=com',
+                'cn=bob,ou=people,dc=example,dc=com',
+                'ou=people,dc=example,dc=com',
+            ],
+            $this->sortedDns($deletes),
+        );
+        foreach ($deletes as $record) {
+            self::assertNotNull($record->change->preImage);
+        }
+    }
+
     public function test_add_is_journaled_when_a_recorder_is_set(): void
     {
         [$backend, $journal] = $this->journalingBackend();
@@ -2065,5 +2103,21 @@ final class WritableStorageBackendTest extends TestCase
     private function makeGenerator(Entry ...$entries): Generator
     {
         yield from $entries;
+    }
+
+    /**
+     * @param list<ChangeRecord> $records
+     *
+     * @return list<string>
+     */
+    private function sortedDns(array $records): array
+    {
+        $dns = array_map(
+            static fn(ChangeRecord $record): string => $record->change->dn->toString(),
+            $records,
+        );
+        sort($dns);
+
+        return $dns;
     }
 }


### PR DESCRIPTION
Two different optimizations that have good measured performance gains:

1. Subtree deletion logic had quite a bit of waste going on. We now delete based on batched DN IN lookups via a `removeAll` method. Also optimized the list we do to get them all, as it only needs DNs and not attributes. The only thing left here is a race condition I realized which could leave changing entries during a deletion potentially orphaned if the timing is just right. Going to revisit this separately.
2. When an entry is modified / stored we reindex it's trigram values. For an add / move / reindex this is fine. But if an operation modifies 1 attribute, then that's very wasteful and expensive to do. So we now do a lookup and diff when re-index is not explicitly expected. For low attribute changes this has a pretty solid performance boost.