### PR TITLE
[1.0.0] Further lock down ACL defaults.

### DIFF
--- a/docs/Server/Access-Control.md
+++ b/docs/Server/Access-Control.md
@@ -8,6 +8,8 @@ Access Control
 * [Rule-Based Access Control](#rule-based-access-control)
     * [Rule Evaluation Order](#rule-evaluation-order)
     * [Default Effect](#default-effect)
+    * [Grant Helpers](#grant-helpers)
+    * [Self-Service Attributes](#self-service-attributes)
 * [Subject Reference](#subject-reference)
 * [Target Reference](#target-reference)
 * [Attribute Rules](#attribute-rules)
@@ -40,7 +42,9 @@ Bind, WhoAmI, and StartTLS are handled before access control and are always perm
 With no access control configured, the server applies a secure default (`AclRules::secureDefault()`). It configures:
 
 - Anonymous clients are denied.
-- Authenticated clients may perform general operations.
+- Authenticated clients may search and compare any entry.
+- Writes require a grant. An identity may modify its own entry, limited to a small set of personal attributes.
+- Everything else is left to the administrator, when one is configured.
 - `userPassword` can be changed only by the entry owner and the administrator, and is never returned in search results.
 - Password Modify (RFC 3062) is limited to self and the administrator.
 - Privileged controls and extended operations are limited to the administrator.
@@ -50,19 +54,33 @@ methods. This is the recommended way to extend access control, for example to gr
 
 ```php
 AclRules::secureDefault()
-    ->withControlRules(ControlRule::allow(
+    ->withReplicaGrants(Subject::dn('cn=replica,dc=example,dc=com'));
+```
+
+The two families of method behave differently. The [grant helpers](#grant-helpers) such as `withReplicaGrants()` append
+to the current rules. The `with*Rules()` setters replace a whole category, so `withControlRules()` called on
+`secureDefault()` discards the control grants the secure default installed for the administrator. To add to a
+category with a setter, spread the existing rules first:
+
+```php
+$rules = AclRules::secureDefault(Subject::group('cn=admins,ou=groups,dc=example,dc=com'));
+
+$rules = $rules->withControlRules(
+    ...$rules->controls,
+    ...[ControlRule::allow(
         Subject::dn('cn=replica,dc=example,dc=com'),
         Target::subtree('dc=example,dc=com'),
         Control::OID_SYNC_REQUEST,
-    ));
+    )],
+);
 ```
 
-Building from `new AclRules()` instead gives a blank policy with no credential protection, so a `userPassword` rule is
-then yours to add. Composing on `secureDefault()` is the safe default. To apply just the credential protection to a
+Building from `AclRules::fromEmpty()` instead gives a blank policy with no credential protection, so a `userPassword`
+rule is then yours to add. Composing on `secureDefault()` is the safe default. To apply just the credential protection to a
 policy you build from scratch, use `AclRules::withCredentialProtection()`:
 
 ```php
-(new AclRules())
+AclRules::fromEmpty()
     ->withOperationRules(/* your rules */)
     ->withCredentialProtection(Subject::group('cn=admins,ou=groups,dc=example,dc=com'));
 ```
@@ -115,7 +133,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
 $server = new LdapServer(
     (new ServerOptions())
         ->setAclRules(
-            (new AclRules())
+            AclRules::fromEmpty()
                 ->withOperationRules(
                     // Admin group can do anything.
                     OperationRule::allow(
@@ -165,26 +183,97 @@ Rules are evaluated in definition order. For each rule:
 | Operation type | Rule has no operations listed, **or** current operation is in the list | Skip to next rule                                                   |
 | Target DN      | Target matcher returns true for the entry DN                           | Skip to next rule                                                   |
 | Subject        | Subject matcher returns true for the bound user                        | Skip to next rule                                                   |
-| Effect         | —                                                                      | `Allow` → permit; `Deny` → reject with `INSUFFICIENT_ACCESS_RIGHTS` |
+| Effect         | Always reached once the checks above pass                              | `Allow` → permit; `Deny` → reject with `INSUFFICIENT_ACCESS_RIGHTS` |
 
 If no rule matches, the [default effect](#default-effect) is applied.
 
-For attribute rules the same logic applies per attribute. Any attribute that matches no rule is kept (default allow).
+For attribute rules the same logic applies per attribute, but the fallback differs by direction. An attribute write
+that matches no rule is denied. An attribute read that matches no rule is kept.
 
 ### Default Effect
 
-When no operation rule matches, `AclRules::$defaultOperationEffect` determines the outcome (default: `Effect::Deny`).
-Control rules have their own `$defaultControlEffect`, also `Effect::Deny`. Privileged controls are off unless granted.
+The defaults are fixed rather than configurable:
+
+- Operations that match no rule are denied.
+- Attribute writes that match no rule are denied.
+- Attribute reads that match no rule are allowed, so a search still returns attributes you wrote no rule for.
+- Controls and extended operations that match no rule are denied, so privileged controls are off unless granted.
+
+Because writes are denied by default, granting an operation is not enough on its own. A rule that allows `Add` or
+`Modify` still needs a matching attribute rule for the attributes being written, otherwise the operation is
+allowed and then every attribute in it is refused.
 
 ```php
-use FreeDSx\Ldap\Server\AccessControl\AclRules;
-use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;
+use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
 
-// Allow everything not explicitly matched (open policy).
-(new ServerOptions())->setAclRules(
-    new AclRules(defaultOperationEffect: Effect::Allow),
+OperationRule::allow(
+    Subject::group('cn=admins,dc=example,dc=com'),
+),
+// Without this the operation above is permitted but writes no attributes.
+AttributeRule::allow(
+    Subject::group('cn=admins,dc=example,dc=com'),
+    Target::any(),
+)->forWrite(),
+```
+
+`withFullAccess()` writes that pair for you. See [Grant Helpers](#grant-helpers).
+
+### Grant Helpers
+
+These methods bundle grants that are awkward to spell out rule by rule. They append to the current rules rather than
+replacing them, so they compose on `secureDefault()` or on a policy built from `fromEmpty()`.
+
+| Method                                                    | Grants                                                                            |
+|-----------------------------------------------------------|-----------------------------------------------------------------------------------|
+| `withFullAccess($subject, $target = new AnyTargetMatcher())`   | Every operation and every attribute write over the target                         |
+| `withSelfServiceWrites($attributes = AclRules::SELF_WRITABLE_ATTRIBUTES)` | Modify on an identity's own entry, limited to the given attributes |
+| `withCredentialProtection($administrators = null)`        | The `userPassword` and Password Modify rules, plus privileged controls and extended operations for the administrator |
+| `withReplicaGrants($replica, $target = new AnyTargetMatcher())` | The content-sync control, the ppolicy-forward extended operation, and confidential attribute reads |
+
+`AclRules::secureDefault()` is built from the first three. `withFullAccess()` is what it applies to the configured
+[administrator](#administrators), so reaching for it directly is how you grant a second identity the same rights.
+
+It covers operations and attribute writes only. Controls, extended operations, and confidential attributes are gated
+separately, which is why an administrator gets those from `withCredentialProtection()` rather than from this method.
+
+```php
+// A provisioning account with full rights over one subtree.
+AclRules::secureDefault(Subject::group('cn=admins,ou=groups,dc=example,dc=com'))
+    ->withFullAccess(
+        Subject::dn('cn=provisioning,dc=example,dc=com'),
+        Target::subtree('ou=people,dc=example,dc=com'),
+    );
+```
+
+Rule order still applies. These helpers append, so a grant added this way is reached only after the rules already in
+the set. A `deny` sitting earlier continues to win.
+
+### Self-Service Attributes
+
+The secure default lets an identity change a small set of personal attributes on its own entry, listed in
+`AclRules::SELF_WRITABLE_ATTRIBUTES`. Attributes carrying authorization, identity, or account recovery are left out,
+because self-service on those is a route to privilege escalation or account takeover.
+
+Pass a second argument to `secureDefault()` to change the set without rebuilding the policy. Spread the constant to
+keep the defaults and add to them.
+
+```php
+// The shipped set, plus one more.
+AclRules::secureDefault(
+    Subject::group('cn=admins,ou=groups,dc=example,dc=com'),
+    [...AclRules::SELF_WRITABLE_ATTRIBUTES, 'preferredLanguage'],
+);
+
+// Self-service on nothing but the password, which withCredentialProtection still allows.
+AclRules::secureDefault(
+    Subject::group('cn=admins,ou=groups,dc=example,dc=com'),
+    [],
 );
 ```
+
+Widen the set with care. Granting `member` or `memberOf` lets an identity add itself to a group, and granting
+`objectClass` lets it change which attributes its own entry may hold.
 
 ## Subject Reference
 
@@ -240,7 +329,7 @@ Attribute rules are enforced in three places:
 - **Add / Modify**: the request is rejected if the bound user is denied access to any attribute being written.
 
 ```php
-(new AclRules())->withAttributeRules(
+AclRules::fromEmpty()->withAttributeRules(
     // Only admins can see or write userPassword.
     AttributeRule::allow(
         Subject::group('cn=admins,dc=example,dc=com'),
@@ -277,7 +366,7 @@ appears in a result:
 Access is granted with a subject-only rule:
 
 ```php
-(new AclRules())->withConfidentialAccess(
+AclRules::fromEmpty()->withConfidentialAccess(
     // Named attributes, or ConfidentialAccessRule::allowAny() for every confidential attribute.
     ConfidentialAccessRule::allow(
         Subject::group('cn=admins,dc=example,dc=com'),
@@ -329,7 +418,7 @@ use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
 
 // Only the admin group may relax schema constraints, and only under ou=migrate.
-(new AclRules())->withControlRules(
+AclRules::fromEmpty()->withControlRules(
     ControlRule::allow(
         Subject::group('cn=admins,dc=example,dc=com'),
         Target::subtree('ou=migrate,dc=example,dc=com'),
@@ -349,7 +438,7 @@ list matches all). They are denied by default. The set of gated OIDs is configur
 ```php
 use FreeDSx\Ldap\Server\AccessControl\Rule\ExtendedOperationRule;
 
-(new AclRules())->withExtendedOperationRules(
+AclRules::fromEmpty()->withExtendedOperationRules(
     ExtendedOperationRule::allow(
         Subject::group('cn=admins,ou=groups,dc=example,dc=com'),
         '1.3.6.1.4.1....',

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -400,7 +400,7 @@ use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 $server = new LdapServer(
     (new ServerOptions())
         ->setAclRules(
-            (new AclRules())->withOperationRules(
+            AclRules::fromEmpty()->withOperationRules(
                 OperationRule::allow(Subject::authenticated()),
                 OperationRule::deny(Subject::anyone()),
             ),

--- a/src/FreeDSx/Ldap/Server/AccessControl/AclRules.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/AclRules.php
@@ -19,7 +19,6 @@ use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ConfidentialAccessRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
-use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ExtendedOperationRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
@@ -37,14 +36,27 @@ use FreeDSx\Ldap\Server\AccessControl\Target\TargetMatcherInterface;
 final readonly class AclRules
 {
     /**
+     * Personal attributes an identity may change on its own entry, so callers can extend rather than retype them.
+     *
+     * @var list<string>
+     *
+     * @see self::withSelfServiceWrites()
+     */
+    public const SELF_WRITABLE_ATTRIBUTES = [
+        'description',
+        'displayName',
+        'givenName',
+        'initials',
+        'jpegPhoto',
+        'labeledURI',
+    ];
+
+    /**
      * @param OperationRule[] $operations Evaluated in order; first match wins.
      * @param AttributeRule[] $attributes Evaluated per attribute in order; first match wins.
      * @param ControlRule[] $controls Evaluated per control in order; first match wins.
      * @param ExtendedOperationRule[] $extendedOps Evaluated per extended operation in order; first match wins.
      * @param ConfidentialAccessRule[] $confidential Evaluated per confidential attribute in order; first match wins.
-     * @param Effect $defaultOperationEffect Applied when no operation rule matches.
-     * @param Effect $defaultControlEffect Applied when no control rule matches (controls are gated, so Deny).
-     * @param Effect $defaultExtendedOpEffect Applied when no extended-operation rule matches (gated, so Deny).
      */
     private function __construct(
         public array $operations = [],
@@ -52,13 +64,10 @@ final readonly class AclRules
         public array $controls = [],
         public array $extendedOps = [],
         public array $confidential = [],
-        public Effect $defaultOperationEffect = Effect::Deny,
-        public Effect $defaultControlEffect = Effect::Deny,
-        public Effect $defaultExtendedOpEffect = Effect::Deny,
     ) {}
 
     /**
-     * A blank ruleset (deny-by-default) to build up with the with* methods.
+     * A blank ruleset to build up with the with* methods; anything left unmatched is denied.
      *
      * Unlike secureDefault() it adds no credential protection, so any userPassword rule is yours to add.
      *
@@ -74,9 +83,6 @@ final readonly class AclRules
         array $controls = [],
         array $extendedOps = [],
         array $confidential = [],
-        Effect $defaultOperationEffect = Effect::Deny,
-        Effect $defaultControlEffect = Effect::Deny,
-        Effect $defaultExtendedOpEffect = Effect::Deny,
     ): self {
         return new self(
             $operations,
@@ -84,9 +90,6 @@ final readonly class AclRules
             $controls,
             $extendedOps,
             $confidential,
-            $defaultOperationEffect,
-            $defaultControlEffect,
-            $defaultExtendedOpEffect,
         );
     }
 
@@ -98,9 +101,6 @@ final readonly class AclRules
             $this->controls,
             $this->extendedOps,
             $this->confidential,
-            $this->defaultOperationEffect,
-            $this->defaultControlEffect,
-            $this->defaultExtendedOpEffect,
         );
     }
 
@@ -112,9 +112,6 @@ final readonly class AclRules
             $this->controls,
             $this->extendedOps,
             $this->confidential,
-            $this->defaultOperationEffect,
-            $this->defaultControlEffect,
-            $this->defaultExtendedOpEffect,
         );
     }
 
@@ -126,9 +123,6 @@ final readonly class AclRules
             $controls,
             $this->extendedOps,
             $this->confidential,
-            $this->defaultOperationEffect,
-            $this->defaultControlEffect,
-            $this->defaultExtendedOpEffect,
         );
     }
 
@@ -140,9 +134,6 @@ final readonly class AclRules
             $this->controls,
             $extendedOps,
             $this->confidential,
-            $this->defaultOperationEffect,
-            $this->defaultControlEffect,
-            $this->defaultExtendedOpEffect,
         );
     }
 
@@ -157,9 +148,6 @@ final readonly class AclRules
             $this->controls,
             $this->extendedOps,
             $confidential,
-            $this->defaultOperationEffect,
-            $this->defaultControlEffect,
-            $this->defaultExtendedOpEffect,
         );
     }
 
@@ -193,64 +181,120 @@ final readonly class AclRules
                 ...$this->confidential,
                 ConfidentialAccessRule::allowAny($replica),
             ],
-            $this->defaultOperationEffect,
-            $this->defaultControlEffect,
-            $this->defaultExtendedOpEffect,
-        );
-    }
-
-    public function withDefaultOperationEffect(Effect $effect): self
-    {
-        return new self(
-            $this->operations,
-            $this->attributes,
-            $this->controls,
-            $this->extendedOps,
-            $this->confidential,
-            $effect,
-            $this->defaultControlEffect,
-            $this->defaultExtendedOpEffect,
-        );
-    }
-
-    public function withDefaultControlEffect(Effect $effect): self
-    {
-        return new self(
-            $this->operations,
-            $this->attributes,
-            $this->controls,
-            $this->extendedOps,
-            $this->confidential,
-            $this->defaultOperationEffect,
-            $effect,
-            $this->defaultExtendedOpEffect,
-        );
-    }
-
-    public function withDefaultExtendedOpEffect(Effect $effect): self
-    {
-        return new self(
-            $this->operations,
-            $this->attributes,
-            $this->controls,
-            $this->extendedOps,
-            $this->confidential,
-            $this->defaultOperationEffect,
-            $this->defaultControlEffect,
-            $effect,
         );
     }
 
     /**
-     * The secure default.
+     * The secure default. Reads are open to authenticated identities, writes require a grant:
      *
+     * - Search and Compare are allowed to any authenticated identity, on any entry.
+     * - An identity may Modify its own entry, limited to a set of personal attributes.
+     * - Everything else is left to the administrator, when one is configured.
+     *
+     * Nothing can grant itself group membership or edit another entry without an explicit rule.
+     *
+     * @param list<string> $selfWritableAttributes Attributes an identity may change on its own entry.
+     *
+     * @see self::withSelfServiceWrites()
      * @see self::withCredentialProtection()
      */
-    public static function secureDefault(?SubjectMatcherInterface $administrators = null): self
-    {
-        $base = new self(operations: [OperationRule::allow(Subject::authenticated())]);
+    public static function secureDefault(
+        ?SubjectMatcherInterface $administrators = null,
+        array $selfWritableAttributes = self::SELF_WRITABLE_ATTRIBUTES,
+    ): self {
+        $anyTarget = new AnyTargetMatcher();
 
-        return $base->withCredentialProtection($administrators);
+        $rules = self::fromEmpty(
+            operations: [
+                OperationRule::allow(
+                    Subject::authenticated(),
+                    $anyTarget,
+                    OperationType::Search,
+                    OperationType::Compare,
+                ),
+            ],
+        )->withSelfServiceWrites($selfWritableAttributes);
+
+        if ($administrators !== null) {
+            $rules = $rules->withFullAccess($administrators);
+        }
+
+        return $rules->withCredentialProtection($administrators);
+    }
+
+    /**
+     * Append a grant of every operation and every attribute write for a subject over $target.
+     *
+     * Controls, extended operations, and confidential attributes are gated separately and are not included.
+     *
+     * @see self::withCredentialProtection()
+     * @see self::withConfidentialAccess()
+     */
+    public function withFullAccess(
+        SubjectMatcherInterface $subject,
+        TargetMatcherInterface $target = new AnyTargetMatcher(),
+    ): self {
+        return new self(
+            operations: [
+                ...$this->operations,
+                OperationRule::allow(
+                    $subject,
+                    $target,
+                ),
+            ],
+            attributes: [
+                ...$this->attributes,
+                AttributeRule::allow(
+                    $subject,
+                    $target,
+                )->forWrite(),
+            ],
+            controls: $this->controls,
+            extendedOps: $this->extendedOps,
+            confidential: $this->confidential,
+        );
+    }
+
+    /**
+     * Append the self-service rules to this rule set, letting an identity modify its own entry.
+     *
+     * The default set leaves out anything carrying authorization, identity, or account recovery, since self-service
+     * on those is a route to escalation or account takeover. Widen it only with that in mind.
+     *
+     * @param list<string> $attributes Attributes writable on one's own entry; an empty list grants no attribute write.
+     */
+    public function withSelfServiceWrites(array $attributes = self::SELF_WRITABLE_ATTRIBUTES): self
+    {
+        $anyTarget = new AnyTargetMatcher();
+
+        // An AttributeRule with no attributes named matches every attribute, so an empty list must add no rule at all.
+        $selfWrites = $attributes === []
+            ? []
+            : [
+                AttributeRule::allow(
+                    Subject::self(),
+                    $anyTarget,
+                    ...$attributes,
+                )->forWrite(),
+            ];
+
+        return new self(
+            operations: [
+                ...$this->operations,
+                OperationRule::allow(
+                    Subject::self(),
+                    $anyTarget,
+                    OperationType::Modify,
+                ),
+            ],
+            attributes: [
+                ...$this->attributes,
+                ...$selfWrites,
+            ],
+            controls: $this->controls,
+            extendedOps: $this->extendedOps,
+            confidential: $this->confidential,
+        );
     }
 
     /**
@@ -319,9 +363,6 @@ final readonly class AclRules
             controls: [...$controls, ...$this->controls],
             extendedOps: [...$extendedOps, ...$this->extendedOps],
             confidential: $this->confidential,
-            defaultOperationEffect: $this->defaultOperationEffect,
-            defaultControlEffect: $this->defaultControlEffect,
-            defaultExtendedOpEffect: $this->defaultExtendedOpEffect,
         );
     }
 }

--- a/src/FreeDSx/Ldap/Server/AccessControl/RuleBasedAccessControl.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/RuleBasedAccessControl.php
@@ -86,6 +86,7 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
             $dn,
             strtolower($attribute),
             $access,
+            $this->defaultEffectFor($access),
         );
 
         if ($effect === Effect::Deny) {
@@ -182,6 +183,7 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
                 $dn,
                 strtolower($attribute->getName()),
                 AttributeAccess::Read,
+                Effect::Allow,
             );
 
             if ($effect !== Effect::Deny) {
@@ -210,6 +212,16 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
         );
     }
 
+    /**
+     * Writes require a rule to permit them; reads are permitted unless a rule denies.
+     */
+    private function defaultEffectFor(AttributeAccess $access): Effect
+    {
+        return $access === AttributeAccess::Write
+            ? Effect::Deny
+            : Effect::Allow;
+    }
+
     private function isAllowed(
         OperationType $operation,
         TokenInterface $token,
@@ -221,7 +233,7 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
             $operation,
             $token,
             $dn,
-            $this->rules->defaultOperationEffect,
+            Effect::Deny,
         ) === Effect::Allow;
     }
 
@@ -244,7 +256,7 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
             $controlOid,
             $token,
             $dn,
-            $this->rules->defaultControlEffect,
+            Effect::Deny,
         ) === Effect::Allow;
     }
 
@@ -285,7 +297,7 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
             $this->extendedOperationMatches(...),
             $oid,
             $token,
-            $this->rules->defaultExtendedOpEffect,
+            Effect::Deny,
         ) === Effect::Allow;
     }
 
@@ -374,7 +386,8 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
         Dn $dn,
         string $attrName,
         AttributeAccess $access,
-    ): ?Effect {
+        Effect $default,
+    ): Effect {
         foreach ($this->rules->attributes as $rule) {
             if (!$rule->access->includes($access)) {
                 continue;
@@ -395,7 +408,7 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
             return $rule->effect;
         }
 
-        return null;
+        return $default;
     }
 
     /**

--- a/tests/integration/Controls/ServerControlsTest.php
+++ b/tests/integration/Controls/ServerControlsTest.php
@@ -60,7 +60,7 @@ final class ServerControlsTest extends ServerTestCase
 
     public function test_assertion_allows_a_modify_when_it_matches(): void
     {
-        $this->bind();
+        $this->authenticateAdmin();
         $dn = $this->createPerson('assert-ok');
 
         $this->ldapClient()->send(
@@ -73,7 +73,7 @@ final class ServerControlsTest extends ServerTestCase
 
     public function test_assertion_fails_a_modify_when_it_does_not_match(): void
     {
-        $this->bind();
+        $this->authenticateAdmin();
         $dn = $this->createPerson('assert-no');
 
         try {
@@ -124,7 +124,7 @@ final class ServerControlsTest extends ServerTestCase
 
     public function test_pre_read_and_post_read_capture_state_around_a_modify(): void
     {
-        $this->bind();
+        $this->authenticateAdmin();
         $dn = $this->createPerson('prepost');
 
         $response = $this->ldapClient()->send(
@@ -143,7 +143,7 @@ final class ServerControlsTest extends ServerTestCase
 
     public function test_pre_read_returns_the_entry_on_delete(): void
     {
-        $this->bind();
+        $this->authenticateAdmin();
         $dn = $this->createPerson('del-preread');
 
         $response = $this->ldapClient()->send(
@@ -158,7 +158,7 @@ final class ServerControlsTest extends ServerTestCase
 
     public function test_post_read_returns_the_entry_on_add(): void
     {
-        $this->bind();
+        $this->authenticateAdmin();
         $dn = 'cn=add-postread,ou=people,dc=foo,dc=bar';
 
         $response = $this->ldapClient()->send(
@@ -173,7 +173,7 @@ final class ServerControlsTest extends ServerTestCase
 
     public function test_subtree_delete_removes_the_whole_subtree(): void
     {
-        $this->bind();
+        $this->authenticateAdmin();
         $this->ldapClient()->create(Entry::fromArray('ou=del-tree,dc=foo,dc=bar', [
             'objectClass' => ['organizationalUnit'],
             'ou' => ['del-tree'],
@@ -202,7 +202,7 @@ final class ServerControlsTest extends ServerTestCase
 
     public function test_deleting_a_non_leaf_without_the_control_is_rejected(): void
     {
-        $this->bind();
+        $this->authenticateAdmin();
         $this->ldapClient()->create(Entry::fromArray('ou=non-leaf,dc=foo,dc=bar', [
             'objectClass' => ['organizationalUnit'],
             'ou' => ['non-leaf'],

--- a/tests/integration/LdapProxyTest.php
+++ b/tests/integration/LdapProxyTest.php
@@ -68,7 +68,7 @@ final class LdapProxyTest extends ServerTestCase
 
     public function testItForwardsWritesToUpstream(): void
     {
-        $this->authenticate();
+        $this->authenticateAdmin();
         $client = $this->ldapClient();
         $dn = 'cn=written,dc=foo,dc=bar';
 
@@ -115,15 +115,16 @@ final class LdapProxyTest extends ServerTestCase
             $entries->add(...$paging->getEntries()->toArray());
         }
 
+        // Upstream seeds 12 generated entries plus cn=user and cn=admin.
         self::assertCount(
-            13,
+            14,
             $entries,
         );
     }
 
     public function testItForwardsAResponseControlFromUpstream(): void
     {
-        $this->authenticate();
+        $this->authenticateAdmin();
 
         $response = $this->ldapClient()->send(
             Operations::add(Entry::fromArray(

--- a/tests/integration/LdapServerTest.php
+++ b/tests/integration/LdapServerTest.php
@@ -73,7 +73,7 @@ final class LdapServerTest extends ServerTestCase
 
     public function testItPerformsAnAdd(): void
     {
-        $this->authenticate();
+        $this->authenticateAdmin();
         $this->ldapClient()->create(Entry::fromArray(
             'cn=added,dc=foo,dc=bar',
             ['cn' => 'added', 'sn' => 'Test', 'objectClass' => 'inetOrgPerson'],
@@ -89,7 +89,7 @@ final class LdapServerTest extends ServerTestCase
 
     public function testItPerformsDelete(): void
     {
-        $this->authenticate();
+        $this->authenticateAdmin();
         $this->ldapClient()->create(Entry::fromArray(
             'cn=todelete,dc=foo,dc=bar',
             ['cn' => 'todelete', 'sn' => 'Delete', 'objectClass' => 'inetOrgPerson'],
@@ -103,7 +103,7 @@ final class LdapServerTest extends ServerTestCase
 
     public function testItPerformsModify(): void
     {
-        $this->authenticate();
+        $this->authenticateAdmin();
         $this->ldapClient()->create(Entry::fromArray(
             'cn=tomodify,dc=foo,dc=bar',
             ['cn' => 'tomodify', 'sn' => 'Before', 'mail' => 'before@example.com', 'objectClass' => 'inetOrgPerson'],
@@ -153,7 +153,7 @@ final class LdapServerTest extends ServerTestCase
 
     public function testItCanModifyDn(): void
     {
-        $this->authenticate();
+        $this->authenticateAdmin();
         $this->ldapClient()->create(Entry::fromArray(
             'cn=tomove,dc=foo,dc=bar',
             ['cn' => 'tomove', 'sn' => 'Move', 'objectClass' => 'inetOrgPerson'],
@@ -453,7 +453,7 @@ final class LdapServerTest extends ServerTestCase
 
     public function testRenameWithoutDeleteKeepsOldRdn(): void
     {
-        $this->authenticate();
+        $this->authenticateAdmin();
         $this->ldapClient()->create(Entry::fromArray(
             'cn=torenameold,dc=foo,dc=bar',
             [

--- a/tests/integration/Schema/LdapLoadedSchemaTest.php
+++ b/tests/integration/Schema/LdapLoadedSchemaTest.php
@@ -57,7 +57,7 @@ final class LdapLoadedSchemaTest extends ServerTestCase
 
     public function test_an_entry_using_a_loaded_object_class_is_accepted(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=loaded-ok,dc=foo,dc=bar',
@@ -84,7 +84,7 @@ final class LdapLoadedSchemaTest extends ServerTestCase
 
     public function test_a_loaded_object_class_enforces_its_required_attributes(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
@@ -101,7 +101,7 @@ final class LdapLoadedSchemaTest extends ServerTestCase
 
     public function test_a_loaded_object_class_rejects_an_attribute_it_does_not_permit(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
@@ -120,7 +120,7 @@ final class LdapLoadedSchemaTest extends ServerTestCase
 
     public function test_a_loaded_attribute_is_searchable_by_its_matching_rules(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=loaded-search,dc=foo,dc=bar',
@@ -147,7 +147,7 @@ final class LdapLoadedSchemaTest extends ServerTestCase
 
     public function test_the_standard_schema_still_applies_alongside_loaded_definitions(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=loaded-standard,dc=foo,dc=bar',

--- a/tests/integration/Schema/LdapRelaxControlTest.php
+++ b/tests/integration/Schema/LdapRelaxControlTest.php
@@ -57,7 +57,7 @@ final class LdapRelaxControlTest extends ServerTestCase
 
     public function test_relax_control_allows_a_schema_violating_add(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         // 'mail' is not permitted by the 'person' object class; rejected under Strict without the control.
         $this->ldapClient()->create(
@@ -88,7 +88,7 @@ final class LdapRelaxControlTest extends ServerTestCase
 
     public function test_same_add_is_rejected_under_strict_without_the_control(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
@@ -106,7 +106,7 @@ final class LdapRelaxControlTest extends ServerTestCase
 
     public function test_relax_control_does_not_bypass_invalid_attribute_syntax(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);

--- a/tests/integration/Schema/LdapSchemaConstraintTest.php
+++ b/tests/integration/Schema/LdapSchemaConstraintTest.php
@@ -55,7 +55,7 @@ final class LdapSchemaConstraintTest extends ServerTestCase
 
     public function test_add_with_invalid_attribute_syntax_is_rejected(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
@@ -73,7 +73,7 @@ final class LdapSchemaConstraintTest extends ServerTestCase
 
     public function test_add_with_two_unrelated_structural_classes_is_rejected(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
@@ -91,7 +91,7 @@ final class LdapSchemaConstraintTest extends ServerTestCase
 
     public function test_add_missing_a_required_attribute_of_a_built_in_class_is_rejected(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
@@ -108,7 +108,7 @@ final class LdapSchemaConstraintTest extends ServerTestCase
 
     public function test_modify_adding_an_attribute_the_class_does_not_permit_is_rejected(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=strict-modify,dc=foo,dc=bar',
@@ -130,7 +130,7 @@ final class LdapSchemaConstraintTest extends ServerTestCase
 
     public function test_add_with_two_values_for_a_single_valued_attribute_is_rejected(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::CONSTRAINT_VIOLATION);
@@ -149,7 +149,7 @@ final class LdapSchemaConstraintTest extends ServerTestCase
 
     public function test_modify_adding_a_second_value_to_a_single_valued_attribute_is_rejected(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=single-value-modify,dc=foo,dc=bar',
@@ -171,7 +171,7 @@ final class LdapSchemaConstraintTest extends ServerTestCase
 
     public function test_add_writing_a_no_user_modification_attribute_is_rejected(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::CONSTRAINT_VIOLATION);
@@ -190,7 +190,7 @@ final class LdapSchemaConstraintTest extends ServerTestCase
 
     public function test_modify_writing_a_no_user_modification_attribute_is_rejected(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=operational-modify,dc=foo,dc=bar',
@@ -211,7 +211,7 @@ final class LdapSchemaConstraintTest extends ServerTestCase
 
     public function test_add_with_a_non_numeric_value_for_an_integer_attribute_is_rejected(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
@@ -229,7 +229,7 @@ final class LdapSchemaConstraintTest extends ServerTestCase
 
     public function test_add_with_a_non_boolean_value_for_a_boolean_attribute_is_rejected(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
@@ -249,12 +249,12 @@ final class LdapSchemaConstraintTest extends ServerTestCase
 
     public function test_the_nis_schema_is_usable_end_to_end(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->ldapClient()->create(Entry::fromArray(
-            'cn=admins,dc=foo,dc=bar',
+            'cn=posix-users,dc=foo,dc=bar',
             [
-                'cn' => 'admins',
+                'cn' => 'posix-users',
                 'objectClass' => 'posixGroup',
                 'gidNumber' => '5000',
                 'memberUid' => ['alice', 'bob'],
@@ -269,14 +269,14 @@ final class LdapSchemaConstraintTest extends ServerTestCase
 
         self::assertCount(1, $entries);
         self::assertSame(
-            'admins',
+            'posix-users',
             $entries->first()?->get('cn')?->firstValue(),
         );
     }
 
     public function test_a_posix_group_missing_its_required_gid_is_rejected(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);

--- a/tests/integration/Schema/LdapSchemaConstraintTest.php
+++ b/tests/integration/Schema/LdapSchemaConstraintTest.php
@@ -16,10 +16,12 @@ namespace Tests\Integration\FreeDSx\Ldap\Schema;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\Search\Filters;
 use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
 
 /**
- * End-to-end rejection of malformed values and conflicting structural classes under Strict validation.
+ * End-to-end enforcement of what the shipped schema declares, under Strict validation.
  */
 final class LdapSchemaConstraintTest extends ServerTestCase
 {
@@ -83,6 +85,208 @@ final class LdapSchemaConstraintTest extends ServerTestCase
                 'sn' => 'Smith',
                 'ou' => 'People',
                 'objectClass' => ['person', 'organizationalUnit'],
+            ],
+        ));
+    }
+
+    public function test_add_missing_a_required_attribute_of_a_built_in_class_is_rejected(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
+
+        // 'sn' is MUST on the 'person' class.
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=no-surname,dc=foo,dc=bar',
+            [
+                'cn' => 'no-surname',
+                'objectClass' => 'person',
+            ],
+        ));
+    }
+
+    public function test_modify_adding_an_attribute_the_class_does_not_permit_is_rejected(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=strict-modify,dc=foo,dc=bar',
+            [
+                'cn' => 'strict-modify',
+                'sn' => 'Smith',
+                'objectClass' => 'person',
+            ],
+        ));
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
+
+        // 'mail' is neither MUST nor MAY on 'person'.
+        $entry = Entry::fromArray('cn=strict-modify,dc=foo,dc=bar');
+        $entry->set('mail', 'strict-modify@foo.bar');
+        $this->ldapClient()->update($entry);
+    }
+
+    public function test_add_with_two_values_for_a_single_valued_attribute_is_rejected(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::CONSTRAINT_VIOLATION);
+
+        // 'displayName' is SINGLE-VALUE.
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=two-display-names,dc=foo,dc=bar',
+            [
+                'cn' => 'two-display-names',
+                'sn' => 'Smith',
+                'objectClass' => 'inetOrgPerson',
+                'displayName' => ['First', 'Second'],
+            ],
+        ));
+    }
+
+    public function test_modify_adding_a_second_value_to_a_single_valued_attribute_is_rejected(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=single-value-modify,dc=foo,dc=bar',
+            [
+                'cn' => 'single-value-modify',
+                'sn' => 'Smith',
+                'objectClass' => 'inetOrgPerson',
+                'displayName' => 'First',
+            ],
+        ));
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::CONSTRAINT_VIOLATION);
+
+        $entry = Entry::fromArray('cn=single-value-modify,dc=foo,dc=bar');
+        $entry->add('displayName', 'Second');
+        $this->ldapClient()->update($entry);
+    }
+
+    public function test_add_writing_a_no_user_modification_attribute_is_rejected(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::CONSTRAINT_VIOLATION);
+
+        // 'createTimestamp' is NO-USER-MODIFICATION; the server maintains it.
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=client-timestamp,dc=foo,dc=bar',
+            [
+                'cn' => 'client-timestamp',
+                'sn' => 'Smith',
+                'objectClass' => 'person',
+                'createTimestamp' => '20200101000000Z',
+            ],
+        ));
+    }
+
+    public function test_modify_writing_a_no_user_modification_attribute_is_rejected(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=operational-modify,dc=foo,dc=bar',
+            [
+                'cn' => 'operational-modify',
+                'sn' => 'Smith',
+                'objectClass' => 'person',
+            ],
+        ));
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::CONSTRAINT_VIOLATION);
+
+        $entry = Entry::fromArray('cn=operational-modify,dc=foo,dc=bar');
+        $entry->set('modifiersName', 'cn=someone,dc=foo,dc=bar');
+        $this->ldapClient()->update($entry);
+    }
+
+    public function test_add_with_a_non_numeric_value_for_an_integer_attribute_is_rejected(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
+
+        // 'gidNumber' declares the INTEGER syntax.
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=bad-gid,dc=foo,dc=bar',
+            [
+                'cn' => 'bad-gid',
+                'objectClass' => 'posixGroup',
+                'gidNumber' => 'not-a-number',
+            ],
+        ));
+    }
+
+    public function test_add_with_a_non_boolean_value_for_a_boolean_attribute_is_rejected(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
+
+        // 'pwdLockout' declares the BOOLEAN syntax, which permits only TRUE or FALSE.
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=bad-boolean,dc=foo,dc=bar',
+            [
+                'cn' => 'bad-boolean',
+                'sn' => 'Smith',
+                'objectClass' => ['person', 'pwdPolicy'],
+                'pwdAttribute' => 'userPassword',
+                'pwdLockout' => 'maybe',
+            ],
+        ));
+    }
+
+    public function test_the_nis_schema_is_usable_end_to_end(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=admins,dc=foo,dc=bar',
+            [
+                'cn' => 'admins',
+                'objectClass' => 'posixGroup',
+                'gidNumber' => '5000',
+                'memberUid' => ['alice', 'bob'],
+            ],
+        ));
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::equal('gidNumber', '5000'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        self::assertCount(1, $entries);
+        self::assertSame(
+            'admins',
+            $entries->first()?->get('cn')?->firstValue(),
+        );
+    }
+
+    public function test_a_posix_group_missing_its_required_gid_is_rejected(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
+
+        // 'gidNumber' is MUST on 'posixGroup'.
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=no-gid,dc=foo,dc=bar',
+            [
+                'cn' => 'no-gid',
+                'objectClass' => 'posixGroup',
             ],
         ));
     }

--- a/tests/integration/Schema/LdapSchemaValidationTest.php
+++ b/tests/integration/Schema/LdapSchemaValidationTest.php
@@ -53,7 +53,7 @@ final class LdapSchemaValidationTest extends ServerTestCase
 
     public function test_lenient_mode_allows_add_with_disallowed_attribute(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         // 'mail' is not permitted by the 'person' object class; rejected under Strict.
         $this->ldapClient()->create(Entry::fromArray(
@@ -81,7 +81,7 @@ final class LdapSchemaValidationTest extends ServerTestCase
 
     public function test_lenient_mode_allows_modify_into_violating_state(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=drift-modify,dc=foo,dc=bar',

--- a/tests/integration/Search/LdapQueryServerTest.php
+++ b/tests/integration/Search/LdapQueryServerTest.php
@@ -23,6 +23,11 @@ final class LdapQueryServerTest extends ServerTestCase
 {
     private const ENTRY_COUNT = 5;
 
+    /**
+     * The fixed seed adds cn=user and cn=admin on top of the generated entries.
+     */
+    private const SEEDED_PERSON_COUNT = 2;
+
     private const BASE_DN = 'dc=foo,dc=bar';
 
     private LdapQuery $subject;
@@ -66,7 +71,7 @@ final class LdapQueryServerTest extends ServerTestCase
             ->get();
 
         $this->assertCount(
-            self::ENTRY_COUNT + 1,
+            self::ENTRY_COUNT + self::SEEDED_PERSON_COUNT,
             $entries,
         );
     }
@@ -166,7 +171,7 @@ final class LdapQueryServerTest extends ServerTestCase
         }
 
         $this->assertCount(
-            self::ENTRY_COUNT + 1,
+            self::ENTRY_COUNT + self::SEEDED_PERSON_COUNT,
             $entries,
         );
     }
@@ -189,7 +194,7 @@ final class LdapQueryServerTest extends ServerTestCase
         }
 
         $this->assertSame(
-            self::ENTRY_COUNT + 1,
+            self::ENTRY_COUNT + self::SEEDED_PERSON_COUNT,
             $count,
         );
     }

--- a/tests/integration/ServerTestCase.php
+++ b/tests/integration/ServerTestCase.php
@@ -218,6 +218,17 @@ class ServerTestCase extends LdapTestCase
         );
     }
 
+    /**
+     * Binds as an identity the harness configures as an administrator, for tests that write.
+     */
+    protected function authenticateAdmin(): void
+    {
+        $this->ldapClient()->bind(
+            'cn=admin,dc=foo,dc=bar',
+            '12345',
+        );
+    }
+
     protected function setServerMode(string $mode): void
     {
         $this->serverMode = $mode;

--- a/tests/integration/Storage/LdapBackendFileStorageTest.php
+++ b/tests/integration/Storage/LdapBackendFileStorageTest.php
@@ -72,7 +72,7 @@ final class LdapBackendFileStorageTest extends LdapBackendStorageTest
 
     public function testWritesPersistAcrossConnections(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=persistent,dc=foo,dc=bar',

--- a/tests/integration/Storage/LdapBackendSqliteStorageTest.php
+++ b/tests/integration/Storage/LdapBackendSqliteStorageTest.php
@@ -76,10 +76,7 @@ final class LdapBackendSqliteStorageTest extends LdapBackendStorageTest
 
     public function testWritesPersistAcrossConnections(): void
     {
-        $this->ldapClient()->bind(
-            'cn=user,dc=foo,dc=bar',
-            '12345',
-        );
+        $this->authenticateAdmin();
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=persistent,dc=foo,dc=bar',

--- a/tests/integration/Storage/LdapBackendStorageTest.php
+++ b/tests/integration/Storage/LdapBackendStorageTest.php
@@ -669,6 +669,42 @@ class LdapBackendStorageTest extends ServerTestCase
         );
     }
 
+    /**
+     * uidNumber declares the INTEGER syntax, so '99' is below '100' rather than above it bytewise.
+     */
+    public function testGteOnAnIntegerAttributeOrdersNumerically(): void
+    {
+        $this->authenticateUser();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::gte('uidNumber', '100'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        self::assertCount(0, $entries);
+    }
+
+    /**
+     * Bytewise, '99' would sort above '100' and be excluded.
+     */
+    public function testLteOnAnIntegerAttributeOrdersNumerically(): void
+    {
+        $this->authenticateUser();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::lte('uidNumber', '100'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        self::assertCount(1, $entries);
+        self::assertSame(
+            'cn=alice,ou=people,dc=foo,dc=bar',
+            $entries->first()?->getDn()->toString(),
+        );
+    }
+
     public function testNotEqualityExcludesMatches(): void
     {
         $this->authenticateUser();

--- a/tests/integration/Storage/LdapBackendStorageTest.php
+++ b/tests/integration/Storage/LdapBackendStorageTest.php
@@ -104,7 +104,7 @@ class LdapBackendStorageTest extends ServerTestCase
         );
 
         self::assertCount(
-            3,
+            5,
             $entries,
         );
     }
@@ -276,7 +276,7 @@ class LdapBackendStorageTest extends ServerTestCase
 
     public function testAddStoresEntry(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=charlie,dc=foo,dc=bar',
@@ -293,7 +293,7 @@ class LdapBackendStorageTest extends ServerTestCase
 
     public function testAddPreservesAttributeOptionsOnRoundTrip(): void
     {
-        $this->authenticateUser();
+        $this->authenticateAdmin();
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=tagged,dc=foo,dc=bar',
@@ -325,7 +325,7 @@ class LdapBackendStorageTest extends ServerTestCase
 
     public function testInexactFilterOnUnrequestedAttributeStillMatchesAndProjects(): void
     {
-        $this->authenticateUser();
+        $this->authenticateAdmin();
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=hazard,dc=foo,dc=bar',
@@ -361,7 +361,7 @@ class LdapBackendStorageTest extends ServerTestCase
 
     public function testNoAttributesRequestStillMatchesAnInexactFilter(): void
     {
-        $this->authenticateUser();
+        $this->authenticateAdmin();
 
         $this->ldapClient()->create(Entry::fromArray(
             'cn=noattr,dc=foo,dc=bar',
@@ -393,7 +393,7 @@ class LdapBackendStorageTest extends ServerTestCase
 
     public function testAddDuplicateDnFails(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::ENTRY_ALREADY_EXISTS);
@@ -406,7 +406,7 @@ class LdapBackendStorageTest extends ServerTestCase
 
     public function testDeleteRemovesEntry(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
         $this->ldapClient()->delete('cn=alice,ou=people,dc=foo,dc=bar');
 
         $entries = $this->ldapClient()->search(
@@ -419,7 +419,7 @@ class LdapBackendStorageTest extends ServerTestCase
 
     public function testDeleteNonLeafEntryFails(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::NOT_ALLOWED_ON_NON_LEAF);
@@ -430,7 +430,7 @@ class LdapBackendStorageTest extends ServerTestCase
 
     public function testModifyReplacesAttributeValue(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
 
         $entry = Entry::fromArray('cn=alice,ou=people,dc=foo,dc=bar');
         $entry->set('sn', 'Jones');
@@ -447,7 +447,7 @@ class LdapBackendStorageTest extends ServerTestCase
 
     public function testRenameChangesRdn(): void
     {
-        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+        $this->authenticateAdmin();
         $this->ldapClient()->rename('cn=alice,ou=people,dc=foo,dc=bar', 'cn=bob', true);
 
         $found = $this->ldapClient()->search(
@@ -512,7 +512,7 @@ class LdapBackendStorageTest extends ServerTestCase
         }
 
         self::assertCount(
-            5,
+            7,
             $allEntries,
         );
     }
@@ -738,9 +738,9 @@ class LdapBackendStorageTest extends ServerTestCase
             $entries->toArray(),
         );
 
-        // Seed: cn=user (sn=Admin), cn=alice (sn=Smith). Admin < Smith ascending.
+        // Seed: cn=user and cn=admin (sn=Admin), cn=alice (sn=Smith). Admin < Smith ascending.
         self::assertSame(
-            ['Admin', 'Smith'],
+            ['Admin', 'Admin', 'Smith'],
             $sns,
         );
     }
@@ -761,9 +761,9 @@ class LdapBackendStorageTest extends ServerTestCase
             $entries->toArray(),
         );
 
-        // Seed: cn=user (sn=Admin), cn=alice (sn=Smith). Smith > Admin descending.
+        // Seed: cn=user and cn=admin (sn=Admin), cn=alice (sn=Smith). Smith > Admin descending.
         self::assertSame(
-            ['Smith', 'Admin'],
+            ['Smith', 'Admin', 'Admin'],
             $sns,
         );
     }
@@ -779,12 +779,9 @@ class LdapBackendStorageTest extends ServerTestCase
             new SortingControl(SortKey::ascending('sn')),
         )->toArray();
 
-        $last = $entries[count($entries) - 1];
-        self::assertNull($last->get('sn'));
-        self::assertSame(
-            'nosn',
-            $last->get('cn')?->getValues()[0],
-        );
+        // More than one seed entry lacks 'sn', so assert the ordering rather than which of them sorts last.
+        self::assertNull($entries[count($entries) - 1]->get('sn'));
+        self::assertNotNull($entries[0]->get('sn'));
     }
 
     public function testSortControlPlacesMissingAttributeFirstWhenDescending(): void
@@ -798,12 +795,9 @@ class LdapBackendStorageTest extends ServerTestCase
             new SortingControl(SortKey::descending('sn')),
         )->toArray();
 
-        $first = $entries[0];
-        self::assertNull($first->get('sn'));
-        self::assertSame(
-            'nosn',
-            $first->get('cn')?->getValues()[0],
-        );
+        // More than one seed entry lacks 'sn', so assert the ordering rather than which of them sorts first.
+        self::assertNull($entries[0]->get('sn'));
+        self::assertNotNull($entries[count($entries) - 1]->get('sn'));
     }
 
     public function testInexactSearchTripsLookthroughLimit(): void
@@ -833,7 +827,7 @@ class LdapBackendStorageTest extends ServerTestCase
     {
         $this->stopServer();
         $this->createServerProcess('tcp', static::storageExtraArgs());
-        $this->authenticateUser();
+        $this->authenticateAdmin();
 
         $this->ldapClient()->create(Entry::fromArray('cn=ref,dc=foo,dc=bar', [
             'objectClass' => ['top', 'alias', 'extensibleObject'],

--- a/tests/integration/Sync/SyncReplNativeTest.php
+++ b/tests/integration/Sync/SyncReplNativeTest.php
@@ -70,6 +70,7 @@ final class SyncReplNativeTest extends ServerTestCase
         // A cookieless poll runs the present phase: the whole subtree comes across, nothing more.
         self::assertSame(
             [
+                'cn=admin,dc=foo,dc=bar',
                 'cn=alice,ou=people,dc=foo,dc=bar',
                 'cn=bob,ou=people,dc=foo,dc=bar',
                 'cn=carol,ou=people,dc=foo,dc=bar',
@@ -99,7 +100,8 @@ final class SyncReplNativeTest extends ServerTestCase
 
     public function testAnIncrementalPollWithACookieReturnsOnlyChangesSinceTheCookie(): void
     {
-        $this->authenticate();
+        // Writes below need an administrator, who also holds the privileged sync control.
+        $this->authenticateAdmin();
 
         $cookie = null;
         $initial = $this->syncRepl();

--- a/tests/integration/Sync/SyncReplPersistTestCase.php
+++ b/tests/integration/Sync/SyncReplPersistTestCase.php
@@ -211,7 +211,7 @@ abstract class SyncReplPersistTestCase extends ServerTestCase
         $writer = $this->buildClient('tcp');
 
         try {
-            $writer->bind('cn=user,dc=foo,dc=bar', '12345');
+            $writer->bind('cn=admin,dc=foo,dc=bar', '12345');
             $do($writer);
         } finally {
             $writer->unbind();

--- a/tests/integration/Sync/SyncReplReplicaTestCase.php
+++ b/tests/integration/Sync/SyncReplReplicaTestCase.php
@@ -230,7 +230,7 @@ abstract class SyncReplReplicaTestCase extends ServerTestCase
 
         try {
             $provider->bind(
-                'cn=user,dc=foo,dc=bar',
+                'cn=admin,dc=foo,dc=bar',
                 '12345',
             );
             $write($provider);

--- a/tests/performance/Compare/BenchCompareCommand.php
+++ b/tests/performance/Compare/BenchCompareCommand.php
@@ -32,7 +32,10 @@ final class BenchCompareCommand extends Command
 
     private const DEFAULT_SOURCE_PORT = 10389;
 
-    private const DEFAULT_SOURCE_BIND_DN = 'cn=user,dc=foo,dc=bar';
+    /**
+     * The write mixes need an identity the harness treats as an administrator.
+     */
+    private const DEFAULT_SOURCE_BIND_DN = 'cn=admin,dc=foo,dc=bar';
 
     private const DEFAULT_SOURCE_BIND_PASSWORD = '12345';
 

--- a/tests/performance/Config.php
+++ b/tests/performance/Config.php
@@ -56,7 +56,10 @@ final class Config
 
     public const DEFAULT_MIX = 'bind=5,search-read=50,search-eq=25,search-sub=10,search-list=5,search-sort=3,add=2,modify=2,delete=1';
 
-    public const DEFAULT_BIND_DN = 'cn=user,dc=foo,dc=bar';
+    /**
+     * The write mixes need an identity the harness treats as an administrator.
+     */
+    public const DEFAULT_BIND_DN = 'cn=admin,dc=foo,dc=bar';
 
     public const DEFAULT_BIND_PASSWORD = '12345';
 

--- a/tests/resources/seed/backend-storage-seed.ldif
+++ b/tests/resources/seed/backend-storage-seed.ldif
@@ -1,0 +1,47 @@
+version: 1
+
+# Fixed seed for the ldap-backend-storage harness. The --seed-entries entries are generated in the
+# command itself, since their count is a run-time option.
+
+# Domain root
+dn: dc=foo,dc=bar
+objectClass: domain
+dc: foo
+
+# Bind identity for suites that do not need to write
+dn: cn=user,dc=foo,dc=bar
+objectClass: inetOrgPerson
+cn: user
+sn: Admin
+userPassword: {SHA}jLIjfQZ5yojbZGTqxg2pY0VROWQ=
+
+# Administrator, a member of the group the harness configures via setAdministrators()
+dn: cn=admin,dc=foo,dc=bar
+objectClass: inetOrgPerson
+cn: admin
+sn: Admin
+userPassword: {SHA}jLIjfQZ5yojbZGTqxg2pY0VROWQ=
+
+dn: cn=admins,dc=foo,dc=bar
+objectClass: groupOfNames
+cn: admins
+member: cn=admin,dc=foo,dc=bar
+
+dn: ou=people,dc=foo,dc=bar
+objectClass: organizationalUnit
+ou: people
+
+dn: cn=alice,ou=people,dc=foo,dc=bar
+objectClass: inetOrgPerson
+objectClass: extensibleObject
+cn: alice
+sn: Smith
+mail: alice@foo.bar
+uidNumber: 99
+# Matched case-exactly by the schema, so searches on it prove the configured schema is in play.
+employeeNumber: A1b2C3
+
+dn: cn=nosn,dc=foo,dc=bar
+objectClass: groupOfNames
+cn: nosn
+member: cn=user,dc=foo,dc=bar

--- a/tests/resources/seed/server-sasl-seed.ldif
+++ b/tests/resources/seed/server-sasl-seed.ldif
@@ -1,0 +1,23 @@
+version: 1
+
+# Fixed seed for the ldap-server harness under --sasl. Passwords stay cleartext, since the SASL
+# mechanisms need the original value rather than a hash.
+
+# Domain root
+dn: dc=foo,dc=bar
+objectClass: domain
+dc: foo
+
+dn: cn=user,dc=foo,dc=bar
+objectClass: inetOrgPerson
+cn: user
+sn: User
+uid: user
+userPassword: 12345
+
+dn: cn=other,dc=foo,dc=bar
+objectClass: inetOrgPerson
+cn: other
+sn: Other
+uid: other
+userPassword: secret

--- a/tests/resources/seed/server-seed.ldif
+++ b/tests/resources/seed/server-seed.ldif
@@ -1,0 +1,23 @@
+version: 1
+
+# Fixed seed for the ldap-server harness. The --entries entries are generated in the command itself,
+# since their count is a run-time option.
+
+# Domain root
+dn: dc=foo,dc=bar
+objectClass: domain
+dc: foo
+
+# Bind identity for suites that do not need to write
+dn: cn=user,dc=foo,dc=bar
+objectClass: inetOrgPerson
+cn: user
+sn: User
+userPassword: {SHA}jLIjfQZ5yojbZGTqxg2pY0VROWQ=
+
+# Writes are denied by default, so suites that write bind as this identity
+dn: cn=admin,dc=foo,dc=bar
+objectClass: inetOrgPerson
+cn: admin
+sn: Admin
+userPassword: {SHA}jLIjfQZ5yojbZGTqxg2pY0VROWQ=

--- a/tests/resources/seed/sync-seed.ldif
+++ b/tests/resources/seed/sync-seed.ldif
@@ -11,6 +11,13 @@ cn: user
 sn: User
 userPassword: {SHA}jLIjfQZ5yojbZGTqxg2pY0VROWQ=
 
+# Writes are denied by default, so suites that write to the provider bind as this identity
+dn: cn=admin,dc=foo,dc=bar
+objectClass: inetOrgPerson
+cn: admin
+sn: Admin
+userPassword: {SHA}jLIjfQZ5yojbZGTqxg2pY0VROWQ=
+
 dn: ou=people,dc=foo,dc=bar
 objectClass: organizationalUnit
 ou: people

--- a/tests/support/LdapAclCommand.php
+++ b/tests/support/LdapAclCommand.php
@@ -155,6 +155,15 @@ class LdapAclCommand extends Command
                                 Target::any(),
                                 'userPassword',
                             ),
+                            // Writes are denied unless a rule allows them, so mirror the operation grants above.
+                            AttributeRule::allow(
+                                Subject::group('cn=admins,dc=foo,dc=bar'),
+                                Target::any(),
+                            )->forWrite(),
+                            AttributeRule::allow(
+                                Subject::self(),
+                                Target::any(),
+                            )->forWrite(),
                         )
                         // userPassword ships confidential, so reading it needs a grant on top of the rules above.
                         ->withConfidentialAccess(

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Config\JsonStorageConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
+use FreeDSx\Ldap\Ldif\Loader\FileLdifLoader;
 use FreeDSx\Ldap\Schema\LdifSchemaSource;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
@@ -40,6 +41,11 @@ final class LdapBackendStorageCommand extends Command
     public const MANAGER_DN = 'cn=manager';
 
     public const MANAGER_PASSWORD = 'manager-pass';
+
+    /**
+     * The fixed directory content every suite using this harness starts from.
+     */
+    private const SEED_LDIF = __DIR__ . '/../resources/seed/backend-storage-seed.ldif';
 
     protected function configure(): void
     {
@@ -198,43 +204,8 @@ final class LdapBackendStorageCommand extends Command
             return Command::FAILURE;
         }
 
-        $passwordHash = '{SHA}' . base64_encode(sha1('12345', true));
-
-        $entries = [
-            new Entry(
-                new Dn('dc=foo,dc=bar'),
-                new Attribute('dc', 'foo'),
-                new Attribute('objectClass', 'domain'),
-            ),
-            new Entry(
-                new Dn('cn=user,dc=foo,dc=bar'),
-                new Attribute('cn', 'user'),
-                new Attribute('sn', 'Admin'),
-                new Attribute('objectClass', 'inetOrgPerson'),
-                new Attribute('userPassword', $passwordHash),
-            ),
-            new Entry(
-                new Dn('ou=people,dc=foo,dc=bar'),
-                new Attribute('ou', 'people'),
-                new Attribute('objectClass', 'organizationalUnit'),
-            ),
-            new Entry(
-                new Dn('cn=alice,ou=people,dc=foo,dc=bar'),
-                new Attribute('cn', 'alice'),
-                new Attribute('objectClass', 'inetOrgPerson', 'extensibleObject'),
-                new Attribute('sn', 'Smith'),
-                new Attribute('mail', 'alice@foo.bar'),
-                new Attribute('uidNumber', '99'),
-                // Matched case-exactly by the schema, so searches on it prove the configured schema is in play.
-                new Attribute('employeeNumber', 'A1b2C3'),
-            ),
-            new Entry(
-                new Dn('cn=nosn,dc=foo,dc=bar'),
-                new Attribute('cn', 'nosn'),
-                new Attribute('objectClass', 'groupOfNames'),
-                new Attribute('member', 'cn=user,dc=foo,dc=bar'),
-            ),
-        ];
+        // The fixed content comes from SEED_LDIF; only the generated entries are built here.
+        $entries = [];
 
         for ($i = 1; $i <= $seedEntries; $i++) {
             $attributes = [
@@ -268,6 +239,7 @@ final class LdapBackendStorageCommand extends Command
                 $this->getStringOption($input, 'schema-ldif'),
             ),
         ))
+            ->setAdministrators(Subject::group('cn=admins,dc=foo,dc=bar'))
             ->setMonitorEnabled((bool) $input->getOption('monitor'))
             ->setSyncEnabled((bool) $input->getOption('journal'))
             ->setMaxSearchLookthrough((int) $this->getStringOption($input, 'max-search-lookthrough'))
@@ -307,7 +279,7 @@ final class LdapBackendStorageCommand extends Command
         }
 
         if ($storage === 'memory') {
-            $config = InMemoryStorageConfig::withEntries($entries);
+            $config = InMemoryStorageConfig::withEntries();
         } elseif ($storage === 'json') {
             $filePath = sys_get_temp_dir() . '/ldap_test_backend_storage.json';
 
@@ -359,15 +331,20 @@ final class LdapBackendStorageCommand extends Command
             $container,
         );
 
-        // The in-memory config carries its seed entries; other backends get a raw import (no schema validation).
-        if ($storage !== 'memory') {
-            $importer = new LdapImporter($container->get(EntryStorageInterface::class));
+        $seed = function () use ($server, $entries, $container): void {
+            $server->seed(new FileLdifLoader(self::SEED_LDIF));
 
-            if ($runner === 'swoole') {
-                \Swoole\Coroutine\run(fn() => $importer->importEntries($entries));
-            } else {
-                $importer->importEntries($entries);
+            // The generated entries stay a raw import, since they exist to widen the return path rather than to
+            // be valid directory content.
+            if ($entries !== []) {
+                (new LdapImporter($container->get(EntryStorageInterface::class)))->importEntries($entries);
             }
+        };
+
+        if ($runner === 'swoole') {
+            \Swoole\Coroutine\run($seed);
+        } else {
+            $seed();
         }
 
         $server->run();

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -50,6 +50,15 @@ final class LdapServerCommand extends Command
 
     public const MANAGER_PASSWORD = 'manager-pass';
 
+    /**
+     * Writes are denied by default, so tests that write bind as this identity.
+     */
+    private const ADMIN_DN = 'cn=admin,dc=foo,dc=bar';
+
+    private const SEED_LDIF = __DIR__ . '/../resources/seed/server-seed.ldif';
+
+    private const SASL_SEED_LDIF = __DIR__ . '/../resources/seed/server-sasl-seed.ldif';
+
     private const SSL_KEY = __DIR__ . '/../resources/cert/slapd.key';
 
     private const SSL_CERT = __DIR__ . '/../resources/cert/slapd.crt';
@@ -227,7 +236,7 @@ final class LdapServerCommand extends Command
             $useSsl = true;
         }
 
-        $entries = $sasl ? $this->buildSaslEntries() : $this->buildDefaultEntries();
+        $entries = [];
 
         if ($external) {
             // Subject "/DC=bar/DC=foo/CN=extuser" maps (reversed) to this DN via SubjectDnCredentialMapper.
@@ -266,6 +275,7 @@ final class LdapServerCommand extends Command
         $options = (new ServerOptions($this->createStorageConfig($storageType), $network))
             ->setRunnerConfig(new RunnerConfig($runner === 'swoole' ? RunnerMode::Swoole : RunnerMode::Pcntl))
             ->setAllowAnonymous($allowAnonymous)
+            ->setAdministrators(Subject::dn(self::ADMIN_DN))
             ->setMaxSearchLookthrough((int) $this->getStringOption($input, 'max-search-lookthrough'))
             ->setMaxSearchPagedLookthrough((int) $this->getStringOption($input, 'max-search-paged-lookthrough'))
             ->setSyncEnabled(true)
@@ -310,32 +320,36 @@ final class LdapServerCommand extends Command
         }
 
         if ($external && $input->getOption('external-allow-proxy') === true) {
-            // Compose on the current rules (the secure default): grant the EXTERNAL cert identity proxied-auth.
+            // The with* methods replace rather than append, so carry the existing rules through.
+            $rules = $options->getAclRules();
             $options->setAclRules(
-                $options->getAclRules()->withControlRules(
-                    ControlRule::allow(
+                $rules->withControlRules(
+                    ...$rules->controls,
+                    ...[ControlRule::allow(
                         Subject::dn('cn=extuser,dc=foo,dc=bar'),
                         Target::subtree('dc=foo,dc=bar'),
                         Control::OID_PROXY_AUTHORIZATION,
-                    ),
+                    )],
                 ),
             );
         }
 
         if ($input->getOption('allow-sync') === true) {
-            // Compose on the current rules (the secure default) and add the one sync-specific grant.
+            $rules = $options->getAclRules();
             $options->setAclRules(
-                $options->getAclRules()->withControlRules(
-                    ControlRule::allow(
+                $rules->withControlRules(
+                    ...$rules->controls,
+                    ...[ControlRule::allow(
                         Subject::dn('cn=user,dc=foo,dc=bar'),
                         Target::subtree('dc=foo,dc=bar'),
                         Control::OID_SYNC_REQUEST,
-                    ),
+                    )],
                 ),
             );
         }
 
         if ($input->getOption('allow-ppolicy-forward') === true) {
+            $rules = $options->getAclRules();
             $options
                 ->setPasswordPolicy(new PasswordPolicy(
                     lockout: new PasswordLockoutRules(
@@ -344,11 +358,12 @@ final class LdapServerCommand extends Command
                     ),
                 ))
                 ->setAclRules(
-                    $options->getAclRules()->withExtendedOperationRules(
-                        ExtendedOperationRule::allow(
+                    $rules->withExtendedOperationRules(
+                        ...$rules->extendedOps,
+                        ...[ExtendedOperationRule::allow(
                             Subject::dn('cn=user,dc=foo,dc=bar'),
                             ExtendedRequest::OID_PPOLICY_STATE_FORWARD,
-                        ),
+                        )],
                     ),
                 );
         }
@@ -360,10 +375,15 @@ final class LdapServerCommand extends Command
             ));
         }
 
-        $loadData = function () use ($server, $storage, $seedFile, $entries, $changesFile, $dumpFile): void {
-            if ($seedFile !== '') {
-                $server->seed(new FileLdifLoader($seedFile));
-            } else {
+        $fixedSeed = $sasl
+            ? self::SASL_SEED_LDIF
+            : self::SEED_LDIF;
+
+        $loadData = function () use ($server, $storage, $seedFile, $fixedSeed, $entries, $changesFile, $dumpFile): void {
+            $server->seed(new FileLdifLoader($seedFile !== '' ? $seedFile : $fixedSeed));
+
+            // The generated and cert-mapped entries stay a raw import, since they carry synthetic attributes.
+            if ($entries !== []) {
                 (new LdapImporter($storage))->importEntries($entries);
             }
 
@@ -431,66 +451,5 @@ final class LdapServerCommand extends Command
         }
 
         return InMemoryStorageConfig::withEntries();
-    }
-
-    /**
-     * @return list<Entry>
-     */
-    private function buildDefaultEntries(): array
-    {
-        $passwordHash = '{SHA}' . base64_encode(sha1('12345', true));
-
-        return [
-            Entry::fromArray(
-                'dc=foo,dc=bar',
-                [
-                    'dc' => 'foo',
-                    'objectClass' => 'domain',
-                ],
-            ),
-            Entry::fromArray(
-                'cn=user,dc=foo,dc=bar',
-                [
-                    'cn' => 'user',
-                    'sn' => 'User',
-                    'objectClass' => 'inetOrgPerson',
-                    'userPassword' => $passwordHash,
-                ],
-            ),
-        ];
-    }
-
-    /**
-     * @return list<Entry>
-     */
-    private function buildSaslEntries(): array
-    {
-        return [
-            Entry::fromArray(
-                'dc=foo,dc=bar',
-                [
-                    'dc' => 'foo',
-                    'objectClass' => 'domain',
-                ],
-            ),
-            Entry::fromArray(
-                'cn=user,dc=foo,dc=bar',
-                [
-                    'objectClass' => 'inetOrgPerson',
-                    'cn' => 'user',
-                    'uid' => 'user',
-                    'userPassword' => '12345',
-                ],
-            ),
-            Entry::fromArray(
-                'cn=other,dc=foo,dc=bar',
-                [
-                    'objectClass' => 'inetOrgPerson',
-                    'cn' => 'other',
-                    'uid' => 'other',
-                    'userPassword' => 'secret',
-                ],
-            ),
-        ];
     }
 }

--- a/tests/unit/Server/AccessControl/AclRulesTest.php
+++ b/tests/unit/Server/AccessControl/AclRulesTest.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\AccessControl\AclRules;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
@@ -174,7 +175,7 @@ final class AclRulesTest extends TestCase
         );
     }
 
-    public function test_secureDefault_allows_authenticated_general_operations(): void
+    public function test_secureDefault_allows_authenticated_reads_of_any_entry(): void
     {
         $this->subject->authorizeOperation(
             OperationType::Search,
@@ -182,12 +183,150 @@ final class AclRulesTest extends TestCase
             new Dn(self::OTHER_DN),
         );
         $this->subject->authorizeOperation(
-            OperationType::Modify,
+            OperationType::Compare,
             $this->user(),
             new Dn(self::OTHER_DN),
         );
 
         $this->addToAssertionCount(1);
+    }
+
+    public function test_secureDefault_allows_an_identity_to_modify_its_own_entry(): void
+    {
+        $this->subject->authorizeOperation(
+            OperationType::Modify,
+            $this->user(),
+            new Dn(self::USER_DN),
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_secureDefault_denies_modifying_another_entry(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->subject->authorizeOperation(
+            OperationType::Modify,
+            $this->user(),
+            new Dn(self::OTHER_DN),
+        );
+    }
+
+    /**
+     * Writing member on a group entry would otherwise let an identity grant itself that group's rules.
+     */
+    public function test_secureDefault_denies_granting_yourself_group_membership(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->subject->authorizeAttribute(
+            $this->user(),
+            new Dn('cn=admins,dc=foo,dc=bar'),
+            'member',
+            AttributeAccess::Write,
+        );
+    }
+
+    public function test_secureDefault_allows_self_service_on_personal_attributes(): void
+    {
+        $this->subject->authorizeAttribute(
+            $this->user(),
+            new Dn(self::USER_DN),
+            'displayName',
+            AttributeAccess::Write,
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_secureDefault_denies_self_service_on_anything_else(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->subject->authorizeAttribute(
+            $this->user(),
+            new Dn(self::USER_DN),
+            'mail',
+            AttributeAccess::Write,
+        );
+    }
+
+    public function test_secureDefault_honors_an_overridden_self_writable_attribute_set(): void
+    {
+        $acl = new RuleBasedAccessControl(AclRules::secureDefault(
+            Subject::dn(self::ADMIN_DN),
+            ['mail'],
+        ));
+
+        $acl->authorizeAttribute(
+            $this->user(),
+            new Dn(self::USER_DN),
+            'mail',
+            AttributeAccess::Write,
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_secureDefault_denies_a_default_attribute_when_the_set_is_overridden(): void
+    {
+        $acl = new RuleBasedAccessControl(AclRules::secureDefault(
+            Subject::dn(self::ADMIN_DN),
+            ['mail'],
+        ));
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $acl->authorizeAttribute(
+            $this->user(),
+            new Dn(self::USER_DN),
+            'displayName',
+            AttributeAccess::Write,
+        );
+    }
+
+    /**
+     * An AttributeRule naming no attributes matches every attribute, so an empty set must grant nothing.
+     */
+    public function test_secureDefault_with_an_empty_self_writable_set_grants_no_self_write(): void
+    {
+        $acl = new RuleBasedAccessControl(AclRules::secureDefault(
+            Subject::dn(self::ADMIN_DN),
+            [],
+        ));
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $acl->authorizeAttribute(
+            $this->user(),
+            new Dn(self::USER_DN),
+            'displayName',
+            AttributeAccess::Write,
+        );
+    }
+
+    public function test_secureDefault_with_an_empty_self_writable_set_still_denies_sensitive_attributes(): void
+    {
+        $acl = new RuleBasedAccessControl(AclRules::secureDefault(
+            Subject::dn(self::ADMIN_DN),
+            [],
+        ));
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $acl->authorizeAttribute(
+            $this->user(),
+            new Dn(self::USER_DN),
+            'objectClass',
+            AttributeAccess::Write,
+        );
     }
 
     public function test_secureDefault_denies_anonymous(): void

--- a/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
+++ b/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
@@ -24,7 +24,6 @@ use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ConfidentialAccessRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
-use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;
 use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
 use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
 use FreeDSx\Ldap\Server\AccessControl\BackendAwareInterface;
@@ -87,12 +86,12 @@ final class RuleBasedAccessControlTest extends TestCase
         );
     }
 
-    public function test_it_should_deny_when_no_rules_match_and_default_effect_is_deny(): void
+    public function test_it_should_deny_when_no_rules_match(): void
     {
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
 
-        $subject = new RuleBasedAccessControl(AclRules::fromEmpty(defaultOperationEffect: Effect::Deny));
+        $subject = new RuleBasedAccessControl(AclRules::fromEmpty());
 
         $subject->authorizeOperation(
             OperationType::Search,
@@ -101,11 +100,13 @@ final class RuleBasedAccessControlTest extends TestCase
         );
     }
 
-    public function test_it_should_allow_when_no_rules_match_and_default_effect_is_allow(): void
+    public function test_it_should_allow_when_a_rule_permits_anyone(): void
     {
         $this->expectNotToPerformAssertions();
 
-        $subject = new RuleBasedAccessControl(AclRules::fromEmpty(defaultOperationEffect: Effect::Allow));
+        $subject = new RuleBasedAccessControl(AclRules::fromEmpty(
+            operations: [OperationRule::allow(new AnySubjectMatcher())],
+        ));
 
         $subject->authorizeOperation(
             OperationType::Search,
@@ -126,7 +127,6 @@ final class RuleBasedAccessControlTest extends TestCase
                     OperationType::Add,
                 ),
             ],
-            defaultOperationEffect: Effect::Deny,
         ));
 
         $subject->authorizeOperation(
@@ -468,9 +468,10 @@ final class RuleBasedAccessControlTest extends TestCase
         ));
     }
 
-    public function test_authorize_attribute_access_does_not_throw_when_no_deny_rule_matches(): void
+    public function test_authorize_attribute_write_throws_when_no_rule_allows_it(): void
     {
-        $this->expectNotToPerformAssertions();
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
 
         $subject = new RuleBasedAccessControl(AclRules::fromEmpty());
 
@@ -479,6 +480,20 @@ final class RuleBasedAccessControlTest extends TestCase
             $this->dn,
             'userPassword',
             AttributeAccess::Write,
+        );
+    }
+
+    public function test_authorize_attribute_read_does_not_throw_when_no_rule_matches(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $subject = new RuleBasedAccessControl(AclRules::fromEmpty());
+
+        $subject->authorizeAttribute(
+            $this->bindToken,
+            $this->dn,
+            'cn',
+            AttributeAccess::Read,
         );
     }
 


### PR DESCRIPTION
This further locks down the ACL defaults by denying writes by default with a limited set of self writes allowed. The admin is the only one granted writes / all operations by default.

I added some helpers for those wanting to make a subtree / something writable by another subject.