### PR TITLE
[1.0.0] Run tests in parallel with paratest.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,14 +25,15 @@
     "phpunit/phpunit": "^11",
     "symplify/easy-coding-standard": "^13.1",
     "phpstan/phpstan": "^2.1",
-    "symfony/process": "^5.4",
+    "symfony/process": "^7.0",
     "symfony/console": "^6.4",
-    "squizlabs/php_codesniffer": "^3.7",
+    "squizlabs/php_codesniffer": "^3.13.6",
     "slevomat/coding-standard": "^7.2",
     "phpstan/phpstan-phpunit": "^2.0",
     "phpstan/extension-installer": "^1.4",
     "swoole/ide-helper": "^6.0",
-    "shipmonk/dead-code-detector": "^1.2"
+    "shipmonk/dead-code-detector": "^1.2",
+    "brianium/paratest": "~7.8.5"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,
@@ -70,10 +71,10 @@
       "@php -d xdebug.mode=coverage vendor/bin/phpunit --testsuite integration-openldap --coverage-clover=coverage-integration-openldap.xml"
     ],
     "test-unit": [
-      "@php -d xdebug.mode=off vendor/bin/phpunit --testsuite unit"
+      "@php -d xdebug.mode=off vendor/bin/paratest --testsuite unit"
     ],
     "test-integration": [
-      "@php -d xdebug.mode=off vendor/bin/phpunit --testsuite integration"
+      "@php -d xdebug.mode=off vendor/bin/paratest --testsuite integration"
     ],
     "test-integration-local": [
       "docker compose -f tests/resources/openldap/docker-compose.yml down --rmi local",

--- a/tests/bin/ldap-proxy.php
+++ b/tests/bin/ldap-proxy.php
@@ -8,15 +8,18 @@ use FreeDSx\Ldap\ProxyOptions;
 use FreeDSx\Ldap\ProxyServerOptions;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use Symfony\Component\Process\Process;
+use Tests\Support\FreeDSx\Ldap\TestWorker;
 
 require __DIR__ . '/../../vendor/autoload.php';
+
+$upstreamPort = TestWorker::port(TestWorker::OFFSET_UPSTREAM);
 
 $upstream = new Process([
     'php',
     '-dpcov.enabled=0',
     __DIR__ . '/ldap-server.php',
     '--transport=ssl',
-    '--port=10390',
+    '--port=' . $upstreamPort,
     '--entries=12',
 ]);
 $upstream->start();
@@ -36,14 +39,14 @@ register_shutdown_function(static fn() => $upstream->stop());
 
 $server = new LdapProxyServer(new ProxyOptions(
     serverOptions: (new ProxyServerOptions((new NetworkConfig())
-        ->setPort(10389)
+        ->setPort(TestWorker::port())
         ->setSslCert(__DIR__ . '/../resources/cert/slapd.crt')
         ->setSslCertKey(__DIR__ . '/../resources/cert/slapd.key')
         ->setSocketAcceptTimeout(0.1)))
         ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL)),
     clientOptions: (new ClientOptions())
         ->setServers(['127.0.0.1'])
-        ->setPort(10390)
+        ->setPort($upstreamPort)
         ->setUseSsl(true)
         ->setSslValidateCert(false)
         ->setSslAllowSelfSigned(true),

--- a/tests/integration/Ldif/LdapDumpServerTest.php
+++ b/tests/integration/Ldif/LdapDumpServerTest.php
@@ -22,6 +22,7 @@ use FreeDSx\Ldap\Ldif\Loader\FileLdifLoader;
 use FreeDSx\Ldap\Ldif\Loader\StringLdifLoader;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+use Tests\Support\FreeDSx\Ldap\TestWorker;
 
 final class LdapDumpServerTest extends ServerTestCase
 {
@@ -33,7 +34,7 @@ final class LdapDumpServerTest extends ServerTestCase
     {
         parent::setUpBeforeClass();
 
-        self::$dumpPath = sys_get_temp_dir() . '/freedsx-ldap-dump-integration.ldif';
+        self::$dumpPath = TestWorker::path('dump-integration.ldif');
 
         if (!extension_loaded('pcntl')) {
             return;

--- a/tests/integration/Security/LdapExternalSaslProxyServerTest.php
+++ b/tests/integration/Security/LdapExternalSaslProxyServerTest.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Sasl\Options\ExternalOptions;
 use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+use Tests\Support\FreeDSx\Ldap\TestWorker;
 use Throwable;
 
 use function strtolower;
@@ -113,7 +114,7 @@ final class LdapExternalSaslProxyServerTest extends ServerTestCase
         $client = new LdapClient(
             (new ClientOptions())
                 ->setServers(['127.0.0.1'])
-                ->setPort(10389)
+                ->setPort(TestWorker::port())
                 ->setTransport('tcp')
                 ->setUseSsl(true)
                 ->setSslValidateCert(false)

--- a/tests/integration/Security/LdapExternalSaslServerTest.php
+++ b/tests/integration/Security/LdapExternalSaslServerTest.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Operation\Response\BindResponse;
 use FreeDSx\Sasl\Mechanism\MechanismName;
 use FreeDSx\Sasl\Options\ExternalOptions;
 use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+use Tests\Support\FreeDSx\Ldap\TestWorker;
 use Throwable;
 
 use function strtolower;
@@ -135,7 +136,7 @@ final class LdapExternalSaslServerTest extends ServerTestCase
         $client = new LdapClient(
             (new ClientOptions())
                 ->setServers(['127.0.0.1'])
-                ->setPort(10389)
+                ->setPort(TestWorker::port())
                 ->setTransport('tcp')
                 ->setUseSsl(true)
                 ->setSslValidateCert(false)

--- a/tests/integration/Security/SaslIntegrationTest.php
+++ b/tests/integration/Security/SaslIntegrationTest.php
@@ -28,6 +28,7 @@ use FreeDSx\Socket\SocketOptions;
 use FreeDSx\Socket\SocketPool;
 use FreeDSx\Socket\SocketPoolOptions;
 use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+use Tests\Support\FreeDSx\Ldap\TestWorker;
 
 final class SaslIntegrationTest extends ServerTestCase
 {
@@ -162,7 +163,7 @@ final class SaslIntegrationTest extends ServerTestCase
         $queue = new ClientQueue(new SocketPool(
             (new SocketPoolOptions(
                 (new SocketOptions())
-                    ->setPort(10389)
+                    ->setPort(TestWorker::port())
                     ->setTimeoutConnect(1),
             ))->setServers(['127.0.0.1']),
         ));

--- a/tests/integration/ServerTestCase.php
+++ b/tests/integration/ServerTestCase.php
@@ -17,6 +17,7 @@ use Exception;
 use FreeDSx\Ldap\LdapClient;
 use RuntimeException;
 use Symfony\Component\Process\Process;
+use Tests\Support\FreeDSx\Ldap\TestWorker;
 
 class ServerTestCase extends LdapTestCase
 {
@@ -253,12 +254,12 @@ class ServerTestCase extends LdapTestCase
             $useSsl = true;
         }
         if ($transport === 'unix') {
-            $servers = sys_get_temp_dir() . '/ldap.socket';
+            $servers = TestWorker::path('ldap.socket');
         }
 
         return $this->getClient(
             $this->makeOptions()
-                ->setPort(10389)
+                ->setPort(TestWorker::port())
                 ->setTransport($transport)
                 ->setServers((array) $servers)
                 ->setSslValidateCert(false)

--- a/tests/integration/Sync/SyncReplForwardTestCase.php
+++ b/tests/integration/Sync/SyncReplForwardTestCase.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Operation\Request\PasswordModifyRequest;
 use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
 use Tests\Support\FreeDSx\Ldap\LdapServerCommand;
+use Tests\Support\FreeDSx\Ldap\TestWorker;
 use Throwable;
 
 /**
@@ -27,8 +28,6 @@ use Throwable;
  */
 abstract class SyncReplForwardTestCase extends ServerTestCase
 {
-    private const PROVIDER_PORT = 10391;
-
     private const PWD_LOCKED_TIME = 'pwdAccountLockedTime';
 
     public function setUp(): void
@@ -217,7 +216,7 @@ abstract class SyncReplForwardTestCase extends ServerTestCase
     {
         return $this->getClient(
             (new ClientOptions())
-                ->setPort(self::PROVIDER_PORT)
+                ->setPort(TestWorker::port(TestWorker::OFFSET_PROVIDER))
                 ->setServers(['127.0.0.1'])
                 ->setSslValidateCert(false),
         );

--- a/tests/integration/Sync/SyncReplPersistTestCase.php
+++ b/tests/integration/Sync/SyncReplPersistTestCase.php
@@ -21,6 +21,7 @@ use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
 use FreeDSx\Ldap\Sync\Session;
 use FreeDSx\Ldap\Sync\SyncRepl;
 use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+use Tests\Support\FreeDSx\Ldap\TestWorker;
 
 /**
  * Shared end-to-end RFC 4533 refreshAndPersist coverage.
@@ -235,7 +236,7 @@ abstract class SyncReplPersistTestCase extends ServerTestCase
     {
         return $this->getClient(
             $this->makeOptions()
-                ->setPort(10389)
+                ->setPort(TestWorker::port())
                 ->setTransport('tcp')
                 ->setServers(['127.0.0.1'])
                 ->setSslValidateCert(false)

--- a/tests/integration/Sync/SyncReplReplicaTestCase.php
+++ b/tests/integration/Sync/SyncReplReplicaTestCase.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Exception\ReferralException;
 use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Operations;
 use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+use Tests\Support\FreeDSx\Ldap\TestWorker;
 use Throwable;
 
 /**
@@ -255,7 +256,7 @@ abstract class SyncReplReplicaTestCase extends ServerTestCase
     {
         $provider = $this->getClient(
             (new ClientOptions())
-                ->setPort(10391)
+                ->setPort(TestWorker::port(TestWorker::OFFSET_PROVIDER))
                 ->setServers(['127.0.0.1'])
                 ->setSslValidateCert(false),
         );

--- a/tests/performance/Threshold/CiThresholds.php
+++ b/tests/performance/Threshold/CiThresholds.php
@@ -50,12 +50,12 @@ final class CiThresholds
             'json:swoole' => new ThresholdSet(
                 maxErrors: 0,
                 minThroughput: 500.0,
-                maxP99Ms: 200.0,
+                maxP99Ms: 800.0,
             ),
             'sqlite:pcntl' => new ThresholdSet(
                 maxErrors: 0,
                 minThroughput: 935.0,
-                maxP99Ms: 200.0,
+                maxP99Ms: 300.0,
             ),
             'sqlite:swoole' => new ThresholdSet(
                 maxErrors: 0,
@@ -78,7 +78,7 @@ final class CiThresholds
             'mysql:swoole' => new ThresholdSet(
                 maxErrors: 0,
                 minThroughput: 720.0,
-                maxP99Ms: 200.0,
+                maxP99Ms: 300.0,
                 perOpMaxP99Ms: ['search-sort' => 250.0],
             ),
             default => throw new InvalidArgumentException(sprintf(

--- a/tests/support/LdapAclCommand.php
+++ b/tests/support/LdapAclCommand.php
@@ -150,7 +150,7 @@ class LdapAclCommand extends Command
         ];
 
         $network = (new NetworkConfig())
-            ->setPort(10389)
+            ->setPort(TestWorker::port())
             ->setTransport($transport)
             ->setSocketAcceptTimeout(0.1);
 

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -86,7 +86,7 @@ final class LdapBackendStorageCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Port to listen on',
-                '10389',
+                (string) TestWorker::port(),
             )
             ->addOption(
                 'seed-entries',
@@ -328,7 +328,7 @@ final class LdapBackendStorageCommand extends Command
         if ($storage === 'memory') {
             $config = InMemoryStorageConfig::withEntries();
         } elseif ($storage === 'json') {
-            $filePath = sys_get_temp_dir() . '/ldap_test_backend_storage.json';
+            $filePath = TestWorker::path('backend_storage.json');
 
             if (file_exists($filePath)) {
                 unlink($filePath);
@@ -336,7 +336,7 @@ final class LdapBackendStorageCommand extends Command
 
             $config = JsonStorageConfig::forFile($filePath);
         } elseif ($storage === 'sqlite') {
-            $dbPath = sys_get_temp_dir() . '/ldap_test_backend_storage.sqlite';
+            $dbPath = TestWorker::path('backend_storage.sqlite');
 
             foreach ([$dbPath, $dbPath . '-wal', $dbPath . '-shm'] as $path) {
                 if (file_exists($path)) {

--- a/tests/support/LdapPasswordPolicyCommand.php
+++ b/tests/support/LdapPasswordPolicyCommand.php
@@ -39,7 +39,7 @@ final class LdapPasswordPolicyCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Port to listen on',
-                '10389',
+                (string) TestWorker::port(),
             )
             ->addOption(
                 'subentry-policy',

--- a/tests/support/LdapReplicaCommand.php
+++ b/tests/support/LdapReplicaCommand.php
@@ -37,8 +37,14 @@ final class LdapReplicaCommand extends Command
             ->setName('ldap-replica')
             ->setDescription('Run a read-only replica of a locally spawned provider')
             ->addOption('transport', null, InputOption::VALUE_REQUIRED, 'The replica transport.', 'tcp')
-            ->addOption('port', null, InputOption::VALUE_REQUIRED, 'The replica listen port.', '10389')
-            ->addOption('provider-port', null, InputOption::VALUE_REQUIRED, 'The provider listen port.', '10391')
+            ->addOption('port', null, InputOption::VALUE_REQUIRED, 'The replica listen port.', (string) TestWorker::port())
+            ->addOption(
+                'provider-port',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'The provider listen port.',
+                (string) TestWorker::port(TestWorker::OFFSET_PROVIDER),
+            )
             ->addOption('runner', null, InputOption::VALUE_REQUIRED, 'The server runner (pcntl/swoole).', 'pcntl')
             ->addOption('forward', null, InputOption::VALUE_NONE, 'Enable ppolicy-state forwarding to the provider.');
     }
@@ -147,7 +153,7 @@ final class LdapReplicaCommand extends Command
 
     private function createReplicaStorageConfig(): PdoConfig
     {
-        $dbPath = sys_get_temp_dir() . '/ldap_replica.sqlite';
+        $dbPath = TestWorker::path('replica.sqlite');
 
         foreach ([$dbPath, $dbPath . '-wal', $dbPath . '-shm'] as $path) {
             if (file_exists($path)) {

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -87,7 +87,7 @@ final class LdapServerCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Port to listen on',
-                '10389',
+                (string) TestWorker::port(),
             )
             ->addOption(
                 'runner',
@@ -281,7 +281,7 @@ final class LdapServerCommand extends Command
         $network = (new NetworkConfig())
             ->setPort($port)
             ->setTransport($transport)
-            ->setUnixSocket(sys_get_temp_dir() . '/ldap.socket')
+            ->setUnixSocket(TestWorker::path('ldap.socket'))
             ->setSslCert(self::SSL_CERT)
             ->setSslCertKey(self::SSL_KEY)
             ->setUseSsl($useSsl)
@@ -427,7 +427,7 @@ final class LdapServerCommand extends Command
     private function createStorageConfig(string $storageType): StorageConfigInterface
     {
         if ($storageType === 'json') {
-            $filePath = sys_get_temp_dir() . '/ldap_test_server.json';
+            $filePath = TestWorker::path('server.json');
 
             if (file_exists($filePath)) {
                 unlink($filePath);
@@ -437,7 +437,7 @@ final class LdapServerCommand extends Command
         }
 
         if ($storageType === 'sqlite') {
-            $dbPath = sys_get_temp_dir() . '/ldap_test_server.sqlite';
+            $dbPath = TestWorker::path('server.sqlite');
 
             foreach ([$dbPath, $dbPath . '-wal', $dbPath . '-shm'] as $path) {
                 if (file_exists($path)) {

--- a/tests/support/TestWorker.php
+++ b/tests/support/TestWorker.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Support\FreeDSx\Ldap;
+
+use function getenv;
+use function sprintf;
+use function sys_get_temp_dir;
+
+/**
+ * Scopes the ports and files a test server uses to the worker running it, so parallel workers cannot collide.
+ *
+ * Spawned server processes inherit the environment, so they derive the same values as the test that started them.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class TestWorker
+{
+    /**
+     * The upstream a proxy test puts behind itself.
+     */
+    public const OFFSET_UPSTREAM = 1;
+
+    /**
+     * The provider a replication test reads from.
+     */
+    public const OFFSET_PROVIDER = 2;
+
+    /**
+     * The port a serial run uses, kept as-is so a lone worker listens where it always has.
+     */
+    private const BASE_PORT = 10389;
+
+    /**
+     * Ports reserved per worker, leaving room for the upstream and provider a single test also spawns.
+     */
+    private const PORT_STRIDE = 10;
+
+    private function __construct() {}
+
+    /**
+     * Index of the parallel worker running this process; 0 when the suite runs serially.
+     */
+    public static function token(): int
+    {
+        $token = getenv('TEST_TOKEN');
+
+        return $token === false
+            ? 0
+            : (int) $token;
+    }
+
+    public static function port(int $offset = 0): int
+    {
+        return self::BASE_PORT
+            + (self::token() * self::PORT_STRIDE)
+            + $offset;
+    }
+
+    /**
+     * A worker-scoped path under the system temp directory.
+     */
+    public static function path(string $name): string
+    {
+        return sprintf(
+            '%s/freedsx_%d_%s',
+            sys_get_temp_dir(),
+            self::token(),
+            $name,
+        );
+    }
+}


### PR DESCRIPTION
This implements paratest to run unit / integration tests in parallel. Most of the integration tests run fast, but running them sequentially slows things down the more that's added. This speeds things up a ton for local dev, where tests go from 1m15s to roughly 15s.