### PR TITLE
[1.0.0] Search filters now respect the schema's matching rules.

### DIFF
--- a/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
@@ -42,6 +42,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionSweeper;
 use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
 use FreeDSx\Ldap\Server\Backend\Storage\OperationalAttributeGenerator;
+use FreeDSx\Ldap\Server\Backend\Storage\SearchStreamBuilder;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Server\Clock\ClockInterface;
 use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
@@ -92,6 +93,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
             FilterEvaluatorInterface::class => $this->makeFilterEvaluator(...),
             EntryStorageInterface::class => $this->makeStorage(...),
             OperationalAttributeGenerator::class => $this->makeOperationalAttributeGenerator(...),
+            SearchStreamBuilder::class => $this->makeSearchStreamBuilder(...),
             LdapImporter::class => $this->makeLdapImporter(...),
             PdoBackendBuilder::class => $this->makePdoBackendBuilder(...),
             WritableStorageBackend::class => $this->makeBackend(...),
@@ -249,6 +251,19 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
             operationalAttrs: $container->get(OperationalAttributeGenerator::class),
             changeRecorder: $this->changeRecorderFor($container, $storage),
             schema: $options->getSchema(),
+            searchStream: $container->get(SearchStreamBuilder::class),
+        );
+    }
+
+    /**
+     * Streams search results, post-filtering on the shared evaluator so matching rules follow the configured schema.
+     */
+    private function makeSearchStreamBuilder(Container $container): SearchStreamBuilder
+    {
+        return new SearchStreamBuilder(
+            $container->get(EntryStorageInterface::class),
+            $container->get(ServerOptions::class)->makeSearchLimits(),
+            $container->get(FilterEvaluatorInterface::class),
         );
     }
 

--- a/src/FreeDSx/Ldap/Schema/Schema.php
+++ b/src/FreeDSx/Ldap/Schema/Schema.php
@@ -29,6 +29,14 @@ use FreeDSx\Ldap\Schema\Matching\MatchingRuleComparatorInterface;
 final class Schema
 {
     /**
+     * Equality rules that ignore case, so a case-folded comparison is equivalent to them.
+     */
+    private const CASE_INSENSITIVE_EQUALITY_OIDS = [
+        MatchingRuleOid::OID_CASE_IGNORE_MATCH,
+        MatchingRuleOid::OID_CASE_IGNORE_IA5_MATCH,
+    ];
+
+    /**
      * @var array<string, AttributeType>
      */
     private array $attributeTypes = [];
@@ -108,6 +116,24 @@ final class Schema
         }
 
         return $attributeType->syntaxOid === SyntaxOid::OID_INTEGER;
+    }
+
+    /**
+     * Whether the attribute matches without regard to case, or null when it is not defined here.
+     */
+    public function isCaseInsensitiveMatched(string $nameOrOid): ?bool
+    {
+        $attributeType = $this->getAttributeType($nameOrOid);
+
+        if ($attributeType?->equalityOid === null) {
+            return null;
+        }
+
+        return in_array(
+            $attributeType->equalityOid,
+            self::CASE_INSENSITIVE_EQUALITY_OIDS,
+            true,
+        );
     }
 
     public function getObjectClass(string $nameOrOid): ?ObjectClass

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -185,6 +185,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
         $filterResult = $this->translator->translate(
             $options->filter,
             $options->isIntegerOrdered(...),
+            $options->isCaseInsensitive(...),
         );
 
         // A composed filter with a selective drivable leaf streams off that leaf; PHP re-evaluates the full filter.

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/FilterTranslatorInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/FilterTranslatorInterface.php
@@ -28,9 +28,11 @@ interface FilterTranslatorInterface
 {
     /**
      * @param (\Closure(string): (bool|null))|null $isIntegerOrdered Resolves whether an attribute orders numerically.
+     * @param (\Closure(string): (bool|null))|null $isCaseInsensitive Resolves whether an attribute matches without regard to case.
      */
     public function translate(
         FilterInterface $filter,
         ?Closure $isIntegerOrdered = null,
+        ?Closure $isCaseInsensitive = null,
     ): ?SqlFilterResult;
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
@@ -43,13 +43,21 @@ trait SqlFilterTranslatorTrait
     private ?Closure $integerOrderedResolver = null;
 
     /**
+     * @var (\Closure(string): (bool|null))|null Resolves whether an attribute ignores case, for the current call.
+     */
+    private ?Closure $caseInsensitiveResolver = null;
+
+    /**
      * @param (\Closure(string): (bool|null))|null $isIntegerOrdered Resolves numeric ordering; null = unknown.
+     * @param (\Closure(string): (bool|null))|null $isCaseInsensitive Resolves case-insensitive matching; null = unknown.
      */
     public function translate(
         FilterInterface $filter,
         ?Closure $isIntegerOrdered = null,
+        ?Closure $isCaseInsensitive = null,
     ): ?SqlFilterResult {
         $this->integerOrderedResolver = $isIntegerOrdered;
+        $this->caseInsensitiveResolver = $isCaseInsensitive;
 
         return $this->dispatch($filter);
     }
@@ -129,7 +137,9 @@ trait SqlFilterTranslatorTrait
         return new SqlFilterResult(
             $this->buildValueExists($attribute, "$alias = ?"),
             [$this->prepareMatchValue($value)],
-            isExact: $this->isExactEquality($value) && !$this->attributeHasOption($filter->getAttribute()),
+            isExact: $this->isExactEquality($value)
+                && $this->matchesCaseFolded($attribute)
+                && !$this->attributeHasOption($filter->getAttribute()),
             referencedAttributes: [$attribute],
             sidecarCondition: $this->sidecarCondition(
                 $attribute,
@@ -149,7 +159,9 @@ trait SqlFilterTranslatorTrait
         return new SqlFilterResult(
             $this->buildValueExists($attribute, "$alias = ?"),
             [$this->prepareMatchValue($value)],
-            isExact: $this->isExactEquality($value) && !$this->attributeHasOption($filter->getAttribute()),
+            isExact: $this->isExactEquality($value)
+                && $this->matchesCaseFolded($attribute)
+                && !$this->attributeHasOption($filter->getAttribute()),
             referencedAttributes: [$attribute],
             sidecarCondition: $this->sidecarCondition(
                 $attribute,
@@ -220,7 +232,10 @@ trait SqlFilterTranslatorTrait
         return new SqlFilterResult(
             $this->buildValueExists($attribute, $condition),
             [$this->prepareMatchValue($value)],
-            isExact: $lexicalCanBeExact && $this->isExactOrdered($value) && !$hasOption,
+            isExact: $lexicalCanBeExact
+                && $this->isExactOrdered($value)
+                && $this->matchesCaseFolded($attribute)
+                && !$hasOption,
             referencedAttributes: [$attribute],
             sidecarCondition: $this->sidecarCondition(
                 $attribute,
@@ -275,11 +290,15 @@ trait SqlFilterTranslatorTrait
             );
         }
 
-        $isExact = $this->isExactSubstring(
+        $fragmentsAreExact = $this->isExactSubstring(
             $startsWith,
             $contains,
             $endsWith,
-        ) && !$this->attributeHasOption($filter->getAttribute());
+        );
+
+        $isExact = $fragmentsAreExact
+            && $this->matchesCaseFolded($attribute)
+            && !$this->attributeHasOption($filter->getAttribute());
 
         return new SqlFilterResult(
             $sql,
@@ -337,6 +356,20 @@ trait SqlFilterTranslatorTrait
         return Text::isAscii($value)
             && Text::isUtf8($value)
             && Text::lengthOf($value) <= SqlFilterUtility::MAX_INDEXED_VALUE_CHARS;
+    }
+
+    /**
+     * Values are indexed and compared case-folded, so a case-sensitive attribute needs the caller to re-check.
+     *
+     * Unresolved attributes fall back to true, keeping the schema-less behaviour the in-process evaluator also has.
+     */
+    private function matchesCaseFolded(string $attribute): bool
+    {
+        if ($this->caseInsensitiveResolver === null) {
+            return true;
+        }
+
+        return ($this->caseInsensitiveResolver)($attribute) ?? true;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/SearchStreamBuilder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/SearchStreamBuilder.php
@@ -30,10 +30,13 @@ use Generator;
  */
 final readonly class SearchStreamBuilder
 {
+    /**
+     * @param FilterEvaluatorInterface $filterEvaluator Must know the configured schema, or matching rules are ignored.
+     */
     public function __construct(
         private EntryStorageInterface $storage,
-        private SearchLimits $limits = new SearchLimits(),
-        private FilterEvaluatorInterface $filterEvaluator = new FilterEvaluator(),
+        private SearchLimits $limits,
+        private FilterEvaluatorInterface $filterEvaluator,
     ) {}
 
     public function effectiveTimeLimit(

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
@@ -30,6 +30,7 @@ final class StorageListOptions
      * @param SortKey[] $sortKeys
      * @param list<string>|null $attributes Lowercase base attribute names to materialize, or null for all.
      * @param (\Closure(string): (bool|null))|null $isIntegerOrderedResolver Resolves whether an attribute orders numerically.
+     * @param (\Closure(string): (bool|null))|null $isCaseInsensitiveResolver Resolves whether an attribute matches without regard to case.
      */
     public function __construct(
         public readonly Dn $baseDn,
@@ -41,6 +42,7 @@ final class StorageListOptions
         public readonly int $lookthroughLimit = 0,
         public readonly ?array $attributes = null,
         public readonly ?Closure $isIntegerOrderedResolver = null,
+        public readonly ?Closure $isCaseInsensitiveResolver = null,
     ) {}
 
     /**
@@ -50,6 +52,16 @@ final class StorageListOptions
     {
         return $this->isIntegerOrderedResolver !== null
             ? ($this->isIntegerOrderedResolver)($attribute)
+            : null;
+    }
+
+    /**
+     * Whether the attribute matches without regard to case. null when unresolved (no schema was supplied).
+     */
+    public function isCaseInsensitive(string $attribute): ?bool
+    {
+        return $this->isCaseInsensitiveResolver !== null
+            ? ($this->isCaseInsensitiveResolver)($attribute)
             : null;
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -70,10 +70,13 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         private readonly WriteEntryOperationHandler $entryHandler = new WriteEntryOperationHandler(),
         private readonly ?ChangeRecorder $changeRecorder = null,
         private readonly ?Schema $schema = null,
+        ?SearchStreamBuilder $searchStream = null,
     ) {
-        $this->searchStream = new SearchStreamBuilder(
-            $this->storage,
-            $this->limits,
+        // Falling back to the schema this backend was given, so post-filtering never silently drops matching rules.
+        $this->searchStream = $searchStream ?? new SearchStreamBuilder(
+            $storage,
+            $limits,
+            new FilterEvaluator($schema),
         );
     }
 
@@ -175,6 +178,7 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             lookthroughLimit: $limits->maxSearchLookthrough,
             attributes: $this->materializedAttributes($request),
             isIntegerOrderedResolver: fn(string $attribute): ?bool => $this->schema?->isIntegerOrdered($attribute),
+            isCaseInsensitiveResolver: fn(string $attribute): ?bool => $this->schema?->isCaseInsensitiveMatched($attribute),
         );
 
         try {

--- a/tests/integration/Storage/LdapBackendStorageTest.php
+++ b/tests/integration/Storage/LdapBackendStorageTest.php
@@ -173,6 +173,33 @@ class LdapBackendStorageTest extends ServerTestCase
         self::assertCount(0, $entries);
     }
 
+    public function testSearchFilterAppliesTheSchemaDeclaredMatchingRule(): void
+    {
+        $this->authenticateUser();
+
+        $exact = $this->ldapClient()->search(
+            Operations::search(Filters::equal('employeeNumber', 'A1b2C3'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+        // The schema matches employeeNumber case-exactly. Storage post-filters results itself, so a case-folded
+        // value matching here would mean that path evaluated without the schema.
+        $caseFolded = $this->ldapClient()->search(
+            Operations::search(Filters::equal('employeeNumber', 'a1b2c3'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        self::assertCount(
+            1,
+            $exact,
+        );
+        self::assertCount(
+            0,
+            $caseFolded,
+        );
+    }
+
     public function testAddStoresEntry(): void
     {
         $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -218,6 +218,8 @@ final class LdapBackendStorageCommand extends Command
                 new Attribute('sn', 'Smith'),
                 new Attribute('mail', 'alice@foo.bar'),
                 new Attribute('uidNumber', '99'),
+                // Matched case-exactly by the schema, so searches on it prove the configured schema is in play.
+                new Attribute('employeeNumber', 'A1b2C3'),
             ),
             new Entry(
                 new Dn('cn=nosn,dc=foo,dc=bar'),


### PR DESCRIPTION
Discovered this hole while go through moving things into the container provider. One component used the FilterEvaluator but didn't override a default value. This also exposed an issue with case comparison and PDO (as an integration test was added), which also gets fixed here.