### PR TITLE
[1.0.0] Various security focused fixes and functionality.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=8.2",
     "freedsx/asn1": "dev-main#d6cee05",
-    "freedsx/socket": "dev-main#6acac64",
+    "freedsx/socket": "dev-main#091b092",
     "freedsx/sasl": "dev-main#ebf53ad",
     "psr/log": "^3"
   },

--- a/docs/Server/Access-Control.md
+++ b/docs/Server/Access-Control.md
@@ -58,23 +58,41 @@ AclRules::secureDefault()
     ->withReplicaGrants(Subject::dn('cn=replica,dc=example,dc=com'));
 ```
 
-The two families of method behave differently. The [grant helpers](#grant-helpers) such as `withReplicaGrants()` append
-to the current rules. The `with*Rules()` setters replace a whole category, so `withControlRules()` called on
-`secureDefault()` discards the control grants the secure default installed for the administrator. To add to a
-category with a setter, spread the existing rules first:
+Each category has three setters. Rules are evaluated in order and the first match wins, so the one you pick decides
+precedence:
+
+| Setter        | Effect                                                        |
+|---------------|---------------------------------------------------------------|
+| `append*`     | Adds to the end, so existing rules match first.                |
+| `prepend*`    | Adds to the front, so the new rules match first.               |
+| `replace*`    | Discards the whole category, including the secure default's.   |
+
+`append*` is what you want when composing on `secureDefault()`:
 
 ```php
 $rules = AclRules::secureDefault(Subject::group('cn=admins,ou=groups,dc=example,dc=com'));
 
-$rules = $rules->withControlRules(
-    ...$rules->controls,
-    ...[ControlRule::allow(
-        Subject::dn('cn=replica,dc=example,dc=com'),
-        Target::subtree('dc=example,dc=com'),
-        Control::OID_SYNC_REQUEST,
-    )],
+$rules = $rules->appendControlRules(ControlRule::allow(
+    Subject::dn('cn=replica,dc=example,dc=com'),
+    Target::subtree('dc=example,dc=com'),
+    Control::OID_SYNC_REQUEST,
+));
+```
+
+A deny only takes effect if it is matched before anything that would allow the same thing, so use `prepend*` for it:
+
+```php
+$rules = $rules->prependAttributeRules(
+    AttributeRule::deny(
+        Subject::anyone(),
+        Target::any(),
+        'employeeNumber',
+    )->forRead(),
 );
 ```
+
+`replace*` drops what the secure default installed, including the `userPassword` protection, so reach for it only
+when you are defining a category from scratch.
 
 Building from `AclRules::fromEmpty()` instead gives a blank policy with no credential protection, so a `userPassword`
 rule is then yours to add. Composing on `secureDefault()` is the safe default. To apply just the credential protection to a
@@ -82,7 +100,7 @@ policy you build from scratch, use `AclRules::withCredentialProtection()`:
 
 ```php
 AclRules::fromEmpty()
-    ->withOperationRules(/* your rules */)
+    ->replaceOperationRules(/* your rules */)
     ->withCredentialProtection(Subject::group('cn=admins,ou=groups,dc=example,dc=com'));
 ```
 
@@ -118,7 +136,7 @@ read-only replica it bypasses access control for reads, but writes are still ref
 
 Bundle operation, attribute, and control rules in an `AclRules` object and set it on `ServerOptions`. Rules are
 evaluated in definition order (first match wins). If no rule matches, a configurable default effect applies (deny by
-default). `AclRules` is immutable; the `with*` methods are variadic and return a new instance.
+default). `AclRules` is immutable; every setter is variadic and returns a new instance.
 
 ```php
 use FreeDSx\Ldap\LdapServer;
@@ -135,7 +153,7 @@ $server = new LdapServer(
     (new ServerOptions())
         ->setAclRules(
             AclRules::fromEmpty()
-                ->withOperationRules(
+                ->replaceOperationRules(
                     // Admin group can do anything.
                     OperationRule::allow(
                         Subject::group('cn=admins,dc=example,dc=com'),
@@ -156,7 +174,7 @@ $server = new LdapServer(
                     // Deny everything else.
                     OperationRule::deny(Subject::anyone()),
                 )
-                ->withAttributeRules(
+                ->replaceAttributeRules(
                     // Users can see their own userPassword.
                     AttributeRule::allow(
                         Subject::self(),
@@ -378,7 +396,7 @@ Attribute rules are enforced in three places:
 - **Add / Modify**: the request is rejected if the bound user is denied access to any attribute being written.
 
 ```php
-AclRules::fromEmpty()->withAttributeRules(
+AclRules::fromEmpty()->replaceAttributeRules(
     // Only admins can see or write userPassword.
     AttributeRule::allow(
         Subject::group('cn=admins,dc=example,dc=com'),
@@ -415,7 +433,7 @@ appears in a result:
 Access is granted with a subject-only rule:
 
 ```php
-AclRules::fromEmpty()->withConfidentialAccess(
+AclRules::fromEmpty()->replaceConfidentialAccess(
     // Named attributes, or ConfidentialAccessRule::allowAny() for every confidential attribute.
     ConfidentialAccessRule::allow(
         Subject::group('cn=admins,dc=example,dc=com'),
@@ -467,7 +485,7 @@ use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
 
 // Only the admin group may relax schema constraints, and only under ou=migrate.
-AclRules::fromEmpty()->withControlRules(
+AclRules::fromEmpty()->replaceControlRules(
     ControlRule::allow(
         Subject::group('cn=admins,dc=example,dc=com'),
         Target::subtree('ou=migrate,dc=example,dc=com'),
@@ -487,7 +505,7 @@ list matches all). They are denied by default. The set of gated OIDs is configur
 ```php
 use FreeDSx\Ldap\Server\AccessControl\Rule\ExtendedOperationRule;
 
-AclRules::fromEmpty()->withExtendedOperationRules(
+AclRules::fromEmpty()->replaceExtendedOperationRules(
     ExtendedOperationRule::allow(
         Subject::group('cn=admins,ou=groups,dc=example,dc=com'),
         '1.3.6.1.4.1....',

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -6,6 +6,7 @@ LDAP Server Configuration
     * [ServerOptions:setEventLogPolicy](#seteventlogpolicy)
     * [ServerOptions:setRequireAuthentication](#setrequireauthentication)
     * [ServerOptions:setAllowAnonymous](#setallowanonymous)
+    * [ServerOptions:setRequireConfidentiality](#setrequireconfidentiality)
 * [Network Configuration](#network-configuration)
     * [NetworkConfig:setIp](#setip)
     * [NetworkConfig:setPort](#setport)
@@ -133,6 +134,29 @@ Whether authentication (bind) should be required before an operation is allowed.
 Whether anonymous binds should be allowed.
 
 **Default**: `false`
+
+------------------
+#### setRequireConfidentiality
+
+How much of a session the server refuses to serve over an unprotected connection.
+
+```php
+use FreeDSx\Ldap\Server\Config\ConfidentialityRequirement;
+
+$options->setRequireConfidentiality(ConfidentialityRequirement::CredentialBind);
+```
+
+| Value            | Effect                                                                              |
+|------------------|-------------------------------------------------------------------------------------|
+| `None`           | Nothing is refused, including a password sent in the clear.                          |
+| `CredentialBind` | Refuses simple binds and SASL binds other than EXTERNAL. Anonymous reads still work. |
+| `AllOperations`  | Refuses every request apart from StartTLS, Unbind and Abandon.                       |
+
+A connection satisfies the requirement when it is encrypted, through either `setUseSsl` or a completed StartTLS, or
+when the transport is a unix socket. Configure [TLS](#tls) before turning this on, otherwise a unix transport is the
+only way left to satisfy it.
+
+**Default**: `ConfidentialityRequirement::None`
 
 ## Runner Configuration
 

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -424,7 +424,7 @@ use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 $server = new LdapServer(
     (new ServerOptions())
         ->setAclRules(
-            AclRules::fromEmpty()->withOperationRules(
+            AclRules::fromEmpty()->replaceOperationRules(
                 OperationRule::allow(Subject::authenticated()),
                 OperationRule::deny(Subject::anyone()),
             ),

--- a/docs/Server/General-Usage.md
+++ b/docs/Server/General-Usage.md
@@ -286,6 +286,10 @@ TLS terminates at each hop: configure the **upstream** hop on the `ClientOptions
 or `ProxyOptions` `useStartTls: true`), and the **downstream** hop on the `ProxyServerOptions` network config
 (LDAPS, or a client StartTLS upgrade using the configured server cert).
 
+`ProxyServerOptions` also accepts
+[setRequireConfidentiality](Configuration.md#setrequireconfidentiality), which refuses proxied binds that would
+otherwise carry a password to the proxy in the clear.
+
 **Note**: only simple and anonymous binds are proxied (SASL is not), and every request is forwarded to the
 single configured upstream.
 

--- a/docs/Server/Replication.md
+++ b/docs/Server/Replication.md
@@ -42,7 +42,7 @@ $syncGrant = ControlRule::allow(
 );
 
 // Add that grant to your directory's AclRules (see the Access Control page for the rest).
-$aclRules = $myAclRules->withControlRules($syncGrant);
+$aclRules = $myAclRules->appendControlRules($syncGrant);
 
 // A storage config that is visible across connections (see Storage and Runner Requirements below).
 $storageConfig = PdoConfig::forSqlite('/var/lib/freedsx/directory.sqlite');

--- a/src/FreeDSx/Ldap/Container/Provider/ConnectionGraphContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/ConnectionGraphContainerProvider.php
@@ -102,6 +102,7 @@ final class ConnectionGraphContainerProvider implements ContainerProviderInterfa
         return new AssertionEvaluator(
             $container->get(FilterEvaluatorInterface::class),
             $container->get(WritableStorageBackend::class),
+            $container->get(AccessControlInterface::class),
         );
     }
 

--- a/src/FreeDSx/Ldap/Entry/Dn.php
+++ b/src/FreeDSx/Ldap/Entry/Dn.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Entry;
 use ArrayIterator;
 use Countable;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Exception\InvalidDnSyntaxException;
 use FreeDSx\Ldap\Exception\UnexpectedValueException;
 use IteratorAggregate;
 use Stringable;
@@ -261,7 +262,7 @@ class Dn implements IteratorAggregate, Countable, Stringable
         $pieces = ($pieces === false) ? [] : $pieces;
 
         if (count($pieces) === 0) {
-            throw new UnexpectedValueException(sprintf(
+            throw new InvalidDnSyntaxException(sprintf(
                 'The DN value "%s" is not valid.',
                 $this->dn,
             ));

--- a/src/FreeDSx/Ldap/Entry/Dn.php
+++ b/src/FreeDSx/Ldap/Entry/Dn.php
@@ -65,6 +65,18 @@ class Dn implements IteratorAggregate, Countable, Stringable
     }
 
     /**
+     * Where an RDN sits under $parent, or at the root when there is none.
+     */
+    public static function fromRdn(
+        Rdn $rdn,
+        ?Dn $parent = null,
+    ): self {
+        return $parent === null
+            ? new self($rdn->toString())
+            : new self($rdn->toString() . ',' . $parent->toString());
+    }
+
+    /**
      * @throws UnexpectedValueException
      */
     public function getRdn(): Rdn

--- a/src/FreeDSx/Ldap/Entry/Rdn.php
+++ b/src/FreeDSx/Ldap/Entry/Rdn.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Entry;
 
-use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Exception\InvalidDnSyntaxException;
 use Stringable;
 
 use function array_keys;
@@ -111,6 +111,14 @@ class Rdn implements Stringable
         return null;
     }
 
+    /**
+     * Whether this holds a comma a DN would read as an RDN separator rather than as part of a value.
+     */
+    public function hasUnescapedComma(): bool
+    {
+        return preg_match('/(?<!\\\\),/', $this->toString()) === 1;
+    }
+
     public function toString(): string
     {
         $rdn = $this->name . '=' . $this->value;
@@ -123,7 +131,7 @@ class Rdn implements Stringable
     }
 
     /**
-     * @throws InvalidArgumentException
+     * @throws InvalidDnSyntaxException
      */
     public static function create(string $rdn): Rdn
     {
@@ -132,7 +140,7 @@ class Rdn implements Stringable
             $rdn,
         );
         if ($pieces === false) {
-            throw new InvalidArgumentException(sprintf(
+            throw new InvalidDnSyntaxException(sprintf(
                 'The RDN "%s" is invalid.',
                 $rdn,
             ));
@@ -147,7 +155,7 @@ class Rdn implements Stringable
                 limit: 2,
             );
             if (count($parts) !== 2) {
-                throw new InvalidArgumentException(sprintf(
+                throw new InvalidDnSyntaxException(sprintf(
                     'The RDN "%s" is invalid.',
                     $piece,
                 ));
@@ -166,7 +174,7 @@ class Rdn implements Stringable
         }
 
         if ($obj === null) {
-            throw new InvalidArgumentException(sprintf(
+            throw new InvalidDnSyntaxException(sprintf(
                 "The RDN '%s' is not valid.",
                 $rdn,
             ));

--- a/src/FreeDSx/Ldap/Exception/InvalidDnSyntaxException.php
+++ b/src/FreeDSx/Ldap/Exception/InvalidDnSyntaxException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Exception;
+
+/**
+ * Thrown when a DN or RDN cannot be parsed, so a client-supplied one can be answered with invalidDNSyntax.
+ */
+class InvalidDnSyntaxException extends InvalidArgumentException {}

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/AssertionEvaluator.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/AssertionEvaluator.php
@@ -19,11 +19,21 @@ use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
  * Evaluates an RFC 4528 assertion control against the operation's target entry.
+ *
+ * The outcome is observable, so an assertion on an attribute the identity may not read would otherwise answer a
+ * question it may not ask. Matching against the readable entry makes a withheld attribute assert as absent, exactly
+ * as it does on the search path.
+ *
+ * Whether the target may be read at all is authorized before this runs.
+ *
+ * @see \FreeDSx\Ldap\Server\Middleware\OperationAuthorizationMiddleware::authorizeControlledReads()
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -32,6 +42,7 @@ final readonly class AssertionEvaluator
     public function __construct(
         private FilterEvaluatorInterface $filterEvaluator,
         private LdapBackendInterface $backend,
+        private AccessControlInterface $accessControl,
     ) {}
 
     /**
@@ -42,6 +53,7 @@ final readonly class AssertionEvaluator
     public function assertSatisfied(
         Dn $targetDn,
         ControlBag $controls,
+        TokenInterface $token,
     ): void {
         $control = $controls->get(Control::OID_ASSERTION);
 
@@ -55,7 +67,12 @@ final readonly class AssertionEvaluator
             return;
         }
 
-        if ($this->filterEvaluator->evaluate($entry, $control->getFilter())) {
+        $readable = $this->accessControl->stripUnreadableAttributes(
+            $token,
+            $entry,
+        );
+
+        if ($this->filterEvaluator->evaluate($readable, $control->getFilter())) {
             return;
         }
 

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ReadEntryControlHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ReadEntryControlHandler.php
@@ -23,10 +23,15 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\Request;
 use FreeDSx\Ldap\Schema\Schema;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
  * Builds RFC 4527 Pre-Read / Post-Read response controls from the entry state around a write.
+ *
+ * The entry goes back to the client, so read policy applies to it as it would to a search result: a write privilege
+ * over an entry must not disclose what the identity may not read.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -35,6 +40,7 @@ final readonly class ReadEntryControlHandler
     public function __construct(
         private LdapBackendInterface $backend,
         private Schema $schema,
+        private AccessControlInterface $accessControl,
     ) {}
 
     /**
@@ -43,11 +49,12 @@ final readonly class ReadEntryControlHandler
     public function preReadFor(
         Request\RequestInterface $request,
         ControlBag $controls,
+        TokenInterface $token,
     ): ?PreReadResponseControl {
         $dn = $this->preReadDn($request);
 
         return $dn !== null
-            ? $this->preRead($dn, $controls)
+            ? $this->preRead($dn, $controls, $token)
             : null;
     }
 
@@ -57,22 +64,25 @@ final readonly class ReadEntryControlHandler
     public function postReadFor(
         Request\RequestInterface $request,
         ControlBag $controls,
+        TokenInterface $token,
     ): ?PostReadResponseControl {
         $dn = $this->postReadDn($request);
 
         return $dn !== null
-            ? $this->postRead($dn, $controls)
+            ? $this->postRead($dn, $controls, $token)
             : null;
     }
 
     public function preRead(
         Dn $dn,
         ControlBag $controls,
+        TokenInterface $token,
     ): ?PreReadResponseControl {
         $entry = $this->readEntry(
             Control::OID_PRE_READ,
             $dn,
             $controls,
+            $token,
         );
 
         return $entry !== null
@@ -83,11 +93,13 @@ final readonly class ReadEntryControlHandler
     public function postRead(
         Dn $dn,
         ControlBag $controls,
+        TokenInterface $token,
     ): ?PostReadResponseControl {
         $entry = $this->readEntry(
             Control::OID_POST_READ,
             $dn,
             $controls,
+            $token,
         );
 
         return $entry !== null
@@ -99,6 +111,7 @@ final readonly class ReadEntryControlHandler
         string $oid,
         Dn $dn,
         ControlBag $controls,
+        TokenInterface $token,
     ): ?Entry {
         $control = $controls->get($oid);
 
@@ -112,6 +125,13 @@ final readonly class ReadEntryControlHandler
             return null;
         }
 
+        // Stripped before selection, so naming an unreadable attribute cannot pull it into the response. Entry-level
+        // visibility is settled by the write authorization that precedes this, so only attribute rules apply.
+        $readable = $this->accessControl->stripUnreadableAttributes(
+            $token,
+            $entry,
+        );
+
         $projection = AttributeProjection::forRequest(
             array_map(
                 static fn(string $name): Attribute => new Attribute($name),
@@ -122,7 +142,7 @@ final readonly class ReadEntryControlHandler
         );
 
         // Make a copy so live references don't leak.
-        return $projection->project($entry)->makeCopy();
+        return $projection->project($readable)->makeCopy();
     }
 
     private function preReadDn(Request\RequestInterface $request): ?Dn

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ReadEntryControlHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ReadEntryControlHandler.php
@@ -24,6 +24,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\Request;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\AccessControl\OperationTargetDn;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
@@ -32,6 +33,11 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  *
  * The entry goes back to the client, so read policy applies to it as it would to a search result: a write privilege
  * over an entry must not disclose what the identity may not read.
+ *
+ * A critical control the identity cannot satisfy fails the operation before this runs; a non-critical one degrades
+ * to no control rather than failing an otherwise valid write.
+ *
+ * @see \FreeDSx\Ldap\Server\Middleware\OperationAuthorizationMiddleware::authorizeControlledReads()
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -125,12 +131,14 @@ final readonly class ReadEntryControlHandler
             return null;
         }
 
-        // Stripped before selection, so naming an unreadable attribute cannot pull it into the response. Entry-level
-        // visibility is settled by the write authorization that precedes this, so only attribute rules apply.
-        $readable = $this->accessControl->stripUnreadableAttributes(
+        $readable = $this->accessControl->filterEntry(
             $token,
             $entry,
         );
+
+        if ($readable === null) {
+            return null;
+        }
 
         $projection = AttributeProjection::forRequest(
             array_map(
@@ -160,22 +168,8 @@ final readonly class ReadEntryControlHandler
         return match (true) {
             $request instanceof Request\AddRequest => $request->getEntry()->getDn(),
             $request instanceof Request\ModifyRequest => $request->getDn(),
-            $request instanceof Request\ModifyDnRequest => $this->newDnFor($request),
+            $request instanceof Request\ModifyDnRequest => OperationTargetDn::resultOf($request),
             default => null,
         };
-    }
-
-    /**
-     * Resulting DN of a ModifyDN, mirroring the backend move semantics (new RDN under the new or existing parent).
-     */
-    private function newDnFor(Request\ModifyDnRequest $request): Dn
-    {
-        $parent = $request->getNewParentDn() ?? $request->getDn()->getParent();
-
-        if ($parent === null) {
-            return new Dn($request->getNewRdn()->toString());
-        }
-
-        return new Dn($request->getNewRdn()->toString() . ',' . $parent->toString());
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -56,6 +56,7 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
         $this->readEntryControlHandler = new ReadEntryControlHandler(
             $this->backend,
             $schema,
+            $this->accessControl,
         );
     }
 
@@ -127,7 +128,11 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
         TokenInterface $token,
         SchemaViolations $schemaViolations,
     ): ResponseStream {
-        $preRead = $this->readEntryControlHandler->preReadFor($request, $controls);
+        $preRead = $this->readEntryControlHandler->preReadFor(
+            $request,
+            $controls,
+            $token,
+        );
 
         $this->dispatchWrite(
             $request,
@@ -136,7 +141,11 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
             $schemaViolations,
         );
 
-        $postRead = $this->readEntryControlHandler->postReadFor($request, $controls);
+        $postRead = $this->readEntryControlHandler->postReadFor(
+            $request,
+            $controls,
+            $token,
+        );
 
         return ResponseStream::of(
             [$this->responseFactory->getStandardResponse(

--- a/src/FreeDSx/Ldap/Server/AccessControl/AclRules.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/AclRules.php
@@ -96,7 +96,10 @@ final readonly class AclRules
         );
     }
 
-    public function withOperationRules(OperationRule ...$operations): self
+    /**
+     * Discards every operation rule already present, including any the secure default installed.
+     */
+    public function replaceOperationRules(OperationRule ...$operations): self
     {
         return new self(
             $operations,
@@ -107,7 +110,10 @@ final readonly class AclRules
         );
     }
 
-    public function withAttributeRules(AttributeRule ...$attributes): self
+    /**
+     * Discards every attribute rule already present, including the credential protection of the secure default.
+     */
+    public function replaceAttributeRules(AttributeRule ...$attributes): self
     {
         return new self(
             $this->operations,
@@ -118,7 +124,10 @@ final readonly class AclRules
         );
     }
 
-    public function withControlRules(ControlRule ...$controls): self
+    /**
+     * Discards every control rule already present, including any the secure default installed.
+     */
+    public function replaceControlRules(ControlRule ...$controls): self
     {
         return new self(
             $this->operations,
@@ -129,7 +138,10 @@ final readonly class AclRules
         );
     }
 
-    public function withExtendedOperationRules(ExtendedOperationRule ...$extendedOps): self
+    /**
+     * Discards every extended operation rule already present, including any the secure default installed.
+     */
+    public function replaceExtendedOperationRules(ExtendedOperationRule ...$extendedOps): self
     {
         return new self(
             $this->operations,
@@ -142,8 +154,10 @@ final readonly class AclRules
 
     /**
      * Rules gating reads of schema attributes marked X-CONFIDENTIAL; nothing may read them without a grant.
+     *
+     * Discards every confidential rule already present.
      */
-    public function withConfidentialAccess(ConfidentialAccessRule ...$confidential): self
+    public function replaceConfidentialAccess(ConfidentialAccessRule ...$confidential): self
     {
         return new self(
             $this->operations,
@@ -155,6 +169,116 @@ final readonly class AclRules
     }
 
     /**
+     * Append operation rules, so anything already present matches first.
+     */
+    public function appendOperationRules(OperationRule ...$operations): self
+    {
+        return $this->replaceOperationRules(
+            ...$this->operations,
+            ...$operations,
+        );
+    }
+
+    /**
+     * Append attribute rules, so anything already present matches first.
+     */
+    public function appendAttributeRules(AttributeRule ...$attributes): self
+    {
+        return $this->replaceAttributeRules(
+            ...$this->attributes,
+            ...$attributes,
+        );
+    }
+
+    /**
+     * Append control rules, so anything already present matches first.
+     */
+    public function appendControlRules(ControlRule ...$controls): self
+    {
+        return $this->replaceControlRules(
+            ...$this->controls,
+            ...$controls,
+        );
+    }
+
+    /**
+     * Append extended operation rules, so anything already present matches first.
+     */
+    public function appendExtendedOperationRules(ExtendedOperationRule ...$extendedOps): self
+    {
+        return $this->replaceExtendedOperationRules(
+            ...$this->extendedOps,
+            ...$extendedOps,
+        );
+    }
+
+    /**
+     * Append confidential access rules, so anything already present matches first.
+     */
+    public function appendConfidentialAccess(ConfidentialAccessRule ...$confidential): self
+    {
+        return $this->replaceConfidentialAccess(
+            ...$this->confidential,
+            ...$confidential,
+        );
+    }
+
+    /**
+     * Prepend operation rules, so these match ahead of anything already present.
+     */
+    public function prependOperationRules(OperationRule ...$operations): self
+    {
+        return $this->replaceOperationRules(
+            ...$operations,
+            ...$this->operations,
+        );
+    }
+
+    /**
+     * Prepend attribute rules, so these match ahead of anything already present.
+     */
+    public function prependAttributeRules(AttributeRule ...$attributes): self
+    {
+        return $this->replaceAttributeRules(
+            ...$attributes,
+            ...$this->attributes,
+        );
+    }
+
+    /**
+     * Prepend control rules, so these match ahead of anything already present.
+     */
+    public function prependControlRules(ControlRule ...$controls): self
+    {
+        return $this->replaceControlRules(
+            ...$controls,
+            ...$this->controls,
+        );
+    }
+
+    /**
+     * Prepend extended operation rules, so these match ahead of anything already present.
+     */
+    public function prependExtendedOperationRules(ExtendedOperationRule ...$extendedOps): self
+    {
+        return $this->replaceExtendedOperationRules(
+            ...$extendedOps,
+            ...$this->extendedOps,
+        );
+    }
+
+    /**
+     * Prepend confidential access rules, so these match ahead of anything already present.
+     */
+    public function prependConfidentialAccess(ConfidentialAccessRule ...$confidential): self
+    {
+        return $this->replaceConfidentialAccess(
+            ...$confidential,
+            ...$this->confidential,
+        );
+    }
+
+    /**
      * Grant a replica's bind identity the privileged capabilities it needs: the content-sync control over $target,
      * the password-policy forward extended operation, and confidential attributes so those replicate.
      */
@@ -162,29 +286,17 @@ final readonly class AclRules
         SubjectMatcherInterface $replica,
         TargetMatcherInterface $target = new AnyTargetMatcher(),
     ): self {
-        return new self(
-            $this->operations,
-            $this->attributes,
-            [
-                ...$this->controls,
-                ControlRule::allow(
-                    $replica,
-                    $target,
-                    Control::OID_SYNC_REQUEST,
-                ),
-            ],
-            [
-                ...$this->extendedOps,
-                ExtendedOperationRule::allow(
-                    $replica,
-                    ExtendedRequest::OID_PPOLICY_STATE_FORWARD,
-                ),
-            ],
-            [
-                ...$this->confidential,
-                ConfidentialAccessRule::allowAny($replica),
-            ],
-        );
+        return $this
+            ->appendControlRules(ControlRule::allow(
+                $replica,
+                $target,
+                Control::OID_SYNC_REQUEST,
+            ))
+            ->appendExtendedOperationRules(ExtendedOperationRule::allow(
+                $replica,
+                ExtendedRequest::OID_PPOLICY_STATE_FORWARD,
+            ))
+            ->appendConfidentialAccess(ConfidentialAccessRule::allowAny($replica));
     }
 
     /**
@@ -235,31 +347,21 @@ final readonly class AclRules
      * Controls, extended operations, and confidential attributes are gated separately and are not included.
      *
      * @see self::withCredentialProtection()
-     * @see self::withConfidentialAccess()
+     * @see self::replaceConfidentialAccess()
      */
     public function withFullAccess(
         SubjectMatcherInterface $subject,
         TargetMatcherInterface $target = new AnyTargetMatcher(),
     ): self {
-        return new self(
-            operations: [
-                ...$this->operations,
-                OperationRule::allow(
-                    $subject,
-                    $target,
-                ),
-            ],
-            attributes: [
-                ...$this->attributes,
-                AttributeRule::allow(
-                    $subject,
-                    $target,
-                )->forWrite(),
-            ],
-            controls: $this->controls,
-            extendedOps: $this->extendedOps,
-            confidential: $this->confidential,
-        );
+        return $this
+            ->appendOperationRules(OperationRule::allow(
+                $subject,
+                $target,
+            ))
+            ->appendAttributeRules(AttributeRule::allow(
+                $subject,
+                $target,
+            )->forWrite());
     }
 
     /**
@@ -309,23 +411,13 @@ final readonly class AclRules
                 )->forWrite(),
             ];
 
-        return new self(
-            operations: [
-                ...$this->operations,
-                OperationRule::allow(
-                    Subject::self(),
-                    $anyTarget,
-                    OperationType::Modify,
-                ),
-            ],
-            attributes: [
-                ...$this->attributes,
-                ...$selfWrites,
-            ],
-            controls: $this->controls,
-            extendedOps: $this->extendedOps,
-            confidential: $this->confidential,
-        );
+        return $this
+            ->appendOperationRules(OperationRule::allow(
+                Subject::self(),
+                $anyTarget,
+                OperationType::Modify,
+            ))
+            ->appendAttributeRules(...$selfWrites);
     }
 
     /**
@@ -388,13 +480,11 @@ final readonly class AclRules
             'userPassword',
         )->forRead();
 
-        return new self(
-            operations: [...$passwordModify, ...$this->operations],
-            attributes: [...$userPassword, ...$this->attributes],
-            controls: [...$controls, ...$this->controls],
-            extendedOps: [...$extendedOps, ...$this->extendedOps],
-            confidential: $this->confidential,
-        );
+        return $this
+            ->prependOperationRules(...$passwordModify)
+            ->prependAttributeRules(...$userPassword)
+            ->prependControlRules(...$controls)
+            ->prependExtendedOperationRules(...$extendedOps);
     }
 
     /**
@@ -416,20 +506,13 @@ final readonly class AclRules
                 ),
             ];
 
-        return new self(
-            operations: [
-                ...$grant,
-                OperationRule::deny(
-                    Subject::anyone(),
-                    $target,
-                    OperationType::Search,
-                ),
-                ...$this->operations,
-            ],
-            attributes: $this->attributes,
-            controls: $this->controls,
-            extendedOps: $this->extendedOps,
-            confidential: $this->confidential,
+        return $this->prependOperationRules(
+            ...$grant,
+            ...[OperationRule::deny(
+                Subject::anyone(),
+                $target,
+                OperationType::Search,
+            )],
         );
     }
 }

--- a/src/FreeDSx/Ldap/Server/AccessControl/OperationTargetDn.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/OperationTargetDn.php
@@ -39,4 +39,15 @@ final class OperationTargetDn
             default => null,
         };
     }
+
+    /**
+     * Where a rename leaves the entry, derived the same way the backend derives it.
+     */
+    public static function resultOf(ModifyDnRequest $request): Dn
+    {
+        return Dn::fromRdn(
+            $request->getNewRdn(),
+            $request->getNewParentDn() ?? $request->getDn()->getParent(),
+        );
+    }
 }

--- a/src/FreeDSx/Ldap/Server/AccessControl/RuleBasedAccessControl.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/RuleBasedAccessControl.php
@@ -123,25 +123,13 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
         TokenInterface $token,
         string $controlOid,
     ): bool {
-        if (!$token instanceof AuthenticatedTokenInterface) {
-            return false;
-        }
-
-        foreach ($this->rules->controls as $rule) {
-            if ($rule->effect !== Effect::Allow) {
-                continue;
-            }
-
-            if (!$this->controlMatches($rule, $controlOid)) {
-                continue;
-            }
-
-            if ($rule->subject->matches($token, $token->getResolvedDn())) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->resolveSubjectEffect(
+            $this->rules->controls,
+            $this->controlMatches(...),
+            $controlOid,
+            $token,
+            Effect::Deny,
+        ) === Effect::Allow;
     }
 
     /**
@@ -315,7 +303,7 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
      * The {@see resolveEffect} counterpart for rules carrying no target, so the subject is matched against the
      * token's own resolved DN. Anonymous identities never match, as they cannot hold a grant.
      *
-     * @template TRule of ConfidentialAccessRule|ExtendedOperationRule
+     * @template TRule of ConfidentialAccessRule|ControlRule|ExtendedOperationRule
      * @template TValue
      * @param TRule[] $rules
      * @param callable(TRule, TValue): bool $selectorMatches

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/MoveOperation.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/MoveOperation.php
@@ -29,12 +29,10 @@ final class MoveOperation
         Entry $entry,
         MoveCommand $command,
     ): Entry {
-        $parent = $command->newParent ?? $command->dn->getParent();
-        $newDnString = $parent !== null
-            ? $command->newRdn->toString() . ',' . $parent->toString()
-            : $command->newRdn->toString();
-
-        $newDn = new Dn($newDnString);
+        $newDn = Dn::fromRdn(
+            $command->newRdn,
+            $command->newParent ?? $command->dn->getParent(),
+        );
         $newEntry = new Entry($newDn, ...$entry->getAttributes());
 
         if ($command->deleteOldRdn) {

--- a/src/FreeDSx/Ldap/Server/Backend/Write/WriteCommandFactory.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/WriteCommandFactory.php
@@ -44,16 +44,34 @@ final class WriteCommandFactory
                 $request->getDn(),
                 $request->getChanges(),
             ),
-            $request instanceof ModifyDnRequest => new MoveCommand(
-                $request->getDn(),
-                $request->getNewRdn(),
-                $request->getDeleteOldRdn(),
-                $request->getNewParentDn(),
-            ),
+            $request instanceof ModifyDnRequest => $this->moveCommand($request),
             default => throw new OperationException(
                 'The requested operation is not supported.',
                 ResultCode::NO_SUCH_OPERATION,
             ),
         };
+    }
+
+    /**
+     * An unescaped comma parses without complaint and then reads as an RDN separator, which would land the entry
+     * under a name the client never asked for.
+     *
+     * @throws OperationException
+     */
+    private function moveCommand(ModifyDnRequest $request): MoveCommand
+    {
+        if ($request->getNewRdn()->hasUnescapedComma()) {
+            throw new OperationException(
+                'The new RDN contains an unescaped comma.',
+                ResultCode::INVALID_DN_SYNTAX,
+            );
+        }
+
+        return new MoveCommand(
+            $request->getDn(),
+            $request->getNewRdn(),
+            $request->getDeleteOldRdn(),
+            $request->getNewParentDn(),
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Config/ConfidentialityRequirement.php
+++ b/src/FreeDSx/Ldap/Server/Config/ConfidentialityRequirement.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Config;
+
+/**
+ * How much of a session the server refuses to serve over an unprotected connection.
+ *
+ * @api
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+enum ConfidentialityRequirement
+{
+    /**
+     * Anything goes, including a password in the clear.
+     */
+    case None;
+
+    /**
+     * Binds that put a credential on the wire, leaving anonymous reads available in the clear.
+     */
+    case CredentialBind;
+
+    /**
+     * Every request, so nothing about the directory crosses an unprotected connection.
+     */
+    case AllOperations;
+}

--- a/src/FreeDSx/Ldap/Server/Config/NetworkConfig.php
+++ b/src/FreeDSx/Ldap/Server/Config/NetworkConfig.php
@@ -131,6 +131,14 @@ final class NetworkConfig
         return $this;
     }
 
+    /**
+     * Whether connections arrive over a local socket rather than a network.
+     */
+    public function isUnixSocket(): bool
+    {
+        return $this->transport === 'unix';
+    }
+
     public function getIdleTimeout(): int
     {
         return $this->idleTimeout;

--- a/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
+++ b/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
@@ -56,6 +56,7 @@ use FreeDSx\Ldap\Server\Middleware\AssertionMiddleware;
 use FreeDSx\Ldap\Server\Middleware\AuthorizationResolutionMiddleware;
 use FreeDSx\Ldap\Server\Middleware\BindMiddleware;
 use FreeDSx\Ldap\Server\Middleware\ConfidentialAttributeMiddleware;
+use FreeDSx\Ldap\Server\Middleware\ConfidentialityMiddleware;
 use FreeDSx\Ldap\Server\Middleware\CriticalControlMiddleware;
 use FreeDSx\Ldap\Server\Middleware\MetricsMiddleware;
 use FreeDSx\Ldap\Server\Middleware\OperationAuditMiddleware;
@@ -386,6 +387,11 @@ final class ConnectionHandlerBuilder implements ConnectionHandlerBuilderInterfac
                 // Order matters: AuthorizationResolutionMiddleware injects the token via withToken(), so
                 // every middleware after it may rely on tokenOrFail(). Keep token consumers below it.
                 new RequestValidationMiddleware(),
+                // Ahead of the bind, so a credential is refused before it is read rather than after it is compared.
+                new ConfidentialityMiddleware(
+                    $options,
+                    $queue,
+                ),
                 new BindMiddleware(
                     $authorization,
                     new Authenticator($authenticators),

--- a/src/FreeDSx/Ldap/Server/Middleware/AssertionMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/AssertionMiddleware.php
@@ -59,6 +59,7 @@ final readonly class AssertionMiddleware implements MiddlewareInterface
             $this->evaluator->assertSatisfied(
                 $target,
                 $message->controls(),
+                $context->tokenOrFail(),
             );
         }
 

--- a/src/FreeDSx/Ldap/Server/Middleware/ConfidentialityMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/ConfidentialityMiddleware.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\AbandonRequest;
+use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
+use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
+use FreeDSx\Ldap\Operation\Request\UnbindRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Queue\ConnectionControl;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
+use FreeDSx\Ldap\Server\Config\ConfidentialityRequirement;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\ServerListenerOptionsInterface;
+use FreeDSx\Ldap\ServerOptions;
+
+/**
+ * Refuses what the configured {@see ConfidentialityRequirement} will not allow over an unprotected connection.
+ *
+ * Placed ahead of the bind so a credential is refused before it is read, rather than after it has been compared.
+ *
+ * @internal
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ConfidentialityMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private ServerListenerOptionsInterface $options,
+        private ConnectionControl $connection,
+    ) {}
+
+    /**
+     * @throws OperationException
+     */
+    public function process(
+        ServerRequestContext $context,
+        MiddlewareHandlerInterface $next,
+    ): ResponseStream {
+        if ($this->isPermitted($context->message->getRequest())) {
+            return $next->handle($context);
+        }
+
+        throw new OperationException(
+            'This operation requires a confidential connection.',
+            ResultCode::CONFIDENTIALITY_REQUIRED,
+        );
+    }
+
+    private function isPermitted(RequestInterface $request): bool
+    {
+        if ($this->isConfidential()) {
+            return true;
+        }
+
+        return match ($this->options->getRequireConfidentiality()) {
+            ConfidentialityRequirement::None => true,
+            ConfidentialityRequirement::CredentialBind => !$this->carriesCredential($request),
+            ConfidentialityRequirement::AllOperations => $this->reachesConfidentiality($request),
+        };
+    }
+
+    /**
+     * Whether the connection cannot be read in transit.
+     *
+     * A unix socket qualifies, since the connection itself never traverses a network.
+     */
+    private function isConfidential(): bool
+    {
+        return $this->connection->isEncrypted()
+            || $this->options->getNetworkConfig()->isUnixSocket();
+    }
+
+    /**
+     * Whether the bind puts a credential on the wire.
+     *
+     * EXTERNAL carries none, authenticating instead from the TLS certificate already in play. Every other mechanism
+     * is treated as credential-bearing, including the challenge-response ones, whose exchanges can be attacked
+     * offline once captured.
+     */
+    private function carriesCredential(RequestInterface $request): bool
+    {
+        if ($request instanceof SaslBindRequest) {
+            return $request->getMechanism() !== ServerOptions::SASL_EXTERNAL;
+        }
+
+        return $request instanceof SimpleBindRequest;
+    }
+
+    /**
+     * Whether the request is one a plaintext client must keep, to negotiate protection or to leave.
+     *
+     * Without the StartTLS exemption the requirement could never be satisfied on a connection that begins in the
+     * clear. Unbind and Abandon disclose nothing and carry no response.
+     */
+    private function reachesConfidentiality(RequestInterface $request): bool
+    {
+        if ($request instanceof ExtendedRequest) {
+            return $request->getName() === ExtendedRequest::OID_START_TLS;
+        }
+
+        return $request instanceof UnbindRequest
+            || $request instanceof AbandonRequest;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
@@ -346,12 +346,53 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
     }
 
     /**
+     * Authorizes the attribute values a rename writes.
+     *
+     * A rename adds the new RDN's value to the entry, and removes the old one when deleteOldRdn is set, so it is an
+     * attribute write and must be authorized as one.
+     *
+     * @throws OperationException
+     */
+    private function authorizeRdnAttributes(
+        ModifyDnRequest $request,
+        TokenInterface $token,
+    ): void {
+        $dn = OperationTargetDn::resultOf($request);
+        $components = $request->getNewRdn()->getAll();
+
+        if ($request->getDeleteOldRdn()) {
+            $components = [
+                ...$components,
+                ...$request->getDn()->getRdn()->getAll(),
+            ];
+        }
+
+        foreach ($components as $component) {
+            $this->accessControl->authorizeAttribute(
+                $token,
+                $dn,
+                $component->getName(),
+                AttributeAccess::Write,
+            );
+        }
+    }
+
+    /**
      * @throws OperationException
      */
     private function authorizeWriteAttributes(
         RequestInterface $request,
         TokenInterface $token,
     ): void {
+        if ($request instanceof ModifyDnRequest) {
+            $this->authorizeRdnAttributes(
+                $request,
+                $token,
+            );
+
+            return;
+        }
+
         if ($request instanceof AddRequest) {
             $dn = $request->getEntry()->getDn();
             foreach ($request->getEntry()->getAttributes() as $attribute) {

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
@@ -67,6 +67,7 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
         MiddlewareHandlerInterface $next,
     ): ResponseStream {
         $this->authorizePrivilegedExtendedOperation($context);
+        $this->authorizePrivilegedControls($context);
         $this->authorizeControlledReads($context);
 
         $routeId = $this->routeResolver->routeIdFor(
@@ -80,10 +81,8 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
                 $context->tokenOrFail(),
             );
         } elseif ($routeId === HandlerId::Sync) {
-            $this->authorizeSync(
-                $context->message,
-                $context->tokenOrFail(),
-            );
+            // No operation gate of its own. The privileged sync-request control is authorized above, and the handler
+            // settles what the identity may see per entry via isEntryVisible().
         } elseif ($routeId === HandlerId::Monitor) {
             $this->accessControl->authorizeOperation(
                 OperationType::Search,
@@ -132,6 +131,39 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
     }
 
     /**
+     * Authorize every privileged control on the request ahead of routing so that no route can omit the gate.
+     *
+     * @throws OperationException
+     */
+    private function authorizePrivilegedControls(ServerRequestContext $context): void
+    {
+        $controls = $context->message->controls();
+        $dn = $this->targetDnFor($context->message->getRequest()) ?? new Dn('');
+
+        foreach ($this->privilegedControls as $oid) {
+            if (!$controls->has($oid)) {
+                continue;
+            }
+
+            $this->accessControl->authorizeControl(
+                $context->tokenOrFail(),
+                $dn,
+                $oid,
+            );
+        }
+    }
+
+    /**
+     * The entry a request acts on: a search names it as its base, anything else as its target DN.
+     */
+    private function targetDnFor(RequestInterface $request): ?Dn
+    {
+        return $request instanceof SearchRequest
+            ? $request->getBaseDn()
+            : OperationTargetDn::of($request);
+    }
+
+    /**
      * Fails a request whose control cannot be honored without a read the identity is not allowed to perform.
      *
      * Only controls the client marked critical are enforced here, per RFC 4511 section 4.1.11. A non-critical
@@ -170,9 +202,7 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
         $targets = [];
 
         if ($controls->has(Control::OID_ASSERTION)) {
-            $targets[] = $request instanceof SearchRequest
-                ? $request->getBaseDn()
-                : OperationTargetDn::of($request);
+            $targets[] = $this->targetDnFor($request);
         }
 
         // Pre-read has nothing to snapshot on an Add, since the entry does not exist yet.
@@ -226,28 +256,6 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
     }
 
     /**
-     * Gates a content-synchronization search on the privileged sync-request control, targeted at its base DN.
-     *
-     * @throws OperationException
-     */
-    private function authorizeSync(
-        LdapMessageRequest $message,
-        TokenInterface $token,
-    ): void {
-        $request = $message->getRequest();
-
-        if (!$request instanceof SearchRequest) {
-            return;
-        }
-
-        $this->authorizeControls(
-            $request->getBaseDn(),
-            $message->controls(),
-            $token,
-        );
-    }
-
-    /**
      * @throws OperationException
      */
     private function authorizeDispatch(
@@ -273,15 +281,7 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
                 $this->attributeFromString($request->getFilter()->getAttribute())->getName(),
                 AttributeAccess::Read,
             );
-
-            return;
         }
-
-        $this->authorizeControls(
-            OperationTargetDn::of($request),
-            $message->controls(),
-            $token,
-        );
     }
 
     /**
@@ -385,32 +385,5 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
     private function attributeFromString(string $attribute): Attribute
     {
         return new Attribute($attribute);
-    }
-
-    /**
-     * Authorizes any privileged control attached to the request before it is dispatched.
-     *
-     * @throws OperationException
-     */
-    private function authorizeControls(
-        ?Dn $dn,
-        ControlBag $controls,
-        TokenInterface $token,
-    ): void {
-        if ($dn === null) {
-            return;
-        }
-
-        foreach ($this->privilegedControls as $oid) {
-            if (!$controls->has($oid)) {
-                continue;
-            }
-
-            $this->accessControl->authorizeControl(
-                $token,
-                $dn,
-                $oid,
-            );
-        }
     }
 }

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
@@ -67,6 +67,7 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
         MiddlewareHandlerInterface $next,
     ): ResponseStream {
         $this->authorizePrivilegedExtendedOperation($context);
+        $this->authorizeControlledReads($context);
 
         $routeId = $this->routeResolver->routeIdFor(
             $context->message->getRequest(),
@@ -128,6 +129,74 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
             $context->tokenOrFail(),
             $request->getName(),
         );
+    }
+
+    /**
+     * Fails a request whose control cannot be honored without a read the identity is not allowed to perform.
+     *
+     * Only controls the client marked critical are enforced here, per RFC 4511 section 4.1.11. A non-critical
+     * read-entry control is left to be dropped from the response instead of failing an otherwise valid operation.
+     *
+     * An assertion is always enforced, critical or not, since ignoring a precondition would let a write land that
+     * the client conditioned on state it cannot verify.
+     *
+     * @see \FreeDSx\Ldap\Protocol\ServerProtocolHandler\ReadEntryControlHandler
+     *
+     * @throws OperationException
+     */
+    private function authorizeControlledReads(ServerRequestContext $context): void
+    {
+        $request = $context->message->getRequest();
+        $controls = $context->message->controls();
+
+        foreach ($this->enforcedReadTargetsFor($request, $controls) as $dn) {
+            $this->accessControl->authorizeOperation(
+                OperationType::Search,
+                $context->tokenOrFail(),
+                $dn,
+            );
+        }
+    }
+
+    /**
+     * The DNs a request's read-bearing controls will read, limited to the controls that must fail rather than degrade.
+     *
+     * @return list<Dn>
+     */
+    private function enforcedReadTargetsFor(
+        RequestInterface $request,
+        ControlBag $controls,
+    ): array {
+        $targets = [];
+
+        if ($controls->has(Control::OID_ASSERTION)) {
+            $targets[] = $request instanceof SearchRequest
+                ? $request->getBaseDn()
+                : OperationTargetDn::of($request);
+        }
+
+        // Pre-read has nothing to snapshot on an Add, since the entry does not exist yet.
+        if ($this->hasCritical($controls, Control::OID_PRE_READ) && !$request instanceof AddRequest) {
+            $targets[] = OperationTargetDn::of($request);
+        }
+
+        if ($this->hasCritical($controls, Control::OID_POST_READ)) {
+            $targets[] = $request instanceof ModifyDnRequest
+                ? OperationTargetDn::resultOf($request)
+                : OperationTargetDn::of($request);
+        }
+
+        return array_values(array_filter($targets));
+    }
+
+    /**
+     * Whether the control is present and the client marked it critical.
+     */
+    private function hasCritical(
+        ControlBag $controls,
+        string $oid,
+    ): bool {
+        return $controls->get($oid)?->getCriticality() === true;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Middleware/ResponseWriterMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/ResponseWriterMiddleware.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Middleware;
 
+use FreeDSx\Ldap\Exception\InvalidDnSyntaxException;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseWriter;
@@ -58,6 +60,20 @@ final readonly class ResponseWriterMiddleware implements MiddlewareInterface
         } catch (OperationException $e) {
             $outcome = $this->writer->write(
                 $this->errorStream($context, $e),
+                $messageId,
+            );
+        } catch (InvalidDnSyntaxException $e) {
+            // A DN is only parsed once something needs its pieces, which is well past the decode. Answering it here
+            // keeps a malformed one from ending the session on its way out as an unhandled failure.
+            $outcome = $this->writer->write(
+                $this->errorStream(
+                    $context,
+                    new OperationException(
+                        $e->getMessage(),
+                        ResultCode::INVALID_DN_SYNTAX,
+                        $e,
+                    ),
+                ),
                 $messageId,
             );
         }

--- a/src/FreeDSx/Ldap/Server/PasswordModify/PasswordModifyService.php
+++ b/src/FreeDSx/Ldap/Server/PasswordModify/PasswordModifyService.php
@@ -59,16 +59,27 @@ final readonly class PasswordModifyService
         AuthenticatedTokenInterface $token,
         ControlBag $controls,
     ): PasswordModifyResult {
-        $entry = $this->targetResolver->resolve(
+        $found = $this->targetResolver->find(
             $request,
             $token,
         );
-        $targetDn = $entry->getDn();
 
+        // Authorized ahead of reporting the absence, so a missing entry cannot be told from a forbidden one.
         $this->authorizeRequest(
             $token,
-            $targetDn,
+            $found?->getDn() ?? new Dn(''),
         );
+
+        if ($found === null) {
+            throw new OperationException(
+                'The target entry does not exist.',
+                ResultCode::NO_SUCH_OBJECT,
+            );
+        }
+
+        $entry = $found;
+        $targetDn = $entry->getDn();
+
         $this->verifyOldPassword(
             $request,
             $entry,

--- a/src/FreeDSx/Ldap/Server/PasswordModify/PasswordModifyTargetResolver.php
+++ b/src/FreeDSx/Ldap/Server/PasswordModify/PasswordModifyTargetResolver.php
@@ -14,9 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\PasswordModify;
 
 use FreeDSx\Ldap\Entry\Entry;
-use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\PasswordModifyRequest;
-use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
@@ -32,28 +30,21 @@ final readonly class PasswordModifyTargetResolver
     ) {}
 
     /**
-     * @throws OperationException when the target entry does not exist.
+     * The targeted entry, or null when nothing matches.
      */
-    public function resolve(
+    public function find(
         PasswordModifyRequest $request,
         AuthenticatedTokenInterface $token,
-    ): Entry {
+    ): ?Entry {
         $userIdentity = $request->getUsername();
 
-        $entry = $userIdentity === null || $userIdentity === ''
-            ? $this->backend->get($token->getResolvedDn())
-            : $this->identityResolver->resolve(
-                $userIdentity,
-                $this->backend,
-            );
-
-        if ($entry === null) {
-            throw new OperationException(
-                'The target entry does not exist.',
-                ResultCode::NO_SUCH_OBJECT,
-            );
+        if ($userIdentity === null || $userIdentity === '') {
+            return $this->backend->get($token->getResolvedDn());
         }
 
-        return $entry;
+        return $this->identityResolver->resolve(
+            $userIdentity,
+            $this->backend,
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyProtocolFactory.php
@@ -25,6 +25,7 @@ use FreeDSx\Ldap\ProxyOptions;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Middleware\AuthorizationResolutionMiddleware;
 use FreeDSx\Ldap\Server\Middleware\BindMiddleware;
+use FreeDSx\Ldap\Server\Middleware\ConfidentialityMiddleware;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareChain;
 use FreeDSx\Ldap\Server\Middleware\RequestValidationMiddleware;
 use FreeDSx\Ldap\Server\ServerConnectionScaffoldingTrait;
@@ -76,6 +77,11 @@ final class ProxyProtocolFactory implements ServerProtocolFactoryInterface
         $pipeline = new MiddlewareChain(
             [
                 new RequestValidationMiddleware(),
+                // Ahead of the bind, so a credential is refused before it is read rather than after it is compared.
+                new ConfidentialityMiddleware(
+                    $this->options,
+                    $queue,
+                ),
                 new BindMiddleware(
                     $serverAuthorization,
                     new Authenticator($authenticators),

--- a/src/FreeDSx/Ldap/Server/SocketServerFactory.php
+++ b/src/FreeDSx/Ldap/Server/SocketServerFactory.php
@@ -35,7 +35,7 @@ class SocketServerFactory
 
     public function makeAndBind(): SocketServer
     {
-        $isUnixSocket = $this->network->getTransport() === 'unix';
+        $isUnixSocket = $this->network->isUnixSocket();
         $resource = $isUnixSocket
             ? $this->network->getUnixSocket()
             : $this->network->getIp();

--- a/src/FreeDSx/Ldap/ServerListenerOptionsInterface.php
+++ b/src/FreeDSx/Ldap/ServerListenerOptionsInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap;
 
 use Closure;
+use FreeDSx\Ldap\Server\Config\ConfidentialityRequirement;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\Server\Config\RunnerConfig;
 use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
@@ -34,6 +35,8 @@ interface ServerListenerOptionsInterface
     public function isRequireAuthentication(): bool;
 
     public function isAllowAnonymous(): bool;
+
+    public function getRequireConfidentiality(): ConfidentialityRequirement;
 
     /**
      * @return string[]

--- a/src/FreeDSx/Ldap/ServerListenerOptionsTrait.php
+++ b/src/FreeDSx/Ldap/ServerListenerOptionsTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap;
 
 use Closure;
+use FreeDSx\Ldap\Server\Config\ConfidentialityRequirement;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\Server\Config\RunnerConfig;
 use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
@@ -33,6 +34,8 @@ trait ServerListenerOptionsTrait
     private bool $requireAuthentication = true;
 
     private bool $allowAnonymous = false;
+
+    private ConfidentialityRequirement $requireConfidentiality = ConfidentialityRequirement::None;
 
     private ?LoggerInterface $logger = null;
 
@@ -80,6 +83,24 @@ trait ServerListenerOptionsTrait
     public function setAllowAnonymous(bool $allowAnonymous): self
     {
         $this->allowAnonymous = $allowAnonymous;
+
+        return $this;
+    }
+
+    public function getRequireConfidentiality(): ConfidentialityRequirement
+    {
+        return $this->requireConfidentiality;
+    }
+
+    /**
+     * Refuse to serve part or all of a session over an unprotected connection.
+     *
+     * A unix socket counts as protected, since the connection itself never traverses a network. Anything relaying a
+     * remote client into that socket is trusted to have protected the hop it terminated.
+     */
+    public function setRequireConfidentiality(ConfidentialityRequirement $requireConfidentiality): self
+    {
+        $this->requireConfidentiality = $requireConfidentiality;
 
         return $this;
     }

--- a/tests/integration/Controls/ServerControlsTest.php
+++ b/tests/integration/Controls/ServerControlsTest.php
@@ -30,6 +30,8 @@ use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
  */
 final class ServerControlsTest extends ServerTestCase
 {
+    private const SEEDED_PASSWORD_HASH = '{SHA}jLIjfQZ5yojbZGTqxg2pY0VROWQ=';
+
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
@@ -120,6 +122,99 @@ final class ServerControlsTest extends ServerTestCase
             Operations::search(Filters::present('objectClass'))->base('dc=foo,dc=bar'),
         );
         self::assertGreaterThan(0, $entries->count());
+    }
+
+    public function test_assertion_on_an_unreadable_attribute_cannot_match_its_value(): void
+    {
+        $this->authenticateUser();
+
+        try {
+            $this->ldapClient()->search(
+                Operations::search(Filters::present('objectClass'))
+                    ->base('cn=user,dc=foo,dc=bar')
+                    ->useBaseScope(),
+                Controls::assertion(Filters::equal(
+                    'userPassword',
+                    self::SEEDED_PASSWORD_HASH,
+                )),
+            );
+            self::fail('Expected an OperationException was not thrown.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::ASSERTION_FAILED,
+                $e->getCode(),
+            );
+        }
+    }
+
+    public function test_assertion_substring_cannot_probe_an_unreadable_attribute(): void
+    {
+        $this->authenticateUser();
+
+        try {
+            $this->ldapClient()->search(
+                Operations::search(Filters::present('objectClass'))
+                    ->base('cn=user,dc=foo,dc=bar')
+                    ->useBaseScope(),
+                Controls::assertion(Filters::startsWith(
+                    'userPassword',
+                    '{SHA}',
+                )),
+            );
+            self::fail('Expected an OperationException was not thrown.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::ASSERTION_FAILED,
+                $e->getCode(),
+            );
+        }
+    }
+
+    public function test_assertion_on_a_readable_attribute_still_matches(): void
+    {
+        $this->authenticateUser();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'))
+                ->base('cn=user,dc=foo,dc=bar')
+                ->useBaseScope(),
+            Controls::assertion(Filters::equal(
+                'cn',
+                'user',
+            )),
+        );
+
+        self::assertCount(
+            1,
+            $entries,
+        );
+    }
+
+    public function test_assertion_on_an_unreadable_attribute_blocks_a_write_it_would_otherwise_gate(): void
+    {
+        $this->authenticateAdmin();
+
+        try {
+            $this->ldapClient()->send(
+                Operations::modify(
+                    'cn=user,dc=foo,dc=bar',
+                    Change::replace(
+                        'sn',
+                        'Asserted',
+                    ),
+                ),
+                Controls::assertion(Filters::equal(
+                    'userPassword',
+                    self::SEEDED_PASSWORD_HASH,
+                )),
+            );
+            self::fail('Expected an OperationException was not thrown.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::ASSERTION_FAILED,
+                $e->getCode(),
+            );
+        }
     }
 
     public function test_pre_read_and_post_read_capture_state_around_a_modify(): void

--- a/tests/integration/Controls/ServerControlsTest.php
+++ b/tests/integration/Controls/ServerControlsTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Integration\FreeDSx\Ldap\Controls;
 
 use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Operation\Response\CompareResponse;
 use FreeDSx\Ldap\Control\ReadEntry\PostReadResponseControl;
 use FreeDSx\Ldap\Control\ReadEntry\PreReadResponseControl;
 use FreeDSx\Ldap\Controls;
@@ -348,6 +349,93 @@ final class ServerControlsTest extends ServerTestCase
         );
     }
 
+    public function test_a_privileged_control_on_a_compare_is_denied_to_a_non_administrator(): void
+    {
+        $this->authenticateUser();
+
+        try {
+            $this->ldapClient()->send(
+                Operations::compare(
+                    'cn=user,dc=foo,dc=bar',
+                    'cn',
+                    'user',
+                ),
+                Controls::relaxRules(),
+            );
+            self::fail('Expected an OperationException was not thrown.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+                $e->getCode(),
+            );
+        }
+    }
+
+    public function test_a_privileged_control_on_an_extended_operation_is_denied_to_a_non_administrator(): void
+    {
+        $this->authenticateUser();
+
+        try {
+            $this->ldapClient()->send(
+                Operations::passwordModify(
+                    'cn=user,dc=foo,dc=bar',
+                    '12345',
+                    'newpass123',
+                ),
+                $this->nonCritical(Controls::relaxRules()),
+            );
+            self::fail('Expected an OperationException was not thrown.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+                $e->getCode(),
+            );
+        }
+    }
+
+    public function test_a_privileged_control_on_a_search_is_denied_to_a_non_administrator(): void
+    {
+        $this->authenticateUser();
+
+        try {
+            $this->ldapClient()->search(
+                Operations::search(Filters::present('objectClass'))
+                    ->base('dc=foo,dc=bar')
+                    ->useSubtreeScope(),
+                $this->nonCritical(Controls::relaxRules()),
+            );
+            self::fail('Expected an OperationException was not thrown.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+                $e->getCode(),
+            );
+        }
+    }
+
+    public function test_an_administrator_may_use_a_privileged_control_on_a_compare(): void
+    {
+        $this->authenticateAdmin();
+
+        $response = $this->ldapClient()->send(
+            Operations::compare(
+                'cn=user,dc=foo,dc=bar',
+                'cn',
+                'user',
+            ),
+            Controls::relaxRules(),
+        );
+
+        self::assertInstanceOf(
+            CompareResponse::class,
+            $response?->getResponse(),
+        );
+        self::assertSame(
+            ResultCode::COMPARE_TRUE,
+            $response->getResponse()->getResultCode(),
+        );
+    }
+
     public function test_subtree_delete_removes_the_whole_subtree(): void
     {
         $this->authenticateAdmin();
@@ -390,6 +478,11 @@ final class ServerControlsTest extends ServerTestCase
         $this->expectExceptionCode(ResultCode::NOT_ALLOWED_ON_NON_LEAF);
 
         $this->ldapClient()->send(Operations::delete('ou=non-leaf,dc=foo,dc=bar'));
+    }
+
+    private function nonCritical(Control $control): Control
+    {
+        return $control->setCriticality(false);
     }
 
     private function bind(): void

--- a/tests/integration/Controls/ServerControlsTest.php
+++ b/tests/integration/Controls/ServerControlsTest.php
@@ -171,6 +171,88 @@ final class ServerControlsTest extends ServerTestCase
         self::assertSame(['add-postread'], $postRead->getEntry()->get('cn')?->getValues());
     }
 
+    public function test_pre_read_withholds_an_attribute_the_identity_may_not_read(): void
+    {
+        $this->authenticateAdmin();
+
+        $response = $this->ldapClient()->send(
+            Operations::modify(
+                'cn=user,dc=foo,dc=bar',
+                Change::replace(
+                    'sn',
+                    'Read-Policy',
+                ),
+            ),
+            Controls::preRead(),
+        );
+
+        $preRead = $response?->controls()->get(Control::OID_PRE_READ);
+        self::assertInstanceOf(
+            PreReadResponseControl::class,
+            $preRead,
+        );
+        self::assertNull($preRead->getEntry()->get('userPassword'));
+        self::assertSame(
+            ['user'],
+            $preRead->getEntry()->get('cn')?->getValues(),
+        );
+    }
+
+    public function test_post_read_cannot_name_an_attribute_the_identity_may_not_read(): void
+    {
+        $this->authenticateAdmin();
+
+        $response = $this->ldapClient()->send(
+            Operations::modify(
+                'cn=user,dc=foo,dc=bar',
+                Change::replace(
+                    'sn',
+                    'Read-Policy-Named',
+                ),
+            ),
+            Controls::postRead('userPassword'),
+        );
+
+        $postRead = $response?->controls()->get(Control::OID_POST_READ);
+        self::assertInstanceOf(
+            PostReadResponseControl::class,
+            $postRead,
+        );
+        self::assertSame(
+            [],
+            $postRead->getEntry()->getAttributes(),
+        );
+    }
+
+    public function test_post_read_on_add_withholds_the_password_just_written(): void
+    {
+        $this->authenticateAdmin();
+        $entry = $this->person(
+            'cn=add-secret,ou=people,dc=foo,dc=bar',
+            'add-secret',
+        );
+        $entry->set(
+            'userPassword',
+            '{SHA}jLIjfQZ5yojbZGTqxg2pY0VROWQ=',
+        );
+
+        $response = $this->ldapClient()->send(
+            Operations::add($entry),
+            Controls::postRead(),
+        );
+
+        $postRead = $response?->controls()->get(Control::OID_POST_READ);
+        self::assertInstanceOf(
+            PostReadResponseControl::class,
+            $postRead,
+        );
+        self::assertNull($postRead->getEntry()->get('userPassword'));
+        self::assertSame(
+            ['add-secret'],
+            $postRead->getEntry()->get('cn')?->getValues(),
+        );
+    }
+
     public function test_subtree_delete_removes_the_whole_subtree(): void
     {
         $this->authenticateAdmin();

--- a/tests/integration/LdapServerTest.php
+++ b/tests/integration/LdapServerTest.php
@@ -15,6 +15,7 @@ namespace Tests\Integration\FreeDSx\Ldap;
 
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Entry\Rdn;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Response\BindResponse;
@@ -524,6 +525,91 @@ final class LdapServerTest extends ServerTestCase
         $this->assertNotNull($this->ldapClient()->read(''));
     }
 
+    public function testAMalformedDnIsAnsweredRatherThanEndingTheSession(): void
+    {
+        $this->authenticateAdmin();
+
+        try {
+            $this->ldapClient()->send(Operations::rename(
+                'garbage-no-equals',
+                'cn=x',
+                true,
+            ));
+            $this->fail('Expected the rename to be refused.');
+        } catch (OperationException $e) {
+            $this->assertSame(
+                ResultCode::INVALID_DN_SYNTAX,
+                $e->getCode(),
+            );
+        }
+
+        // The session must survive: a malformed DN is one operation failing, not a protocol error.
+        $this->assertNotNull($this->ldapClient()->read(''));
+    }
+
+    public function testAnUnescapedCommaInANewRdnIsRefused(): void
+    {
+        $this->authenticateAdmin();
+        $this->ldapClient()->create($this->personEntry('comma-src'));
+
+        try {
+            $this->ldapClient()->send(Operations::rename(
+                'cn=comma-src,dc=foo,dc=bar',
+                new Rdn('cn', 'Smith, John'),
+                true,
+            ));
+            $this->fail('Expected the rename to be refused.');
+        } catch (OperationException $e) {
+            $this->assertSame(
+                ResultCode::INVALID_DN_SYNTAX,
+                $e->getCode(),
+            );
+        }
+
+        $this->assertNotNull($this->ldapClient()->read('cn=comma-src,dc=foo,dc=bar'));
+    }
+
+    public function testAnAddWithAMalformedDnIsAnsweredRatherThanEndingTheSession(): void
+    {
+        $this->authenticateAdmin();
+
+        try {
+            $this->ldapClient()->send(Operations::add(Entry::fromArray('garbage-no-equals', [
+                'objectClass' => ['inetOrgPerson'],
+                'cn' => ['x'],
+                'sn' => ['y'],
+            ])));
+            $this->fail('Expected the add to be refused.');
+        } catch (OperationException $e) {
+            $this->assertSame(
+                ResultCode::INVALID_DN_SYNTAX,
+                $e->getCode(),
+            );
+        }
+
+        $this->assertNotNull($this->ldapClient()->read(''));
+    }
+
+    public function testASearchWithAMalformedBaseDnReportsNoSuchObject(): void
+    {
+        $this->authenticateAdmin();
+
+        // The search path only normalizes, which never decomposes the DN, so there is nothing to reject.
+        try {
+            $this->ldapClient()->search(
+                Operations::search(Filters::present('objectClass'))
+                    ->base('garbage-no-equals')
+                    ->useSubtreeScope(),
+            );
+            $this->fail('Expected the search to be refused.');
+        } catch (OperationException $e) {
+            $this->assertSame(
+                ResultCode::NO_SUCH_OBJECT,
+                $e->getCode(),
+            );
+        }
+    }
+
     public function testItCanHandleMultipleClients(): void
     {
         $this->ldapClient()->read();
@@ -648,5 +734,14 @@ final class LdapServerTest extends ServerTestCase
                 // Connection may already be closed; ignore unbind failures.
             }
         }
+    }
+
+    private function personEntry(string $cn): Entry
+    {
+        return Entry::fromArray("cn={$cn},dc=foo,dc=bar", [
+            'objectClass' => ['inetOrgPerson'],
+            'cn' => [$cn],
+            'sn' => ['Test'],
+        ]);
     }
 }

--- a/tests/integration/LdapServerTest.php
+++ b/tests/integration/LdapServerTest.php
@@ -426,6 +426,104 @@ final class LdapServerTest extends ServerTestCase
         $this->assertNotNull($result);
     }
 
+    public function testItRefusesASimpleBindInTheClearWhenConfidentialityIsRequired(): void
+    {
+        $this->stopServer();
+        $this->createServerProcess('tcp', ['--require-confidentiality=bind']);
+
+        try {
+            $this->ldapClient()->bind(
+                'cn=user,dc=foo,dc=bar',
+                '12345',
+            );
+            $this->fail('Expected the bind to be refused.');
+        } catch (BindException $e) {
+            $this->assertSame(
+                ResultCode::CONFIDENTIALITY_REQUIRED,
+                $e->getCode(),
+            );
+        }
+    }
+
+    public function testItAcceptsTheSameBindAfterStartTLS(): void
+    {
+        $this->stopServer();
+        $this->createServerProcess('tcp', ['--require-confidentiality=bind']);
+
+        $this->ldapClient()->startTls();
+        $this->ldapClient()->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+
+        $this->assertSame(
+            'dn:cn=user,dc=foo,dc=bar',
+            $this->ldapClient()->whoami(),
+        );
+    }
+
+    public function testItAcceptsABindOverSSLWhenConfidentialityIsRequired(): void
+    {
+        $this->stopServer();
+        $this->createServerProcess('ssl', ['--require-confidentiality=bind']);
+
+        $this->ldapClient()->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+
+        $this->assertSame(
+            'dn:cn=user,dc=foo,dc=bar',
+            $this->ldapClient()->whoami(),
+        );
+    }
+
+    public function testAUnixSocketSatisfiesTheConfidentialityRequirement(): void
+    {
+        $this->stopServer();
+        $this->createServerProcess('unix', ['--require-confidentiality=bind']);
+
+        $this->ldapClient()->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+
+        $this->assertSame(
+            'dn:cn=user,dc=foo,dc=bar',
+            $this->ldapClient()->whoami(),
+        );
+    }
+
+    public function testRequiringAllOperationsRefusesASearchInTheClear(): void
+    {
+        $this->stopServer();
+        $this->createServerProcess('tcp', ['--require-confidentiality=all']);
+
+        try {
+            $this->ldapClient()->read('');
+            $this->fail('Expected the search to be refused.');
+        } catch (OperationException $e) {
+            $this->assertSame(
+                ResultCode::CONFIDENTIALITY_REQUIRED,
+                $e->getCode(),
+            );
+        }
+    }
+
+    public function testRequiringAllOperationsStillPermitsStartTLS(): void
+    {
+        $this->stopServer();
+        $this->createServerProcess('tcp', ['--require-confidentiality=all']);
+
+        $this->ldapClient()->startTls();
+        $this->ldapClient()->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+
+        $this->assertNotNull($this->ldapClient()->read(''));
+    }
+
     public function testItCanHandleMultipleClients(): void
     {
         $this->ldapClient()->read();

--- a/tests/integration/Security/AclIntegrationTest.php
+++ b/tests/integration/Security/AclIntegrationTest.php
@@ -285,6 +285,93 @@ final class AclIntegrationTest extends ServerTestCase
         );
     }
 
+    public function testRenameCannotWriteAnRdnAttributeWithoutAGrant(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        // The rename itself is permitted over ou=people, but only cn is writable there.
+        $this->ldapClient()->rename(
+            'cn=alice,ou=people,dc=foo,dc=bar',
+            'uid=alice-uid',
+            true,
+        );
+    }
+
+    public function testRenameLeavesTheEntryUntouchedWhenTheRdnAttributeIsDenied(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        try {
+            $this->ldapClient()->rename(
+                'cn=alice,ou=people,dc=foo,dc=bar',
+                'uid=alice-uid',
+                true,
+            );
+        } catch (OperationException) {
+        }
+
+        $results = $this->ldapClient()->search(
+            Operations::search(Filters::equal('cn', 'alice'))
+                ->base('ou=people,dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        self::assertCount(1, $results);
+        self::assertNull($results->first()?->get('uid'));
+    }
+
+    public function testRenameDeletingTheOldRdnRequiresAWriteOfThatAttributeToo(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        // cn is writable here, but dropping the old RDN would delete a uid value that is not.
+        $this->ldapClient()->rename(
+            'uid=bob,ou=people,dc=foo,dc=bar',
+            'cn=bob-renamed',
+            true,
+        );
+    }
+
+    public function testTheSameRenameIsAllowedWhenTheOldRdnIsKept(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->ldapClient()->rename(
+            'uid=bob2,ou=people,dc=foo,dc=bar',
+            'cn=bob2-renamed',
+            false,
+        );
+
+        $results = $this->ldapClient()->search(
+            Operations::search(Filters::equal('cn', 'bob2-renamed'))
+                ->base('ou=people,dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        self::assertCount(1, $results);
+    }
+
+    public function testRenameAuthorizesEveryComponentOfAMultivaluedRdn(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        // cn alone is writable, so pairing it with uid must not smuggle the second component through.
+        $this->ldapClient()->rename(
+            'cn=alice,ou=people,dc=foo,dc=bar',
+            'cn=alice-multi+uid=alice-multi',
+            false,
+        );
+    }
+
     public function testUserCannotMoveEntryToRestrictedParent(): void
     {
         $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');

--- a/tests/integration/Security/AclIntegrationTest.php
+++ b/tests/integration/Security/AclIntegrationTest.php
@@ -734,6 +734,49 @@ final class AclIntegrationTest extends ServerTestCase
         );
     }
 
+    public function testPasswordModifyDoesNotRevealWhetherAForbiddenTargetExists(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $missing = $this->passwordModifyCodeFor('cn=ghost,ou=people,dc=foo,dc=bar');
+        $existing = $this->passwordModifyCodeFor('cn=alice,ou=people,dc=foo,dc=bar');
+
+        self::assertSame(
+            ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+            $missing,
+        );
+        self::assertSame(
+            $existing,
+            $missing,
+            'A forbidden target must answer the same whether or not it exists.',
+        );
+    }
+
+    public function testPasswordModifyStillReportsAMissingTargetToAnAuthorizedIdentity(): void
+    {
+        $this->authenticateAdmin();
+
+        self::assertSame(
+            ResultCode::NO_SUCH_OBJECT,
+            $this->passwordModifyCodeFor('cn=ghost,ou=people,dc=foo,dc=bar'),
+        );
+    }
+
+    private function passwordModifyCodeFor(string $dn): int
+    {
+        try {
+            $this->ldapClient()->send(Operations::passwordModify(
+                $dn,
+                'irrelevant',
+                'newpass123',
+            ));
+        } catch (OperationException $e) {
+            return $e->getCode();
+        }
+
+        self::fail('Expected an OperationException was not thrown.');
+    }
+
     private function bindHidden(): void
     {
         $this->ldapClient()->bind(

--- a/tests/integration/Security/AclIntegrationTest.php
+++ b/tests/integration/Security/AclIntegrationTest.php
@@ -13,6 +13,10 @@ declare(strict_types=1);
 
 namespace Tests\Integration\FreeDSx\Ldap\Security;
 
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\ReadEntry\PreReadResponseControl;
+use FreeDSx\Ldap\Controls;
+use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
@@ -488,6 +492,167 @@ final class AclIntegrationTest extends ServerTestCase
         $alice = $results->first();
         self::assertNotNull($alice);
         self::assertNull($alice->get('secretCode'));
+    }
+
+    public function testAnAssertionCannotProbeAnEntryTheIdentityCannotSearch(): void
+    {
+        $this->bindHidden();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->ldapClient()->send(
+            Operations::modify(
+                LdapAclCommand::HIDDEN_DN,
+                Change::replace(
+                    'description',
+                    'asserted',
+                ),
+            ),
+            Controls::assertion(Filters::equal(
+                'sn',
+                'Hidden',
+            )),
+        );
+    }
+
+    public function testTheSameModifySucceedsWithoutTheAssertion(): void
+    {
+        $this->bindHidden();
+
+        $this->ldapClient()->send(Operations::modify(
+            LdapAclCommand::HIDDEN_DN,
+            Change::replace(
+                'description',
+                'unasserted',
+            ),
+        ));
+
+        $this->authenticateAdmin();
+        $results = $this->ldapClient()->search(
+            Operations::search(Filters::equal('cn', 'hidden'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        self::assertSame(
+            'unasserted',
+            $results->first()?->get('description')?->firstValue(),
+        );
+    }
+
+    public function testAnAdministratorCanStillAssertOnTheSameEntry(): void
+    {
+        $this->authenticateAdmin();
+
+        $this->ldapClient()->send(
+            Operations::modify(
+                LdapAclCommand::HIDDEN_DN,
+                Change::replace(
+                    'description',
+                    'admin-asserted',
+                ),
+            ),
+            Controls::assertion(Filters::equal(
+                'sn',
+                'Hidden',
+            )),
+        );
+
+        $results = $this->ldapClient()->search(
+            Operations::search(Filters::equal('cn', 'hidden'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        self::assertSame(
+            'admin-asserted',
+            $results->first()?->get('description')?->firstValue(),
+        );
+    }
+
+    public function testANonCriticalPreReadOnAnUnreadableTargetIsOmittedAndTheWriteStands(): void
+    {
+        $this->bindHidden();
+
+        $response = $this->ldapClient()->send(
+            Operations::modify(
+                LdapAclCommand::HIDDEN_DN,
+                Change::replace(
+                    'description',
+                    'preread-probe',
+                ),
+            ),
+            Controls::preRead(),
+        );
+
+        self::assertNull($response?->controls()->get(Control::OID_PRE_READ));
+
+        $this->authenticateAdmin();
+        $results = $this->ldapClient()->search(
+            Operations::search(Filters::equal('cn', 'hidden'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+        self::assertSame(
+            'preread-probe',
+            $results->first()?->get('description')?->firstValue(),
+        );
+    }
+
+    public function testACriticalPreReadOnAnUnreadableTargetFailsTheOperation(): void
+    {
+        $this->bindHidden();
+        $preRead = Controls::preRead();
+        $preRead->setCriticality(true);
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->ldapClient()->send(
+            Operations::modify(
+                LdapAclCommand::HIDDEN_DN,
+                Change::replace(
+                    'description',
+                    'preread-critical',
+                ),
+            ),
+            $preRead,
+        );
+    }
+
+    public function testPreReadIsPermittedForAnIdentityThatCanSearchTheTarget(): void
+    {
+        $this->authenticateAdmin();
+
+        $response = $this->ldapClient()->send(
+            Operations::modify(
+                LdapAclCommand::HIDDEN_DN,
+                Change::replace(
+                    'description',
+                    'admin-preread',
+                ),
+            ),
+            Controls::preRead('cn'),
+        );
+
+        $preRead = $response?->controls()->get(Control::OID_PRE_READ);
+        self::assertInstanceOf(
+            PreReadResponseControl::class,
+            $preRead,
+        );
+        self::assertSame(
+            ['hidden'],
+            $preRead->getEntry()->get('cn')?->getValues(),
+        );
+    }
+
+    private function bindHidden(): void
+    {
+        $this->ldapClient()->bind(
+            LdapAclCommand::HIDDEN_DN,
+            LdapAclCommand::HIDDEN_PASSWORD,
+        );
     }
 
     private static function alicePasswordHash(): string

--- a/tests/support/LdapAclCommand.php
+++ b/tests/support/LdapAclCommand.php
@@ -146,7 +146,7 @@ class LdapAclCommand extends Command
                 ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL))
                 ->setAclRules(
                     (AclRules::fromEmpty())
-                        ->withOperationRules(
+                        ->replaceOperationRules(
                             OperationRule::allow(
                                 Subject::group('cn=admins,dc=foo,dc=bar'),
                             ),
@@ -175,7 +175,7 @@ class LdapAclCommand extends Command
                             ),
                             OperationRule::deny(Subject::anyone()),
                         )
-                        ->withAttributeRules(
+                        ->replaceAttributeRules(
                             // Self may set its own password but never read it back.
                             AttributeRule::allow(
                                 Subject::self(),
@@ -209,7 +209,7 @@ class LdapAclCommand extends Command
                             )->forWrite(),
                         )
                         // userPassword ships confidential, so reading it needs a grant on top of the rules above.
-                        ->withConfidentialAccess(
+                        ->replaceConfidentialAccess(
                             ConfidentialAccessRule::allow(
                                 Subject::group('cn=admins,dc=foo,dc=bar'),
                                 'userPassword',

--- a/tests/support/LdapAclCommand.php
+++ b/tests/support/LdapAclCommand.php
@@ -107,6 +107,21 @@ class LdapAclCommand extends Command
                 new Attribute('userPassword', $alicePasswordHash),
                 new Attribute('secretCode', self::SECRET_CODE),
             ),
+            // RDN is uid, which is not writable under ou=people, so a rename that touches it must be refused.
+            new Entry(
+                new Dn('uid=bob,ou=people,dc=foo,dc=bar'),
+                new Attribute('uid', 'bob'),
+                new Attribute('cn', 'bob'),
+                new Attribute('sn', 'Bob'),
+                new Attribute('objectClass', 'inetOrgPerson'),
+            ),
+            new Entry(
+                new Dn('uid=bob2,ou=people,dc=foo,dc=bar'),
+                new Attribute('uid', 'bob2'),
+                new Attribute('cn', 'bob2'),
+                new Attribute('sn', 'Bob'),
+                new Attribute('objectClass', 'inetOrgPerson'),
+            ),
             new Entry(
                 new Dn(self::HIDDEN_DN),
                 new Attribute('cn', 'hidden'),
@@ -185,6 +200,12 @@ class LdapAclCommand extends Command
                             AttributeRule::allow(
                                 Subject::self(),
                                 Target::any(),
+                            )->forWrite(),
+                            // A rename writes the RDN attribute, so delegating renames means granting it too.
+                            AttributeRule::allow(
+                                Subject::authenticated(),
+                                Target::subtree('ou=people,dc=foo,dc=bar'),
+                                'cn',
                             )->forWrite(),
                         )
                         // userPassword ships confidential, so reading it needs a grant on top of the rules above.

--- a/tests/support/LdapAclCommand.php
+++ b/tests/support/LdapAclCommand.php
@@ -32,6 +32,13 @@ class LdapAclCommand extends Command
     public const SECRET_CODE = 'S3CR3T-alice';
 
     /**
+     * An identity that may modify its own entry but may not search it, so read policy and write policy diverge.
+     */
+    public const HIDDEN_DN = 'cn=hidden,ou=people,dc=foo,dc=bar';
+
+    public const HIDDEN_PASSWORD = 'hiddenpass';
+
+    /**
      * Defines secretCode as confidential; loaded so the harness exercises the same path an operator would.
      */
     private const SECRET_CODE_SCHEMA = __DIR__ . '/../resources/schema/acl-secret-code.ldif';
@@ -59,6 +66,7 @@ class LdapAclCommand extends Command
         $adminPasswordHash = '{SHA}' . base64_encode(sha1('12345', true));
         $userPasswordHash = '{SHA}' . base64_encode(sha1('12345', true));
         $alicePasswordHash = '{SHA}' . base64_encode(sha1('alicepass', true));
+        $hiddenPasswordHash = '{SHA}' . base64_encode(sha1(self::HIDDEN_PASSWORD, true));
 
         $entries = [
             new Entry(
@@ -99,6 +107,13 @@ class LdapAclCommand extends Command
                 new Attribute('userPassword', $alicePasswordHash),
                 new Attribute('secretCode', self::SECRET_CODE),
             ),
+            new Entry(
+                new Dn(self::HIDDEN_DN),
+                new Attribute('cn', 'hidden'),
+                new Attribute('sn', 'Hidden'),
+                new Attribute('objectClass', 'inetOrgPerson'),
+                new Attribute('userPassword', $hiddenPasswordHash),
+            ),
         ];
 
         $network = (new NetworkConfig())
@@ -119,6 +134,13 @@ class LdapAclCommand extends Command
                         ->withOperationRules(
                             OperationRule::allow(
                                 Subject::group('cn=admins,dc=foo,dc=bar'),
+                            ),
+                            // Ahead of the blanket search grant, so this entry stays writable by its own identity
+                            // while being unreadable to everyone but an administrator.
+                            OperationRule::deny(
+                                Subject::anyone(),
+                                Target::dn(self::HIDDEN_DN),
+                                OperationType::Search,
                             ),
                             OperationRule::allow(
                                 Subject::authenticated(),

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -265,9 +265,8 @@ final class LdapBackendStorageCommand extends Command
             ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL));
 
         if ($input->getOption('allow-relax')) {
-            // Compose on the current rules (the secure default): grant the relax control.
             $serverOptions->setAclRules(
-                $serverOptions->getAclRules()->withControlRules(
+                $serverOptions->getAclRules()->appendControlRules(
                     ControlRule::allow(
                         Subject::authenticated(),
                         Target::any(),
@@ -278,9 +277,8 @@ final class LdapBackendStorageCommand extends Command
         }
 
         if ($input->getOption('allow-proxy')) {
-            // Compose on the current rules (the secure default): grant cn=user proxied-auth over ou=people.
             $serverOptions->setAclRules(
-                $serverOptions->getAclRules()->withControlRules(
+                $serverOptions->getAclRules()->appendControlRules(
                     ControlRule::allow(
                         Subject::dn('cn=user,dc=foo,dc=bar'),
                         Target::subtree('ou=people,dc=foo,dc=bar'),
@@ -306,14 +304,15 @@ final class LdapBackendStorageCommand extends Command
         }
 
         if ($input->getOption('hide-rootdse-vendor')) {
+            // Prepended rather than appended, since a deny only takes effect if it is matched first.
             $rules = $serverOptions->getAclRules();
             $serverOptions->setAclRules(
-                $rules->withAttributeRules(
-                    ...[AttributeRule::deny(
+                $rules->replaceAttributeRules(
+                    AttributeRule::deny(
                         Subject::anyone(),
                         Target::dn(''),
                         'vendorName',
-                    )->forRead()],
+                    )->forRead(),
                     ...$rules->attributes,
                 ),
             );

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -29,6 +29,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Config\JsonStorageConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Config\StorageConfigInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
+use FreeDSx\Ldap\Server\Config\ConfidentialityRequirement;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\Server\Config\RunnerConfig;
 use FreeDSx\Ldap\ServerOptions;
@@ -141,6 +142,13 @@ final class LdapServerCommand extends Command
                 'Allow anonymous bind',
             )
             ->addOption(
+                'require-confidentiality',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Refuse unprotected connections: none, bind (credential-bearing binds), or all (every operation)',
+                'none',
+            )
+            ->addOption(
                 'external',
                 null,
                 InputOption::VALUE_NONE,
@@ -236,6 +244,12 @@ final class LdapServerCommand extends Command
             $useSsl = true;
         }
 
+        $confidentiality = match ($this->getStringOption($input, 'require-confidentiality')) {
+            'bind' => ConfidentialityRequirement::CredentialBind,
+            'all' => ConfidentialityRequirement::AllOperations,
+            default => ConfidentialityRequirement::None,
+        };
+
         $entries = [];
 
         if ($external) {
@@ -275,6 +289,7 @@ final class LdapServerCommand extends Command
         $options = (new ServerOptions($this->createStorageConfig($storageType), $network))
             ->setRunnerConfig(new RunnerConfig($runner === 'swoole' ? RunnerMode::Swoole : RunnerMode::Pcntl))
             ->setAllowAnonymous($allowAnonymous)
+            ->setRequireConfidentiality($confidentiality)
             ->setAdministrators(Subject::dn(self::ADMIN_DN))
             ->setMaxSearchLookthrough((int) $this->getStringOption($input, 'max-search-lookthrough'))
             ->setMaxSearchPagedLookthrough((int) $this->getStringOption($input, 'max-search-paged-lookthrough'))

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -335,36 +335,26 @@ final class LdapServerCommand extends Command
         }
 
         if ($external && $input->getOption('external-allow-proxy') === true) {
-            // The with* methods replace rather than append, so carry the existing rules through.
-            $rules = $options->getAclRules();
             $options->setAclRules(
-                $rules->withControlRules(
-                    ...$rules->controls,
-                    ...[ControlRule::allow(
-                        Subject::dn('cn=extuser,dc=foo,dc=bar'),
-                        Target::subtree('dc=foo,dc=bar'),
-                        Control::OID_PROXY_AUTHORIZATION,
-                    )],
-                ),
+                $options->getAclRules()->appendControlRules(ControlRule::allow(
+                    Subject::dn('cn=extuser,dc=foo,dc=bar'),
+                    Target::subtree('dc=foo,dc=bar'),
+                    Control::OID_PROXY_AUTHORIZATION,
+                )),
             );
         }
 
         if ($input->getOption('allow-sync') === true) {
-            $rules = $options->getAclRules();
             $options->setAclRules(
-                $rules->withControlRules(
-                    ...$rules->controls,
-                    ...[ControlRule::allow(
-                        Subject::dn('cn=user,dc=foo,dc=bar'),
-                        Target::subtree('dc=foo,dc=bar'),
-                        Control::OID_SYNC_REQUEST,
-                    )],
-                ),
+                $options->getAclRules()->appendControlRules(ControlRule::allow(
+                    Subject::dn('cn=user,dc=foo,dc=bar'),
+                    Target::subtree('dc=foo,dc=bar'),
+                    Control::OID_SYNC_REQUEST,
+                )),
             );
         }
 
         if ($input->getOption('allow-ppolicy-forward') === true) {
-            $rules = $options->getAclRules();
             $options
                 ->setPasswordPolicy(new PasswordPolicy(
                     lockout: new PasswordLockoutRules(
@@ -373,12 +363,11 @@ final class LdapServerCommand extends Command
                     ),
                 ))
                 ->setAclRules(
-                    $rules->withExtendedOperationRules(
-                        ...$rules->extendedOps,
-                        ...[ExtendedOperationRule::allow(
+                    $options->getAclRules()->appendExtendedOperationRules(
+                        ExtendedOperationRule::allow(
                             Subject::dn('cn=user,dc=foo,dc=bar'),
                             ExtendedRequest::OID_PPOLICY_STATE_FORWARD,
-                        )],
+                        ),
                     ),
                 );
         }

--- a/tests/unit/Protocol/ServerProtocolHandler/AssertionEvaluatorTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/AssertionEvaluatorTest.php
@@ -12,8 +12,15 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\AssertionEvaluator;
 use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\AccessControl\AclRules;
+use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
+use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
+use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
+use FreeDSx\Ldap\Server\AccessControl\Target\Target;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluator;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -25,13 +32,17 @@ final class AssertionEvaluatorTest extends TestCase
 
     private Dn $targetDn;
 
+    private TokenInterface $token;
+
     protected function setUp(): void
     {
         $this->backend = $this->createMock(LdapBackendInterface::class);
         $this->targetDn = new Dn('cn=foo,dc=ex,dc=com');
+        $this->token = BindToken::fromDn('cn=foo,dc=ex,dc=com');
         $this->subject = new AssertionEvaluator(
             new FilterEvaluator(),
             $this->backend,
+            new RuleBasedAccessControl(AclRules::fromEmpty()),
         );
     }
 
@@ -44,6 +55,7 @@ final class AssertionEvaluatorTest extends TestCase
         $this->subject->assertSatisfied(
             $this->targetDn,
             new ControlBag(),
+            $this->token,
         );
     }
 
@@ -57,6 +69,7 @@ final class AssertionEvaluatorTest extends TestCase
         $this->subject->assertSatisfied(
             $this->targetDn,
             new ControlBag(new AssertionControl(Filters::equal('cn', 'foo'))),
+            $this->token,
         );
     }
 
@@ -72,6 +85,7 @@ final class AssertionEvaluatorTest extends TestCase
         $this->subject->assertSatisfied(
             $this->targetDn,
             new ControlBag(new AssertionControl(Filters::equal('cn', 'bar'))),
+            $this->token,
         );
     }
 
@@ -86,6 +100,77 @@ final class AssertionEvaluatorTest extends TestCase
         $this->subject->assertSatisfied(
             $this->targetDn,
             new ControlBag(new AssertionControl(Filters::equal('cn', 'bar'))),
+            $this->token,
+        );
+    }
+
+    public function test_an_assertion_on_an_unreadable_attribute_cannot_match(): void
+    {
+        $this->backend
+            ->method('get')
+            ->willReturn(Entry::fromArray('cn=foo,dc=ex,dc=com', [
+                'cn' => ['foo'],
+                'userPassword' => ['{SSHA}secret'],
+            ]));
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::ASSERTION_FAILED);
+
+        $this->denyingUserPassword()->assertSatisfied(
+            $this->targetDn,
+            new ControlBag(new AssertionControl(Filters::equal('userPassword', '{SSHA}secret'))),
+            $this->token,
+        );
+    }
+
+    public function test_a_substring_assertion_on_an_unreadable_attribute_cannot_probe_its_value(): void
+    {
+        $this->backend
+            ->method('get')
+            ->willReturn(Entry::fromArray('cn=foo,dc=ex,dc=com', [
+                'cn' => ['foo'],
+                'userPassword' => ['{SSHA}secret'],
+            ]));
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::ASSERTION_FAILED);
+
+        $this->denyingUserPassword()->assertSatisfied(
+            $this->targetDn,
+            new ControlBag(new AssertionControl(Filters::startsWith('userPassword', '{SSHA}s'))),
+            $this->token,
+        );
+    }
+
+    public function test_a_readable_attribute_still_asserts_normally_under_the_same_rules(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $this->backend
+            ->method('get')
+            ->willReturn(Entry::fromArray('cn=foo,dc=ex,dc=com', [
+                'cn' => ['foo'],
+                'userPassword' => ['{SSHA}secret'],
+            ]));
+
+        $this->denyingUserPassword()->assertSatisfied(
+            $this->targetDn,
+            new ControlBag(new AssertionControl(Filters::equal('cn', 'foo'))),
+            $this->token,
+        );
+    }
+
+    private function denyingUserPassword(): AssertionEvaluator
+    {
+        return new AssertionEvaluator(
+            new FilterEvaluator(),
+            $this->backend,
+            new RuleBasedAccessControl(AclRules::fromEmpty(attributes: [
+                AttributeRule::deny(
+                    Subject::anyone(),
+                    Target::any(),
+                    'userPassword',
+                )->forRead(),
+            ])),
         );
     }
 }

--- a/tests/unit/Protocol/ServerProtocolHandler/ReadEntryControlHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ReadEntryControlHandlerTest.php
@@ -14,7 +14,9 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ReadEntryControlHandler;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\AccessControl\AclRules;
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
 use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\AccessControl\Target\Target;
@@ -42,7 +44,7 @@ final class ReadEntryControlHandlerTest extends TestCase
         $this->subject = new ReadEntryControlHandler(
             $this->backend,
             new Schema(),
-            new RuleBasedAccessControl(AclRules::fromEmpty()),
+            new RuleBasedAccessControl(AclRules::fromEmpty(operations: self::searchAllowed())),
         );
     }
 
@@ -187,18 +189,54 @@ final class ReadEntryControlHandlerTest extends TestCase
         );
     }
 
+    public function test_no_control_is_returned_when_the_token_may_not_read_the_target(): void
+    {
+        $this->backend
+            ->method('get')
+            ->willReturn(Entry::fromArray('cn=foo,dc=ex,dc=com', ['cn' => ['foo']]));
+
+        $subject = new ReadEntryControlHandler(
+            $this->backend,
+            new Schema(),
+            new RuleBasedAccessControl(AclRules::fromEmpty()),
+        );
+
+        self::assertNull($subject->preRead(
+            $this->dn,
+            new ControlBag(new PreReadControl()),
+            $this->token,
+        ));
+    }
+
+    /**
+     * @return list<OperationRule>
+     */
+    private static function searchAllowed(): array
+    {
+        return [
+            OperationRule::allow(
+                Subject::anyone(),
+                Target::any(),
+                OperationType::Search,
+            ),
+        ];
+    }
+
     private function denyingUserPassword(): ReadEntryControlHandler
     {
         return new ReadEntryControlHandler(
             $this->backend,
             new Schema(),
-            new RuleBasedAccessControl(AclRules::fromEmpty(attributes: [
-                AttributeRule::deny(
-                    Subject::anyone(),
-                    Target::any(),
-                    'userPassword',
-                )->forRead(),
-            ])),
+            new RuleBasedAccessControl(AclRules::fromEmpty(
+                operations: self::searchAllowed(),
+                attributes: [
+                    AttributeRule::deny(
+                        Subject::anyone(),
+                        Target::any(),
+                        'userPassword',
+                    )->forRead(),
+                ],
+            )),
         );
     }
 }

--- a/tests/unit/Protocol/ServerProtocolHandler/ReadEntryControlHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ReadEntryControlHandlerTest.php
@@ -13,7 +13,14 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ReadEntryControlHandler;
 use FreeDSx\Ldap\Schema\Schema;
+use FreeDSx\Ldap\Server\AccessControl\AclRules;
+use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
+use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
+use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
+use FreeDSx\Ldap\Server\AccessControl\Target\Target;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Token\BindToken;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -25,13 +32,17 @@ final class ReadEntryControlHandlerTest extends TestCase
 
     private Dn $dn;
 
+    private TokenInterface $token;
+
     protected function setUp(): void
     {
         $this->backend = $this->createMock(LdapBackendInterface::class);
         $this->dn = new Dn('cn=foo,dc=ex,dc=com');
+        $this->token = BindToken::fromDn('cn=foo,dc=ex,dc=com');
         $this->subject = new ReadEntryControlHandler(
             $this->backend,
             new Schema(),
+            new RuleBasedAccessControl(AclRules::fromEmpty()),
         );
     }
 
@@ -42,14 +53,14 @@ final class ReadEntryControlHandlerTest extends TestCase
             ->method('get');
 
         self::assertNull(
-            $this->subject->preRead($this->dn, new ControlBag()),
+            $this->subject->preRead($this->dn, new ControlBag(), $this->token),
         );
     }
 
     public function test_post_read_returns_null_without_the_control(): void
     {
         self::assertNull(
-            $this->subject->postRead($this->dn, new ControlBag()),
+            $this->subject->postRead($this->dn, new ControlBag(), $this->token),
         );
     }
 
@@ -60,7 +71,7 @@ final class ReadEntryControlHandlerTest extends TestCase
             ->willReturn(null);
 
         self::assertNull(
-            $this->subject->preRead($this->dn, new ControlBag(new PreReadControl())),
+            $this->subject->preRead($this->dn, new ControlBag(new PreReadControl()), $this->token),
         );
     }
 
@@ -73,6 +84,7 @@ final class ReadEntryControlHandlerTest extends TestCase
         $control = $this->subject->preRead(
             $this->dn,
             new ControlBag(new PreReadControl()),
+            $this->token,
         );
 
         self::assertInstanceOf(PreReadResponseControl::class, $control);
@@ -94,6 +106,7 @@ final class ReadEntryControlHandlerTest extends TestCase
         $control = $this->subject->postRead(
             $this->dn,
             new ControlBag(new PostReadControl('cn')),
+            $this->token,
         );
 
         self::assertInstanceOf(PostReadResponseControl::class, $control);
@@ -116,6 +129,7 @@ final class ReadEntryControlHandlerTest extends TestCase
         $control = $this->subject->preRead(
             $this->dn,
             new ControlBag(new PreReadControl()),
+            $this->token,
         );
 
         // Mutate the stored entry in place after the snapshot was taken.
@@ -125,6 +139,66 @@ final class ReadEntryControlHandlerTest extends TestCase
         self::assertSame(
             ['foo'],
             $control->getEntry()->get('cn')?->getValues(),
+        );
+    }
+
+    public function test_pre_read_omits_an_attribute_the_token_may_not_read(): void
+    {
+        $this->backend
+            ->method('get')
+            ->willReturn(Entry::fromArray('cn=foo,dc=ex,dc=com', [
+                'cn' => ['foo'],
+                'userPassword' => ['{SSHA}secret'],
+            ]));
+
+        $control = $this->denyingUserPassword()->preRead(
+            $this->dn,
+            new ControlBag(new PreReadControl()),
+            $this->token,
+        );
+
+        self::assertInstanceOf(PreReadResponseControl::class, $control);
+        self::assertNull($control->getEntry()->get('userPassword'));
+        self::assertSame(
+            ['foo'],
+            $control->getEntry()->get('cn')?->getValues(),
+        );
+    }
+
+    public function test_post_read_cannot_name_an_attribute_the_token_may_not_read(): void
+    {
+        $this->backend
+            ->method('get')
+            ->willReturn(Entry::fromArray('cn=foo,dc=ex,dc=com', [
+                'cn' => ['foo'],
+                'userPassword' => ['{SSHA}secret'],
+            ]));
+
+        $control = $this->denyingUserPassword()->postRead(
+            $this->dn,
+            new ControlBag(new PostReadControl('userPassword')),
+            $this->token,
+        );
+
+        self::assertInstanceOf(PostReadResponseControl::class, $control);
+        self::assertSame(
+            [],
+            $control->getEntry()->getAttributes(),
+        );
+    }
+
+    private function denyingUserPassword(): ReadEntryControlHandler
+    {
+        return new ReadEntryControlHandler(
+            $this->backend,
+            new Schema(),
+            new RuleBasedAccessControl(AclRules::fromEmpty(attributes: [
+                AttributeRule::deny(
+                    Subject::anyone(),
+                    Target::any(),
+                    'userPassword',
+                )->forRead(),
+            ])),
         );
     }
 }

--- a/tests/unit/Server/AccessControl/AclRulesTest.php
+++ b/tests/unit/Server/AccessControl/AclRulesTest.php
@@ -24,10 +24,12 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerMonitorHandler;
 use FreeDSx\Ldap\Server\AccessControl\AclRules;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
+use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;
 use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
+use FreeDSx\Ldap\Server\AccessControl\Target\Target;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -489,6 +491,85 @@ final class AclRulesTest extends TestCase
         );
 
         $this->addToAssertionCount(1);
+    }
+
+    public function test_replaceAttributeRules_discards_the_credential_protection(): void
+    {
+        $rules = AclRules::secureDefault(Subject::dn(self::ADMIN_DN))
+            ->replaceAttributeRules(AttributeRule::allow(
+                Subject::authenticated(),
+                Target::any(),
+                'description',
+            )->forWrite());
+
+        self::assertSame(
+            ['description'],
+            array_merge(...array_map(
+                static fn(AttributeRule $rule): array => $rule->attributes,
+                $rules->attributes,
+            )),
+        );
+    }
+
+    public function test_appendAttributeRules_keeps_the_credential_protection(): void
+    {
+        $rules = AclRules::secureDefault(Subject::dn(self::ADMIN_DN))
+            ->appendAttributeRules(AttributeRule::allow(
+                Subject::authenticated(),
+                Target::any(),
+                'description',
+            )->forWrite());
+
+        // userPassword must still be unreadable to everyone once another rule has been added.
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        (new RuleBasedAccessControl($rules))->authorizeAttribute(
+            $this->admin(),
+            new Dn(self::USER_DN),
+            'userPassword',
+            AttributeAccess::Read,
+        );
+    }
+
+    public function test_appendControlRules_leaves_existing_rules_matching_first(): void
+    {
+        $rules = AclRules::fromEmpty()
+            ->appendControlRules(ControlRule::deny(
+                Subject::anyone(),
+                Target::any(),
+                Control::OID_PROXY_AUTHORIZATION,
+            ))
+            ->appendControlRules(ControlRule::allow(
+                Subject::anyone(),
+                Target::any(),
+                Control::OID_PROXY_AUTHORIZATION,
+            ));
+
+        self::assertFalse((new RuleBasedAccessControl($rules))->mayUseControl(
+            $this->user(),
+            Control::OID_PROXY_AUTHORIZATION,
+        ));
+    }
+
+    public function test_prependControlRules_matches_ahead_of_existing_rules(): void
+    {
+        $rules = AclRules::fromEmpty()
+            ->appendControlRules(ControlRule::allow(
+                Subject::anyone(),
+                Target::any(),
+                Control::OID_PROXY_AUTHORIZATION,
+            ))
+            ->prependControlRules(ControlRule::deny(
+                Subject::anyone(),
+                Target::any(),
+                Control::OID_PROXY_AUTHORIZATION,
+            ));
+
+        self::assertFalse((new RuleBasedAccessControl($rules))->mayUseControl(
+            $this->user(),
+            Control::OID_PROXY_AUTHORIZATION,
+        ));
     }
 
     private function user(): TokenInterface

--- a/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
+++ b/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
@@ -230,6 +230,67 @@ final class RuleBasedAccessControlTest extends TestCase
         ));
     }
 
+    public function test_may_use_control_honours_an_earlier_deny_over_a_later_allow(): void
+    {
+        $subject = new RuleBasedAccessControl(AclRules::fromEmpty(
+            controls: [
+                ControlRule::deny(
+                    new AnySubjectMatcher(),
+                    new AnyTargetMatcher(),
+                    Control::OID_PROXY_AUTHORIZATION,
+                ),
+                ControlRule::allow(
+                    new AnySubjectMatcher(),
+                    new AnyTargetMatcher(),
+                    Control::OID_PROXY_AUTHORIZATION,
+                ),
+            ],
+        ));
+
+        self::assertFalse($subject->mayUseControl(
+            $this->bindToken,
+            Control::OID_PROXY_AUTHORIZATION,
+        ));
+    }
+
+    public function test_may_use_control_agrees_with_authorize_control_on_the_same_rules(): void
+    {
+        $rules = AclRules::fromEmpty(
+            controls: [
+                ControlRule::deny(
+                    new AnySubjectMatcher(),
+                    new AnyTargetMatcher(),
+                    Control::OID_PROXY_AUTHORIZATION,
+                ),
+                ControlRule::allow(
+                    new AnySubjectMatcher(),
+                    new AnyTargetMatcher(),
+                    Control::OID_PROXY_AUTHORIZATION,
+                ),
+            ],
+        );
+        $subject = new RuleBasedAccessControl($rules);
+
+        $authorized = true;
+        try {
+            $subject->authorizeControl(
+                $this->bindToken,
+                $this->bindToken->getResolvedDn(),
+                Control::OID_PROXY_AUTHORIZATION,
+            );
+        } catch (OperationException) {
+            $authorized = false;
+        }
+
+        self::assertSame(
+            $authorized,
+            $subject->mayUseControl(
+                $this->bindToken,
+                Control::OID_PROXY_AUTHORIZATION,
+            ),
+        );
+    }
+
     public function test_may_use_control_is_false_for_an_unauthenticated_token(): void
     {
         $subject = new RuleBasedAccessControl(AclRules::fromEmpty(

--- a/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
+++ b/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
@@ -275,7 +275,7 @@ final class RuleBasedAccessControlTest extends TestCase
         try {
             $subject->authorizeControl(
                 $this->bindToken,
-                $this->bindToken->getResolvedDn(),
+                new Dn('cn=foo,dc=foo,dc=bar'),
                 Control::OID_PROXY_AUTHORIZATION,
             );
         } catch (OperationException) {

--- a/tests/unit/Server/Middleware/AssertionMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/AssertionMiddlewareTest.php
@@ -25,6 +25,8 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\AssertionEvaluator;
 use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\AccessControl\AclRules;
+use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluator;
 use FreeDSx\Ldap\Server\Middleware\AssertionMiddleware;
@@ -56,6 +58,7 @@ final class AssertionMiddlewareTest extends TestCase
         $this->subject = new AssertionMiddleware(new AssertionEvaluator(
             new FilterEvaluator(),
             $this->backend,
+            new RuleBasedAccessControl(AclRules::fromEmpty()),
         ));
         $this->next = new RecordingMiddlewareHandler(new CallLog());
     }

--- a/tests/unit/Server/Middleware/ConfidentialityMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/ConfidentialityMiddlewareTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\AbandonRequest;
+use FreeDSx\Ldap\Operation\Request\AnonBindRequest;
+use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Request\SaslBindRequest;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
+use FreeDSx\Ldap\Operation\Request\UnbindRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\Queue\ConnectionControl;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\Config\ConfidentialityRequirement;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
+use FreeDSx\Ldap\Server\Middleware\ConfidentialityMiddleware;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\ServerOptions;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Middleware\CallLog;
+use Tests\Support\FreeDSx\Ldap\Middleware\RecordingMiddlewareHandler;
+
+final class ConfidentialityMiddlewareTest extends TestCase
+{
+    private ConnectionControl&MockObject $connection;
+
+    private RecordingMiddlewareHandler $next;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->createMock(ConnectionControl::class);
+        $this->next = new RecordingMiddlewareHandler(new CallLog());
+    }
+
+    public function test_nothing_is_refused_when_no_requirement_is_configured(): void
+    {
+        $this->connectionIsEncrypted(false);
+
+        $this->subjectFor(ConfidentialityRequirement::None)->process(
+            $this->contextFor(new SimpleBindRequest('cn=foo,dc=bar', 'secret')),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    /**
+     * @return array<string, array{RequestInterface}>
+     */
+    public static function credentialBearingRequests(): array
+    {
+        return [
+            'simple bind' => [new SimpleBindRequest('cn=foo,dc=bar', 'secret')],
+            'sasl plain' => [new SaslBindRequest(ServerOptions::SASL_PLAIN)],
+            'sasl cram-md5' => [new SaslBindRequest(ServerOptions::SASL_CRAM_MD5)],
+            'sasl scram-sha-256' => [new SaslBindRequest(ServerOptions::SASL_SCRAM_SHA_256)],
+        ];
+    }
+
+    #[DataProvider('credentialBearingRequests')]
+    public function test_a_credential_bearing_bind_is_refused_in_the_clear(RequestInterface $request): void
+    {
+        $this->connectionIsEncrypted(false);
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::CONFIDENTIALITY_REQUIRED);
+
+        $this->subjectFor(ConfidentialityRequirement::CredentialBind)->process(
+            $this->contextFor($request),
+            $this->next,
+        );
+    }
+
+    #[DataProvider('credentialBearingRequests')]
+    public function test_the_same_bind_is_allowed_once_encrypted(RequestInterface $request): void
+    {
+        $this->connectionIsEncrypted(true);
+
+        $this->subjectFor(ConfidentialityRequirement::CredentialBind)->process(
+            $this->contextFor($request),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    /**
+     * @return array<string, array{RequestInterface}>
+     */
+    public static function requestsCarryingNoCredential(): array
+    {
+        return [
+            'anonymous bind' => [new AnonBindRequest()],
+            'sasl external' => [new SaslBindRequest(ServerOptions::SASL_EXTERNAL)],
+            'search' => [(new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar')],
+            'unbind' => [new UnbindRequest()],
+        ];
+    }
+
+    #[DataProvider('requestsCarryingNoCredential')]
+    public function test_a_request_carrying_no_credential_is_allowed_in_the_clear(RequestInterface $request): void
+    {
+        $this->connectionIsEncrypted(false);
+
+        $this->subjectFor(ConfidentialityRequirement::CredentialBind)->process(
+            $this->contextFor($request),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    public function test_a_unix_socket_satisfies_the_requirement_without_encryption(): void
+    {
+        $this->connectionIsEncrypted(false);
+
+        $this->subjectFor(
+            ConfidentialityRequirement::CredentialBind,
+            (new NetworkConfig())->setTransport('unix'),
+        )->process(
+            $this->contextFor(new SimpleBindRequest('cn=foo,dc=bar', 'secret')),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    public function test_requiring_all_operations_refuses_a_search_in_the_clear(): void
+    {
+        $this->connectionIsEncrypted(false);
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::CONFIDENTIALITY_REQUIRED);
+
+        $this->subjectFor(ConfidentialityRequirement::AllOperations)->process(
+            $this->contextFor((new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar')),
+            $this->next,
+        );
+    }
+
+    /**
+     * @return array<string, array{RequestInterface}>
+     */
+    public static function requestsThatReachConfidentiality(): array
+    {
+        return [
+            'start tls' => [new ExtendedRequest(ExtendedRequest::OID_START_TLS)],
+            'unbind' => [new UnbindRequest()],
+            'abandon' => [new AbandonRequest(1)],
+        ];
+    }
+
+    #[DataProvider('requestsThatReachConfidentiality')]
+    public function test_requiring_all_operations_still_allows_reaching_confidentiality(
+        RequestInterface $request,
+    ): void {
+        $this->connectionIsEncrypted(false);
+
+        $this->subjectFor(ConfidentialityRequirement::AllOperations)->process(
+            $this->contextFor($request),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    public function test_requiring_all_operations_allows_everything_once_encrypted(): void
+    {
+        $this->connectionIsEncrypted(true);
+
+        $this->subjectFor(ConfidentialityRequirement::AllOperations)->process(
+            $this->contextFor((new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar')),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    public function test_requiring_all_operations_refuses_an_unrelated_extended_operation(): void
+    {
+        $this->connectionIsEncrypted(false);
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::CONFIDENTIALITY_REQUIRED);
+
+        $this->subjectFor(ConfidentialityRequirement::AllOperations)->process(
+            $this->contextFor(new ExtendedRequest(ExtendedRequest::OID_WHOAMI)),
+            $this->next,
+        );
+    }
+
+    private function connectionIsEncrypted(bool $isEncrypted): void
+    {
+        $this->connection
+            ->method('isEncrypted')
+            ->willReturn($isEncrypted);
+    }
+
+    private function subjectFor(
+        ConfidentialityRequirement $requirement,
+        ?NetworkConfig $networkConfig = null,
+    ): ConfidentialityMiddleware {
+        $options = new ServerOptions(networkConfig: $networkConfig ?? new NetworkConfig());
+        $options->setRequireConfidentiality($requirement);
+
+        return new ConfidentialityMiddleware(
+            $options,
+            $this->connection,
+        );
+    }
+
+    private function contextFor(RequestInterface $request): ServerRequestContext
+    {
+        return new ServerRequestContext(new LdapMessageRequest(
+            1,
+            $request,
+        ));
+    }
+}

--- a/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
@@ -21,6 +21,7 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Operation\Request\CompareRequest;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
+use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
@@ -649,6 +650,124 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
         );
 
         self::assertNotNull($this->next->received);
+    }
+
+    /**
+     * @return array<string, array{HandlerId, RequestInterface}>
+     */
+    public static function routesCarryingAPrivilegedControl(): array
+    {
+        return [
+            'compare' => [HandlerId::Dispatch, new CompareRequest('cn=foo,dc=bar', Filters::equal('cn', 'foo'))],
+            'extended' => [HandlerId::UnsupportedExtended, new ExtendedRequest('1.2.3.4')],
+            'search' => [HandlerId::Search, (new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar')],
+            'paging' => [HandlerId::Paging, (new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar')],
+            'sync' => [HandlerId::Sync, (new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar')],
+        ];
+    }
+
+    #[DataProvider('routesCarryingAPrivilegedControl')]
+    public function test_a_privileged_control_is_gated_on_every_route(
+        HandlerId $routeId,
+        RequestInterface $request,
+    ): void {
+        $this->routeResolvesTo($routeId);
+        $this->accessControl
+            ->expects(self::once())
+            ->method('authorizeControl')
+            ->with(
+                $this->token,
+                self::isInstanceOf(Dn::class),
+                Control::OID_RELAX_RULES,
+            );
+
+        $this->subject->process(
+            $this->contextFor(
+                $request,
+                Controls::relaxRules(),
+            ),
+            $this->next,
+        );
+    }
+
+    #[DataProvider('routesCarryingAPrivilegedControl')]
+    public function test_a_privileged_control_denial_blocks_every_route(
+        HandlerId $routeId,
+        RequestInterface $request,
+    ): void {
+        $this->routeResolvesTo($routeId);
+        $this->accessControl
+            ->method('authorizeControl')
+            ->willThrowException($this->denied());
+
+        try {
+            $this->subject->process(
+                $this->contextFor(
+                    $request,
+                    Controls::relaxRules(),
+                ),
+                $this->next,
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+                $e->getCode(),
+            );
+        }
+
+        self::assertNull(
+            $this->next->received,
+            'Dispatch must be blocked on denial.',
+        );
+    }
+
+    public function test_a_request_naming_no_entry_gates_the_control_against_the_root(): void
+    {
+        $this->routeResolvesTo(HandlerId::UnsupportedExtended);
+        $this->accessControl
+            ->expects(self::once())
+            ->method('authorizeControl')
+            ->with(
+                $this->token,
+                self::callback(static fn(Dn $dn): bool => $dn->toString() === ''),
+                Control::OID_RELAX_RULES,
+            );
+
+        $this->subject->process(
+            $this->contextFor(
+                new ExtendedRequest('1.2.3.4'),
+                Controls::relaxRules(),
+            ),
+            $this->next,
+        );
+    }
+
+    public function test_the_sync_control_is_gated_against_the_search_base(): void
+    {
+        $subject = new OperationAuthorizationMiddleware(
+            $this->resolver,
+            $this->accessControl,
+            new Dn(self::SUBSCHEMA_DN),
+            [Control::OID_SYNC_REQUEST],
+        );
+        $this->routeResolvesTo(HandlerId::Sync);
+        $this->accessControl
+            ->expects(self::once())
+            ->method('authorizeControl')
+            ->with(
+                $this->token,
+                self::callback(static fn(Dn $dn): bool => $dn->toString() === 'dc=foo,dc=bar'),
+                Control::OID_SYNC_REQUEST,
+            );
+
+        $subject->process(
+            $this->contextFor(
+                (new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar'),
+                new Control(Control::OID_SYNC_REQUEST),
+            ),
+            $this->next,
+        );
     }
 
     private function critical(Control $control): Control

--- a/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
@@ -770,6 +770,114 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
         );
     }
 
+    public function test_a_rename_authorizes_a_write_of_the_new_rdn_attribute_at_the_resulting_dn(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $seen = [];
+        $this->accessControl
+            ->method('authorizeAttribute')
+            ->willReturnCallback(
+                function (TokenInterface $token, Dn $dn, string $attribute, AttributeAccess $access) use (&$seen): void {
+                    $seen[] = $dn->toString() . '/' . $attribute . '/' . $access->name;
+                },
+            );
+
+        $this->subject->process(
+            $this->contextFor(new ModifyDnRequest(
+                'cn=foo,dc=bar',
+                'uid=bar',
+                false,
+            )),
+            $this->next,
+        );
+
+        self::assertSame(
+            ['uid=bar,dc=bar/uid/Write'],
+            $seen,
+        );
+    }
+
+    public function test_a_rename_deleting_the_old_rdn_authorizes_a_write_of_both_attributes(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $seen = [];
+        $this->accessControl
+            ->method('authorizeAttribute')
+            ->willReturnCallback(
+                function (TokenInterface $token, Dn $dn, string $attribute) use (&$seen): void {
+                    $seen[] = $attribute;
+                },
+            );
+
+        $this->subject->process(
+            $this->contextFor(new ModifyDnRequest(
+                'cn=foo,dc=bar',
+                'uid=bar',
+                true,
+            )),
+            $this->next,
+        );
+
+        self::assertSame(
+            ['uid', 'cn'],
+            $seen,
+        );
+    }
+
+    public function test_a_rename_authorizes_every_component_of_a_multivalued_rdn(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $seen = [];
+        $this->accessControl
+            ->method('authorizeAttribute')
+            ->willReturnCallback(
+                function (TokenInterface $token, Dn $dn, string $attribute) use (&$seen): void {
+                    $seen[] = $attribute;
+                },
+            );
+
+        $this->subject->process(
+            $this->contextFor(new ModifyDnRequest(
+                'cn=foo,dc=bar',
+                'cn=bar+uid=baz',
+                false,
+            )),
+            $this->next,
+        );
+
+        self::assertSame(
+            ['cn', 'uid'],
+            $seen,
+        );
+    }
+
+    public function test_a_denied_rdn_attribute_write_blocks_the_rename(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $this->accessControl
+            ->method('authorizeAttribute')
+            ->willThrowException($this->denied());
+
+        try {
+            $this->subject->process(
+                $this->contextFor(new ModifyDnRequest(
+                    'cn=foo,dc=bar',
+                    'uid=bar',
+                    false,
+                )),
+                $this->next,
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+                $e->getCode(),
+            );
+        }
+
+        self::assertNull($this->next->received);
+    }
+
     private function critical(Control $control): Control
     {
         return $control->setCriticality(true);

--- a/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Server\Middleware;
 
 use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Controls;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -500,6 +501,161 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
         yield 'unbind' => [HandlerId::Unbind];
     }
 
+    public function test_a_critical_pre_read_control_authorizes_a_read_of_the_target(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $this->accessControl
+            ->expects(self::atLeastOnce())
+            ->method('authorizeOperation')
+            ->willReturnCallback(function (OperationType $operation, TokenInterface $token, Dn $dn): void {
+                if ($operation === OperationType::Search) {
+                    self::assertSame(
+                        'cn=foo,dc=bar',
+                        $dn->toString(),
+                    );
+                }
+            });
+
+        $this->subject->process(
+            $this->contextFor(
+                new DeleteRequest('cn=foo,dc=bar'),
+                $this->critical(Controls::preRead()),
+            ),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    public function test_a_critical_post_read_on_a_rename_authorizes_a_read_of_the_resulting_dn(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $seen = [];
+        $this->accessControl
+            ->method('authorizeOperation')
+            ->willReturnCallback(function (OperationType $operation, TokenInterface $token, Dn $dn) use (&$seen): void {
+                if ($operation === OperationType::Search) {
+                    $seen[] = $dn->toString();
+                }
+            });
+
+        $this->subject->process(
+            $this->contextFor(
+                new ModifyDnRequest(
+                    'cn=foo,dc=bar',
+                    'cn=bar',
+                    true,
+                ),
+                $this->critical(Controls::postRead()),
+            ),
+            $this->next,
+        );
+
+        self::assertSame(
+            ['cn=bar,dc=bar'],
+            $seen,
+        );
+    }
+
+    public function test_a_read_denial_blocks_a_write_carrying_a_critical_pre_read_control(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $this->accessControl
+            ->method('authorizeOperation')
+            ->willReturnCallback(function (OperationType $operation): void {
+                if ($operation === OperationType::Search) {
+                    throw $this->denied();
+                }
+            });
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->subject->process(
+            $this->contextFor(
+                new DeleteRequest('cn=foo,dc=bar'),
+                $this->critical(Controls::preRead()),
+            ),
+            $this->next,
+        );
+    }
+
+    public function test_a_non_critical_pre_read_control_authorizes_no_read(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $this->accessControl
+            ->method('authorizeOperation')
+            ->willReturnCallback(static function (OperationType $operation): void {
+                self::assertNotSame(
+                    OperationType::Search,
+                    $operation,
+                );
+            });
+
+        $this->subject->process(
+            $this->contextFor(
+                new DeleteRequest('cn=foo,dc=bar'),
+                Controls::preRead(),
+            ),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    public function test_a_non_critical_assertion_still_authorizes_a_read_of_the_target(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $seen = [];
+        $this->accessControl
+            ->method('authorizeOperation')
+            ->willReturnCallback(function (OperationType $operation, TokenInterface $token, Dn $dn) use (&$seen): void {
+                if ($operation === OperationType::Search) {
+                    $seen[] = $dn->toString();
+                }
+            });
+        $assertion = Controls::assertion(Filters::equal('cn', 'foo'));
+        $assertion->setCriticality(false);
+
+        $this->subject->process(
+            $this->contextFor(
+                new DeleteRequest('cn=foo,dc=bar'),
+                $assertion,
+            ),
+            $this->next,
+        );
+
+        self::assertSame(
+            ['cn=foo,dc=bar'],
+            $seen,
+        );
+    }
+
+    public function test_a_request_without_a_read_bearing_control_authorizes_no_read(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $this->accessControl
+            ->method('authorizeOperation')
+            ->willReturnCallback(static function (OperationType $operation): void {
+                self::assertNotSame(
+                    OperationType::Search,
+                    $operation,
+                );
+            });
+
+        $this->subject->process(
+            $this->contextFor(new DeleteRequest('cn=foo,dc=bar')),
+            $this->next,
+        );
+
+        self::assertNotNull($this->next->received);
+    }
+
+    private function critical(Control $control): Control
+    {
+        return $control->setCriticality(true);
+    }
+
     private function routeResolvesTo(HandlerId $id): void
     {
         $this->resolver
@@ -507,10 +663,16 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
             ->willReturn($id);
     }
 
-    private function contextFor(RequestInterface $request): ServerRequestContext
-    {
+    private function contextFor(
+        RequestInterface $request,
+        Control ...$controls,
+    ): ServerRequestContext {
         return new ServerRequestContext(
-            new LdapMessageRequest(1, $request),
+            new LdapMessageRequest(
+                1,
+                $request,
+                ...$controls,
+            ),
             $this->token,
         );
     }

--- a/tests/unit/Server/PasswordModify/PasswordModifyServiceTest.php
+++ b/tests/unit/Server/PasswordModify/PasswordModifyServiceTest.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Control\PwdPolicyError;
 use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\PasswordModifyRequest;
@@ -299,6 +300,60 @@ final class PasswordModifyServiceTest extends TestCase
         self::assertSame(
             PwdPolicyError::CHANGE_AFTER_RESET,
             $this->context->getOutcome()?->errorCode,
+        );
+    }
+
+    public function test_a_missing_target_answers_as_forbidden_when_the_identity_holds_no_rights(): void
+    {
+        $this->resolver
+            ->method('resolve')
+            ->willReturn(null);
+        $this->accessControl
+            ->method('authorizeOperation')
+            ->willThrowException(new OperationException(
+                'Access denied.',
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+            ));
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->subject->change(
+            new PasswordModifyRequest(
+                'cn=ghost,dc=foo,dc=bar',
+                null,
+                'newpass',
+            ),
+            $this->userToken,
+            new ControlBag(),
+        );
+    }
+
+    public function test_a_target_that_resolved_to_nothing_is_authorized_against_the_root(): void
+    {
+        $this->resolver
+            ->method('resolve')
+            ->willReturn(null);
+        $this->accessControl
+            ->expects(self::once())
+            ->method('authorizeOperation')
+            ->with(
+                OperationType::PasswordModify,
+                $this->userToken,
+                self::callback(static fn(Dn $dn): bool => $dn->toString() === ''),
+            );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::NO_SUCH_OBJECT);
+
+        $this->subject->change(
+            new PasswordModifyRequest(
+                'cn=ghost,dc=foo,dc=bar',
+                null,
+                'newpass',
+            ),
+            $this->userToken,
+            new ControlBag(),
         );
     }
 


### PR DESCRIPTION
This is a collection of fixes, largely security focused:

* Correctly apply ACL to pre / post read controls (these predated the read / write attribute distinction in ACLs).
* Make assertion controls respect ACL filtering.
* More broadly enforce privileged controls in the middleware.
* Modify RDN operations should respect attribute ACLs in both directions.
* Allow confidentiality to be enforced in the config (requiring TLS / SSL for binds or all operations)
* Fixed a target existence leak in the password modify op (another oracle based security issue).
* Unify control ACL ordering enforcement (it uses the helper now).
* More broadly handle malformed DNs and return a proper response code.
* Rework the AclRules helpers to have explicit prepend* and append* methods to make ordering rules more natural (and less likely to make mistakes). 

Added integration tests where applicable for a bunch of these. And docs regarding the new ACL rule helpers and the confidentiality requirement config.