### PR TITLE
[1.0.0] Add a retry mechanism for failed PDO transactions.

### DIFF
--- a/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
@@ -142,6 +142,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
         return new PdoBackendBuilder(
             $config,
             $options->getRunner(),
+            $container->get(SleeperInterface::class),
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/MysqlDialect.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/MysqlDialect.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\FilterTranslatorInterf
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\MysqlFilterTranslator;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SubstringIndex\SubstringIndexInterface;
 use PDO;
+use PDOException;
 
 /**
  * MySQL/MariaDB SQL for PdoStorage; requires MySQL 8.0+ or MariaDB 10.6+.
@@ -29,9 +30,30 @@ final class MysqlDialect implements PdoDialectInterface
     use PdoJournalDialectTrait;
     use PdoSchemaTrait;
 
+    /**
+     * Deadlock found when trying to get lock. The transaction has already been rolled back.
+     */
+    private const ERROR_DEADLOCK = 1213;
+
+    /**
+     * Lock wait timeout exceeded.
+     */
+    private const ERROR_LOCK_WAIT_TIMEOUT = 1205;
+
     public function createFilterTranslator(?SubstringIndexInterface $substringIndex): FilterTranslatorInterface
     {
         return new MysqlFilterTranslator($substringIndex);
+    }
+
+    /**
+     * InnoDB resolves lock conflicts by failing one transaction, which is then safe to reissue unchanged.
+     */
+    public function isRetryableConflict(PDOException $exception): bool
+    {
+        $driverCode = $exception->errorInfo[1] ?? null;
+
+        return $driverCode === self::ERROR_DEADLOCK
+            || $driverCode === self::ERROR_LOCK_WAIT_TIMEOUT;
     }
 
     public function lockRowForWrite(

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoEntryDialectInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoEntryDialectInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
 
 use PDO;
+use PDOException;
 
 /**
  * Database-specific SQL for the entry + sidecar tables, transactions, and sort keys.
@@ -47,6 +48,14 @@ interface PdoEntryDialectInterface
      * Roll back the current transaction started by beginTransaction().
      */
     public function rollBack(PDO $pdo): void;
+
+    /**
+     * Whether the database guarantees the failed transaction applied nothing, so reissuing it cannot double-apply.
+     *
+     * Being transient is not sufficient: a lost connection may have dropped after the commit was sent, leaving the
+     * outcome unknown, so only failures with a defined rollback belong here.
+     */
+    public function isRetryableConflict(PDOException $exception): bool;
 
     /**
      * Existence check: `SELECT 1 FROM entries WHERE lc_dn = ? LIMIT 1`. Parameters: [lc_dn]

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SqliteDialect.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SqliteDialect.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\FilterTranslatorInterf
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqliteFilterTranslator;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SubstringIndex\SubstringIndexInterface;
 use PDO;
+use PDOException;
 
 /**
  * SQLite-specific SQL for PdoStorage.
@@ -29,9 +30,30 @@ final class SqliteDialect implements PdoDialectInterface
     use PdoJournalDialectTrait;
     use PdoSchemaTrait;
 
+    /**
+     * The database file is locked by another writer.
+     */
+    private const ERROR_BUSY = 5;
+
+    /**
+     * A table in the database is locked, which the busy handler is never invoked for.
+     */
+    private const ERROR_LOCKED = 6;
+
     public function createFilterTranslator(?SubstringIndexInterface $substringIndex): FilterTranslatorInterface
     {
         return new SqliteFilterTranslator($substringIndex);
+    }
+
+    /**
+     * `busy_timeout` absorbs most contention by waiting, but it still gives up once the timeout is exhausted.
+     */
+    public function isRetryableConflict(PDOException $exception): bool
+    {
+        $driverCode = $exception->errorInfo[1] ?? null;
+
+        return $driverCode === self::ERROR_BUSY
+            || $driverCode === self::ERROR_LOCKED;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/Connection/PdoTransactor.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/Connection/PdoTransactor.php
@@ -14,7 +14,11 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection;
 
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
+use FreeDSx\Ldap\Server\Utility\ExponentialBackoff;
 use PDO;
+use PDOException;
 use Throwable;
 
 /**
@@ -27,6 +31,12 @@ final readonly class PdoTransactor
     public function __construct(
         private PdoConnectionProviderInterface $provider,
         private PdoDialectInterface $dialect,
+        private SleeperInterface $sleeper = new BlockingSleeper(),
+        private int $maxRetries = 15,
+        private ExponentialBackoff $backoff = new ExponentialBackoff(
+            base: 0.001,
+            max: 0.05,
+        ),
     ) {}
 
     public function pdo(): PDO
@@ -51,9 +61,47 @@ final readonly class PdoTransactor
     }
 
     /**
+     * Runs the operation in a transaction, reissuing it when the database rejects it as a transient conflict.
+     *
      * @param callable(): void $operation
      */
     public function atomic(callable $operation): void
+    {
+        $attempt = 0;
+
+        while (true) {
+            try {
+                $this->runAtomic($operation);
+
+                return;
+            } catch (PDOException $e) {
+                $attempt++;
+
+                if (!$this->canRetry($e, $attempt)) {
+                    throw $e;
+                }
+
+                $this->sleeper->sleep($this->backoff->delayFor($attempt));
+            }
+        }
+    }
+
+    /**
+     * Only the outermost transaction can be reissued, since a savepoint cannot be replayed on its own.
+     */
+    private function canRetry(
+        PDOException $exception,
+        int $attempt,
+    ): bool {
+        return $attempt <= $this->maxRetries
+            && $this->provider->txState()->depth === 0
+            && $this->dialect->isRetryableConflict($exception);
+    }
+
+    /**
+     * @param callable(): void $operation
+     */
+    private function runAtomic(callable $operation): void
     {
         $pdo = $this->provider->get();
         $txState = $this->provider->txState();
@@ -81,12 +129,18 @@ final readonly class PdoTransactor
                 $pdo->exec("RELEASE SAVEPOINT {$this->savepointName($depth)}");
             }
         } catch (Throwable $e) {
-            if ($transactionStarted) {
-                $this->dialect->rollBack($pdo);
-            } elseif ($savepointCreated) {
-                $pdo->exec("ROLLBACK TO SAVEPOINT {$this->savepointName($depth)}");
-            } elseif ($depth > 0) {
-                // Savepoint creation itself failed; the outer transaction is now in an unknown state and must not be committed.
+            try {
+                if ($transactionStarted) {
+                    $this->dialect->rollBack($pdo);
+                } elseif ($savepointCreated) {
+                    $pdo->exec("ROLLBACK TO SAVEPOINT {$this->savepointName($depth)}");
+                } elseif ($depth > 0) {
+                    // Savepoint creation itself failed; the outer transaction is now in an unknown state and must not be committed.
+                    $txState->broken = true;
+                }
+            } catch (Throwable) {
+                // Unwinding failed too
+                // Keep the error that caused it and stop the outer transaction committing.
                 $txState->broken = true;
             }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoBackendBuilder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoBackendBuilder.php
@@ -21,6 +21,8 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\PdoReplicaPasswordStateStore;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Writer\SwooleWriterQueue;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Writer\WriteSerializingStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\SerializingReplicaPasswordStateStore;
 use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
@@ -38,9 +40,13 @@ final class PdoBackendBuilder
 
     private ReplicaPasswordStateStoreInterface $replicaPasswordStateStore;
 
+    /**
+     * @param SleeperInterface $sleeper Paces a retried transaction.
+     */
     public function __construct(
         private readonly PdoConfig $config,
         RunnerMode $runner,
+        private readonly SleeperInterface $sleeper = new BlockingSleeper(),
     ) {
         if ($runner === RunnerMode::Swoole && $config->getSerializeSwooleWrites()) {
             $this->assembleSerializedSwoole();
@@ -69,6 +75,7 @@ final class PdoBackendBuilder
         $this->storage = PdoStorageFactory::storageOn(
             $this->config,
             $provider,
+            $this->sleeper,
         );
         $this->replicaPasswordStateStore = $this->replicaStore($provider);
     }
@@ -83,6 +90,7 @@ final class PdoBackendBuilder
         $writeStorage = PdoStorageFactory::storageOn(
             $this->config,
             $writes,
+            $this->sleeper,
         );
         $queue = new SwooleWriterQueue(
             batchWrapper: static fn(Closure $cb) => $writeStorage->atomic(static fn() => $cb()),
@@ -92,6 +100,7 @@ final class PdoBackendBuilder
             reads: PdoStorageFactory::storageOn(
                 $this->config,
                 $reads,
+                $this->sleeper,
             ),
             writes: $writeStorage,
             queue: $queue,
@@ -109,6 +118,7 @@ final class PdoBackendBuilder
             new PdoTransactor(
                 $provider,
                 $this->config->getDialect(),
+                $this->sleeper,
             ),
             $this->config->getDialect(),
             new PdoStatementPool($provider),

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoStorageFactory.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoStorageFactory.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\PdoConnectionProv
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\SharedPdoConnectionProvider;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Statement\PdoStatementPool;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\PdoStorage;
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
 use PDO;
 
 /**
@@ -56,6 +57,7 @@ final class PdoStorageFactory
     public static function storageOn(
         PdoConfig $config,
         PdoConnectionProviderInterface $provider,
+        ?SleeperInterface $sleeper = null,
     ): PdoStorage {
         // Storage and its index writer share one statement pool, so both draw from the same connection and cache.
         $statements = new PdoStatementPool($provider);
@@ -70,6 +72,7 @@ final class PdoStorageFactory
                 $statements,
                 $config->getSubstringIndex(),
             ),
+            $sleeper,
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -23,6 +23,8 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\EntryIndexWriter;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query\PdoListQueryBuilder;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\PdoTransactor;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Statement\PdoStatementPool;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Statement\PooledStatement;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query\SqlQuery;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SidecarLeaf;
@@ -91,6 +93,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
         private readonly PdoDialectInterface $dialect,
         ?PdoStatementPool $statements = null,
         ?EntryIndexWriter $indexes = null,
+        ?SleeperInterface $sleeper = null,
     ) {
         if (!extension_loaded('mbstring')) {
             throw new RuntimeException(
@@ -102,6 +105,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
         $this->transactor = new PdoTransactor(
             $provider,
             $dialect,
+            $sleeper ?? new BlockingSleeper(),
         );
         $this->statements = $statements ?? new PdoStatementPool($provider);
         $this->indexes = $indexes ?? new EntryIndexWriter(

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -274,6 +274,13 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         AddCommand $command,
         WriteContext $context,
     ): void {
+        // Validated up front: the entry is the caller's, and applying operational attributes below mutates it, so a
+        // replayed transaction would otherwise re-validate an entry that now carries them.
+        $this->validateForAdd(
+            $command,
+            $context,
+        );
+
         $this->writeAtomic(function (EntryStorageInterface $storage) use ($command, $context): void {
             $dn = $command->entry->getDn()->normalize();
             $this->assertParentExists(
@@ -286,10 +293,6 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
                 $this->throwEntryAlreadyExists($command->entry->getDn());
             }
 
-            $this->validateForAdd(
-                $command,
-                $context,
-            );
             $this->operationalAttrs->applyForAdd(
                 $command->entry,
                 $context,

--- a/src/FreeDSx/Ldap/Server/Utility/ExponentialBackoff.php
+++ b/src/FreeDSx/Ldap/Server/Utility/ExponentialBackoff.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Utility;
+
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+
+use function min;
+use function random_int;
+
+/**
+ * A bounded exponential backoff with jitter, for spacing out retries of a contended operation.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ExponentialBackoff
+{
+    /**
+     * Resolution of the random draw used to spread a delay across its jitter window.
+     */
+    private const JITTER_STEPS = 1_000;
+
+    /**
+     * @param float $jitter Fraction of the delay to spread it by, from 0.0 (none) to 1.0 (down to zero or double).
+     */
+    public function __construct(
+        private float $base,
+        private float $max,
+        private float $jitter = 0.5,
+    ) {
+        if ($this->base <= 0.0) {
+            throw new InvalidArgumentException('The backoff base delay must be greater than zero.');
+        }
+
+        if ($this->max < $this->base) {
+            throw new InvalidArgumentException('The backoff ceiling cannot be less than the base delay.');
+        }
+
+        if ($this->jitter < 0.0 || $this->jitter > 1.0) {
+            throw new InvalidArgumentException('The backoff jitter must be between 0.0 and 1.0.');
+        }
+    }
+
+    /**
+     * The delay before the given attempt, doubling per attempt up to the ceiling.
+     */
+    public function delayFor(int $attempt): float
+    {
+        if ($attempt < 1) {
+            throw new InvalidArgumentException('The backoff attempt must be one or greater.');
+        }
+
+        $delay = min(
+            $this->base * (2 ** ($attempt - 1)),
+            $this->max,
+        );
+
+        return $this->jittered($delay);
+    }
+
+    private function jittered(float $delay): float
+    {
+        if ($this->jitter === 0.0) {
+            return $delay;
+        }
+
+        $spread = $delay * $this->jitter;
+        $position = random_int(0, self::JITTER_STEPS) / self::JITTER_STEPS;
+
+        return $delay - $spread + ($spread * 2.0 * $position);
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Adapter/Dialect/MysqlDialectTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Dialect/MysqlDialectTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
+
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\MysqlDialect;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+
+final class MysqlDialectTest extends TestCase
+{
+    private MysqlDialect $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new MysqlDialect();
+    }
+
+    public function test_a_deadlock_is_retryable(): void
+    {
+        self::assertTrue($this->subject->isRetryableConflict($this->exceptionWithDriverCode(1213)));
+    }
+
+    public function test_a_lock_wait_timeout_is_retryable(): void
+    {
+        self::assertTrue($this->subject->isRetryableConflict($this->exceptionWithDriverCode(1205)));
+    }
+
+    public function test_an_unrelated_database_error_is_not_retryable(): void
+    {
+        self::assertFalse($this->subject->isRetryableConflict($this->exceptionWithDriverCode(1064)));
+    }
+
+    public function test_an_exception_without_driver_error_info_is_not_retryable(): void
+    {
+        self::assertFalse($this->subject->isRetryableConflict(new PDOException('Connection refused')));
+    }
+
+    public function test_a_lost_connection_is_not_retryable(): void
+    {
+        self::assertFalse($this->subject->isRetryableConflict($this->exceptionWithDriverCode(2006)));
+        self::assertFalse($this->subject->isRetryableConflict($this->exceptionWithDriverCode(2013)));
+    }
+
+    private function exceptionWithDriverCode(int $driverCode): PDOException
+    {
+        $exception = new PDOException('Database failure.');
+        $exception->errorInfo = [
+            '40001',
+            $driverCode,
+            'Database failure.',
+        ];
+
+        return $exception;
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Adapter/Dialect/SqliteDialectTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Dialect/SqliteDialectTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect;
+
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SqliteDialect;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+
+final class SqliteDialectTest extends TestCase
+{
+    private SqliteDialect $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new SqliteDialect();
+    }
+
+    public function test_a_busy_database_is_retryable(): void
+    {
+        self::assertTrue($this->subject->isRetryableConflict($this->exceptionWithDriverCode(5)));
+    }
+
+    public function test_a_locked_table_is_retryable(): void
+    {
+        self::assertTrue($this->subject->isRetryableConflict($this->exceptionWithDriverCode(6)));
+    }
+
+    public function test_a_constraint_violation_is_not_retryable(): void
+    {
+        self::assertFalse($this->subject->isRetryableConflict($this->exceptionWithDriverCode(19)));
+    }
+
+    public function test_an_exception_without_driver_error_info_is_not_retryable(): void
+    {
+        self::assertFalse($this->subject->isRetryableConflict(new PDOException('Unable to open database file')));
+    }
+
+    private function exceptionWithDriverCode(int $driverCode): PDOException
+    {
+        $exception = new PDOException('Database failure.');
+        $exception->errorInfo = [
+            'HY000',
+            $driverCode,
+            'Database failure.',
+        ];
+
+        return $exception;
+    }
+}

--- a/tests/unit/Server/Backend/Storage/Adapter/Pdo/Connection/PdoTransactorTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Pdo/Connection/PdoTransactorTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection;
+
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\PdoTransactor;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\SharedPdoConnectionProvider;
+use FreeDSx\Ldap\Server\Utility\ExponentialBackoff;
+use PDO;
+use PDOException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Tests\Support\FreeDSx\Ldap\Server\Clock\RecordingSleeper;
+
+final class PdoTransactorTest extends TestCase
+{
+    private PdoDialectInterface&MockObject $dialect;
+
+    private SharedPdoConnectionProvider $provider;
+
+    private RecordingSleeper $sleeper;
+
+    private PdoTransactor $subject;
+
+    protected function setUp(): void
+    {
+        $this->dialect = $this->createMock(PdoDialectInterface::class);
+        $this->provider = new SharedPdoConnectionProvider(new PDO('sqlite::memory:'));
+        $this->sleeper = new RecordingSleeper();
+        $this->subject = new PdoTransactor(
+            $this->provider,
+            $this->dialect,
+            $this->sleeper,
+            maxRetries: 3,
+            backoff: new ExponentialBackoff(
+                base: 0.001,
+                max: 0.05,
+                jitter: 0.0,
+            ),
+        );
+    }
+
+    public function test_it_reissues_the_transaction_until_the_conflict_clears(): void
+    {
+        $this->dialect->method('isRetryableConflict')
+            ->willReturn(true);
+
+        $attempts = 0;
+        $this->subject->atomic(function () use (&$attempts): void {
+            $attempts++;
+
+            if ($attempts < 3) {
+                throw new PDOException('Deadlock found when trying to get lock');
+            }
+        });
+
+        self::assertSame(
+            3,
+            $attempts,
+        );
+        self::assertSame(
+            [0.001, 0.002],
+            $this->sleeper->durations,
+        );
+    }
+
+    public function test_it_gives_up_once_the_retry_budget_is_spent(): void
+    {
+        $this->dialect->method('isRetryableConflict')
+            ->willReturn(true);
+
+        $attempts = 0;
+
+        try {
+            $this->subject->atomic(function () use (&$attempts): void {
+                $attempts++;
+
+                throw new PDOException('Deadlock found when trying to get lock');
+            });
+            self::fail('Expected the conflict to be rethrown.');
+        } catch (PDOException) {
+            // Expected once the budget is spent.
+        }
+
+        self::assertSame(
+            4,
+            $attempts,
+        );
+    }
+
+    public function test_it_does_not_reissue_a_failure_the_dialect_does_not_own(): void
+    {
+        $this->dialect->method('isRetryableConflict')
+            ->willReturn(false);
+
+        $attempts = 0;
+
+        $this->expectException(PDOException::class);
+
+        try {
+            $this->subject->atomic(function () use (&$attempts): void {
+                $attempts++;
+
+                throw new PDOException('Syntax error');
+            });
+        } finally {
+            self::assertSame(
+                1,
+                $attempts,
+            );
+            self::assertSame(
+                [],
+                $this->sleeper->durations,
+            );
+        }
+    }
+
+    public function test_it_reissues_only_the_outermost_transaction(): void
+    {
+        $this->dialect->method('isRetryableConflict')
+            ->willReturn(true);
+
+        $outer = 0;
+        $inner = 0;
+
+        try {
+            $this->subject->atomic(function () use (&$outer, &$inner): void {
+                $outer++;
+
+                $this->subject->atomic(function () use (&$inner): void {
+                    $inner++;
+
+                    throw new PDOException('Deadlock found when trying to get lock');
+                });
+            });
+            self::fail('Expected the conflict to be rethrown.');
+        } catch (PDOException) {
+            // Expected once the budget is spent.
+        }
+
+        self::assertSame(
+            4,
+            $outer,
+        );
+        self::assertSame(
+            4,
+            $inner,
+        );
+    }
+
+    public function test_it_keeps_the_original_failure_when_unwinding_also_fails(): void
+    {
+        $this->dialect->method('isRetryableConflict')
+            ->willReturn(false);
+        $this->dialect->method('rollBack')
+            ->willThrowException(new PDOException('SAVEPOINT sp_1 does not exist'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('the original failure');
+
+        $this->subject->atomic(static function (): void {
+            throw new RuntimeException('the original failure');
+        });
+    }
+
+    public function test_it_does_not_reissue_a_non_database_failure(): void
+    {
+        $attempts = 0;
+
+        $this->expectException(RuntimeException::class);
+
+        try {
+            $this->subject->atomic(function () use (&$attempts): void {
+                $attempts++;
+
+                throw new RuntimeException('application failure');
+            });
+        } finally {
+            self::assertSame(
+                1,
+                $attempts,
+            );
+        }
+    }
+}

--- a/tests/unit/Server/Utility/ExponentialBackoffTest.php
+++ b/tests/unit/Server/Utility/ExponentialBackoffTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Utility;
+
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Server\Utility\ExponentialBackoff;
+use PHPUnit\Framework\TestCase;
+
+final class ExponentialBackoffTest extends TestCase
+{
+    private ExponentialBackoff $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new ExponentialBackoff(
+            base: 0.001,
+            max: 0.05,
+            jitter: 0.0,
+        );
+    }
+
+    public function test_it_doubles_the_delay_for_each_attempt(): void
+    {
+        self::assertSame(
+            0.001,
+            $this->subject->delayFor(1),
+        );
+        self::assertSame(
+            0.002,
+            $this->subject->delayFor(2),
+        );
+        self::assertSame(
+            0.004,
+            $this->subject->delayFor(3),
+        );
+    }
+
+    public function test_it_caps_the_delay_at_the_ceiling(): void
+    {
+        self::assertSame(
+            0.05,
+            $this->subject->delayFor(20),
+        );
+    }
+
+    public function test_it_spreads_jittered_delays_across_the_window(): void
+    {
+        $subject = new ExponentialBackoff(
+            base: 1.0,
+            max: 10.0,
+            jitter: 0.5,
+        );
+
+        $delays = [];
+        for ($i = 0; $i < 200; $i++) {
+            $delays[] = $subject->delayFor(1);
+        }
+
+        self::assertGreaterThanOrEqual(
+            0.5,
+            min($delays),
+        );
+        self::assertLessThanOrEqual(
+            1.5,
+            max($delays),
+        );
+        self::assertGreaterThan(
+            1,
+            count(array_unique($delays)),
+        );
+    }
+
+    public function test_it_returns_an_exact_delay_when_jitter_is_disabled(): void
+    {
+        $delays = [];
+        for ($i = 0; $i < 20; $i++) {
+            $delays[] = $this->subject->delayFor(2);
+        }
+
+        self::assertSame(
+            [0.002],
+            array_values(array_unique($delays)),
+        );
+    }
+
+    public function test_it_rejects_an_attempt_below_one(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->subject->delayFor(0);
+    }
+
+    public function test_it_rejects_a_base_delay_of_zero(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new ExponentialBackoff(
+            base: 0.0,
+            max: 1.0,
+        );
+    }
+
+    public function test_it_rejects_a_ceiling_below_the_base_delay(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new ExponentialBackoff(
+            base: 2.0,
+            max: 1.0,
+        );
+    }
+
+    public function test_it_rejects_jitter_outside_the_unit_range(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new ExponentialBackoff(
+            base: 1.0,
+            max: 2.0,
+            jitter: 1.5,
+        );
+    }
+}


### PR DESCRIPTION
During some concurrency testing I discovered that a write heavy workload can get into a state of repeated transaction failures. This is more of a MySQL occurrence than an SQLite occurrence. However, this resolves that by adding a backoff with jitter specifically for those codes that can be retried. This wasn't surfaced by the default load tests because the mix isn't write heavy enough (and the directory is already sufficiently seeded, which also plays a role).