### PR TITLE
[1.0.0] Add subentry support (Part 3).

### DIFF
--- a/docs/Server/Password-Policy.md
+++ b/docs/Server/Password-Policy.md
@@ -143,13 +143,42 @@ $options->setDefaultPasswordPolicyDn(new Dn('cn=default,ou=policies,dc=example,d
 
 Per-user policies are supported by setting `pwdPolicySubentry` on the user entry to the DN of a `pwdPolicy` entry.
 
+### Subtree-Scoped Policies
+
+A policy can govern a branch of the directory rather than one entry at a time. Add a subentry that carries both
+the `subentry` and `pwdPolicy` object classes directly below an administrative point, and its `subtreeSpecification`
+decides which entries it applies to:
+
+```ldif
+dn: ou=secure,dc=example,dc=com
+objectClass: organizationalUnit
+ou: secure
+administrativeRole: 2.5.23.4
+
+dn: cn=policy,ou=secure,dc=example,dc=com
+objectClass: subentry
+objectClass: pwdPolicy
+cn: policy
+subtreeSpecification: { specificExclusions { chopBefore:"ou=contractors" } }
+pwdAttribute: userPassword
+pwdLockout: TRUE
+pwdMaxFailure: 3
+```
+
+Every entry under `ou=secure` is then governed by that policy, except the `ou=contractors` branch the specification
+chops out. See the subtree specification grammar in RFC 3672 for the full set of components.
+
+Subentries are not returned by ordinary searches. Read one back with a base scope search on its DN, or use the
+subentries control.
+
 ### Policy Resolution Order
 
 For a given user the governing policy is resolved as:
 
 1. The `pwdPolicy` entry named by the user's `pwdPolicySubentry` (if present).
-2. The default DN from `setDefaultPasswordPolicyDn()` (if configured).
-3. The in-memory policy from `setPasswordPolicy()` (if configured).
+2. The nearest governing `pwdPolicy` subentry whose `subtreeSpecification` covers the user.
+3. The default DN from `setDefaultPasswordPolicyDn()` (if configured).
+4. The in-memory policy from `setPasswordPolicy()` (if configured).
 
 If none apply, then no policy is enforced for the user.
 

--- a/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
@@ -568,7 +568,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
         $options = $container->get(ServerOptions::class);
         $config = $options->getReplicaConfig();
 
-        if ($config === null || !$options->isPasswordPolicyEnabled()) {
+        if ($config === null) {
             return null;
         }
 
@@ -602,9 +602,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
         $storage = $container->get(EntryStorageInterface::class);
 
         // Pair reconciliation with forwarding: the store drops forwarded state once the primary's entry replicates back.
-        $passwordStateStore = $options->isPasswordPolicyEnabled()
-            ? $container->get(ReplicaPasswordStateStoreInterface::class)
-            : null;
+        $passwordStateStore = $container->get(ReplicaPasswordStateStoreInterface::class);
 
         return $hostManagedShutdown
             ? LdapReplica::forSwoole(

--- a/src/FreeDSx/Ldap/Container/Provider/PasswordPolicyContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/PasswordPolicyContainerProvider.php
@@ -34,6 +34,9 @@ use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\UniquePolicyTimeFactory;
+use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
+use FreeDSx\Ldap\Server\Subentry\GoverningSubentryResolver;
+use FreeDSx\Ldap\Server\Subentry\SubtreeSpecificationEvaluator;
 use FreeDSx\Ldap\ServerOptions;
 
 /**
@@ -112,11 +115,16 @@ final class PasswordPolicyContainerProvider implements ContainerProviderInterfac
     private function makePasswordPolicyResolver(Container $container): PasswordPolicyResolver
     {
         $options = $container->get(ServerOptions::class);
+        $backend = $container->get(WritableStorageBackend::class);
 
         return new PasswordPolicyResolver(
-            $container->get(WritableStorageBackend::class),
+            $backend,
             $options->getDefaultPasswordPolicyDn(),
             $options->getPasswordPolicy(),
+            new GoverningSubentryResolver(
+                $backend,
+                new SubtreeSpecificationEvaluator($container->get(FilterEvaluatorInterface::class)),
+            ),
         );
     }
 

--- a/src/FreeDSx/Ldap/Entry/Dn.php
+++ b/src/FreeDSx/Ldap/Entry/Dn.php
@@ -178,6 +178,16 @@ class Dn implements IteratorAggregate, Countable, Stringable
     }
 
     /**
+     * Return true if this DN and $other name the same entry.
+     *
+     * @throws UnexpectedValueException
+     */
+    public function equals(Dn $other): bool
+    {
+        return $this->normalize()->toString() === $other->normalize()->toString();
+    }
+
+    /**
      * Return true if this DN is a direct child of $parent.
      *
      * @throws UnexpectedValueException

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandler.php
@@ -89,19 +89,25 @@ readonly class ServerPasswordPolicyForwardHandler implements ServerProtocolHandl
         ForwardPasswordPolicyStateRequest $request,
         TokenInterface $token,
     ): void {
+        $target = $this->backend->get($request->getDn());
+
+        if ($target === null) {
+            return;
+        }
+
+        // Resolved before the transaction opens to avoid potential write locks in atomic.
+        $policy = $this->policyResolver->resolveFor($target);
+        if ($policy === null) {
+            return;
+        }
+
         $this->backend->atomicUpdate(
             $request->getDn(),
             WriteContext::system(
                 new SystemToken(),
                 new ControlBag(),
             ),
-            function (Entry $entry) use ($request, $token): array {
-                $policy = $this->policyResolver->resolveFor($entry);
-
-                if ($policy === null) {
-                    return [];
-                }
-
+            function (Entry $entry) use ($request, $token, $policy): array {
                 $changes = $this->engine->recordForwardedState(
                     UserPasswordState::fromEntry($entry),
                     $policy,

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/AliasDetector.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/AliasDetector.php
@@ -14,9 +14,8 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage;
 
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Schema\Definition\ObjectClassOid;
-
-use function strcasecmp;
 
 /**
  * Recognizes alias entries (RFC 4512: an entry whose objectClass includes "alias").
@@ -27,17 +26,11 @@ final class AliasDetector
 
     public static function isAlias(Entry $entry): bool
     {
-        $objectClass = $entry->get('objectClass');
-        if ($objectClass === null) {
-            return false;
-        }
-
-        foreach ($objectClass->getValues() as $value) {
-            if (strcasecmp($value, ObjectClassOid::NAME_ALIAS) === 0) {
-                return true;
-            }
-        }
-
-        return false;
+        return $entry
+            ->get(AttributeTypeOid::NAME_OBJECT_CLASS)
+            ?->has(
+                ObjectClassOid::NAME_ALIAS,
+                caseSensitive: false,
+            ) === true;
     }
 }

--- a/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
+++ b/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
@@ -108,18 +108,15 @@ final class ConnectionHandlerBuilder implements ConnectionHandlerBuilderInterfac
         $backend = $this->container->get(WritableStorageBackend::class);
         $passwordAuthenticator = $this->container->get(PasswordAuthenticatableInterface::class);
 
-        $policyContext = null;
-        $interceptors = [];
-        if ($options->isPasswordPolicyEnabled()) {
-            $policyContext = new PasswordPolicyContext();
-            $interceptors[] = new PasswordPolicyResponseInterceptor($policyContext);
-            $passwordAuthenticator = $this->decoratePasswordAuthenticator(
-                $passwordAuthenticator,
-                $backend,
-                $policyContext,
-                $eventLogger,
-            );
-        }
+        // Always composed: policy may come from a DIT entry that appears after the server starts.
+        $policyContext = new PasswordPolicyContext();
+        $interceptors = [new PasswordPolicyResponseInterceptor($policyContext)];
+        $passwordAuthenticator = $this->decoratePasswordAuthenticator(
+            $passwordAuthenticator,
+            $backend,
+            $policyContext,
+            $eventLogger,
+        );
 
         $manager = $options->getManager();
         if ($manager !== null) {

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyComponentFactory.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyComponentFactory.php
@@ -63,7 +63,7 @@ final readonly class PasswordPolicyComponentFactory
         EventLogger $eventLogger,
         ?PasswordPolicyContext $passwordPolicyContext,
     ): ?PasswordPolicyChangeGuard {
-        if ($passwordPolicyContext === null || !$this->options->isPasswordPolicyEnabled()) {
+        if ($passwordPolicyContext === null) {
             return null;
         }
 

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyResolver.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyResolver.php
@@ -15,8 +15,11 @@ namespace FreeDSx\Ldap\Server\PasswordPolicy;
 
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Subentry\GoverningSubentryResolver;
 
 /**
  * Locates the {@see PasswordPolicy} that governs a given user entry.
@@ -30,15 +33,25 @@ final class PasswordPolicyResolver
      */
     private array $cache = [];
 
+    /**
+     * @param ?GoverningSubentryResolver $subentries Null when subentry-based policy is not enabled.
+     */
     public function __construct(
         private readonly LdapBackendInterface $backend,
         private readonly ?Dn $defaultPolicyDn,
         private readonly ?PasswordPolicy $inMemoryFallback,
+        private readonly ?GoverningSubentryResolver $subentries = null,
     ) {}
 
+    /**
+     * The explicit per-user pointer outranks a subentry, which in turn outranks the server-wide default.
+     *
+     * @throws OperationException
+     */
     public function resolveFor(Entry $user): ?PasswordPolicy
     {
         return $this->fromUserSubentry($user)
+            ?? $this->fromSubtreePolicy($user)
             ?? $this->fromDefaultDn()
             ?? $this->inMemoryFallback;
     }
@@ -62,6 +75,33 @@ final class PasswordPolicyResolver
         }
 
         return $this->loadFromDit(new Dn($value));
+    }
+
+    /**
+     * The nearest governing subentry carrying a policy, since govern() returns them innermost first.
+     *
+     * @throws OperationException
+     */
+    private function fromSubtreePolicy(Entry $user): ?PasswordPolicy
+    {
+        if ($this->subentries === null) {
+            return null;
+        }
+
+        foreach ($this->subentries->govern($user) as $subentry) {
+            $isPolicy = $subentry
+                ->get(AttributeTypeOid::NAME_OBJECT_CLASS)
+                ?->has(
+                    PasswordPolicyOid::NAME_PWD_POLICY,
+                    caseSensitive: false,
+                ) === true;
+
+            if ($isPolicy) {
+                return PasswordPolicy::fromEntry($subentry);
+            }
+        }
+
+        return null;
     }
 
     private function fromDefaultDn(): ?PasswordPolicy

--- a/src/FreeDSx/Ldap/Server/Subentry/GoverningSubentryResolver.php
+++ b/src/FreeDSx/Ldap/Server/Subentry/GoverningSubentryResolver.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Subentry;
+
+use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Exception\SubtreeSpecificationParseException;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+
+use function iterator_to_array;
+use function sprintf;
+
+/**
+ * Finds the subentries that govern an entry, by walking its ancestry for administrative points. RFC 3672.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class GoverningSubentryResolver
+{
+    public function __construct(
+        private LdapBackendInterface $backend,
+        private SubtreeSpecificationEvaluator $evaluator = new SubtreeSpecificationEvaluator(),
+        private SubtreeSpecificationParser $parser = new SubtreeSpecificationParser(),
+    ) {}
+
+    /**
+     * The subentries whose specification covers the entry, nearest administrative point first.
+     *
+     * @return list<Entry>
+     *
+     * @throws OperationException
+     */
+    public function govern(Entry $entry): array
+    {
+        $governing = [];
+
+        // The entry may itself be an administrative point, so the walk starts at its own DN.
+        for ($current = $entry->getDn(); $current !== null; $current = $current->getParent()) {
+            $administrativePoint = $current->normalize();
+
+            foreach ($this->subentriesUnder($administrativePoint) as $subentry) {
+                if ($this->covers($subentry, $administrativePoint, $entry)) {
+                    $governing[] = $subentry;
+                }
+            }
+        }
+
+        return $governing;
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function covers(
+        Entry $subentry,
+        Dn $administrativePoint,
+        Entry $entry,
+    ): bool {
+        $value = $subentry
+            ->get(AttributeTypeOid::NAME_SUBTREE_SPECIFICATION)
+            ?->firstValue();
+
+        if ($value === null) {
+            return false;
+        }
+
+        return $this->evaluator->covers(
+            $this->parse($value),
+            $administrativePoint,
+            $entry,
+        );
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function parse(string $value): SubtreeSpecification
+    {
+        try {
+            return $this->parser->parse($value);
+        } catch (SubtreeSpecificationParseException $e) {
+            // Declining to guess: a stored value that cannot be read leaves the governing set undecidable.
+            throw new OperationException(
+                sprintf(
+                    'A stored "%s" value could not be parsed.',
+                    AttributeTypeOid::NAME_SUBTREE_SPECIFICATION,
+                ),
+                ResultCode::OTHER,
+                $e,
+            );
+        }
+    }
+
+    /**
+     * @return list<Entry>
+     *
+     * @throws OperationException
+     */
+    private function subentriesUnder(Dn $administrativePoint): array
+    {
+        $entry = $this->backend->get($administrativePoint);
+
+        if ($entry === null || !$this->isAdministrativePoint($entry)) {
+            return [];
+        }
+
+        // RFC 3672 places subentries directly below the administrative point, so one level is enough.
+        $request = (new SearchRequest(Filters::present(AttributeTypeOid::NAME_OBJECT_CLASS)))
+            ->base($administrativePoint)
+            ->useSingleLevelScope();
+
+        /** @var list<Entry> $subentries */
+        $subentries = iterator_to_array(
+            $this->backend->search(
+                $request,
+                SubentryVisibility::Only,
+                new ControlBag(),
+            )->entries,
+            false,
+        );
+
+        return $subentries;
+    }
+
+    private function isAdministrativePoint(Entry $entry): bool
+    {
+        return ($entry->get(AttributeTypeOid::NAME_ADMINISTRATIVE_ROLE)?->getValues() ?? []) !== [];
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Subentry/SubentryDetector.php
+++ b/src/FreeDSx/Ldap/Server/Subentry/SubentryDetector.php
@@ -17,8 +17,6 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Schema\Definition\ObjectClassOid;
 
-use function strcasecmp;
-
 /**
  * Recognizes subentries (RFC 3672: an entry whose objectClass includes "subentry").
  *
@@ -30,19 +28,12 @@ final class SubentryDetector
 
     public static function isSubentry(Entry $entry): bool
     {
-        $objectClass = $entry->get(AttributeTypeOid::NAME_OBJECT_CLASS);
-
-        if ($objectClass === null) {
-            return false;
-        }
-
-        foreach ($objectClass->getValues() as $value) {
-            if (strcasecmp($value, ObjectClassOid::NAME_SUBENTRY) === 0) {
-                return true;
-            }
-        }
-
-        return false;
+        return $entry
+            ->get(AttributeTypeOid::NAME_OBJECT_CLASS)
+            ?->has(
+                ObjectClassOid::NAME_SUBENTRY,
+                caseSensitive: false,
+            ) === true;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Subentry/SubtreeSpecificationEvaluator.php
+++ b/src/FreeDSx/Ldap/Server/Subentry/SubtreeSpecificationEvaluator.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Subentry;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluator;
+use FreeDSx\Ldap\Server\Backend\Storage\FilterEvaluatorInterface;
+
+/**
+ * Decides whether a subtree specification covers an entry. RFC 3672.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class SubtreeSpecificationEvaluator
+{
+    public function __construct(
+        private FilterEvaluatorInterface $filterEvaluator = new FilterEvaluator(),
+    ) {}
+
+    /**
+     * Whether the specification, read relative to its administrative point, selects the candidate.
+     */
+    public function covers(
+        SubtreeSpecification $specification,
+        Dn $administrativePoint,
+        Entry $candidate,
+    ): bool {
+        $base = $this->absolute(
+            $specification->base,
+            $administrativePoint,
+        );
+        $candidateDn = $candidate->getDn();
+
+        if (!$candidateDn->isDescendantOf($base)) {
+            return false;
+        }
+
+        if (!$this->withinDepth($specification, $candidateDn, $base)) {
+            return false;
+        }
+
+        if ($this->isChopped($specification, $candidateDn, $base)) {
+            return false;
+        }
+
+        return $specification->specificationFilter === null
+            || $this->filterEvaluator->evaluate($candidate, $specification->specificationFilter);
+    }
+
+    private function withinDepth(
+        SubtreeSpecification $specification,
+        Dn $candidateDn,
+        Dn $base,
+    ): bool {
+        if ($specification->minimum === 0 && $specification->maximum === null) {
+            return true;
+        }
+
+        $depth = $candidateDn->count() - $base->count();
+
+        return $depth >= $specification->minimum
+            && ($specification->maximum === null || $depth <= $specification->maximum);
+    }
+
+    /**
+     * A chopBefore point is excluded along with everything beneath it; a chopAfter point is kept.
+     */
+    private function isChopped(
+        SubtreeSpecification $specification,
+        Dn $candidateDn,
+        Dn $base,
+    ): bool {
+        foreach ($specification->chopBefore as $chop) {
+            if ($candidateDn->isDescendantOf($this->absolute($chop, $base))) {
+                return true;
+            }
+        }
+
+        foreach ($specification->chopAfter as $chop) {
+            $chopPoint = $this->absolute($chop, $base);
+
+            if ($candidateDn->isDescendantOf($chopPoint) && !$candidateDn->equals($chopPoint)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * A local name resolved against the name it is relative to.
+     */
+    private function absolute(
+        Dn $relative,
+        Dn $base,
+    ): Dn {
+        $name = $relative->toString();
+
+        if ($name === '') {
+            return $base;
+        }
+
+        $baseName = $base->toString();
+
+        return $baseName === ''
+            ? new Dn($name)
+            : new Dn($name . ',' . $baseName);
+    }
+}

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -401,15 +401,6 @@ final class ServerOptions implements ServerListenerOptionsInterface
     }
 
     /**
-     * Whether any password-policy source is configured.
-     */
-    public function isPasswordPolicyEnabled(): bool
-    {
-        return $this->passwordPolicy !== null
-            || $this->defaultPasswordPolicyDn !== null;
-    }
-
-    /**
      * Output scheme used by the password hasher when writing a new password.
      */
     public function getPasswordHashScheme(): PasswordHashScheme

--- a/tests/integration/Security/LdapPasswordPolicyServerTest.php
+++ b/tests/integration/Security/LdapPasswordPolicyServerTest.php
@@ -17,10 +17,20 @@ use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\PwdPolicyError;
 use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
 use FreeDSx\Ldap\Controls;
+use FreeDSx\Ldap\Exception\BindException;
 use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
 
 final class LdapPasswordPolicyServerTest extends ServerTestCase
 {
+    private const PASSWORD = '12345';
+
+    private const WRONG_PASSWORD = 'nope';
+
+    /**
+     * The pwdMaxFailure the subentry seed configures.
+     */
+    private const MAX_FAILURE = 2;
+
     public function setUp(): void
     {
         $this->setServerMode('ldap-password-policy');
@@ -62,5 +72,91 @@ final class LdapPasswordPolicyServerTest extends ServerTestCase
             $response->controls()->has(Control::OID_PWD_POLICY),
             'A clean bind should not carry a password policy response control.',
         );
+    }
+
+    public function testAUserGovernedByAPolicySubentryIsLockedOut(): void
+    {
+        $this->useSubentryPolicyServer();
+        $dn = 'cn=inside-user,ou=secure,dc=foo,dc=bar';
+        $this->failBinds($dn, self::MAX_FAILURE);
+
+        $this->expectException(BindException::class);
+
+        $this->ldapClient()->bind($dn, self::PASSWORD);
+    }
+
+    public function testAUserOutsideAnyAdministrativePointIsNotGoverned(): void
+    {
+        $this->useSubentryPolicyServer();
+        $dn = 'cn=outside-user,dc=foo,dc=bar';
+        $this->failBinds($dn, self::MAX_FAILURE + 1);
+
+        $this->ldapClient()->bind($dn, self::PASSWORD);
+
+        $this->assertSame(
+            'dn:' . $dn,
+            $this->ldapClient()->whoami(),
+        );
+    }
+
+    /**
+     * The specification chops ou=exempt, so the policy does not reach entries beneath it.
+     */
+    public function testABranchChoppedFromTheSpecificationIsNotGoverned(): void
+    {
+        $this->useSubentryPolicyServer();
+        $dn = 'cn=exempt-user,ou=exempt,ou=secure,dc=foo,dc=bar';
+        $this->failBinds($dn, self::MAX_FAILURE + 1);
+
+        $this->ldapClient()->bind($dn, self::PASSWORD);
+
+        $this->assertSame(
+            'dn:' . $dn,
+            $this->ldapClient()->whoami(),
+        );
+    }
+
+    /**
+     * Its pwdPolicySubentry names a policy with lockout disabled, which outranks the governing subentry.
+     */
+    public function testAnExplicitPointerOutranksTheGoverningSubentry(): void
+    {
+        $this->useSubentryPolicyServer();
+        $dn = 'cn=pointer-user,ou=secure,dc=foo,dc=bar';
+        $this->failBinds($dn, self::MAX_FAILURE + 1);
+
+        $this->ldapClient()->bind($dn, self::PASSWORD);
+
+        $this->assertSame(
+            'dn:' . $dn,
+            $this->ldapClient()->whoami(),
+        );
+    }
+
+    /**
+     * No policy is configured in PHP for this run, so enforcement can only come from the DIT.
+     */
+    private function useSubentryPolicyServer(): void
+    {
+        $this->stopServer();
+        $this->createServerProcess(
+            'tcp',
+            ['--subentry-policy'],
+        );
+    }
+
+    private function failBinds(
+        string $dn,
+        int $times,
+    ): void {
+        for ($i = 0; $i < $times; $i++) {
+            try {
+                $this->ldapClient()->bind($dn, self::WRONG_PASSWORD);
+
+                self::fail('A bind with the wrong password should not succeed.');
+            } catch (BindException) {
+                // Expected: the point is to accumulate failures.
+            }
+        }
     }
 }

--- a/tests/resources/seed/password-policy-seed.ldif
+++ b/tests/resources/seed/password-policy-seed.ldif
@@ -1,0 +1,24 @@
+version: 1
+
+# Seed for the ldap-password-policy harness, where the policy itself is configured in PHP.
+# Passwords are plaintext so both simple bind and SASL PLAIN can verify against the stored value.
+
+dn: dc=foo,dc=bar
+objectClass: top
+objectClass: domain
+dc: foo
+
+dn: cn=user,dc=foo,dc=bar
+objectClass: inetOrgPerson
+cn: user
+uid: user
+sn: User
+userPassword: 12345
+
+dn: cn=reset-user,dc=foo,dc=bar
+objectClass: inetOrgPerson
+cn: reset-user
+uid: reset-user
+sn: Reset
+userPassword: 12345
+pwdReset: TRUE

--- a/tests/resources/seed/subentry-policy-seed.ldif
+++ b/tests/resources/seed/subentry-policy-seed.ldif
@@ -1,0 +1,70 @@
+version: 1
+
+# Seed for subtree-scoped password policy.
+# Passwords are plaintext so both simple bind and SASL PLAIN can verify against the stored value.
+
+dn: dc=foo,dc=bar
+objectClass: top
+objectClass: domain
+dc: foo
+
+# Outside any administrative point, so no policy governs it
+dn: cn=outside-user,dc=foo,dc=bar
+objectClass: inetOrgPerson
+cn: outside-user
+uid: outside-user
+sn: User
+userPassword: 12345
+
+# The policy this run is really about, pointed at by cn=pointer-user below
+dn: cn=lenient,dc=foo,dc=bar
+objectClass: top
+objectClass: extensibleObject
+objectClass: pwdPolicy
+cn: lenient
+pwdAttribute: userPassword
+pwdLockout: FALSE
+
+dn: ou=secure,dc=foo,dc=bar
+objectClass: organizationalUnit
+ou: secure
+administrativeRole: 2.5.23.4
+
+# Locks out after two failures, everywhere under ou=secure except the chopped branch
+dn: cn=policy,ou=secure,dc=foo,dc=bar
+objectClass: subentry
+objectClass: pwdPolicy
+cn: policy
+subtreeSpecification: { specificExclusions { chopBefore:"ou=exempt" } }
+pwdAttribute: userPassword
+pwdLockout: TRUE
+pwdMaxFailure: 2
+
+# Governed by the subentry
+dn: cn=inside-user,ou=secure,dc=foo,dc=bar
+objectClass: inetOrgPerson
+cn: inside-user
+uid: inside-user
+sn: User
+userPassword: 12345
+
+# An explicit pointer outranks the governing subentry
+dn: cn=pointer-user,ou=secure,dc=foo,dc=bar
+objectClass: inetOrgPerson
+cn: pointer-user
+uid: pointer-user
+sn: User
+userPassword: 12345
+pwdPolicySubentry: cn=lenient,dc=foo,dc=bar
+
+dn: ou=exempt,ou=secure,dc=foo,dc=bar
+objectClass: organizationalUnit
+ou: exempt
+
+# Chopped out of the specification, so the policy does not reach it
+dn: cn=exempt-user,ou=exempt,ou=secure,dc=foo,dc=bar
+objectClass: inetOrgPerson
+cn: exempt-user
+uid: exempt-user
+sn: User
+userPassword: 12345

--- a/tests/support/LdapPasswordPolicyCommand.php
+++ b/tests/support/LdapPasswordPolicyCommand.php
@@ -4,12 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Support\FreeDSx\Ldap;
 
-use FreeDSx\Ldap\Entry\Attribute;
-use FreeDSx\Ldap\Entry\Dn;
-use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\LdapServer;
-use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
-use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
+use FreeDSx\Ldap\Ldif\Loader\FileLdifLoader;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\ServerOptions;
@@ -21,6 +17,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class LdapPasswordPolicyCommand extends Command
 {
     use ConsoleOptionsTrait;
+
+    private const POLICY_SEED_LDIF = __DIR__ . '/../resources/seed/password-policy-seed.ldif';
+
+    private const SUBENTRY_SEED_LDIF = __DIR__ . '/../resources/seed/subentry-policy-seed.ldif';
 
     protected function configure(): void
     {
@@ -40,6 +40,12 @@ final class LdapPasswordPolicyCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Port to listen on',
                 '10389',
+            )
+            ->addOption(
+                'subentry-policy',
+                null,
+                InputOption::VALUE_NONE,
+                'Seed a pwdPolicy subentry under an administrative point instead of configuring a policy in PHP',
             );
     }
 
@@ -49,46 +55,28 @@ final class LdapPasswordPolicyCommand extends Command
     ): int {
         $transport = $this->getStringOption($input, 'transport');
         $port = (int) $this->getStringOption($input, 'port');
-        // Plaintext so both simple bind and SASL PLAIN can verify against the stored value.
-        $password = '12345';
-
-        $entries = [
-            new Entry(
-                new Dn('dc=foo,dc=bar'),
-                new Attribute('dc', 'foo'),
-                new Attribute('objectClass', 'domain'),
-            ),
-            new Entry(
-                new Dn('cn=user,dc=foo,dc=bar'),
-                new Attribute('cn', 'user'),
-                new Attribute('uid', 'user'),
-                new Attribute('sn', 'User'),
-                new Attribute('objectClass', 'inetOrgPerson'),
-                new Attribute('userPassword', $password),
-            ),
-            new Entry(
-                new Dn('cn=reset-user,dc=foo,dc=bar'),
-                new Attribute('cn', 'reset-user'),
-                new Attribute('uid', 'reset-user'),
-                new Attribute('sn', 'Reset'),
-                new Attribute('objectClass', 'inetOrgPerson'),
-                new Attribute('userPassword', $password),
-                new Attribute(PasswordPolicyOid::NAME_PWD_RESET, 'TRUE'),
-            ),
-        ];
+        $useSubentries = $input->getOption('subentry-policy') === true;
 
         $network = (new NetworkConfig())
             ->setPort($port)
             ->setTransport($transport)
             ->setSocketAcceptTimeout(0.1);
 
-        $server = new LdapServer(
-            (new ServerOptions(networkConfig: $network))
-                ->setPasswordPolicy(new PasswordPolicy())
-                ->setSaslMechanisms(ServerOptions::SASL_PLAIN)
-                ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL)),
-        );
-        $server->getOptions()->setStorageConfig(InMemoryStorageConfig::withEntries($entries));
+        $options = (new ServerOptions(networkConfig: $network))
+            ->setSaslMechanisms(ServerOptions::SASL_PLAIN)
+            ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL));
+
+        // Left unset for the subentry run, so any enforcement observed can only come from the DIT.
+        if (!$useSubentries) {
+            $options->setPasswordPolicy(new PasswordPolicy());
+        }
+
+        $server = new LdapServer($options);
+        $server->seed(new FileLdifLoader(
+            $useSubentries
+                ? self::SUBENTRY_SEED_LDIF
+                : self::POLICY_SEED_LDIF,
+        ));
         $server->run();
 
         return Command::SUCCESS;

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandlerTest.php
@@ -128,20 +128,60 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
 
     public function test_it_still_acks_and_does_not_write_when_no_policy_applies(): void
     {
-        $changes = $this->captureComputedChanges(
-            new ForwardPasswordPolicyStateRequest(self::DN, 'uuid', [
+        $this->backend
+            ->method('get')
+            ->willReturn(Entry::fromArray(self::DN, ['cn' => ['user']]));
+        $this->backend
+            ->expects(self::never())
+            ->method('atomicUpdate');
+
+        // A resolver with no source at all, so nothing governs the target.
+        $subject = new ServerPasswordPolicyForwardHandler(
+            $this->backend,
+            new PasswordPolicyResolver(
+                $this->backend,
+                null,
+                null,
+            ),
+            new PasswordPolicyEngine(
+                FrozenClock::fromString(self::NOW),
+                new PasswordChangeConstraintChain([]),
+            ),
+            $this->accessControl,
+        );
+
+        $stream = $subject->handleRequest(
+            $this->messageFor(new ForwardPasswordPolicyStateRequest(self::DN, 'uuid', [
                 new DateTimeImmutable('2026-05-20 11:59:00', new DateTimeZone('UTC')),
-            ]),
-            null,
+            ])),
+            $this->createMock(TokenInterface::class),
         );
 
         self::assertCount(
             1,
-            [...$this->lastStream->messages],
+            [...$stream->messages],
         );
-        self::assertSame(
-            [],
-            $changes,
+    }
+
+    public function test_it_still_acks_and_does_not_write_when_the_target_is_missing(): void
+    {
+        $this->backend
+            ->method('get')
+            ->willReturn(null);
+        $this->backend
+            ->expects(self::never())
+            ->method('atomicUpdate');
+
+        $stream = $this->subject->handleRequest(
+            $this->messageFor(new ForwardPasswordPolicyStateRequest(self::DN, 'uuid', [
+                new DateTimeImmutable('2026-05-20 11:59:00', new DateTimeZone('UTC')),
+            ])),
+            $this->createMock(TokenInterface::class),
+        );
+
+        self::assertCount(
+            1,
+            [...$stream->messages],
         );
     }
 
@@ -187,6 +227,9 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
             ));
 
         $compute = null;
+        $this->backend
+            ->method('get')
+            ->willReturn(Entry::fromArray(self::DN, ['cn' => ['user']]));
         $this->backend
             ->method('atomicUpdate')
             ->with(
@@ -237,9 +280,14 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
      */
     private function captureComputedChanges(
         ForwardPasswordPolicyStateRequest $request,
-        ?Entry $entry,
+        Entry $entry,
     ): array {
         $captured = [];
+
+        $this->backend
+            ->method('get')
+            ->willReturn($entry);
+
         $this->backend
             ->expects(self::once())
             ->method('atomicUpdate')
@@ -247,9 +295,7 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
                 self::callback(fn(Dn $dn): bool => $dn->toString() === self::DN),
                 self::isInstanceOf(WriteContext::class),
                 self::callback(function (callable $compute) use (&$captured, $entry): bool {
-                    $result = $entry === null
-                        ? []
-                        : $compute($entry);
+                    $result = $compute($entry);
 
                     foreach (is_array($result) ? $result : [] as $change) {
                         if ($change instanceof Change) {

--- a/tests/unit/Server/PasswordPolicy/PasswordPolicyResolverTest.php
+++ b/tests/unit/Server/PasswordPolicy/PasswordPolicyResolverTest.php
@@ -19,6 +19,11 @@ use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
+use FreeDSx\Ldap\Schema\Definition\ObjectClassOid;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
+use FreeDSx\Ldap\Server\Subentry\GoverningSubentryResolver;
+use Generator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -166,6 +171,125 @@ final class PasswordPolicyResolverTest extends TestCase
             1,
             $this->getCalls[self::DEFAULT_DN] ?? 0,
         );
+    }
+
+    public function test_resolves_from_a_governing_subentry_when_the_user_has_no_pointer(): void
+    {
+        $resolver = new PasswordPolicyResolver(
+            $this->backend(),
+            defaultPolicyDn: null,
+            inMemoryFallback: null,
+            subentries: $this->governedBy(['pwdMinLength' => '9']),
+        );
+
+        $resolved = $resolver->resolveFor($this->userEntry());
+
+        self::assertNotNull($resolved);
+        self::assertSame(
+            9,
+            $resolved->quality->minLength,
+        );
+    }
+
+    public function test_the_user_pointer_outranks_a_governing_subentry(): void
+    {
+        $backend = $this->backend([
+            self::SUBENTRY_DN => $this->policyEntry(
+                self::SUBENTRY_DN,
+                ['pwdMinLength' => '12'],
+            ),
+        ]);
+
+        $resolver = new PasswordPolicyResolver(
+            $backend,
+            defaultPolicyDn: null,
+            inMemoryFallback: null,
+            subentries: $this->governedBy(['pwdMinLength' => '9']),
+        );
+
+        $resolved = $resolver->resolveFor(
+            $this->userEntry(['pwdPolicySubentry' => self::SUBENTRY_DN]),
+        );
+
+        self::assertNotNull($resolved);
+        self::assertSame(
+            12,
+            $resolved->quality->minLength,
+        );
+    }
+
+    public function test_a_governing_subentry_outranks_the_default_dn(): void
+    {
+        $backend = $this->backend([
+            self::DEFAULT_DN => $this->policyEntry(
+                self::DEFAULT_DN,
+                ['pwdMinLength' => '6'],
+            ),
+        ]);
+
+        $resolver = new PasswordPolicyResolver(
+            $backend,
+            defaultPolicyDn: new Dn(self::DEFAULT_DN),
+            inMemoryFallback: null,
+            subentries: $this->governedBy(['pwdMinLength' => '9']),
+        );
+
+        $resolved = $resolver->resolveFor($this->userEntry());
+
+        self::assertNotNull($resolved);
+        self::assertSame(
+            9,
+            $resolved->quality->minLength,
+        );
+    }
+
+    public function test_a_governing_subentry_without_a_policy_class_is_ignored(): void
+    {
+        $resolver = new PasswordPolicyResolver(
+            $this->backend(),
+            defaultPolicyDn: null,
+            inMemoryFallback: null,
+            subentries: $this->governedBy(policyClass: false),
+        );
+
+        self::assertNull($resolver->resolveFor($this->userEntry()));
+    }
+
+    /**
+     * A real resolver over a backend that hosts one administrative point holding one subentry.
+     *
+     * @param array<string, string> $extra
+     */
+    private function governedBy(
+        array $extra = [],
+        bool $policyClass = true,
+    ): GoverningSubentryResolver {
+        $objectClasses = $policyClass
+            ? [ObjectClassOid::NAME_SUBENTRY, PasswordPolicyOid::NAME_PWD_POLICY]
+            : [ObjectClassOid::NAME_SUBENTRY];
+        $subentry = Entry::fromArray(
+            'cn=policy,dc=example,dc=com',
+            [
+                'objectClass' => $objectClasses,
+                'subtreeSpecification' => '{ }',
+                'pwdAttribute' => 'userPassword',
+            ] + $extra,
+        );
+
+        $backend = $this->createMock(LdapBackendInterface::class);
+        $backend->method('get')
+            ->willReturnCallback(static fn(Dn $dn): ?Entry => $dn->toString() === 'dc=example,dc=com'
+                ? Entry::fromArray(
+                    'dc=example,dc=com',
+                    ['administrativeRole' => '2.5.23.4'],
+                )
+                : null);
+        $backend->method('search')
+            ->willReturn(new EntryStream((static function () use ($subentry): Generator {
+                yield $subentry;
+            })()));
+
+        return new GoverningSubentryResolver($backend);
     }
 
     /**

--- a/tests/unit/Server/Subentry/SubtreeSpecificationEvaluatorTest.php
+++ b/tests/unit/Server/Subentry/SubtreeSpecificationEvaluatorTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Subentry;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Server\Subentry\SubtreeSpecificationEvaluator;
+use FreeDSx\Ldap\Server\Subentry\SubtreeSpecificationParser;
+use PHPUnit\Framework\TestCase;
+
+final class SubtreeSpecificationEvaluatorTest extends TestCase
+{
+    private const ADMIN_POINT = 'ou=area,dc=foo,dc=bar';
+
+    private SubtreeSpecificationEvaluator $subject;
+
+    private SubtreeSpecificationParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->subject = new SubtreeSpecificationEvaluator();
+        $this->parser = new SubtreeSpecificationParser();
+    }
+
+    public function test_an_empty_specification_covers_the_administrative_point_itself(): void
+    {
+        self::assertTrue($this->covers('{ }', self::ADMIN_POINT));
+    }
+
+    public function test_an_empty_specification_covers_everything_beneath(): void
+    {
+        self::assertTrue($this->covers('{ }', 'cn=deep,ou=people,' . self::ADMIN_POINT));
+    }
+
+    public function test_it_does_not_cover_entries_outside_the_administrative_point(): void
+    {
+        self::assertFalse($this->covers('{ }', 'cn=elsewhere,dc=foo,dc=bar'));
+    }
+
+    /**
+     * The base is a local name, so it resolves against the administrative point.
+     */
+    public function test_a_base_narrows_to_that_branch(): void
+    {
+        self::assertTrue($this->covers('{ base "ou=people" }', 'cn=alice,ou=people,' . self::ADMIN_POINT));
+        self::assertFalse($this->covers('{ base "ou=people" }', 'cn=bob,ou=other,' . self::ADMIN_POINT));
+    }
+
+    public function test_a_minimum_excludes_entries_above_it(): void
+    {
+        $specification = '{ minimum 1 }';
+
+        self::assertFalse($this->covers($specification, self::ADMIN_POINT));
+        self::assertTrue($this->covers($specification, 'ou=people,' . self::ADMIN_POINT));
+        self::assertTrue($this->covers($specification, 'cn=alice,ou=people,' . self::ADMIN_POINT));
+    }
+
+    public function test_a_maximum_excludes_entries_below_it(): void
+    {
+        $specification = '{ maximum 1 }';
+
+        self::assertTrue($this->covers($specification, self::ADMIN_POINT));
+        self::assertTrue($this->covers($specification, 'ou=people,' . self::ADMIN_POINT));
+        self::assertFalse($this->covers($specification, 'cn=alice,ou=people,' . self::ADMIN_POINT));
+    }
+
+    public function test_depth_is_measured_from_the_base_not_the_administrative_point(): void
+    {
+        $specification = '{ base "ou=people", maximum 0 }';
+
+        self::assertTrue($this->covers($specification, 'ou=people,' . self::ADMIN_POINT));
+        self::assertFalse($this->covers($specification, 'cn=alice,ou=people,' . self::ADMIN_POINT));
+    }
+
+    /**
+     * The chop point itself is excluded along with everything beneath it.
+     */
+    public function test_chop_before_excludes_the_chop_point(): void
+    {
+        $specification = '{ specificExclusions { chopBefore:"ou=hidden" } }';
+
+        self::assertFalse($this->covers($specification, 'ou=hidden,' . self::ADMIN_POINT));
+        self::assertFalse($this->covers($specification, 'cn=alice,ou=hidden,' . self::ADMIN_POINT));
+        self::assertTrue($this->covers($specification, 'ou=shown,' . self::ADMIN_POINT));
+    }
+
+    /**
+     * The chop point is kept; only what sits beneath it is excluded.
+     */
+    public function test_chop_after_keeps_the_chop_point(): void
+    {
+        $specification = '{ specificExclusions { chopAfter:"ou=edge" } }';
+
+        self::assertTrue($this->covers($specification, 'ou=edge,' . self::ADMIN_POINT));
+        self::assertFalse($this->covers($specification, 'cn=alice,ou=edge,' . self::ADMIN_POINT));
+        self::assertTrue($this->covers($specification, 'ou=other,' . self::ADMIN_POINT));
+    }
+
+    /**
+     * Had the chop resolved against the administrative point instead, this branch would not be chopped.
+     */
+    public function test_chop_points_resolve_against_the_base(): void
+    {
+        $specification = '{ base "ou=people", specificExclusions { chopBefore:"ou=temps" } }';
+
+        self::assertFalse($this->covers($specification, 'ou=temps,ou=people,' . self::ADMIN_POINT));
+        self::assertTrue($this->covers($specification, 'ou=staff,ou=people,' . self::ADMIN_POINT));
+    }
+
+    public function test_a_refinement_selects_on_object_class(): void
+    {
+        $specification = '{ specificationFilter item:inetOrgPerson }';
+
+        self::assertTrue($this->covers(
+            $specification,
+            'cn=alice,' . self::ADMIN_POINT,
+            ['objectClass' => 'inetOrgPerson'],
+        ));
+        self::assertFalse($this->covers(
+            $specification,
+            'ou=people,' . self::ADMIN_POINT,
+            ['objectClass' => 'organizationalUnit'],
+        ));
+    }
+
+    public function test_a_negated_refinement_excludes_the_named_class(): void
+    {
+        $specification = '{ specificationFilter not:item:device }';
+
+        self::assertFalse($this->covers(
+            $specification,
+            'cn=printer,' . self::ADMIN_POINT,
+            ['objectClass' => 'device'],
+        ));
+        self::assertTrue($this->covers(
+            $specification,
+            'cn=alice,' . self::ADMIN_POINT,
+            ['objectClass' => 'inetOrgPerson'],
+        ));
+    }
+
+    public function test_every_component_must_hold_at_once(): void
+    {
+        $specification = '{ base "ou=people", specificExclusions { chopBefore:"ou=temps" }, '
+            . 'minimum 1, maximum 2, specificationFilter item:inetOrgPerson }';
+        $attributes = ['objectClass' => 'inetOrgPerson'];
+
+        self::assertTrue($this->covers(
+            $specification,
+            'cn=alice,ou=people,' . self::ADMIN_POINT,
+            $attributes,
+        ));
+        // Excluded by the chop.
+        self::assertFalse($this->covers(
+            $specification,
+            'cn=temp,ou=temps,ou=people,' . self::ADMIN_POINT,
+            $attributes,
+        ));
+        // Excluded by the minimum.
+        self::assertFalse($this->covers(
+            $specification,
+            'ou=people,' . self::ADMIN_POINT,
+            $attributes,
+        ));
+        // Excluded by the refinement.
+        self::assertFalse($this->covers(
+            $specification,
+            'cn=printer,ou=people,' . self::ADMIN_POINT,
+            ['objectClass' => 'device'],
+        ));
+    }
+
+    /**
+     * @param array<string, string> $attributes
+     */
+    private function covers(
+        string $specification,
+        string $candidateDn,
+        array $attributes = [],
+    ): bool {
+        return $this->subject->covers(
+            $this->parser->parse($specification),
+            new Dn(self::ADMIN_POINT),
+            Entry::fromArray($candidateDn, $attributes),
+        );
+    }
+}

--- a/tests/unit/ServerOptionsTest.php
+++ b/tests/unit/ServerOptionsTest.php
@@ -576,33 +576,30 @@ final class ServerOptionsTest extends TestCase
         );
     }
 
-    public function test_password_policy_is_disabled_by_default(): void
+    public function test_no_password_policy_source_is_configured_by_default(): void
     {
-        self::assertFalse($this->subject->isPasswordPolicyEnabled());
         self::assertNull($this->subject->getPasswordPolicy());
         self::assertNull($this->subject->getDefaultPasswordPolicyDn());
     }
 
-    public function test_setting_in_memory_policy_enables_the_feature(): void
+    public function test_the_in_memory_policy_is_retained(): void
     {
         $policy = new PasswordPolicy(quality: new PasswordQualityRules(minLength: 8));
 
         $this->subject->setPasswordPolicy($policy);
 
-        self::assertTrue($this->subject->isPasswordPolicyEnabled());
         self::assertSame(
             $policy,
             $this->subject->getPasswordPolicy(),
         );
     }
 
-    public function test_setting_default_policy_dn_enables_the_feature(): void
+    public function test_the_default_policy_dn_is_retained(): void
     {
         $dn = new Dn('cn=default,ou=policies,dc=example,dc=com');
 
         $this->subject->setDefaultPasswordPolicyDn($dn);
 
-        self::assertTrue($this->subject->isPasswordPolicyEnabled());
         self::assertSame(
             $dn,
             $this->subject->getDefaultPasswordPolicyDn(),


### PR DESCRIPTION
This adds password policy resolution from a subentry. So the ordering is now: an explicit policy named on the entry -> a subentry policy the entry falls under -> the default directory policy (if it exists) -> inmemory policy (if configured).