### PR TITLE
[1.0.0] Fix LDAPS connections being dropped under PCNTL.

### DIFF
--- a/src/FreeDSx/Ldap/Server/Process/ChildProcess.php
+++ b/src/FreeDSx/Ldap/Server/Process/ChildProcess.php
@@ -42,4 +42,12 @@ readonly class ChildProcess
     {
         $this->socket->close();
     }
+
+    /**
+     * Drop this process's own handle on the connection, leaving the process that owns it unaffected.
+     */
+    public function releaseSocket(): void
+    {
+        $this->socket->close(shutdown: false);
+    }
 }

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -478,9 +478,9 @@ class PcntlServerRunner implements ServerRunnerInterface
         int $pid,
         ?ChildChannel $channel,
     ): never {
-        // Cleanup the child's inherited FD copy without shutting down the parent accept loop.
+        // Cleanup the inherited FD copies without disturbing the accept loop or the connections still in flight.
         $this->server->close(shutdown: false);
-        $this->closeInheritedChannels();
+        $this->closeInheritedConnections();
         $channel?->childKeepWrite();
         if ($channel !== null) {
             $this->operationRollup?->enterChild($channel);
@@ -490,6 +490,12 @@ class PcntlServerRunner implements ServerRunnerInterface
         $this->isMainProcess = false;
 
         $this->resettable?->reset();
+
+        if (!$this->encryptConnectionIfDeferred($socket, $context)) {
+            $socket->close();
+
+            exit(0);
+        }
 
         $serverProtocolHandler = $this->serverProtocolFactory->make(
             $socket,
@@ -523,13 +529,13 @@ class PcntlServerRunner implements ServerRunnerInterface
     }
 
     /**
-     * Prepare a freshly forked background-task child: drop the inherited server socket, channels and signal
+     * Prepare a freshly forked background-task child: drop the inherited server socket, connections and signal
      * handlers, then reset inherited per-connection state.
      */
     private function enterChild(): void
     {
         $this->server->close(shutdown: false);
-        $this->closeInheritedChannels();
+        $this->closeInheritedConnections();
         $this->isMainProcess = false;
 
         // A sweep child is terminated by SIGTERM; the replica daemon installs its own handlers when it runs.
@@ -548,13 +554,41 @@ class PcntlServerRunner implements ServerRunnerInterface
     }
 
     /**
-     * Close the parent's channel read ends inherited by this fork so they do not leak in the child.
+     * Release the channel read ends and client sockets of connections already in flight, so this fork neither leaks
+     * them nor ends them when it exits.
      */
-    private function closeInheritedChannels(): void
+    private function closeInheritedConnections(): void
     {
         foreach ($this->childProcesses as $childProcess) {
             $childProcess->getChannel()?->close();
+            $childProcess->releaseSocket();
         }
+
+        $this->childProcesses = [];
+    }
+
+    /**
+     * Negotiate TLS for connections whose handshake the listener left to the handler.
+     *
+     * @param array<string, mixed> $context
+     */
+    private function encryptConnectionIfDeferred(
+        Socket $socket,
+        array $context,
+    ): bool {
+        if (!$this->socketServerFactory->isTlsHandshakeDeferred()) {
+            return true;
+        }
+
+        try {
+            $socket->encrypt(true);
+        } catch (Throwable $e) {
+            $this->logTlsHandshakeError($e, $context);
+
+            return false;
+        }
+
+        return true;
     }
 
     private function makeChildChannel(): ?ChildChannel

--- a/src/FreeDSx/Ldap/Server/ServerRunner/ServerRunnerLoggerTrait.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/ServerRunnerLoggerTrait.php
@@ -91,6 +91,20 @@ trait ServerRunnerLoggerTrait
     /**
      * @param array<string, mixed> $context
      */
+    private function logTlsHandshakeError(
+        Throwable $e,
+        array $context = [],
+    ): void {
+        $this->getRunnerLogger()?->log(
+            LogLevel::WARNING,
+            'Unable to negotiate TLS with the client. Closing connection.',
+            array_merge($context, self::exceptionContext($e)),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
     private function logConnectionLimitReached(array $context = []): void
     {
         $this->getRunnerLogger()?->log(

--- a/src/FreeDSx/Ldap/Server/SocketServerFactory.php
+++ b/src/FreeDSx/Ldap/Server/SocketServerFactory.php
@@ -33,6 +33,20 @@ class SocketServerFactory
         private readonly bool $reusePort = false,
     ) {}
 
+    /**
+     * Whether the handler that owns a connection must negotiate TLS itself, rather than the listener doing it as part
+     * of accepting.
+     *
+     * A session negotiated in the accept loop is inherited by every connection forked after it, and the first of those
+     * to exit sends the close alert that ends the connection for the handler that actually owns it.
+     */
+    public function isTlsHandshakeDeferred(): bool
+    {
+        return $this->runner === RunnerMode::Pcntl
+            && $this->network->isUseSsl()
+            && Transport::from($this->network->getTransport()) === Transport::Tcp;
+    }
+
     public function makeAndBind(): SocketServer
     {
         $isUnixSocket = $this->network->isUnixSocket();
@@ -53,7 +67,7 @@ class SocketServerFactory
             ->setIdleTimeout($this->network->getIdleTimeout())
             ->setWriteTimeout($this->network->getWriteTimeout())
             ->setWriteTimeoutEnforcer($writeTimeoutEnforcer)
-            ->setUseSsl($this->network->isUseSsl())
+            ->setUseSsl($this->network->isUseSsl() && !$this->isTlsHandshakeDeferred())
             ->setSslCert($this->network->getSslCert())
             ->setSslCertKey($this->network->getSslCertKey())
             ->setSslCertPassphrase($this->network->getSslCertPassphrase())

--- a/tests/integration/LdapServerTest.php
+++ b/tests/integration/LdapServerTest.php
@@ -418,6 +418,30 @@ final class LdapServerTest extends ServerTestCase
         $this->assertNotNull($result);
     }
 
+    public function testItKeepsAnSSLConnectionAliveWhenALaterConnectionEnds(): void
+    {
+        $this->stopServer();
+        $this->createServerProcess('ssl');
+
+        $established = $this->ldapClient();
+        $established->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+
+        $later = $this->buildClient('ssl');
+        $later->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+        $later->unbind();
+
+        // Give the connection handler the moment it needs to end before the established one is used again.
+        usleep(250_000);
+
+        $this->assertNotNull($established->read(''));
+    }
+
     public function testItCanRunOverUnixSocket(): void
     {
         $this->stopServer();

--- a/tests/integration/ServerTestCase.php
+++ b/tests/integration/ServerTestCase.php
@@ -81,14 +81,15 @@ class ServerTestCase extends LdapTestCase
 
     public function tearDown(): void
     {
-        parent::tearDown();
-
+        // Ahead of the parent, which closes the socket. Unbinding afterwards would only reconnect to send it.
         try {
             $this->client?->unbind();
         } catch (\Throwable) {
             // Server may have already closed; ignore unbind failures during teardown.
         }
         $this->client = null;
+
+        parent::tearDown();
 
         if ($this->overrideProcess !== null) {
             self::stopProcessTree($this->overrideProcess);

--- a/tests/unit/Server/Process/ChildProcessTest.php
+++ b/tests/unit/Server/Process/ChildProcessTest.php
@@ -61,6 +61,16 @@ final class ChildProcessTest extends TestCase
         $this->subject->closeSocket();
     }
 
+    public function test_it_should_release_the_socket_without_shutting_it_down(): void
+    {
+        $this->mockSocket
+            ->expects(self::once())
+            ->method('close')
+            ->with(false);
+
+        $this->subject->releaseSocket();
+    }
+
     public function test_the_channel_is_null_by_default(): void
     {
         self::assertNull($this->subject->getChannel());

--- a/tests/unit/Server/SocketServerFactoryTest.php
+++ b/tests/unit/Server/SocketServerFactoryTest.php
@@ -139,6 +139,38 @@ final class SocketServerFactoryTest extends TestCase
         );
     }
 
+    public function test_it_defers_the_tls_handshake_to_the_connection_handler_for_the_pcntl_runner(): void
+    {
+        $subject = new SocketServerFactory(
+            (new NetworkConfig())
+                ->setPort(3394)
+                ->setUseSsl(true),
+            RunnerMode::Pcntl,
+            $this->mockLogger,
+        );
+
+        self::assertTrue($subject->isTlsHandshakeDeferred());
+        self::assertFalse($subject->makeAndBind()->getOptions()->isUseSsl());
+    }
+
+    public function test_it_leaves_the_tls_handshake_to_the_listener_for_the_swoole_runner(): void
+    {
+        $subject = new SocketServerFactory(
+            (new NetworkConfig())
+                ->setPort(3395)
+                ->setUseSsl(true),
+            RunnerMode::Swoole,
+            $this->mockLogger,
+        );
+
+        self::assertFalse($subject->isTlsHandshakeDeferred());
+    }
+
+    public function test_it_has_no_tls_handshake_to_defer_without_ssl(): void
+    {
+        self::assertFalse($this->subject->isTlsHandshakeDeferred());
+    }
+
     public function test_it_should_make_a_unix_based_socket_server(): void
     {
         if (str_starts_with(strtoupper(PHP_OS), 'WIN')) {


### PR DESCRIPTION
This fixes an issue with PCNTL and useSsl that was causing flaky tests. Turns out to be another weird case to handle with forked resources. One like this was already caught and handled, but this one went undiscovered until the tests were changed in a way that started to expose it.