### PR TITLE
[1.0.0] SASL / Password Policy / Validation updates.

### DIFF
--- a/resources/ldap-schema/core.ldif
+++ b/resources/ldap-schema/core.ldif
@@ -95,7 +95,7 @@ attributeTypes: ( 2.5.18.4 NAME 'modifiersName' DESC 'name of the last modifier 
 attributeTypes: ( 2.5.18.10 NAME 'subschemaSubentry' DESC 'DN of the subschema entry governing the entity' EQUALITY 2.5.13.1 SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation )
 attributeTypes: ( 2.5.18.9 NAME 'hasSubordinates' DESC 'whether the entry has any subordinate entries' EQUALITY 2.5.13.13 SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation )
 attributeTypes: ( 2.5.21.9 NAME 'structuralObjectClass' DESC 'structural object class of the entry' EQUALITY 2.5.13.0 SYNTAX 1.3.6.1.4.1.1466.115.121.1.38 SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation )
-attributeTypes: ( 1.3.6.1.1.16.4 NAME 'entryUUID' DESC 'universally unique identifier for the entry' EQUALITY 2.5.13.17 SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation )
+attributeTypes: ( 1.3.6.1.1.16.4 NAME 'entryUUID' DESC 'universally unique identifier for the entry' EQUALITY 2.5.13.17 SYNTAX 1.3.6.1.1.16.1 SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation )
 attributeTypes: ( 1.3.6.1.1.20 NAME 'entryDN' DESC 'DN of the entry' EQUALITY 2.5.13.1 SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 SINGLE-VALUE NO-USER-MODIFICATION USAGE directoryOperation )
 attributeTypes: ( 2.5.21.5 NAME 'attributeTypes' DESC 'attribute type descriptions' EQUALITY 2.5.13.30 SYNTAX 1.3.6.1.4.1.1466.115.121.1.3 NO-USER-MODIFICATION USAGE directoryOperation )
 attributeTypes: ( 2.5.21.6 NAME 'objectClasses' DESC 'object class descriptions' EQUALITY 2.5.13.30 SYNTAX 1.3.6.1.4.1.1466.115.121.1.37 NO-USER-MODIFICATION USAGE directoryOperation )

--- a/src/FreeDSx/Ldap/Entry/Entry.php
+++ b/src/FreeDSx/Ldap/Entry/Entry.php
@@ -115,6 +115,34 @@ class Entry implements IteratorAggregate, Countable, Stringable
     }
 
     /**
+     * Keep the values naming the entry among its attributes.
+     *
+     * RFC 4511 §4.7 makes part of its content whether a client supplied them or not.
+     */
+    public function mergeRdnAttributes(): static
+    {
+        if ($this->dn->toArray() === []) {
+            return $this;
+        }
+
+        foreach ($this->dn->getRdn()->getAll() as $component) {
+            $value = Rdn::unescape($component->getValue());
+            $existing = $this->get($component->getName());
+
+            if ($existing === null) {
+                $this->set(new Attribute($component->getName(), $value));
+
+                continue;
+            }
+            if (!$existing->has($value, caseSensitive: false)) {
+                $existing->add($value);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Add an attribute and its values.
      */
     public function add(

--- a/src/FreeDSx/Ldap/Entry/Rdn.php
+++ b/src/FreeDSx/Ldap/Entry/Rdn.php
@@ -181,6 +181,20 @@ class Rdn implements Stringable
     }
 
     /**
+     * Unescape an RDN value, resolving both the \XX hex form and a backslash before a single character.
+     */
+    public static function unescape(string $value): string
+    {
+        return (string) preg_replace_callback(
+            '/\\\\([0-9A-Fa-f]{2}|.)/s',
+            static fn(array $matches): string => strlen($matches[1]) === 2
+                ? pack('H*', $matches[1])
+                : $matches[1],
+            $value,
+        );
+    }
+
+    /**
      * Escape an RDN value.
      */
     public static function escape(string $value): string

--- a/src/FreeDSx/Ldap/Schema/Definition/GeneralizedTime.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/GeneralizedTime.php
@@ -34,7 +34,7 @@ final class GeneralizedTime
         )?
         (?:[.,](?<fraction>\d+))?
         (?<zone>Z|[+\-]\d{2}(?:\d{2})?)
-    $/x';
+    $/xD';
 
     private function __construct() {}
 

--- a/src/FreeDSx/Ldap/Schema/Definition/SyntaxOid.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/SyntaxOid.php
@@ -112,5 +112,9 @@ final class SyntaxOid
 
     public const DESC_SUBTREE_SPECIFICATION = 'Subtree Specification';
 
+    public const OID_UUID = '1.3.6.1.1.16.1';
+
+    public const DESC_UUID = 'UUID';
+
     private function __construct() {}
 }

--- a/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
@@ -65,6 +65,8 @@ final class SchemaValidator
         if ($this->mode === SchemaValidationMode::Off) {
             return;
         }
+        // Checked first, since a caller relaxing an earlier violation would otherwise stop validation before this.
+        $this->checkAttributeSyntaxes($entry);
 
         if (!$isSystem) {
             $this->checkNoUserModificationInEntry($entry);
@@ -87,6 +89,9 @@ final class SchemaValidator
             return;
         }
 
+        // Checked first, since a caller relaxing an earlier violation would otherwise stop validation before this.
+        $this->checkAttributeSyntaxes($result);
+
         if (!$isSystem) {
             $this->checkNoUserModificationInChanges($command->changes);
         }
@@ -98,8 +103,6 @@ final class SchemaValidator
      */
     private function validateStructure(Entry $entry): void
     {
-        $this->checkAttributeSyntaxes($entry);
-
         if ($this->hasExtensibleObject($entry)) {
             $this->checkSingleValuedAttributes($entry);
 

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/BitStringSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/BitStringSyntaxValidator.php
@@ -20,7 +20,7 @@ namespace FreeDSx\Ldap\Schema\Validation\Syntax;
  */
 final class BitStringSyntaxValidator implements SyntaxValidatorInterface
 {
-    private const PATTERN = "/^'[01]*'[Bb]$/";
+    private const PATTERN = "/^'[01]*'[Bb]$/D";
 
     public function isValid(string $value): bool
     {

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/DirectoryStringSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/DirectoryStringSyntaxValidator.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Validation\Syntax;
+
+use FreeDSx\Ldap\Schema\Text;
+
+/**
+ * Validates the Directory String syntax (RFC 4517 §3.3.6): one or more UTF-8 characters, so never empty.
+ *
+ * e.g. "Jane Doe"
+ */
+final class DirectoryStringSyntaxValidator implements SyntaxValidatorInterface
+{
+    public function isValid(string $value): bool
+    {
+        return $value !== ''
+            && Text::isUtf8($value);
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/NumericStringSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/NumericStringSyntaxValidator.php
@@ -20,7 +20,7 @@ namespace FreeDSx\Ldap\Schema\Validation\Syntax;
  */
 final class NumericStringSyntaxValidator implements SyntaxValidatorInterface
 {
-    private const PATTERN = '/^[0-9 ]+$/';
+    private const PATTERN = '/^[0-9 ]+$/D';
 
     public function isValid(string $value): bool
     {

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/OidSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/OidSyntaxValidator.php
@@ -20,7 +20,7 @@ namespace FreeDSx\Ldap\Schema\Validation\Syntax;
  */
 final class OidSyntaxValidator implements SyntaxValidatorInterface
 {
-    private const PATTERN = '/^([0-9]+(\.[0-9]+)*|[A-Za-z][A-Za-z0-9-]*)$/';
+    private const PATTERN = '/^([0-9]+(\.[0-9]+)*|[A-Za-z][A-Za-z0-9-]*)$/D';
 
     public function isValid(string $value): bool
     {

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/PrintableStringSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/PrintableStringSyntaxValidator.php
@@ -20,7 +20,7 @@ namespace FreeDSx\Ldap\Schema\Validation\Syntax;
  */
 final class PrintableStringSyntaxValidator implements SyntaxValidatorInterface
 {
-    private const PATTERN = '/^[A-Za-z0-9\'()+,\-.\/:? =]+$/';
+    private const PATTERN = '/^[A-Za-z0-9\'()+,\-.\/:? =]+$/D';
 
     public function isValid(string $value): bool
     {

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/SyntaxValidatorRegistry.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/SyntaxValidatorRegistry.php
@@ -31,6 +31,7 @@ final class SyntaxValidatorRegistry
     public static function default(): self
     {
         return new self([
+            SyntaxOid::OID_DIRECTORY_STRING => new DirectoryStringSyntaxValidator(),
             SyntaxOid::OID_INTEGER => new IntegerSyntaxValidator(),
             SyntaxOid::OID_BOOLEAN => new BooleanSyntaxValidator(),
             SyntaxOid::OID_GENERALIZED_TIME => new GeneralizedTimeSyntaxValidator(),

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/SyntaxValidatorRegistry.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/SyntaxValidatorRegistry.php
@@ -42,6 +42,7 @@ final class SyntaxValidatorRegistry
             SyntaxOid::OID_IA5_STRING => new Ia5StringSyntaxValidator(),
             SyntaxOid::OID_BIT_STRING => new BitStringSyntaxValidator(),
             SyntaxOid::OID_SUBTREE_SPECIFICATION => new SubtreeSpecificationSyntaxValidator(),
+            SyntaxOid::OID_UUID => new UuidSyntaxValidator(),
         ]);
     }
 

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/UuidSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/UuidSyntaxValidator.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Validation\Syntax;
+
+/**
+ * Validates the UUID syntax (RFC 4530 §2.1), whose string form RFC 4122 §3 defines as 8-4-4-4-12 hex digits.
+ *
+ * e.g. "597ae2f6-16a6-1027-98f4-d28b5365dc14"
+ */
+final class UuidSyntaxValidator implements SyntaxValidatorInterface
+{
+    /**
+     * Both cases are accepted, since RFC 4122 §3 is case insensitive on input.
+     */
+    private const PATTERN = '/^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$/D';
+
+    public function isValid(string $value): bool
+    {
+        return preg_match(self::PATTERN, $value) === 1;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Auth;
 
+use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
@@ -50,13 +51,12 @@ final class PasswordAuthenticator implements PasswordAuthenticatableInterface
             $this->denyUncomparedCredentials($password);
         }
 
-        $attr = $entry->get('userPassword');
-
-        if ($attr === null) {
+        $credentials = $this->storedCredentials($entry);
+        if ($credentials === []) {
             $this->denyUncomparedCredentials($password);
         }
 
-        foreach ($attr->getValues() as $stored) {
+        foreach ($credentials as $stored) {
             if ($this->hashService->verify($password, $stored)) {
                 return new BindToken(
                     AuthzId::fromDn($entry->getDn()),
@@ -81,8 +81,7 @@ final class PasswordAuthenticator implements PasswordAuthenticatableInterface
             return null;
         }
 
-        $password = $entry->get('userPassword')?->getValues()[0];
-
+        $password = $this->storedCredentials($entry)[0] ?? null;
         if ($password === null) {
             return null;
         }
@@ -97,6 +96,19 @@ final class PasswordAuthenticator implements PasswordAuthenticatableInterface
             $password,
             $entry->getDn(),
         );
+    }
+
+    /**
+     * Stored values usable as a credential. An empty value is the absence of one, not a secret to match or key on.
+     *
+     * @return list<string>
+     */
+    private function storedCredentials(Entry $entry): array
+    {
+        return array_values(array_filter(
+            $entry->get('userPassword')?->getValues() ?? [],
+            static fn(string $value): bool => $value !== '',
+        ));
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordHashService.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordHashService.php
@@ -91,6 +91,11 @@ final readonly class PasswordHashService
         string $plain,
         string $stored,
     ): bool {
+        // An empty value on either side is the absence of a credential, never a match for one.
+        if ($plain === '' || $stored === '') {
+            return false;
+        }
+
         foreach ($this->recognizedPrefixes() as $prefix) {
             if (str_starts_with($stored, $prefix)) {
                 return $this->verifyScheme(

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/MoveOperation.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/MoveOperation.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Operation;
 
-use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Entry\Rdn;
 use FreeDSx\Ldap\Server\Backend\Write\Command\MoveCommand;
 
 /**
@@ -38,24 +38,12 @@ final class MoveOperation
         if ($command->deleteOldRdn) {
             foreach ($command->dn->getRdn()->getAll() as $component) {
                 $newEntry->get($component->getName())?->removeValues(
-                    [$component->getValue()],
+                    [Rdn::unescape($component->getValue())],
                     caseSensitive: false,
                 );
             }
         }
 
-        foreach ($command->newRdn->getAll() as $component) {
-            $existing = $newEntry->get($component->getName());
-            if ($existing === null) {
-                $newEntry->set(new Attribute($component->getName(), $component->getValue()));
-
-                continue;
-            }
-            if (!$existing->has($component->getValue(), caseSensitive: false)) {
-                $existing->add($component->getValue());
-            }
-        }
-
-        return $newEntry;
+        return $newEntry->mergeRdnAttributes();
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -210,6 +210,9 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         AddCommand $command,
         WriteContext $context,
     ): void {
+        // Merged before validation, so the values naming the entry count toward what its object classes require.
+        $command->entry->mergeRdnAttributes();
+
         // Validated up front: the entry is the caller's, and applying operational attributes below mutates it, so a
         // replayed transaction would otherwise re-validate an entry that now carries them.
         $this->validateForAdd(

--- a/src/FreeDSx/Ldap/Server/Backend/Write/PasswordPolicyWriteHandler.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/PasswordPolicyWriteHandler.php
@@ -15,13 +15,16 @@ namespace FreeDSx\Ldap\Server\Backend\Write;
 
 use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 use FreeDSx\Ldap\Server\Backend\Write\SystemChange\SystemChangeWriterInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\Attempt\PasswordModifyAttempt;
+use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
 use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyChangeGuard;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 
@@ -47,8 +50,7 @@ final readonly class PasswordPolicyWriteHandler implements WriteHandlerInterface
 
     public function supports(WriteRequestInterface $request): bool
     {
-        return $request instanceof UpdateCommand
-            && $this->userPasswordValues($request, self::SET_TYPES) !== [];
+        return $this->newPasswordsFor($request) !== [];
     }
 
     /**
@@ -58,7 +60,25 @@ final readonly class PasswordPolicyWriteHandler implements WriteHandlerInterface
         WriteRequestInterface $request,
         WriteContext $context,
     ): void {
-        if (!$request instanceof UpdateCommand) {
+        match (true) {
+            $request instanceof AddCommand => $this->handleAdd($request, $context),
+            $request instanceof UpdateCommand => $this->handleUpdate($request, $context),
+            default => $this->backend->handle($request, $context),
+        };
+    }
+
+    /**
+     * Setting a password while creating an entry is a password change like any other (draft-behera-10 section 4.2),
+     * so it is held to the same policy. The entry has no prior state, so only quality can reject it.
+     *
+     * @throws OperationException
+     */
+    private function handleAdd(
+        AddCommand $request,
+        WriteContext $context,
+    ): void {
+        $newPasswords = $this->entryPasswordValues($request->entry);
+        if ($newPasswords === []) {
             $this->backend->handle(
                 $request,
                 $context,
@@ -67,6 +87,31 @@ final readonly class PasswordPolicyWriteHandler implements WriteHandlerInterface
             return;
         }
 
+        $deltas = $this->changeGuard->enforceAll($this->attemptsFor(
+            $request->entry,
+            $newPasswords,
+            null,
+            $this->isSelf($context, $request->entry->getDn()),
+        ));
+
+        // Folded in rather than written after, so the entry is never stored without the state governing it.
+        $this->applyOperationalChanges(
+            $request->entry,
+            $deltas,
+        );
+        $this->backend->handle(
+            $request,
+            $context,
+        );
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function handleUpdate(
+        UpdateCommand $request,
+        WriteContext $context,
+    ): void {
         $newPasswords = $this->userPasswordValues($request, self::SET_TYPES);
         $entry = $this->backend->get($request->dn);
         if ($newPasswords === [] || $entry === null) {
@@ -78,26 +123,16 @@ final readonly class PasswordPolicyWriteHandler implements WriteHandlerInterface
             return;
         }
 
-        $oldPassword = $this->userPasswordValues($request, [Change::TYPE_DELETE])[0] ?? null;
         $isSelf = $this->isSelf(
             $context,
             $request->dn,
         );
-
-        // Every value being set must satisfy policy; otherwise a weak value could ride along behind a valid one
-        // each value is recorded in history so none can be reused after a multi-valued set.
-        $attempts = array_map(
-            fn(string $newPassword): PasswordModifyAttempt => new PasswordModifyAttempt(
-                target: $entry,
-                newPassword: $newPassword,
-                hashedNewPassword: $newPassword,
-                oldPassword: $oldPassword,
-                isSelf: $isSelf,
-                passwordIsCleartext: !$this->hashService->isHashed($newPassword),
-            ),
+        $deltas = $this->changeGuard->enforceAll($this->attemptsFor(
+            $entry,
             $newPasswords,
-        );
-        $deltas = $this->changeGuard->enforceAll($attempts);
+            $this->userPasswordValues($request, [Change::TYPE_DELETE])[0] ?? null,
+            $isSelf,
+        ));
 
         $this->backend->handle(
             $request,
@@ -112,6 +147,70 @@ final readonly class PasswordPolicyWriteHandler implements WriteHandlerInterface
         $token = $context->getToken();
         if ($isSelf && $token instanceof AuthenticatedTokenInterface) {
             $token->clearMustChangePassword();
+        }
+    }
+
+    /**
+     * Every value being set must satisfy policy.
+     *
+     * @param non-empty-list<string> $newPasswords
+     * @return non-empty-list<PasswordModifyAttempt>
+     */
+    private function attemptsFor(
+        Entry $target,
+        array $newPasswords,
+        ?string $oldPassword,
+        bool $isSelf,
+    ): array {
+        return array_map(
+            fn(string $newPassword): PasswordModifyAttempt => new PasswordModifyAttempt(
+                target: $target,
+                newPassword: $newPassword,
+                hashedNewPassword: $newPassword,
+                oldPassword: $oldPassword,
+                isSelf: $isSelf,
+                passwordIsCleartext: !$this->hashService->isHashed($newPassword),
+            ),
+            $newPasswords,
+        );
+    }
+
+    /**
+     * New password values a command sets, for whichever operation carries them.
+     *
+     * @return list<string>
+     */
+    private function newPasswordsFor(WriteRequestInterface $request): array
+    {
+        return match (true) {
+            $request instanceof AddCommand => $this->entryPasswordValues($request->entry),
+            $request instanceof UpdateCommand => $this->userPasswordValues($request, self::SET_TYPES),
+            default => [],
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function entryPasswordValues(Entry $entry): array
+    {
+        return array_values(
+            $entry->get(AttributeTypeOid::NAME_USER_PASSWORD)?->getValues() ?? [],
+        );
+    }
+
+    private function applyOperationalChanges(
+        Entry $entry,
+        OperationalChanges $deltas,
+    ): void {
+        foreach ($deltas->changes as $change) {
+            if ($change->getType() === Change::TYPE_REPLACE) {
+                $entry->set($change->getAttribute());
+
+                continue;
+            }
+
+            $entry->reset($change->getAttribute());
         }
     }
 

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyResolver.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyResolver.php
@@ -24,23 +24,18 @@ use FreeDSx\Ldap\Server\Subentry\GoverningSubentryResolver;
 /**
  * Locates the {@see PasswordPolicy} that governs a given user entry.
  *
- * One instance is constructed per request so the internal cache lives request-scoped.
+ * Deliberately stateless: resolution runs once per operation.
  */
-final class PasswordPolicyResolver
+final readonly class PasswordPolicyResolver
 {
-    /**
-     * @var array<string, ?PasswordPolicy> normalized DN string to decoded policy (null = not found in DIT)
-     */
-    private array $cache = [];
-
     /**
      * @param ?GoverningSubentryResolver $subentries Null when subentry-based policy is not enabled.
      */
     public function __construct(
-        private readonly LdapBackendInterface $backend,
-        private readonly ?Dn $defaultPolicyDn,
-        private readonly ?PasswordPolicy $inMemoryFallback,
-        private readonly ?GoverningSubentryResolver $subentries = null,
+        private LdapBackendInterface $backend,
+        private ?Dn $defaultPolicyDn,
+        private ?PasswordPolicy $inMemoryFallback,
+        private ?GoverningSubentryResolver $subentries = null,
     ) {}
 
     /**
@@ -115,15 +110,10 @@ final class PasswordPolicyResolver
 
     private function loadFromDit(Dn $dn): ?PasswordPolicy
     {
-        $key = $dn->normalize()->toString();
-
-        if (array_key_exists($key, $this->cache)) {
-            return $this->cache[$key];
-        }
-
         $entry = $this->backend->get($dn);
-        $policy = $entry !== null ? PasswordPolicy::fromEntry($entry) : null;
 
-        return $this->cache[$key] = $policy;
+        return $entry !== null
+            ? PasswordPolicy::fromEntry($entry)
+            : null;
     }
 }

--- a/tests/integration/Schema/LdapLoadedSchemaTest.php
+++ b/tests/integration/Schema/LdapLoadedSchemaTest.php
@@ -285,6 +285,32 @@ final class LdapLoadedSchemaTest extends ServerTestCase
         );
     }
 
+    public function test_a_malformed_uuid_value_is_rejected(): void
+    {
+        $this->authenticateAdmin();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
+
+        $this->createRecord(
+            'uuid-malformed',
+            ['projectUuid' => '597ae2f6-16a6-1027-98f4-not-a-uuid'],
+        );
+    }
+
+    public function test_an_upper_case_uuid_value_is_accepted(): void
+    {
+        $this->createRecord(
+            'uuid-upper',
+            ['projectUuid' => '597AE2F6-16A6-1027-98F4-D28B5365DC14'],
+        );
+
+        self::assertSame(
+            'uuid-upper',
+            $this->findOne(Filters::equal('projectUuid', '597AE2F6-16A6-1027-98F4-D28B5365DC14')),
+        );
+    }
+
     public function test_uuid_is_case_sensitive(): void
     {
         $this->createRecord(

--- a/tests/integration/Schema/LdapRelaxControlTest.php
+++ b/tests/integration/Schema/LdapRelaxControlTest.php
@@ -104,6 +104,28 @@ final class LdapRelaxControlTest extends ServerTestCase
         ));
     }
 
+    public function test_relax_control_does_not_bypass_invalid_syntax_behind_a_relaxed_violation(): void
+    {
+        $this->authenticateAdmin();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
+
+        // entryUUID is NO-USER-MODIFICATION, which relax waives, but its value is still malformed.
+        $this->ldapClient()->create(
+            Entry::fromArray(
+                'cn=relax-bad-uuid,dc=foo,dc=bar',
+                [
+                    'cn' => 'relax-bad-uuid',
+                    'sn' => 'Drift',
+                    'objectClass' => 'person',
+                    'entryUUID' => 'not-a-uuid',
+                ],
+            ),
+            Controls::relaxRules(),
+        );
+    }
+
     public function test_relax_control_does_not_bypass_invalid_attribute_syntax(): void
     {
         $this->authenticateAdmin();

--- a/tests/integration/Schema/LdapSchemaConstraintTest.php
+++ b/tests/integration/Schema/LdapSchemaConstraintTest.php
@@ -71,6 +71,45 @@ final class LdapSchemaConstraintTest extends ServerTestCase
         ));
     }
 
+    public function test_add_with_an_empty_directory_string_value_is_rejected(): void
+    {
+        $this->authenticateAdmin();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
+
+        // 'sn' is a Directory String, which RFC 4517 defines as one or more characters.
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=empty-surname,dc=foo,dc=bar',
+            [
+                'cn' => 'empty-surname',
+                'sn' => '',
+                'objectClass' => 'person',
+            ],
+        ));
+    }
+
+    public function test_modify_setting_an_empty_directory_string_value_is_rejected(): void
+    {
+        $this->authenticateAdmin();
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=empty-description,dc=foo,dc=bar',
+            [
+                'cn' => 'empty-description',
+                'sn' => 'Smith',
+                'objectClass' => 'person',
+            ],
+        ));
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
+
+        $entry = Entry::fromArray('cn=empty-description,dc=foo,dc=bar');
+        $entry->set('description', '');
+        $this->ldapClient()->update($entry);
+    }
+
     public function test_add_with_two_unrelated_structural_classes_is_rejected(): void
     {
         $this->authenticateAdmin();

--- a/tests/integration/Schema/LdapSchemaConstraintTest.php
+++ b/tests/integration/Schema/LdapSchemaConstraintTest.php
@@ -93,6 +93,32 @@ final class LdapSchemaConstraintTest extends ServerTestCase
         );
     }
 
+    public function test_add_omitting_the_naming_attribute_still_stores_it(): void
+    {
+        $this->authenticateAdmin();
+
+        // RFC 4511 section 4.7 lets a client leave the RDN attribute out of the attribute list.
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=implied-cn,dc=foo,dc=bar',
+            [
+                'sn' => 'Smith',
+                'objectClass' => 'person',
+            ],
+        ));
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::equal('cn', 'implied-cn'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        self::assertCount(1, $entries);
+        self::assertSame(
+            'implied-cn',
+            $entries->first()?->get('cn')?->firstValue(),
+        );
+    }
+
     public function test_add_with_an_empty_directory_string_value_is_rejected(): void
     {
         $this->authenticateAdmin();

--- a/tests/integration/Schema/LdapSchemaConstraintTest.php
+++ b/tests/integration/Schema/LdapSchemaConstraintTest.php
@@ -71,6 +71,28 @@ final class LdapSchemaConstraintTest extends ServerTestCase
         ));
     }
 
+    public function test_the_published_subschema_declares_entry_uuid_with_the_uuid_syntax(): void
+    {
+        $this->authenticateAdmin();
+
+        $subschema = $this->ldapClient()->read(
+            'cn=Subschema',
+            ['attributeTypes'],
+        );
+        $definitions = $subschema?->get('attributeTypes')?->getValues() ?? [];
+        $entryUuid = array_values(array_filter(
+            $definitions,
+            static fn(string $definition): bool => str_contains($definition, "NAME 'entryUUID'"),
+        ));
+
+        self::assertCount(1, $entryUuid);
+        self::assertStringContainsString(
+            'SYNTAX 1.3.6.1.1.16.1',
+            $entryUuid[0],
+            'RFC 4530 section 2.1 defines entryUUID with the UUID syntax, not Octet String.',
+        );
+    }
+
     public function test_add_with_an_empty_directory_string_value_is_rejected(): void
     {
         $this->authenticateAdmin();

--- a/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\LdapResult;
+use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
@@ -263,6 +264,110 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
         self::assertFalse(
             $token->mustChangePassword(),
             'A successful self password modify must lift the session restriction without a rebind.',
+        );
+    }
+
+    public function test_add_with_a_password_below_the_minimum_length_is_rejected(): void
+    {
+        $handler = $this->dispatchHandler(
+            new PasswordPolicy(quality: new PasswordQualityRules(
+                minLength: 8,
+                checkQuality: 2,
+            )),
+        );
+
+        try {
+            $handler->handleRequest(
+                $this->add('cn=new,dc=foo,dc=bar', 'short'),
+                $this->token(),
+            );
+            self::fail('Expected the short password to be rejected.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::CONSTRAINT_VIOLATION,
+                $e->getCode(),
+            );
+        }
+    }
+
+    /**
+     * An empty value must reach the quality check rather than read as no password being set.
+     */
+    public function test_add_with_an_empty_password_is_rejected_by_the_minimum_length(): void
+    {
+        $handler = $this->dispatchHandler(
+            new PasswordPolicy(quality: new PasswordQualityRules(
+                minLength: 8,
+                checkQuality: 2,
+            )),
+        );
+
+        try {
+            $handler->handleRequest(
+                $this->add('cn=new,dc=foo,dc=bar', ''),
+                $this->token(),
+            );
+            self::fail('Expected the empty password to be rejected.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::CONSTRAINT_VIOLATION,
+                $e->getCode(),
+            );
+        }
+    }
+
+    public function test_add_stamps_the_password_changed_time(): void
+    {
+        $handler = $this->dispatchHandler(new PasswordPolicy(quality: new PasswordQualityRules(inHistory: 3)));
+
+        $this->handle(
+            $handler,
+            $this->add('cn=new,dc=foo,dc=bar', 'a-fresh-password'),
+            $this->token(),
+        );
+
+        $entry = $this->backend->get(new Dn('cn=new,dc=foo,dc=bar'));
+        self::assertNotNull($entry);
+        self::assertNotNull(
+            $entry->get(PasswordPolicyOid::NAME_PWD_CHANGED_TIME),
+            'Without pwdChangedTime the password has no age, so pwdMaxAge can never expire it.',
+        );
+    }
+
+    public function test_add_by_an_administrator_stamps_pwd_reset_when_must_change_is_set(): void
+    {
+        $handler = $this->dispatchHandler(
+            new PasswordPolicy(change: new PasswordChangeRules(mustChange: true)),
+        );
+
+        $this->handle(
+            $handler,
+            $this->add('cn=new,dc=foo,dc=bar', 'a-fresh-password'),
+            $this->token(),
+        );
+
+        $entry = $this->backend->get(new Dn('cn=new,dc=foo,dc=bar'));
+        self::assertSame(
+            'TRUE',
+            $entry?->get(PasswordPolicyOid::NAME_PWD_RESET)?->firstValue(),
+        );
+    }
+
+    private function add(
+        string $dn,
+        string $password,
+    ): LdapMessageRequest {
+        return new LdapMessageRequest(
+            1,
+            new AddRequest(Entry::fromArray(
+                $dn,
+                [
+                    'objectClass' => ['inetOrgPerson'],
+                    'cn' => ['new'],
+                    'sn' => ['New'],
+                    'userPassword' => [$password],
+                ],
+            )),
         );
     }
 

--- a/tests/integration/Security/SaslIntegrationTest.php
+++ b/tests/integration/Security/SaslIntegrationTest.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Protocol\Queue\ClientQueue;
 use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Sasl\Options\CramMD5Options;
 use FreeDSx\Sasl\Options\PlainOptions;
+use FreeDSx\Sasl\Options\ScramOptions;
 use FreeDSx\Socket\SocketOptions;
 use FreeDSx\Socket\SocketPool;
 use FreeDSx\Socket\SocketPoolOptions;
@@ -130,6 +131,26 @@ final class SaslIntegrationTest extends ServerTestCase
         $this->buildClient('tcp')->bindSasl(
             (new PlainOptions())->setUsername('hashed')->setPassword(self::STOLEN_HASH),
             MechanismName::PLAIN,
+        );
+    }
+
+    public function testSaslCramMD5RefusesAnEmptyStoredPassword(): void
+    {
+        $this->expectException(BindException::class);
+
+        $this->buildClient('tcp')->bindSasl(
+            (new CramMD5Options())->setUsername('empty')->setPassword(''),
+            MechanismName::CRAM_MD5,
+        );
+    }
+
+    public function testSaslScramRefusesAnEmptyStoredPassword(): void
+    {
+        $this->expectException(BindException::class);
+
+        $this->buildClient('tcp')->bindSasl(
+            (new ScramOptions())->setUsername('empty')->setPassword(''),
+            MechanismName::SCRAM_SHA256,
         );
     }
 

--- a/tests/resources/seed/server-sasl-seed.ldif
+++ b/tests/resources/seed/server-sasl-seed.ldif
@@ -30,3 +30,11 @@ cn: hashed
 sn: Hashed
 uid: hashed
 userPassword: {SHA}JDjNt4ihTaLvLHpHhEFSdZmM1KM=
+
+# Empty on purpose: an empty value is the absence of a credential.
+dn: cn=empty,dc=foo,dc=bar
+objectClass: inetOrgPerson
+cn: empty
+sn: Empty
+uid: empty
+userPassword:

--- a/tests/unit/Entry/EntryTest.php
+++ b/tests/unit/Entry/EntryTest.php
@@ -383,4 +383,89 @@ class EntryTest extends TestCase
             $change->getType(),
         );
     }
+
+    public function test_merge_rdn_attributes_adds_a_missing_naming_attribute(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('sn', 'Smith'),
+        );
+
+        $entry->mergeRdnAttributes();
+
+        self::assertSame(
+            ['Alice'],
+            $entry->get('cn')?->getValues(),
+        );
+    }
+
+    public function test_merge_rdn_attributes_keeps_an_existing_value_alongside_the_naming_one(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('cn', 'Other'),
+        );
+
+        $entry->mergeRdnAttributes();
+
+        self::assertSame(
+            ['Other', 'Alice'],
+            $entry->get('cn')?->getValues(),
+        );
+    }
+
+    public function test_merge_rdn_attributes_does_not_duplicate_a_value_differing_only_by_case(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('cn', 'alice'),
+        );
+
+        $entry->mergeRdnAttributes();
+
+        self::assertSame(
+            ['alice'],
+            $entry->get('cn')?->getValues(),
+        );
+    }
+
+    public function test_merge_rdn_attributes_unescapes_the_naming_value(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Smith\2C John,dc=example,dc=com'),
+            new Attribute('sn', 'Smith'),
+        );
+
+        $entry->mergeRdnAttributes();
+
+        self::assertSame(
+            ['Smith, John'],
+            $entry->get('cn')?->getValues(),
+        );
+    }
+
+    public function test_merge_rdn_attributes_covers_every_component_of_a_multivalued_rdn(): void
+    {
+        $entry = new Entry(new Dn('cn=Alice+sn=Smith,dc=example,dc=com'));
+
+        $entry->mergeRdnAttributes();
+
+        self::assertSame(
+            ['Alice'],
+            $entry->get('cn')?->getValues(),
+        );
+        self::assertSame(
+            ['Smith'],
+            $entry->get('sn')?->getValues(),
+        );
+    }
+
+    public function test_merge_rdn_attributes_is_a_no_op_for_the_root_dse(): void
+    {
+        $entry = new Entry(new Dn(''));
+
+        $entry->mergeRdnAttributes();
+
+        self::assertCount(0, $entry->getAttributes());
+    }
 }

--- a/tests/unit/Entry/RdnTest.php
+++ b/tests/unit/Entry/RdnTest.php
@@ -111,6 +111,40 @@ class RdnTest extends TestCase
         );
     }
 
+    public function test_it_should_unescape_a_hex_pair(): void
+    {
+        self::assertSame(
+            'Smith, John',
+            Rdn::unescape('Smith\2C John'),
+        );
+    }
+
+    public function test_it_should_unescape_a_backslash_before_a_single_character(): void
+    {
+        self::assertSame(
+            'Smith, John',
+            Rdn::unescape('Smith\, John'),
+        );
+    }
+
+    public function test_it_should_leave_an_unescaped_value_untouched(): void
+    {
+        self::assertSame(
+            'Plain Name',
+            Rdn::unescape('Plain Name'),
+        );
+    }
+
+    public function test_it_should_round_trip_an_escaped_value(): void
+    {
+        $value = '\foo + "bar", > bar < foo;';
+
+        self::assertSame(
+            $value,
+            Rdn::unescape(Rdn::escape($value)),
+        );
+    }
+
     public function test_has_returns_true_for_the_primary_component(): void
     {
         self::assertTrue($this->subject->has('cn'));

--- a/tests/unit/Schema/CoreSchemaResourceTest.php
+++ b/tests/unit/Schema/CoreSchemaResourceTest.php
@@ -118,6 +118,25 @@ final class CoreSchemaResourceTest extends TestCase
         self::assertNotNull($this->schema->getSyntax(SyntaxOid::OID_INTEGER));
     }
 
+    public function test_uuid_syntax_registered(): void
+    {
+        $syntax = $this->schema->getSyntax(SyntaxOid::OID_UUID);
+
+        self::assertNotNull($syntax);
+        self::assertSame(
+            SyntaxOid::DESC_UUID,
+            $syntax->desc,
+        );
+    }
+
+    public function test_entry_uuid_uses_the_uuid_syntax(): void
+    {
+        self::assertSame(
+            SyntaxOid::OID_UUID,
+            $this->schema->getAttributeType(AttributeTypeOid::NAME_ENTRY_UUID)?->syntaxOid,
+        );
+    }
+
     // --- matching rules ---
 
     public function test_case_ignore_match_registered_by_oid(): void

--- a/tests/unit/Schema/Validation/SchemaValidatorTest.php
+++ b/tests/unit/Schema/Validation/SchemaValidatorTest.php
@@ -313,6 +313,21 @@ final class SchemaValidatorTest extends TestCase
         $this->syntaxValidator()->validateAdd($entry);
     }
 
+    public function test_add_empty_directory_string_value_throws_invalid_attribute_syntax(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('objectClass', 'top', 'person'),
+            new Attribute('cn', 'Alice'),
+            new Attribute('sn', ''),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
+
+        $this->subject->validateAdd($entry);
+    }
+
     public function test_add_with_conforming_values_passes(): void
     {
         $entry = new Entry(

--- a/tests/unit/Schema/Validation/Syntax/BitStringSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/BitStringSyntaxValidatorTest.php
@@ -62,6 +62,7 @@ final class BitStringSyntaxValidatorTest extends TestCase
             'missing suffix' => ["'0101'"],
             'non binary digit' => ["'012'B"],
             'wrong suffix letter' => ["'0101'X"],
+            'trailing newline' => ["'0101'B\n"],
         ];
     }
 }

--- a/tests/unit/Schema/Validation/Syntax/DirectoryStringSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/DirectoryStringSyntaxValidatorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Validation\Syntax;
+
+use FreeDSx\Ldap\Schema\Validation\Syntax\DirectoryStringSyntaxValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DirectoryStringSyntaxValidatorTest extends TestCase
+{
+    private DirectoryStringSyntaxValidator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new DirectoryStringSyntaxValidator();
+    }
+
+    #[DataProvider('validValuesProvider')]
+    public function test_it_accepts_non_empty_utf8_values(string $value): void
+    {
+        self::assertTrue($this->subject->isValid($value));
+    }
+
+    #[DataProvider('invalidValuesProvider')]
+    public function test_it_rejects_empty_and_malformed_values(string $value): void
+    {
+        self::assertFalse($this->subject->isValid($value));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function validValuesProvider(): array
+    {
+        return [
+            'ascii' => ['Jane Doe'],
+            'accented letter' => ['café'],
+            'multibyte' => ['名前'],
+            'single space' => [' '],
+            'emoji' => ['🔒'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidValuesProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'lone continuation byte' => ["\x80"],
+            'truncated multibyte' => ["caf\xC3"],
+            'overlong encoding' => ["\xC0\xAF"],
+            'surrogate half' => ["\xED\xA0\x80"],
+        ];
+    }
+}

--- a/tests/unit/Schema/Validation/Syntax/GeneralizedTimeSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/GeneralizedTimeSyntaxValidatorTest.php
@@ -62,6 +62,7 @@ final class GeneralizedTimeSyntaxValidatorTest extends TestCase
             'not a time' => ['notatime'],
             'missing zone' => ['20240101123000'],
             'invalid month' => ['20241301010000Z'],
+            'trailing newline' => ["20240101123000Z\n"],
         ];
     }
 }

--- a/tests/unit/Schema/Validation/Syntax/NumericStringSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/NumericStringSyntaxValidatorTest.php
@@ -61,6 +61,7 @@ final class NumericStringSyntaxValidatorTest extends TestCase
             'embedded letter' => ['12a45'],
             'hyphen' => ['12-34'],
             'decimal point' => ['12.34'],
+            'trailing newline' => ["1234\n"],
         ];
     }
 }

--- a/tests/unit/Schema/Validation/Syntax/OidSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/OidSyntaxValidatorTest.php
@@ -64,6 +64,7 @@ final class OidSyntaxValidatorTest extends TestCase
             'descriptor starting with digit' => ['1cn'],
             'descriptor with underscore' => ['cn_x'],
             'with space' => ['1.2 3'],
+            'trailing newline' => ["1.2.3\n"],
         ];
     }
 }

--- a/tests/unit/Schema/Validation/Syntax/PrintableStringSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/PrintableStringSyntaxValidatorTest.php
@@ -63,6 +63,7 @@ final class PrintableStringSyntaxValidatorTest extends TestCase
             'at sign' => ['user@host'],
             'asterisk' => ['a*b'],
             'non ascii letter' => ['unicodé'],
+            'trailing newline' => ["abc\n"],
         ];
     }
 }

--- a/tests/unit/Schema/Validation/Syntax/SyntaxValidatorRegistryTest.php
+++ b/tests/unit/Schema/Validation/Syntax/SyntaxValidatorRegistryTest.php
@@ -68,6 +68,7 @@ final class SyntaxValidatorRegistryTest extends TestCase
     public static function constrainedSyntaxProvider(): array
     {
         return [
+            'directory string' => [SyntaxOid::OID_DIRECTORY_STRING],
             'integer' => [SyntaxOid::OID_INTEGER],
             'boolean' => [SyntaxOid::OID_BOOLEAN],
             'generalized time' => [SyntaxOid::OID_GENERALIZED_TIME],

--- a/tests/unit/Schema/Validation/Syntax/SyntaxValidatorRegistryTest.php
+++ b/tests/unit/Schema/Validation/Syntax/SyntaxValidatorRegistryTest.php
@@ -78,6 +78,7 @@ final class SyntaxValidatorRegistryTest extends TestCase
             'printable string' => [SyntaxOid::OID_PRINTABLE_STRING],
             'ia5 string' => [SyntaxOid::OID_IA5_STRING],
             'bit string' => [SyntaxOid::OID_BIT_STRING],
+            'uuid' => [SyntaxOid::OID_UUID],
         ];
     }
 }

--- a/tests/unit/Schema/Validation/Syntax/UuidSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/UuidSyntaxValidatorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Schema\Validation\Syntax;
+
+use FreeDSx\Ldap\Schema\Validation\Syntax\UuidSyntaxValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class UuidSyntaxValidatorTest extends TestCase
+{
+    private UuidSyntaxValidator $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new UuidSyntaxValidator();
+    }
+
+    #[DataProvider('validValuesProvider')]
+    public function test_it_accepts_well_formed_uuids(string $value): void
+    {
+        self::assertTrue($this->subject->isValid($value));
+    }
+
+    #[DataProvider('invalidValuesProvider')]
+    public function test_it_rejects_malformed_uuids(string $value): void
+    {
+        self::assertFalse($this->subject->isValid($value));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function validValuesProvider(): array
+    {
+        return [
+            'lower case' => ['597ae2f6-16a6-1027-98f4-d28b5365dc14'],
+            'upper case' => ['597AE2F6-16A6-1027-98F4-D28B5365DC14'],
+            'mixed case' => ['597ae2f6-16A6-1027-98f4-D28B5365dc14'],
+            'nil uuid' => ['00000000-0000-0000-0000-000000000000'],
+        ];
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidValuesProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'no dashes' => ['597ae2f616a6102798f4d28b5365dc14'],
+            'wrong group lengths' => ['597ae2f-616a6-1027-98f4-d28b5365dc14'],
+            'too short' => ['597ae2f6-16a6-1027-98f4-d28b5365dc1'],
+            'too long' => ['597ae2f6-16a6-1027-98f4-d28b5365dc145'],
+            'non hex digit' => ['597ae2g6-16a6-1027-98f4-d28b5365dc14'],
+            'leading space' => [' 597ae2f6-16a6-1027-98f4-d28b5365dc14'],
+            'trailing newline' => ["597ae2f6-16a6-1027-98f4-d28b5365dc14\n"],
+            'braced form' => ['{597ae2f6-16a6-1027-98f4-d28b5365dc14}'],
+        ];
+    }
+}

--- a/tests/unit/Server/Backend/Auth/NameResolver/PasswordAuthenticatorTest.php
+++ b/tests/unit/Server/Backend/Auth/NameResolver/PasswordAuthenticatorTest.php
@@ -299,6 +299,78 @@ final class PasswordAuthenticatorTest extends TestCase
         );
     }
 
+    /**
+     * Mechanisms keying on the stored value would otherwise take an empty shared secret anyone can reproduce.
+     */
+    public function test_get_sasl_identity_returns_null_for_an_empty_stored_password(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('userPassword', ''),
+        );
+
+        self::assertNull(
+            $this->subject($entry)->getSaslIdentity('alice', MechanismName::CRAM_MD5),
+        );
+    }
+
+    public function test_get_sasl_identity_skips_an_empty_stored_password_for_a_usable_one(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('userPassword', '', 'secret'),
+        );
+
+        $identity = $this->subject($entry)->getSaslIdentity('alice', MechanismName::CRAM_MD5);
+
+        self::assertInstanceOf(SaslIdentity::class, $identity);
+        self::assertSame(
+            'secret',
+            $identity->password,
+        );
+    }
+
+    public function test_get_sasl_identity_keeps_a_whitespace_only_stored_password(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('userPassword', ' '),
+        );
+
+        $identity = $this->subject($entry)->getSaslIdentity('alice', MechanismName::CRAM_MD5);
+
+        self::assertInstanceOf(SaslIdentity::class, $identity);
+        self::assertSame(
+            ' ',
+            $identity->password,
+        );
+    }
+
+    public function test_throws_for_an_empty_stored_password(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('userPassword', ''),
+        );
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        $this->subject($entry)->authenticate('cn=Alice,dc=example,dc=com', '');
+    }
+
+    public function test_an_empty_stored_password_does_not_prevent_a_later_value_from_matching(): void
+    {
+        $entry = new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('userPassword', '', 'secret'),
+        );
+
+        $token = $this->subject($entry)->authenticate('cn=Alice,dc=example,dc=com', 'secret');
+
+        self::assertInstanceOf(BindToken::class, $token);
+    }
+
     public function test_get_sasl_identity_uses_the_same_resolver_as_authenticate(): void
     {
         $entry = new Entry(

--- a/tests/unit/Server/Backend/Auth/PasswordHashServiceTest.php
+++ b/tests/unit/Server/Backend/Auth/PasswordHashServiceTest.php
@@ -131,6 +131,46 @@ final class PasswordHashServiceTest extends TestCase
         ));
     }
 
+    public function test_an_empty_stored_value_does_not_verify_against_an_empty_password(): void
+    {
+        self::assertFalse($this->subject->verify(
+            '',
+            '',
+        ));
+    }
+
+    public function test_an_empty_stored_value_does_not_verify(): void
+    {
+        self::assertFalse($this->subject->verify(
+            'secret',
+            '',
+        ));
+    }
+
+    public function test_an_empty_password_does_not_verify(): void
+    {
+        self::assertFalse($this->subject->verify(
+            '',
+            'secret',
+        ));
+    }
+
+    public function test_an_empty_password_does_not_verify_against_a_hash_of_one(): void
+    {
+        self::assertFalse($this->subject->verify(
+            '',
+            $this->subject->hash(''),
+        ));
+    }
+
+    public function test_a_whitespace_only_password_still_verifies(): void
+    {
+        self::assertTrue($this->subject->verify(
+            ' ',
+            ' ',
+        ));
+    }
+
     public function test_sha_format_verifies(): void
     {
         $hashed = '{SHA}' . base64_encode(sha1('mypassword', true));

--- a/tests/unit/Server/PasswordPolicy/PasswordPolicyResolverTest.php
+++ b/tests/unit/Server/PasswordPolicy/PasswordPolicyResolverTest.php
@@ -149,7 +149,10 @@ final class PasswordPolicyResolverTest extends TestCase
         );
     }
 
-    public function test_repeated_lookups_hit_the_cache(): void
+    /**
+     * Nothing is cached between operations, so an edited policy entry takes effect immediately.
+     */
+    public function test_each_resolution_re_reads_the_policy_entry(): void
     {
         $defaultEntry = $this->policyEntry(
             self::DEFAULT_DN,
@@ -168,7 +171,7 @@ final class PasswordPolicyResolverTest extends TestCase
         $resolver->resolveFor($this->userEntry());
 
         self::assertSame(
-            1,
+            3,
             $this->getCalls[self::DEFAULT_DN] ?? 0,
         );
     }


### PR DESCRIPTION
An assortment of updates as I go through the codebase validating behavior (as the server is now quite complex with many moving parts).

* SASL wasn't handling empty passwords properly like simple bind was. This has been corrected and integration tests have been added.
* Password policy was being enforced on modify operations but not on adds. This has been corrected so both paths have parity. Also added integration tests here.
* The directory syntax validator did not exist, so values that should not be empty were not being rejected (cn, for instance). This has been corrected and integration tests added.
* Fixes trailing new lines which several validators allowed slip past but should not.
* Corrects naming attribute handling for entry writes.