### PR TITLE
[1.0.0] Replica security narrowing, documentation.

### DIFF
--- a/docs/Server/Access-Control.md
+++ b/docs/Server/Access-Control.md
@@ -248,7 +248,7 @@ replacing them, so they compose on `secureDefault()` or on a policy built from `
 | `withFullAccess($subject, $target = new AnyTargetMatcher())`   | Every operation and every attribute write over the target                         |
 | `withSelfServiceWrites($attributes = AclRules::SELF_WRITABLE_ATTRIBUTES)` | Modify on an identity's own entry, limited to the given attributes |
 | `withCredentialProtection($administrators = null)`        | The `userPassword` and Password Modify rules, plus privileged controls and extended operations for the administrator |
-| `withReplicaGrants($replica, $target = new AnyTargetMatcher())` | The content-sync control, the ppolicy-forward extended operation, and confidential attribute reads |
+| `withReplicaGrants($replica, $target = new AnyTargetMatcher())` | The content-sync control, the ppolicy-forward extended operation, and the policy-state writes that forward needs |
 
 `AclRules::secureDefault()` is built from the first three. `withFullAccess()` is what it applies to the configured
 [administrator](#administrators), so reaching for it directly is how you grant a second identity the same rights.
@@ -466,8 +466,8 @@ Four things to keep in mind:
 - A custom schema must carry the extension. Supplying your own `userPassword` definition through
   a schema source without it silently drops the protection.
 
-A replica needs to read confidential attributes in order to replicate them, so `AclRules::withReplicaGrants()`
-includes that grant along with the sync control.
+Replication is not affected. A content sync ships every visible entry whole, so a replica receives confidential
+attributes without a grant for them. See [Replication](Replication.md#access-control).
 
 ## Control Rules
 

--- a/src/FreeDSx/Ldap/Container/Provider/HandlerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/HandlerContainerProvider.php
@@ -143,6 +143,7 @@ final class HandlerContainerProvider implements ContainerProviderInterface
             backend: $container->get(WritableStorageBackend::class),
             policyResolver: $container->get(PasswordPolicyResolver::class),
             engine: $container->get(PasswordPolicyEngine::class),
+            accessControl: $container->get(AccessControlInterface::class),
         );
     }
 

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandler.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Entry\Change;
+use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\LdapResult;
@@ -22,6 +24,8 @@ use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
@@ -43,6 +47,7 @@ readonly class ServerPasswordPolicyForwardHandler implements ServerProtocolHandl
         private WritableLdapBackendInterface $backend,
         private PasswordPolicyResolver $policyResolver,
         private PasswordPolicyEngine $engine,
+        private AccessControlInterface $accessControl,
     ) {}
 
     /**
@@ -62,7 +67,10 @@ readonly class ServerPasswordPolicyForwardHandler implements ServerProtocolHandl
             );
         }
 
-        $this->apply($request);
+        $this->apply(
+            $request,
+            $token,
+        );
 
         return ResponseStream::reply(
             $message,
@@ -72,30 +80,62 @@ readonly class ServerPasswordPolicyForwardHandler implements ServerProtocolHandl
     }
 
     /**
+     * The write itself stays a system write, since these attributes are NO-USER-MODIFICATION. The grant to forward
+     * says nothing about which entries may be forwarded for, so the caller is authorized against the target here.
+     *
      * @throws OperationException
      */
-    private function apply(ForwardPasswordPolicyStateRequest $request): void
-    {
+    private function apply(
+        ForwardPasswordPolicyStateRequest $request,
+        TokenInterface $token,
+    ): void {
         $this->backend->atomicUpdate(
             $request->getDn(),
             WriteContext::system(
                 new SystemToken(),
                 new ControlBag(),
             ),
-            function (Entry $entry) use ($request): array {
+            function (Entry $entry) use ($request, $token): array {
                 $policy = $this->policyResolver->resolveFor($entry);
 
                 if ($policy === null) {
                     return [];
                 }
 
-                return $this->engine->recordForwardedState(
+                $changes = $this->engine->recordForwardedState(
                     UserPasswordState::fromEntry($entry),
                     $policy,
                     $request->getFailureTimes(),
                     $request->getLastSuccess(),
                 )->changes;
+
+                $this->authorizeChanges(
+                    $token,
+                    $entry->getDn(),
+                    $changes,
+                );
+
+                return $changes;
             },
         );
+    }
+
+    /**
+     * @param Change[] $changes
+     * @throws OperationException
+     */
+    private function authorizeChanges(
+        TokenInterface $token,
+        Dn $dn,
+        array $changes,
+    ): void {
+        foreach ($changes as $change) {
+            $this->accessControl->authorizeAttribute(
+                $token,
+                $dn,
+                $change->getAttribute()->getName(),
+                AttributeAccess::Write,
+            );
+        }
     }
 }

--- a/src/FreeDSx/Ldap/Server/AccessControl/AclRules.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/AclRules.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerMonitorHandler;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ConfidentialAccessRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
@@ -281,6 +282,8 @@ final readonly class AclRules
     /**
      * Grant a replica's bind identity the privileged capabilities it needs: the content-sync control over $target,
      * the password-policy forward extended operation, and confidential attributes so those replicate.
+     *
+     * $target bounds both what may be synced and which entries policy state may be forwarded for.
      */
     public function withReplicaGrants(
         SubjectMatcherInterface $replica,
@@ -296,6 +299,14 @@ final readonly class AclRules
                 $replica,
                 ExtendedRequest::OID_PPOLICY_STATE_FORWARD,
             ))
+            // The extended operation carries no target, so the entries it may be forwarded for are bounded here.
+            ->appendAttributeRules(AttributeRule::allow(
+                $replica,
+                $target,
+                PasswordPolicyOid::NAME_PWD_FAILURE_TIME,
+                PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME,
+                PasswordPolicyOid::NAME_PWD_LAST_SUCCESS,
+            )->forWrite())
             ->appendConfidentialAccess(ConfidentialAccessRule::allowAny($replica));
     }
 

--- a/src/FreeDSx/Ldap/Server/AccessControl/AclRules.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/AclRules.php
@@ -280,10 +280,11 @@ final readonly class AclRules
     }
 
     /**
-     * Grant a replica's bind identity the privileged capabilities it needs: the content-sync control over $target,
-     * the password-policy forward extended operation, and confidential attributes so those replicate.
+     * Grant a replica's bind identity the privileged capabilities it needs: the content-sync control over $target and
+     * the password-policy forward extended operation.
      *
-     * $target bounds both what may be synced and which entries policy state may be forwarded for.
+     * $target bounds both what may be synced and which entries policy state may be forwarded for. No attribute read
+     * grant is needed, since a sync ships visible entries whole. This is intentional for replication to work properly.
      */
     public function withReplicaGrants(
         SubjectMatcherInterface $replica,
@@ -306,8 +307,7 @@ final readonly class AclRules
                 PasswordPolicyOid::NAME_PWD_FAILURE_TIME,
                 PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME,
                 PasswordPolicyOid::NAME_PWD_LAST_SUCCESS,
-            )->forWrite())
-            ->appendConfidentialAccess(ConfidentialAccessRule::allowAny($replica));
+            )->forWrite());
     }
 
     /**

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -16,6 +16,8 @@ use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ExtendedOperationRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\Target\Target;
 use FreeDSx\Ldap\Server\Backend\Auth\ManagerIdentity;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
@@ -363,12 +365,23 @@ final class LdapServerCommand extends Command
                     ),
                 ))
                 ->setAclRules(
-                    $options->getAclRules()->appendExtendedOperationRules(
-                        ExtendedOperationRule::allow(
-                            Subject::dn('cn=user,dc=foo,dc=bar'),
-                            ExtendedRequest::OID_PPOLICY_STATE_FORWARD,
+                    $options->getAclRules()
+                        ->appendExtendedOperationRules(
+                            ExtendedOperationRule::allow(
+                                Subject::dn('cn=user,dc=foo,dc=bar'),
+                                ExtendedRequest::OID_PPOLICY_STATE_FORWARD,
+                            ),
+                        )
+                        // Matches the base the replica syncs, so the forward reaches exactly what it replicates.
+                        ->appendAttributeRules(
+                            AttributeRule::allow(
+                                Subject::dn('cn=user,dc=foo,dc=bar'),
+                                Target::subtree('dc=foo,dc=bar'),
+                                PasswordPolicyOid::NAME_PWD_FAILURE_TIME,
+                                PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME,
+                                PasswordPolicyOid::NAME_PWD_LAST_SUCCESS,
+                            )->forWrite(),
                         ),
-                    ),
                 );
         }
 

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandlerTest.php
@@ -27,6 +27,8 @@ use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerPasswordPolicyForwardHandler;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
 use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
@@ -49,9 +51,12 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
 
     private ResponseStream $lastStream;
 
+    private AccessControlInterface&MockObject $accessControl;
+
     protected function setUp(): void
     {
         $this->backend = $this->createMock(WritableLdapBackendInterface::class);
+        $this->accessControl = $this->createMock(AccessControlInterface::class);
         $this->subject = new ServerPasswordPolicyForwardHandler(
             $this->backend,
             new PasswordPolicyResolver(
@@ -66,6 +71,7 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
                 FrozenClock::fromString(self::NOW),
                 new PasswordChangeConstraintChain([]),
             ),
+            $this->accessControl,
         );
     }
 
@@ -137,6 +143,76 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
             [],
             $changes,
         );
+    }
+
+    /**
+     * The grant to forward says nothing about which entries, so each attribute is authorized at the target DN.
+     */
+    public function test_it_authorizes_every_changed_attribute_against_the_target_dn(): void
+    {
+        $seen = [];
+        $this->accessControl
+            ->method('authorizeAttribute')
+            ->willReturnCallback(function (
+                TokenInterface $token,
+                Dn $dn,
+                string $attribute,
+                AttributeAccess $access,
+            ) use (&$seen): void {
+                $seen[] = $dn->toString() . '/' . $attribute . '/' . $access->name;
+            });
+
+        $this->captureComputedChanges(
+            new ForwardPasswordPolicyStateRequest(
+                self::DN,
+                'uuid',
+                [new DateTimeImmutable('2026-05-20 11:59:00', new DateTimeZone('UTC'))],
+            ),
+            Entry::fromArray(self::DN, ['cn' => ['user']]),
+        );
+
+        self::assertSame(
+            [self::DN . '/pwdFailureTime/Write'],
+            $seen,
+        );
+    }
+
+    public function test_a_denied_attribute_stops_the_forwarded_write(): void
+    {
+        $this->accessControl
+            ->method('authorizeAttribute')
+            ->willThrowException(new OperationException(
+                'Access denied.',
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+            ));
+
+        $compute = null;
+        $this->backend
+            ->method('atomicUpdate')
+            ->with(
+                self::anything(),
+                self::anything(),
+                self::callback(function (callable $fn) use (&$compute): bool {
+                    $compute = $fn;
+
+                    return true;
+                }),
+            );
+
+        $this->subject->handleRequest(
+            $this->messageFor(new ForwardPasswordPolicyStateRequest(
+                self::DN,
+                'uuid',
+                [new DateTimeImmutable('2026-05-20 11:59:00', new DateTimeZone('UTC'))],
+            )),
+            $this->createMock(TokenInterface::class),
+        );
+
+        self::assertNotNull($compute);
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $compute(Entry::fromArray(self::DN, ['cn' => ['user']]));
     }
 
     public function test_it_rejects_a_request_of_the_wrong_type(): void

--- a/tests/unit/Server/AccessControl/AclRulesTest.php
+++ b/tests/unit/Server/AccessControl/AclRulesTest.php
@@ -21,6 +21,7 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerMonitorHandler;
 use FreeDSx\Ldap\Server\AccessControl\AclRules;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
@@ -86,6 +87,40 @@ final class AclRulesTest extends TestCase
         self::assertContains(
             ExtendedRequest::OID_PPOLICY_STATE_FORWARD,
             $extendedOp->extendedOpOids,
+        );
+    }
+
+    /**
+     * The forward operation carries no target of its own, so the same target bounds which entries it may reach.
+     */
+    public function test_withReplicaGrants_scopes_the_forwarded_policy_writes_to_its_target(): void
+    {
+        $replica = BindToken::fromSasl(
+            'replica',
+            new Dn('cn=replica,dc=foo,dc=bar'),
+        );
+        $accessControl = new RuleBasedAccessControl(
+            AclRules::fromEmpty()->withReplicaGrants(
+                Subject::dn('cn=replica,dc=foo,dc=bar'),
+                Target::subtree('ou=replicated,dc=foo,dc=bar'),
+            ),
+        );
+
+        $accessControl->authorizeAttribute(
+            $replica,
+            new Dn('cn=bob,ou=replicated,dc=foo,dc=bar'),
+            PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME,
+            AttributeAccess::Write,
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $accessControl->authorizeAttribute(
+            $replica,
+            new Dn('cn=admin,dc=foo,dc=bar'),
+            PasswordPolicyOid::NAME_PWD_ACCOUNT_LOCKED_TIME,
+            AttributeAccess::Write,
         );
     }
 

--- a/tests/unit/Server/AccessControl/AclRulesTest.php
+++ b/tests/unit/Server/AccessControl/AclRulesTest.php
@@ -22,6 +22,7 @@ use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\AccessControl\Rule\ConfidentialAccessRule;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerMonitorHandler;
 use FreeDSx\Ldap\Server\AccessControl\AclRules;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
@@ -124,30 +125,28 @@ final class AclRulesTest extends TestCase
         );
     }
 
-    public function test_withReplicaGrants_allows_confidential_attributes_so_those_replicate(): void
+    /**
+     * A sync ships visible entries whole, so a replica reads confidential attributes without a grant for them.
+     */
+    public function test_withReplicaGrants_adds_no_confidential_grant(): void
     {
         $rules = AclRules::fromEmpty()->withReplicaGrants(Subject::dn('cn=replica,dc=foo,dc=bar'));
 
-        $confidential = $rules->confidential[0];
-        self::assertSame(
-            Effect::Allow,
-            $confidential->effect,
-        );
-        // An empty attribute list covers every confidential attribute, not none of them.
         self::assertSame(
             [],
-            $confidential->attributes,
+            $rules->confidential,
         );
     }
 
     public function test_withCredentialProtection_keeps_confidential_grants_made_earlier(): void
     {
+        $existing = ConfidentialAccessRule::allowAny(Subject::dn(self::ADMIN_DN));
         $rules = AclRules::fromEmpty()
-            ->withReplicaGrants(Subject::dn('cn=replica,dc=foo,dc=bar'))
+            ->appendConfidentialAccess($existing)
             ->withCredentialProtection();
 
-        self::assertCount(
-            1,
+        self::assertContains(
+            $existing,
             $rules->confidential,
         );
     }


### PR DESCRIPTION
The replica account is currently granted a normally denied control (sync) which functions different with ACL (sync needs full copies of entries by design for the most part). However, we should still scope password policy state forwards to the target the sync is actually configured for. This updates that and makes the documentation more explicit.