### PR TITLE
[1.0.0] Add a swoole table metrics recorder. 

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -19,16 +19,18 @@ concurrency:
 jobs:
   load-test:
     runs-on: ubuntu-latest
-    name: ${{ matrix.backend }} + ${{ matrix.runner }}
+    name: ${{ matrix.profile }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { backend: memory, runner: swoole, profile: 'memory:swoole' }
-          - { backend: json,   runner: pcntl,  profile: 'json:pcntl' }
-          - { backend: json,   runner: swoole, profile: 'json:swoole' }
-          - { backend: sqlite, runner: pcntl,  profile: 'sqlite:pcntl' }
-          - { backend: sqlite, runner: swoole, profile: 'sqlite:swoole' }
+          - { id: memory-swoole,      backend: memory, runner: swoole, profile: 'memory:swoole',      workers: 1 }
+          - { id: json-pcntl,         backend: json,   runner: pcntl,  profile: 'json:pcntl',         workers: 1 }
+          - { id: json-swoole,        backend: json,   runner: swoole, profile: 'json:swoole',        workers: 1 }
+          - { id: sqlite-pcntl,       backend: sqlite, runner: pcntl,  profile: 'sqlite:pcntl',       workers: 1 }
+          - { id: sqlite-swoole,      backend: sqlite, runner: swoole, profile: 'sqlite:swoole',      workers: 1 }
+          # Worker count left to auto-detect, so the pool is exercised on whatever cores the runner has.
+          - { id: sqlite-swoole-pool, backend: sqlite, runner: swoole, profile: 'sqlite:swoole-pool', workers: 0 }
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -70,16 +72,17 @@ jobs:
               --backend=${{ matrix.backend }} \
               --runner=${{ matrix.runner }} \
               --ci-profile=${{ matrix.profile }} \
+              --swoole-workers=${{ matrix.workers }} \
               --duration=15 --warmup=3 --clients=16 --rng-seed=1 \
               --output=json \
-              --threshold-report=threshold-${{ matrix.backend }}-${{ matrix.runner }}.json \
-              > raw-${{ matrix.backend }}-${{ matrix.runner }}.json
+              --threshold-report=threshold-${{ matrix.id }}.json \
+              > raw-${{ matrix.id }}.json
 
       - name: Upload load-test artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: load-test-${{ matrix.backend }}-${{ matrix.runner }}
+          name: load-test-${{ matrix.id }}
           path: |
             raw-*.json
             threshold-*.json
@@ -149,6 +152,7 @@ jobs:
               --backend=mysql \
               --runner=${{ matrix.runner }} \
               --ci-profile=mysql:${{ matrix.runner }} \
+              --swoole-workers=1 \
               --duration=15 --warmup=3 --clients=16 --rng-seed=1 \
               --output=json \
               --threshold-report=threshold-mysql-${{ matrix.runner }}.json \

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -132,6 +132,71 @@ Whether anonymous binds should be allowed.
 
 **Default**: `false`
 
+## Runner Configuration
+
+The process model lives on `FreeDSx\Ldap\Server\Config\RunnerConfig`, passed as the third constructor argument to
+`ServerOptions` or set with `setRunnerConfig()`. It selects the runner and, for Swoole, how many worker processes
+accept connections.
+
+```php
+use FreeDSx\Ldap\ServerOptions;
+use FreeDSx\Ldap\Server\Config\RunnerConfig;
+
+$options = new ServerOptions(
+    $storageConfig,
+    $networkConfig,
+    // One worker per available CPU. Pass a count for a fixed number, or 1 for a single process.
+    RunnerConfig::forSwoole(),
+);
+```
+
+`RunnerConfig::forPcntl()` selects the forking runner, which is also the default.
+
+#### setMode
+
+`RunnerMode::Pcntl` forks a process per connection and is Linux only. `RunnerMode::Swoole` handles each connection in
+its own coroutine and requires the Swoole extension.
+
+**Default**: `RunnerMode::Pcntl`
+
+#### setWorkers
+
+Worker processes the Swoole runner accepts on. `1` runs a single process. `0` auto-detects, honouring container CPU
+limits rather than the host total. The forking runner ignores this, since it already spans cores by forking.
+
+**Default**: `1`
+
+### Which backends can use more than one worker
+
+Workers are separate processes, so a directory can only be served by several of them when its entries live outside the
+process. Anything else is clamped back to a single worker with a logged warning.
+
+| Storage | Multiple workers | Why |
+| --- | --- | --- |
+| PDO (`PdoConfig`) | Yes | The database is the shared state |
+| JSON (`JsonStorageConfig`) | No | Cached in-process and rewritten whole, so writers lose each other's updates |
+| In-memory (`InMemoryStorageConfig`) | No | Entries never leave the process that holds them |
+
+A proxy has no local directory, so it can always use multiple workers.
+
+### Signals
+
+| Signal | Single process | Worker pool |
+| --- | --- | --- |
+| `SIGHUP` | Reloads configuration in place | Ignored by the pool master; send it to the **process group** to reload every worker in place |
+| `SIGUSR1` | Not used | Swoole restarts each worker in turn, which drops paged searches and sync streams; prefer `SIGHUP` |
+| `SIGTERM` / `SIGINT` / `SIGQUIT` | Drains, then exits | Every worker drains, then the pool exits |
+
+Reloading a pool in place means sending `SIGHUP` to the process group rather than to the master alone, because the pool
+master cannot forward signals:
+
+```bash
+kill -HUP -$(ps -o pgid= -p "$MASTER_PID" | tr -d ' ')
+```
+
+Each worker adopts the new configuration for subsequent connections while in-flight ones finish under the old one, so
+nothing is dropped. A worker that dies is respawned by the pool and reads the current configuration on start.
+
 ## Network Configuration
 
 The listen socket, timeouts, and TLS settings live on `FreeDSx\Ldap\Server\Config\NetworkConfig`, not on

--- a/docs/Server/General-Usage.md
+++ b/docs/Server/General-Usage.md
@@ -506,7 +506,7 @@ It defaults to the empty (anonymous) DN.
 `seed()` accepts only content records (entries without `changetype:`) and requires depth-first input (parents first,
 then children entries). LDIF produced by `dump()` is already in this order. The operation itself is an upsert that overwrites.
 
-When using the Swoole runner (`setRunnerConfig(new RunnerConfig(RunnerMode::Swoole))`), call `seed()` inside
+When using the Swoole runner (`setRunnerConfig(RunnerConfig::forSwoole())`), call `seed()` inside
 `Swoole\Coroutine\run()` so the storage adapter's per-coroutine connection is available during import.
 
 ### Replaying LDIF Changelogs

--- a/src/FreeDSx/Ldap/Container/Provider/ServerListenerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/ServerListenerContainerProvider.php
@@ -26,6 +26,7 @@ use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
 use FreeDSx\Ldap\Server\Metrics\Recorder\InMemoryMetricsRecorder;
 use FreeDSx\Ldap\Server\Metrics\Recorder\MetricsRecorderChain;
 use FreeDSx\Ldap\Server\Metrics\Recorder\NullMetricsRecorder;
+use FreeDSx\Ldap\Server\Metrics\Recorder\SwooleTableMetricsRecorder;
 use FreeDSx\Ldap\Server\Metrics\Rollup\OperationRollupCoordinator;
 use FreeDSx\Ldap\Server\Process\BackgroundTask\BackgroundTasksInterface;
 use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
@@ -53,6 +54,10 @@ final class ServerListenerContainerProvider implements ContainerProviderInterfac
             ServerAuthorization::class => $this->makeServerAuthorizer(...),
             ServerRunnerInterface::class => $this->makeServerRunner(...),
             InMemoryMetricsRecorder::class => static fn(): InMemoryMetricsRecorder => new InMemoryMetricsRecorder(),
+            // A singleton, so the shared table is allocated once and every forked worker inherits that one mapping.
+            SwooleTableMetricsRecorder::class => static fn(): SwooleTableMetricsRecorder => new SwooleTableMetricsRecorder(
+                SwooleTableMetricsRecorder::createTable(),
+            ),
             MetricsRecorderInterface::class => $this->makeMetricsRecorder(...),
             MetricsSnapshotProvider::class => $this->makeMetricsSnapshotProvider(...),
             OperationRollupCoordinator::class => $this->makeOperationRollupCoordinator(...),
@@ -173,6 +178,11 @@ final class ServerListenerContainerProvider implements ContainerProviderInterfac
             InMemoryMetricsRecorder::class => $container->get(InMemoryMetricsRecorder::class),
         ];
 
+        // Carried so a reload keeps the one shared table rather than allocating a second, empty one.
+        if ($container->get(ServerListenerOptionsInterface::class)->isRunnerMode(RunnerMode::Swoole)) {
+            $shared[SwooleTableMetricsRecorder::class] = $container->get(SwooleTableMetricsRecorder::class);
+        }
+
         $operationRollup = $this->makeOperationRollup($container);
         if ($operationRollup !== null) {
             $shared[OperationRollupCoordinator::class] = $operationRollup;
@@ -229,14 +239,16 @@ final class ServerListenerContainerProvider implements ContainerProviderInterfac
             return $userRecorder;
         }
 
-        $inMemory = $container->get(InMemoryMetricsRecorder::class);
+        $recorder = $options->isRunnerMode(RunnerMode::Swoole)
+            ? $container->get(SwooleTableMetricsRecorder::class)
+            : $container->get(InMemoryMetricsRecorder::class);
 
         if ($userRecorder instanceof NullMetricsRecorder) {
-            return $inMemory;
+            return $recorder;
         }
 
         return new MetricsRecorderChain(
-            $inMemory,
+            $recorder,
             $userRecorder,
         );
     }
@@ -253,6 +265,6 @@ final class ServerListenerContainerProvider implements ContainerProviderInterfac
             return new FileSnapshotProvider($options->getMonitorSnapshotPath());
         }
 
-        return $container->get(InMemoryMetricsRecorder::class);
+        return $container->get(SwooleTableMetricsRecorder::class);
     }
 }

--- a/src/FreeDSx/Ldap/Server/Config/RunnerConfig.php
+++ b/src/FreeDSx/Ldap/Server/Config/RunnerConfig.php
@@ -23,6 +23,11 @@ use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
  */
 final class RunnerConfig
 {
+    /**
+     * Accept on one worker per available CPU.
+     */
+    public const AUTO_DETECT_WORKERS = 0;
+
     private int $workers;
 
     public function __construct(
@@ -30,6 +35,25 @@ final class RunnerConfig
         int $workers = 1,
     ) {
         $this->setWorkers($workers);
+    }
+
+    /**
+     * Coroutine handling, accepting on $workers processes, or on one per available CPU when null.
+     */
+    public static function forSwoole(?int $workers = null): self
+    {
+        return new self(
+            RunnerMode::Swoole,
+            $workers ?? self::AUTO_DETECT_WORKERS,
+        );
+    }
+
+    /**
+     * A forked process per connection, which is Linux only.
+     */
+    public static function forPcntl(): self
+    {
+        return new self(RunnerMode::Pcntl);
     }
 
     public function getMode(): RunnerMode

--- a/src/FreeDSx/Ldap/Server/Metrics/Recorder/SwooleTableMetricsRecorder.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Recorder/SwooleTableMetricsRecorder.php
@@ -1,0 +1,368 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Metrics\Recorder;
+
+use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
+use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
+use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
+use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
+use FreeDSx\Ldap\Operation\OperationType;
+use FreeDSx\Ldap\Server\Metrics\Observation\TrafficObservation;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\ConnectionMetrics;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\LifecycleMetrics;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\MetricsSnapshot;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\OperationMetrics;
+use FreeDSx\Ldap\Server\Metrics\Snapshot\TrafficMetrics;
+use Swoole\Table;
+
+use function is_array;
+use function is_int;
+use function is_string;
+use function max;
+use function str_starts_with;
+use function strlen;
+use function substr;
+
+/**
+ * Records metrics into shared memory so every worker of a pool contributes to one set of totals.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class SwooleTableMetricsRecorder implements MetricsRecorderInterface, MetricsSnapshotProvider
+{
+    private const COLUMN = 'v';
+
+    /**
+     * Keys are truncated past this, which would silently merge two counters into one.
+     */
+    private const MAX_KEY_LENGTH = 63;
+
+    /**
+     * Durations are summed as whole microseconds, since a table column cannot hold a float.
+     */
+    private const MICROSECONDS = 1_000_000;
+
+    private const LIFECYCLE_STARTED = 'life.started';
+
+    private const LIFECYCLE_RELOAD_AT = 'life.reloadAt';
+
+    private const LIFECYCLE_RELOAD_COUNT = 'life.reloadCount';
+
+    private const CONNECTIONS_ACTIVE = 'conn.active';
+
+    private const CONNECTIONS_TOTAL = 'conn.total';
+
+    private const CONNECTIONS_REJECTED = 'conn.rejected';
+
+    private const CONNECTIONS_WRITE_TIMEOUTS = 'conn.writeTimeouts';
+
+    private const CONNECTIONS_IDLE_TIMEOUTS = 'conn.idleTimeouts';
+
+    private const CONNECTIONS_REQUEST_SIZE = 'conn.requestSizeExceeded';
+
+    private const CONNECTIONS_PROTOCOL_ERRORS = 'conn.protocolErrors';
+
+    private const TRAFFIC_SENT = 'traffic.sent';
+
+    private const TRAFFIC_RECEIVED = 'traffic.received';
+
+    private const TRAFFIC_ENTRIES = 'traffic.entries';
+
+    private const OPERATION_COUNT = 'op.n.';
+
+    private const OPERATION_ERROR = 'op.err.';
+
+    private const OPERATION_MICROS = 'op.us.';
+
+    private const OPERATION_IN_PROGRESS = 'op.busy.';
+
+    private const RESULT_CODE = 'rc.';
+
+    private const BIND_METHOD = 'bind.';
+
+    private const SEARCH_SCOPE = 'scope.';
+
+    /**
+     * @param Table $table Must be created before the pool forks, so every worker shares the one mapping.
+     */
+    public function __construct(private readonly Table $table) {}
+
+    /**
+     * Builds the shared table; call before starting a worker pool.
+     */
+    public static function createTable(int $rows = 4096): Table
+    {
+        $table = new Table($rows);
+        $table->column(
+            self::COLUMN,
+            Table::TYPE_INT,
+            8,
+        );
+        $table->create();
+
+        return $table;
+    }
+
+    public function operationStarted(OperationType $operation): void
+    {
+        $this->add(
+            self::OPERATION_IN_PROGRESS . $operation->value,
+            1,
+        );
+    }
+
+    public function operationObserved(OperationObservation $observation): void
+    {
+        $operation = $observation->operation->value;
+
+        $this->add(
+            self::OPERATION_IN_PROGRESS . $operation,
+            -1,
+        );
+        $this->add(
+            self::OPERATION_COUNT . $operation,
+            1,
+        );
+        $this->add(
+            self::OPERATION_MICROS . $operation,
+            (int) ($observation->durationSeconds * self::MICROSECONDS),
+        );
+        $this->add(
+            self::RESULT_CODE . $observation->resultCode,
+            1,
+        );
+
+        if (!$observation->succeeded) {
+            $this->add(
+                self::OPERATION_ERROR . $operation,
+                1,
+            );
+        }
+
+        if ($observation->bindMethod !== null) {
+            $this->add(
+                self::BIND_METHOD . $observation->bindMethod,
+                1,
+            );
+        }
+
+        if ($observation->searchScope !== null) {
+            $this->add(
+                self::SEARCH_SCOPE . $observation->searchScope,
+                1,
+            );
+        }
+    }
+
+    public function trafficObserved(TrafficObservation $observation): void
+    {
+        $this->add(
+            self::TRAFFIC_SENT,
+            $observation->bytesSent,
+        );
+        $this->add(
+            self::TRAFFIC_RECEIVED,
+            $observation->bytesReceived,
+        );
+        $this->add(
+            self::TRAFFIC_ENTRIES,
+            $observation->entriesReturned,
+        );
+    }
+
+    public function connectionObserved(ConnectionObservation $observation): void
+    {
+        match ($observation) {
+            ConnectionObservation::Opened => $this->onOpened(),
+            ConnectionObservation::Closed => $this->add(self::CONNECTIONS_ACTIVE, -1),
+            ConnectionObservation::Rejected => $this->add(self::CONNECTIONS_REJECTED, 1),
+            ConnectionObservation::WriteTimeout => $this->add(self::CONNECTIONS_WRITE_TIMEOUTS, 1),
+            ConnectionObservation::IdleTimeout => $this->add(self::CONNECTIONS_IDLE_TIMEOUTS, 1),
+            ConnectionObservation::RequestSizeExceeded => $this->add(self::CONNECTIONS_REQUEST_SIZE, 1),
+            ConnectionObservation::ProtocolError => $this->add(self::CONNECTIONS_PROTOCOL_ERRORS, 1),
+        };
+    }
+
+    /**
+     * Every worker reports the same start, so the first to record it wins rather than the last.
+     */
+    public function serverStarted(int $startedAt): void
+    {
+        if ($this->get(self::LIFECYCLE_STARTED) === 0) {
+            $this->set(
+                self::LIFECYCLE_STARTED,
+                $startedAt,
+            );
+        }
+    }
+
+    public function serverReloaded(int $reloadedAt): void
+    {
+        $this->set(
+            self::LIFECYCLE_RELOAD_AT,
+            $reloadedAt,
+        );
+        $this->add(
+            self::LIFECYCLE_RELOAD_COUNT,
+            1,
+        );
+    }
+
+    public function snapshot(): MetricsSnapshot
+    {
+        $counts = [];
+        $errors = [];
+        $durations = [];
+        $resultCodes = [];
+        $binds = [];
+        $scopes = [];
+        $inProgress = [];
+
+        foreach ($this->table as $key => $row) {
+            if (!is_string($key)) {
+                continue;
+            }
+
+            $value = $this->rowValue($row);
+
+            match (true) {
+                str_starts_with($key, self::OPERATION_COUNT)
+                    => $counts[$this->suffix($key, self::OPERATION_COUNT)] = $value,
+                str_starts_with($key, self::OPERATION_ERROR)
+                    => $errors[$this->suffix($key, self::OPERATION_ERROR)] = $value,
+                str_starts_with($key, self::OPERATION_MICROS)
+                    => $durations[$this->suffix($key, self::OPERATION_MICROS)] = $value / self::MICROSECONDS,
+                str_starts_with($key, self::OPERATION_IN_PROGRESS)
+                    => $inProgress[$this->suffix($key, self::OPERATION_IN_PROGRESS)] = max(0, $value),
+                str_starts_with($key, self::RESULT_CODE)
+                    => $resultCodes[(int) $this->suffix($key, self::RESULT_CODE)] = $value,
+                str_starts_with($key, self::BIND_METHOD)
+                    => $binds[$this->suffix($key, self::BIND_METHOD)] = $value,
+                str_starts_with($key, self::SEARCH_SCOPE)
+                    => $scopes[$this->suffix($key, self::SEARCH_SCOPE)] = $value,
+                default => null,
+            };
+        }
+
+        return new MetricsSnapshot(
+            lifecycle: new LifecycleMetrics(
+                startedAt: $this->get(self::LIFECYCLE_STARTED),
+                lastReloadAt: $this->get(self::LIFECYCLE_RELOAD_AT),
+                reloadCount: $this->get(self::LIFECYCLE_RELOAD_COUNT),
+            ),
+            connections: new ConnectionMetrics(
+                active: max(0, $this->get(self::CONNECTIONS_ACTIVE)),
+                total: $this->get(self::CONNECTIONS_TOTAL),
+                rejected: $this->get(self::CONNECTIONS_REJECTED),
+                writeTimeouts: $this->get(self::CONNECTIONS_WRITE_TIMEOUTS),
+                idleTimeouts: $this->get(self::CONNECTIONS_IDLE_TIMEOUTS),
+                requestSizeExceeded: $this->get(self::CONNECTIONS_REQUEST_SIZE),
+                protocolErrors: $this->get(self::CONNECTIONS_PROTOCOL_ERRORS),
+            ),
+            operations: new OperationMetrics(
+                counts: $counts,
+                errors: $errors,
+                durationSeconds: $durations,
+                resultCodeCounts: $resultCodes,
+                bindCounts: $binds,
+                searchScopeCounts: $scopes,
+            ),
+            operationsInProgress: $inProgress,
+            traffic: new TrafficMetrics(
+                bytesSent: $this->get(self::TRAFFIC_SENT),
+                bytesReceived: $this->get(self::TRAFFIC_RECEIVED),
+                entriesReturned: $this->get(self::TRAFFIC_ENTRIES),
+            ),
+        );
+    }
+
+    private function onOpened(): void
+    {
+        $this->add(
+            self::CONNECTIONS_ACTIVE,
+            1,
+        );
+        $this->add(
+            self::CONNECTIONS_TOTAL,
+            1,
+        );
+    }
+
+    /**
+     * Atomically adds to a counter, creating its row on first use.
+     */
+    private function add(
+        string $key,
+        int $amount,
+    ): void {
+        $this->table->incr(
+            $this->boundedKey($key),
+            self::COLUMN,
+            $amount,
+        );
+    }
+
+    private function set(
+        string $key,
+        int $value,
+    ): void {
+        $this->table->set(
+            $this->boundedKey($key),
+            [self::COLUMN => $value],
+        );
+    }
+
+    private function get(string $key): int
+    {
+        $value = $this->table->get(
+            $this->boundedKey($key),
+            self::COLUMN,
+        );
+
+        return is_int($value)
+            ? $value
+            : 0;
+    }
+
+    /**
+     * Keeps a key within what the table stores verbatim, since a longer one is truncated without warning.
+     */
+    private function boundedKey(string $key): string
+    {
+        return substr($key, 0, self::MAX_KEY_LENGTH);
+    }
+
+    private function suffix(
+        string $key,
+        string $prefix,
+    ): string {
+        return substr($key, strlen($prefix));
+    }
+
+    /**
+     * Reads a counter out of an iterated row, which the table hands back untyped.
+     */
+    private function rowValue(mixed $row): int
+    {
+        if (!is_array($row)) {
+            return 0;
+        }
+
+        $value = $row[self::COLUMN] ?? null;
+
+        return is_int($value)
+            ? $value
+            : 0;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Metrics/Recorder/SwooleTableMetricsRecorder.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Recorder/SwooleTableMetricsRecorder.php
@@ -26,9 +26,7 @@ use FreeDSx\Ldap\Server\Metrics\Snapshot\OperationMetrics;
 use FreeDSx\Ldap\Server\Metrics\Snapshot\TrafficMetrics;
 use Swoole\Table;
 
-use function is_array;
 use function is_int;
-use function is_string;
 use function max;
 use function str_starts_with;
 use function strlen;
@@ -94,15 +92,18 @@ final class SwooleTableMetricsRecorder implements MetricsRecorderInterface, Metr
     private const SEARCH_SCOPE = 'scope.';
 
     /**
-     * @param Table $table Must be created before the pool forks, so every worker shares the one mapping.
+     * @param Table<array{v: int}> $table Must be created before the pool forks, so every worker shares the one mapping.
      */
     public function __construct(private readonly Table $table) {}
 
     /**
      * Builds the shared table; call before starting a worker pool.
+     *
+     * @return Table<array{v: int}>
      */
     public static function createTable(int $rows = 4096): Table
     {
+        /** @var Table<array{v: int}> $table */
         $table = new Table($rows);
         $table->column(
             self::COLUMN,
@@ -230,11 +231,7 @@ final class SwooleTableMetricsRecorder implements MetricsRecorderInterface, Metr
         $inProgress = [];
 
         foreach ($this->table as $key => $row) {
-            if (!is_string($key)) {
-                continue;
-            }
-
-            $value = $this->rowValue($row);
+            $value = $row[self::COLUMN];
 
             match (true) {
                 str_starts_with($key, self::OPERATION_COUNT)
@@ -348,21 +345,5 @@ final class SwooleTableMetricsRecorder implements MetricsRecorderInterface, Metr
         string $prefix,
     ): string {
         return substr($key, strlen($prefix));
-    }
-
-    /**
-     * Reads a counter out of an iterated row, which the table hands back untyped.
-     */
-    private function rowValue(mixed $row): int
-    {
-        if (!is_array($row)) {
-            return 0;
-        }
-
-        $value = $row[self::COLUMN] ?? null;
-
-        return is_int($value)
-            ? $value
-            : 0;
     }
 }

--- a/src/FreeDSx/Ldap/Server/ServerRunner/Swoole/PooledServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/Swoole/PooledServerRunner.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Server\ServerRunner\Swoole;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Server\Backend\ResettableInterface;
 use FreeDSx\Ldap\Server\ServerRunner\CoroutineServerRunnerInterface;
+use Swoole\Process;
 use Swoole\Process\Pool;
 
 use function extension_loaded;
@@ -56,6 +57,13 @@ class PooledServerRunner implements CoroutineServerRunnerInterface
         $pool->on(
             'WorkerStart',
             fn(Pool $pool, int $workerId): null => $this->runWorker($workerId),
+        );
+
+        // The pool reloads on SIGUSR1 and leaves SIGHUP unhandled, which would terminate the master and orphan
+        // every worker. Registering here only suppresses that default, since the master never dispatches it.
+        Process::signal(
+            SIGHUP,
+            static fn(): null => null,
         );
 
         $pool->start();

--- a/src/FreeDSx/Ldap/Server/ServerRunner/Swoole/Worker.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/Swoole/Worker.php
@@ -22,6 +22,7 @@ use FreeDSx\Ldap\Server\ServerRunner\ReloadsConfigurationTrait;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerLoggerTrait;
 use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Ldap\ServerListenerOptionsInterface;
+use FreeDSx\Ldap\ServerOptions;
 use Psr\Log\LoggerInterface;
 use Swoole\Coroutine;
 use Swoole\Process;
@@ -69,6 +70,7 @@ class Worker
     public function run(array $context = []): void
     {
         Runtime::enableCoroutine(SWOOLE_HOOK_ALL);
+        $this->adoptCurrentConfiguration($context);
 
         $acceptor = new ConnectionAcceptor(
             $this->serverProtocolFactory,
@@ -87,6 +89,20 @@ class Worker
         });
 
         $this->logShutdownCompleted($context);
+    }
+
+    /**
+     * Keeps a worker respawned after a crash on the configuration its siblings already reloaded.
+     *
+     * @param array<string, scalar> $context
+     */
+    private function adoptCurrentConfiguration(array $context): void
+    {
+        if (!$this->options instanceof ServerOptions || $this->options->getConfigReloader() === null) {
+            return;
+        }
+
+        $this->reloadConfiguration($context);
     }
 
     private function getRunnerLogger(): ?LoggerInterface

--- a/tests/performance/Threshold/CiThresholds.php
+++ b/tests/performance/Threshold/CiThresholds.php
@@ -29,6 +29,7 @@ final class CiThresholds
         'json:swoole',
         'sqlite:pcntl',
         'sqlite:swoole',
+        'sqlite:swoole-pool',
         'mysql:pcntl',
         'mysql:swoole',
     ];
@@ -57,6 +58,12 @@ final class CiThresholds
                 maxP99Ms: 200.0,
             ),
             'sqlite:swoole' => new ThresholdSet(
+                maxErrors: 0,
+                minThroughput: 700.0,
+                maxP99Ms: 500.0,
+            ),
+            // Throughput matches the single-worker floor since runner core counts vary; the error ceiling is the guard.
+            'sqlite:swoole-pool' => new ThresholdSet(
                 maxErrors: 0,
                 minThroughput: 700.0,
                 maxP99Ms: 500.0,

--- a/tests/profile/compare-ldap.sh
+++ b/tests/profile/compare-ldap.sh
@@ -8,6 +8,7 @@
 #   composer compare-ldap -- [--source=freedsx|openldap|opendj] [--target=freedsx|openldap|opendj]
 #       [--seed-entries=2000] [--cpus=4] [--storage=sqlite] [--runner=pcntl] [--mix=default]
 #       [--search-value=seed-1] [--duration=15] [--warmup=3] [--clients=8] [--driver-processes=1] [--keep-up]
+#       [--swoole-workers=0] [--server-cpuset=0-3] [--driver-cpuset=4-7]
 #
 # --storage/--runner apply only to a freedsx side.
 # --search-value is the cn prefix the subtree searches filter on (--search-value=seed- matches all).
@@ -38,6 +39,9 @@ WARMUP=3
 CLIENTS=8
 DRIVER_PROCS=1
 KEEP_UP=0
+WORKERS=0
+SERVER_CPUSET=0-3
+DRIVER_CPUSET=4-7
 
 for arg in "$@"; do
     case "$arg" in
@@ -53,6 +57,9 @@ for arg in "$@"; do
         --warmup=*)           WARMUP="${arg#*=}" ;;
         --clients=*)          CLIENTS="${arg#*=}" ;;
         --driver-processes=*) DRIVER_PROCS="${arg#*=}" ;;
+        --swoole-workers=*)   WORKERS="${arg#*=}" ;;
+        --server-cpuset=*)    SERVER_CPUSET="${arg#*=}" ;;
+        --driver-cpuset=*)    DRIVER_CPUSET="${arg#*=}" ;;
         --keep-up)            KEEP_UP=1 ;;
         -h|--help)            sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
         *)                    echo "unknown arg: $arg" >&2; exit 2 ;;
@@ -122,9 +129,10 @@ setup_opendj() {
     || echo "   (index-limit tweak skipped)"
 }
 
-echo "==> up $SRC_LABEL ($SRC_SVC) + $TGT_LABEL ($TGT_SVC) (cpus=$CPUS each, seed=$SEED)"
-# freedsx-server self-seeds via SEED_ENTRIES; here the bench seeds it over LDAP like any other side, so it starts empty.
+echo "==> up $SRC_LABEL ($SRC_SVC) + $TGT_LABEL ($TGT_SVC) (cpuset=$SERVER_CPUSET each, driver on $DRIVER_CPUSET, seed=$SEED)"
+# Sharing cores with the driver can reverse which server looks faster, so each side is pinned to its own.
 PROFILE_CPUS="$CPUS" FREEDSX_STORAGE="$STORAGE" FREEDSX_RUNNER="$RUNNER" SEED_ENTRIES=0 \
+SERVER_CPUSET="$SERVER_CPUSET" SWOOLE_WORKERS="$WORKERS" FREEDSX_JIT="$([[ "$RUNNER" == pcntl ]] && echo off || echo function)" \
     docker compose -f "$COMPOSE" up -d --wait "$SRC_SVC" "$TGT_SVC"
 
 [[ "$SRC_SETUP" == opendj ]] && setup_opendj "$SRC_BIND" "$SRC_PW" "$SRC_BASE"
@@ -133,7 +141,7 @@ PROFILE_CPUS="$CPUS" FREEDSX_STORAGE="$STORAGE" FREEDSX_RUNNER="$RUNNER" SEED_EN
 NET=$(docker inspect -f '{{range $k,$_ := .NetworkSettings.Networks}}{{$k}}{{end}}' "$SRC_CONT")
 
 echo "==> running comparison (driver container on '$NET')"
-docker run --rm --network "$NET" -v "$PWD":/app -w /app --entrypoint php \
+docker run --rm --network "$NET" --cpuset-cpus="$DRIVER_CPUSET" -v "$PWD":/app -w /app --entrypoint php \
     freedsx-profile:latest -d xdebug.mode=off -d opcache.enable_cli=1 -d opcache.jit=off \
     tests/bin/ldap-bench-compare.php \
     --source-host="$SRC_SVC" --source-port="$SRC_PORT" --source-bind-dn="$SRC_BIND" --source-bind-password="$SRC_PW" --source-base-dn="$SRC_BASE" --source-label="$SRC_LABEL" \

--- a/tests/profile/docker-compose.yml
+++ b/tests/profile/docker-compose.yml
@@ -86,6 +86,8 @@ services:
     image: freedsx-profile-openldap:latest
     container_name: freedsx-profile-openldap
     cpus: ${PROFILE_CPUS:-4}
+    # Pinned to the same cores as freedsx-server so a comparison measures the server, not core contention.
+    cpuset: ${SERVER_CPUSET:-}
     ports:
       - "10390:389"
     healthcheck:
@@ -100,6 +102,8 @@ services:
     image: openidentityplatform/opendj:latest
     container_name: freedsx-profile-opendj
     cpus: ${PROFILE_CPUS:-4}
+    # Pinned to the same cores as freedsx-server so a comparison measures the server, not core contention.
+    cpuset: ${SERVER_CPUSET:-}
     ports:
       - "10391:1389"
     environment:

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -282,6 +282,10 @@ class ContainerTest extends TestCase
 
     public function test_the_snapshot_provider_is_the_live_recorder_under_swoole(): void
     {
+        if (!extension_loaded('swoole')) {
+            self::markTestSkipped('The swoole extension is required to construct the shared metrics table.');
+        }
+
         $container = $this->containerFor(
             (new ServerOptions())
                 ->setMonitorEnabled(true)

--- a/tests/unit/Server/Config/RunnerConfigTest.php
+++ b/tests/unit/Server/Config/RunnerConfigTest.php
@@ -56,6 +56,45 @@ final class RunnerConfigTest extends TestCase
         );
     }
 
+    public function test_it_builds_a_coroutine_runner_that_uses_every_cpu_by_default(): void
+    {
+        $subject = RunnerConfig::forSwoole();
+
+        self::assertSame(
+            RunnerMode::Swoole,
+            $subject->getMode(),
+        );
+        self::assertSame(
+            RunnerConfig::AUTO_DETECT_WORKERS,
+            $subject->getWorkers(),
+        );
+    }
+
+    public function test_it_builds_a_coroutine_runner_with_a_fixed_worker_count(): void
+    {
+        $subject = RunnerConfig::forSwoole(4);
+
+        self::assertSame(
+            RunnerMode::Swoole,
+            $subject->getMode(),
+        );
+        self::assertSame(
+            4,
+            $subject->getWorkers(),
+        );
+    }
+
+    public function test_it_builds_a_forking_runner(): void
+    {
+        $subject = RunnerConfig::forPcntl();
+
+        self::assertSame(
+            RunnerMode::Pcntl,
+            $subject->getMode(),
+        );
+        self::assertFalse($subject->isSingleProcess());
+    }
+
     public function test_the_forking_runner_is_never_a_single_process(): void
     {
         self::assertFalse($this->subject->isSingleProcess());

--- a/tests/unit/Server/Metrics/Recorder/SwooleTableMetricsRecorderTest.php
+++ b/tests/unit/Server/Metrics/Recorder/SwooleTableMetricsRecorderTest.php
@@ -1,0 +1,308 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra @gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Metrics\Recorder;
+
+use FreeDSx\Ldap\Operation\OperationType;
+use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
+use FreeDSx\Ldap\Server\Metrics\Observation\OperationObservation;
+use FreeDSx\Ldap\Server\Metrics\Observation\TrafficObservation;
+use FreeDSx\Ldap\Server\Metrics\Recorder\SwooleTableMetricsRecorder;
+use PHPUnit\Framework\TestCase;
+
+final class SwooleTableMetricsRecorderTest extends TestCase
+{
+    private SwooleTableMetricsRecorder $subject;
+
+    protected function setUp(): void
+    {
+        if (!extension_loaded('swoole')) {
+            self::markTestSkipped('The swoole extension is required.');
+        }
+
+        $this->subject = new SwooleTableMetricsRecorder(SwooleTableMetricsRecorder::createTable(1024));
+    }
+
+    public function test_it_starts_empty(): void
+    {
+        $snapshot = $this->subject->snapshot();
+
+        self::assertSame(
+            0,
+            $snapshot->operations->total(),
+        );
+        self::assertSame(
+            0,
+            $snapshot->connections->total,
+        );
+    }
+
+    public function test_it_counts_operations_by_type(): void
+    {
+        $this->observe(OperationType::Search);
+        $this->observe(OperationType::Search);
+        $this->observe(OperationType::Bind);
+
+        $operations = $this->subject->snapshot()->operations;
+
+        self::assertSame(
+            2,
+            $operations->counts[OperationType::Search->value],
+        );
+        self::assertSame(
+            1,
+            $operations->counts[OperationType::Bind->value],
+        );
+        self::assertSame(
+            3,
+            $operations->total(),
+        );
+    }
+
+    public function test_it_counts_only_failed_operations_as_errors(): void
+    {
+        $this->observe(OperationType::Search);
+        $this->observe(
+            OperationType::Search,
+            succeeded: false,
+        );
+
+        $operations = $this->subject->snapshot()->operations;
+
+        self::assertSame(
+            1,
+            $operations->errors[OperationType::Search->value],
+        );
+        self::assertSame(
+            1,
+            $operations->totalErrors(),
+        );
+    }
+
+    public function test_it_sums_durations_back_into_seconds(): void
+    {
+        $this->observe(
+            OperationType::Search,
+            durationSeconds: 0.25,
+        );
+        $this->observe(
+            OperationType::Search,
+            durationSeconds: 0.5,
+        );
+
+        self::assertEqualsWithDelta(
+            0.75,
+            $this->subject->snapshot()->operations->durationSeconds[OperationType::Search->value],
+            0.000001,
+        );
+    }
+
+    public function test_it_counts_result_codes_bind_methods_and_scopes(): void
+    {
+        $this->observe(
+            OperationType::Bind,
+            resultCode: 49,
+            bindMethod: 'simple',
+        );
+        $this->observe(
+            OperationType::Search,
+            searchScope: 'subtree',
+        );
+
+        $operations = $this->subject->snapshot()->operations;
+
+        self::assertSame(
+            1,
+            $operations->resultCodeCounts[49],
+        );
+        self::assertSame(
+            1,
+            $operations->bindCounts['simple'],
+        );
+        self::assertSame(
+            1,
+            $operations->searchScopeCounts['subtree'],
+        );
+    }
+
+    public function test_an_operation_in_flight_is_counted_until_it_completes(): void
+    {
+        $this->subject->operationStarted(OperationType::Search);
+        $this->subject->operationStarted(OperationType::Search);
+
+        self::assertSame(
+            2,
+            $this->subject->snapshot()->operationsInProgress[OperationType::Search->value],
+        );
+
+        $this->observe(OperationType::Search);
+
+        self::assertSame(
+            1,
+            $this->subject->snapshot()->operationsInProgress[OperationType::Search->value],
+        );
+    }
+
+    public function test_an_unmatched_completion_does_not_report_a_negative_gauge(): void
+    {
+        // A worker killed mid-operation leaves the decrement without its increment.
+        $this->observe(OperationType::Search);
+
+        self::assertSame(
+            0,
+            $this->subject->snapshot()->operationsInProgress[OperationType::Search->value],
+        );
+    }
+
+    public function test_it_tracks_connections_opening_and_closing(): void
+    {
+        $this->subject->connectionObserved(ConnectionObservation::Opened);
+        $this->subject->connectionObserved(ConnectionObservation::Opened);
+        $this->subject->connectionObserved(ConnectionObservation::Closed);
+        $this->subject->connectionObserved(ConnectionObservation::Rejected);
+
+        $connections = $this->subject->snapshot()->connections;
+
+        self::assertSame(
+            2,
+            $connections->total,
+        );
+        self::assertSame(
+            1,
+            $connections->active,
+        );
+        self::assertSame(
+            1,
+            $connections->rejected,
+        );
+    }
+
+    public function test_closing_more_connections_than_were_opened_does_not_report_a_negative_gauge(): void
+    {
+        $this->subject->connectionObserved(ConnectionObservation::Closed);
+
+        self::assertSame(
+            0,
+            $this->subject->snapshot()->connections->active,
+        );
+    }
+
+    public function test_it_accumulates_traffic(): void
+    {
+        $this->subject->trafficObserved(new TrafficObservation(
+            bytesSent: 100,
+            bytesReceived: 50,
+            entriesReturned: 3,
+        ));
+        $this->subject->trafficObserved(new TrafficObservation(
+            bytesSent: 20,
+            bytesReceived: 10,
+            entriesReturned: 1,
+        ));
+
+        $traffic = $this->subject->snapshot()->traffic;
+
+        self::assertSame(
+            120,
+            $traffic->bytesSent,
+        );
+        self::assertSame(
+            60,
+            $traffic->bytesReceived,
+        );
+        self::assertSame(
+            4,
+            $traffic->entriesReturned,
+        );
+    }
+
+    public function test_the_first_worker_to_report_the_start_time_wins(): void
+    {
+        $this->subject->serverStarted(1000);
+        $this->subject->serverStarted(2000);
+
+        self::assertSame(
+            1000,
+            $this->subject->snapshot()->lifecycle->startedAt,
+        );
+    }
+
+    public function test_reloads_are_counted_and_the_latest_time_kept(): void
+    {
+        $this->subject->serverReloaded(1000);
+        $this->subject->serverReloaded(2000);
+
+        $lifecycle = $this->subject->snapshot()->lifecycle;
+
+        self::assertSame(
+            2,
+            $lifecycle->reloadCount,
+        );
+        self::assertSame(
+            2000,
+            $lifecycle->lastReloadAt,
+        );
+    }
+
+    public function test_two_recorders_on_one_table_report_combined_totals(): void
+    {
+        // Stands in for two workers sharing the table the pool created before forking.
+        $table = SwooleTableMetricsRecorder::createTable(1024);
+        $workerOne = new SwooleTableMetricsRecorder($table);
+        $workerTwo = new SwooleTableMetricsRecorder($table);
+
+        $workerOne->connectionObserved(ConnectionObservation::Opened);
+        $workerTwo->connectionObserved(ConnectionObservation::Opened);
+        $workerOne->operationObserved(new OperationObservation(
+            operation: OperationType::Search,
+            succeeded: true,
+            durationSeconds: 0.1,
+            resultCode: 0,
+        ));
+        $workerTwo->operationObserved(new OperationObservation(
+            operation: OperationType::Search,
+            succeeded: true,
+            durationSeconds: 0.1,
+            resultCode: 0,
+        ));
+
+        $snapshot = $workerOne->snapshot();
+
+        self::assertSame(
+            2,
+            $snapshot->connections->total,
+        );
+        self::assertSame(
+            2,
+            $snapshot->operations->counts[OperationType::Search->value],
+        );
+    }
+
+    private function observe(
+        OperationType $operation,
+        bool $succeeded = true,
+        float $durationSeconds = 0.01,
+        int $resultCode = 0,
+        ?string $bindMethod = null,
+        ?string $searchScope = null,
+    ): void {
+        $this->subject->operationObserved(new OperationObservation(
+            operation: $operation,
+            succeeded: $succeeded,
+            durationSeconds: $durationSeconds,
+            resultCode: $resultCode,
+            bindMethod: $bindMethod,
+            searchScope: $searchScope,
+        ));
+    }
+}


### PR DESCRIPTION
This makes the cn=monitor in swoole work again. Unlike PCNTL, with swoole we can use true shared memory via a Table to track stats properly without any kind of inter-process comms / file cache. Also updating the bench comparison scripts to make the cpu-sets fair.

Also some other misc fixes here that were discovered along the way. And documentation updates.