### PR TITLE
[1.0.0] Refactor replication config / decouple journaling.

### DIFF
--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -49,15 +49,15 @@ LDAP Server Configuration
     * [ServerOptions:setMaxSearchPagedLookthrough](#setmaxsearchpagedlookthrough)
     * [ServerOptions:setSearchLimitRules](#setsearchlimitrules)
 * [Directory Synchronization](#directory-synchronization)
-    * [ServerOptions:setSyncEnabled](#setsyncenabled)
+    * [ServerOptions:setReplicationConfig](#setreplicationconfig)
     * [ServerOptions:setChangeJournalConfig](#setchangejournalconfig)
 * [Read-Only Replica](#read-only-replica)
-    * [ServerOptions:setReplicaConfig](#setreplicaconfig)
-    * [ReplicaConfig:setBind](#setbind)
-    * [ReplicaConfig:setUseStartTls](#setusestarttls)
-    * [ReplicaConfig:setReferWrites](#setreferwrites)
-    * [ReplicaConfig:setFilter](#setfilter)
-    * [ReplicaConfig:setReconnectBackoff](#setreconnectbackoff)
+    * [ConsumerConfig:setBind](#setbind)
+    * [ConsumerConfig:setUseStartTls](#setusestarttls)
+    * [ConsumerConfig:setReferWrites](#setreferwrites)
+    * [ConsumerConfig:setFilter](#setfilter)
+    * [ConsumerConfig:setReconnectBackoff](#setreconnectbackoff)
+    * [ConsumerConfig:setForwardInterval](#setforwardinterval)
 * [SASL Options](#sasl-options)
     * [ServerOptions:setSaslMechanisms](#setsaslmechanisms)
     * [ServerOptions:setExternalCredentialMapper](#setexternalcredentialmapper)
@@ -761,61 +761,79 @@ Record directory changes and serve them to RFC 4533 sync consumers. See [Directo
 the full guide, including the storage and runner requirements and the required access-control grant.
 
 ------------------
-#### setSyncEnabled
+#### setReplicationConfig
 
-Whether the server records writes in a change journal and answers content-sync requests. The storage must support
-journaling (all built-in storage does), and consumers must be granted the privileged sync control through access
-control. See [Directory Synchronization](Replication.md).
+The replication role the server plays, and its identity within the topology. `ReplicationConfig::forProvider()` answers
+content-sync requests, `ReplicationConfig::forReplica()` mirrors an upstream. Serving sync also needs storage that
+supports journaling (all built-in storage does) and the privileged sync control granted through access control. See
+[Directory Synchronization](Replication.md).
 
-**Default**: `false`
+```php
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
+use FreeDSx\Ldap\Server\Config\Replication\ProviderConfig;
+use FreeDSx\Ldap\Server\Config\ReplicationConfig;
+
+$options->setReplicationConfig(
+    ReplicationConfig::forProvider(
+        (new ProviderConfig())->setPollInterval(1.0),
+    )->setId(new ReplicaId('dc1')),
+);
+```
+
+The identity is stamped into sync cookies, so give each provider a stable, unique one. The poll interval bounds how
+quickly a persisting consumer sees a change, and how quickly the server notices a consumer that has gone away.
+
+**Default**: no role, with the identity `local`.
 
 ------------------
 #### setChangeJournalConfig
 
-The change journal configuration: the origin id stamped into sync cookies, and the retention policy that limits journal
-growth. When the policy sets at least one limit, the journal is pruned on a cadence. See
-[Retention](Replication.md#retention).
+The change journal configuration: the retention policy that limits journal growth, and an optional audit sink. When the
+policy sets at least one limit, the journal is pruned on a cadence. See [Retention](Replication.md#retention).
+
+Recording changes and serving them are separate. A journal configured on its own records every write without making the
+server a sync provider, which is what you want for auditing alone. Sync requests are then refused with
+`unwillingToPerform`. A provider records regardless, so it has a journal whether or not you configure one.
 
 ```php
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Audit\JsonLinesAuditSink;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
 
-$journalConfig = new ChangeJournalConfig(
-    origin: new ReplicaId('dc1'),
+$options->setChangeJournalConfig(new ChangeJournalConfig(
     retention: new RetentionPolicy(maxRecords: 1_000_000),
-);
-
-$options->setChangeJournalConfig($journalConfig);
+    auditSink: new JsonLinesAuditSink('/var/log/freedsx/changes.jsonl'),
+));
 ```
 
-**Default**: origin `local` with no retention limits (the journal is not pruned).
+**Default**: `null`, so nothing is recorded unless a journal or a provider role is configured. A journal defaults to no
+retention limits, meaning it is not pruned.
 
 ## Read-Only Replica
 
 Run the server as a read-only replica that mirrors a provider over RFC 4533. See
 [Read-Only Replica](Replication.md#read-only-replica) for the full guide.
 
-The `ReplicaConfig` is constructed with the provider's `ClientOptions` (servers, TLS, and the base DN of the subtree to
+The `ConsumerConfig` is constructed with the provider's `ClientOptions` (servers, TLS, and the base DN of the subtree to
 mirror) and, optionally, a `ReplicationCheckpointInterface` where the sync cookie is persisted. The checkpoint defaults
-to in-memory; use `FileReplicationCheckpoint` in production so the replica resumes across restarts. The setters below
+to in-memory. Use `FileReplicationCheckpoint` in production so the replica resumes across restarts. The setters below
 configure the rest.
 
-------------------
-#### setReplicaConfig
+Pass it as the replication role, which puts the server into read-only replica mode. Client writes are refused and a
+background daemon keeps the local storage in step with the provider. A replica requires PDO storage. See
+[Storage Requirement](Replication.md#storage-requirement).
 
-A `ServerOptions` setter that puts the server into read-only replica mode against the given `ReplicaConfig`. Client
-writes are refused and a background daemon keeps the local storage in step with the provider.
-`ServerOptions::forReplica($replicaConfig, $storageConfig)` is a shortcut that constructs the options with this
-already set, taking the replica config and the backend storage config for the local mirror. A replica requires PDO
-storage; see [Storage Requirement](Replication.md#storage-requirement).
-
-**Default**: `null` (the server is a normal read-write directory).
+```php
+$options = new ServerOptions(
+    storageConfig: PdoConfig::forSqlite('/var/lib/freedsx/replica.sqlite'),
+    replicationConfig: ReplicationConfig::forReplica($consumerConfig),
+);
+```
 
 ------------------
 #### setBind
 
-A `ReplicaConfig` setter for how the replica authenticates to the provider, as a `BindRequest` from `Operations::bind()`
+A `ConsumerConfig` setter for how the replica authenticates to the provider, as a `BindRequest` from `Operations::bind()`
 (simple) or `Operations::bindSasl()` (SASL, including EXTERNAL for client-certificate auth).
 
 **Default**: none
@@ -823,7 +841,7 @@ A `ReplicaConfig` setter for how the replica authenticates to the provider, as a
 ------------------
 #### setUseStartTls
 
-A `ReplicaConfig` setter for whether to issue StartTLS on the provider connection before binding. LDAPS is configured on
+A `ConsumerConfig` setter for whether to issue StartTLS on the provider connection before binding. LDAPS is configured on
 the primary `ClientOptions` instead.
 
 **Default**: `false`
@@ -831,7 +849,7 @@ the primary `ClientOptions` instead.
 ------------------
 #### setReferWrites
 
-A `ReplicaConfig` setter for whether a client write to the replica is referred to the provider (`true`) or rejected with
+A `ConsumerConfig` setter for whether a client write to the replica is referred to the provider (`true`) or rejected with
 `unwillingToPerform` (`false`).
 
 **Default**: `true`
@@ -839,16 +857,24 @@ A `ReplicaConfig` setter for whether a client write to the replica is referred t
 ------------------
 #### setFilter
 
-A `ReplicaConfig` setter for an optional filter restricting which entries are replicated.
+A `ConsumerConfig` setter for an optional filter restricting which entries are replicated.
 
 **Default**: `null` (all in-scope entries).
 
 ------------------
 #### setReconnectBackoff
 
-A `ReplicaConfig` setter for the bounded exponential backoff applied between reconnect attempts to the provider.
+A `ConsumerConfig` setter for the bounded exponential backoff applied between reconnect attempts to the provider.
 
 **Default**: `new ReconnectBackoff()` (starts at 1s, doubling to a 30s ceiling).
+
+------------------
+#### setForwardInterval
+
+A `ConsumerConfig` setter for how long queued password-policy bind state waits before being forwarded to the provider.
+Batching trades a slower global lockout against constant upstream chatter. Must be greater than zero.
+
+**Default**: `5.0` seconds.
 
 ## Monitoring
 

--- a/docs/Server/Replication.md
+++ b/docs/Server/Replication.md
@@ -21,7 +21,7 @@ Sync is off by default.
 
 ## Quick Start
 
-Sync needs three things: turn it on, use a storage that supports it, and grant the sync control in access control. The
+Sync needs three things: a provider role, a storage that supports it, and the sync control granted in access control. The
 sync control is privileged, so it is the one access-control addition sync requires. Your normal operation and attribute
 rules are unchanged, and they still have to permit the search over the base being synced.
 
@@ -32,6 +32,7 @@ use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\AccessControl\Target\Target;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
+use FreeDSx\Ldap\Server\Config\ReplicationConfig;
 use FreeDSx\Ldap\ServerOptions;
 
 // The one sync-specific grant: the privileged sync control, over the base to sync.
@@ -47,8 +48,10 @@ $aclRules = $myAclRules->appendControlRules($syncGrant);
 // A storage config that is visible across connections (see Storage and Runner Requirements below).
 $storageConfig = PdoConfig::forSqlite('/var/lib/freedsx/directory.sqlite');
 
-$options = (new ServerOptions($storageConfig))
-    ->setSyncEnabled(true)
+$options = (new ServerOptions(
+    storageConfig: $storageConfig,
+    replicationConfig: ReplicationConfig::forProvider(),
+))
     ->setAclRules($aclRules);
 
 $server = new LdapServer($options);
@@ -58,7 +61,7 @@ A consumer can now run a sync against the server.
 
 ## How It Works
 
-With sync enabled, every write (add, modify, delete, and rename) appends one record to the change journal in the same
+While a journal is kept, every write (add, modify, delete, and rename) appends one record to it in the same
 transaction as the write, so a change and its journal record are committed together. Each record carries an increasing
 sequence number, the configured origin, a timestamp, the entry's UUID and DN, and, for deletes, a copy of the removed
 entry.
@@ -109,7 +112,6 @@ The journal grows with every write, so bound it with a retention policy on the j
 
 ```php
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
 
 $retention = new RetentionPolicy(
@@ -117,12 +119,7 @@ $retention = new RetentionPolicy(
     maxAgeSeconds: ((60 * 60) * 24) * 7, // age horizon, here seven days (null for no age limit)
 );
 
-$journalConfig = new ChangeJournalConfig(
-    origin: new ReplicaId('dc1'),
-    retention: $retention,
-);
-
-$options->setChangeJournalConfig($journalConfig);
+$options->setChangeJournalConfig(new ChangeJournalConfig(retention: $retention));
 ```
 
 Set either limit, both, or neither. The default policy keeps everything. A record becomes eligible for removal once it
@@ -142,12 +139,22 @@ On a PDO backend the journal lives in tables that are part of the storage schema
 
 ## Origin and Cookies
 
-Each journal has an origin, which defaults to `local`. Set a stable, unique origin for each provider through the
-journal configuration. It is stamped into the sync cookie so a consumer can tell which server a saved cookie came from.
-Do not reuse one origin across different directories.
+Each server has an origin, which defaults to `local`. Set a stable, unique origin for each provider on the replication
+configuration. It is stamped into the sync cookie so a consumer can tell which server a saved cookie came from. Do not
+reuse one origin across different directories.
+
+```php
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
+use FreeDSx\Ldap\Server\Config\ReplicationConfig;
+
+$options->setReplicationConfig(
+    ReplicationConfig::forProvider()
+        ->setId(new ReplicaId('dc1')),
+);
+```
 
 The cookie itself is opaque. It stands for an origin and a position in the change history. Consumers save it and resume
-with it. Neither side should try to read or build it by hand; treat it as a token handed out by the server.
+with it. Neither side should try to read or build it by hand, so treat it as a token handed out by the server.
 
 ## Operational Notes
 
@@ -164,22 +171,23 @@ A FreeDSx server can run as a read-only replica of a provider. It serves reads f
 runs a background daemon that keeps that copy in step with the provider over RFC 4533. Client writes to a replica are not
 accepted; by default they are referred to the provider.
 
-Build the server with `ServerOptions::forReplica(...)`. A `ReplicaConfig` describes how to reach and authenticate to the
-provider; the replica's own listener and storage are configured as usual.
+A `ConsumerConfig` describes how to reach and authenticate to the provider. Pass it as the replication role on the
+server options. The replica's own listener and storage are configured as usual.
 
 ```php
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Operations;
-use FreeDSx\Ldap\ReplicaConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
+use FreeDSx\Ldap\Server\Config\Replication\ConsumerConfig;
+use FreeDSx\Ldap\Server\Config\ReplicationConfig;
 use FreeDSx\Ldap\Sync\Consumer\Checkpoint\FileReplicationCheckpoint;
 use FreeDSx\Ldap\ServerOptions;
 
 // Persist the sync cookie so the replica resumes across restarts (the default is in-memory).
 $checkpoint = new FileReplicationCheckpoint('/var/lib/freedsx/replica.cookie');
 
-$replicaConfig = new ReplicaConfig(
+$consumerConfig = new ConsumerConfig(
     (new ClientOptions())
         ->setServers(['provider.example.com'])
         ->setPort(636)
@@ -189,11 +197,11 @@ $replicaConfig = new ReplicaConfig(
 );
 
 // How the replica authenticates to the provider (a simple bind here; use Operations::bindSasl() for SASL/EXTERNAL).
-$replicaConfig->setBind(Operations::bind('cn=replica,dc=example,dc=com', 'secret'));
+$consumerConfig->setBind(Operations::bind('cn=replica,dc=example,dc=com', 'secret'));
 
-$options = ServerOptions::forReplica(
-    $replicaConfig,
-    PdoConfig::forSqlite('/var/lib/freedsx/replica.sqlite'),
+$options = new ServerOptions(
+    storageConfig: PdoConfig::forSqlite('/var/lib/freedsx/replica.sqlite'),
+    replicationConfig: ReplicationConfig::forReplica($consumerConfig),
 );
 
 (new LdapServer($options))->run();
@@ -213,7 +221,7 @@ the replica does not re-journal them.
 ### Writes Are Refused
 
 Any client write to a replica (add, modify, delete, rename, password modify) is refused. By default it is returned as a
-referral to the provider; call `ReplicaConfig::setReferWrites(false)` to reject it with `unwillingToPerform` instead.
+referral to the provider. Call `ConsumerConfig::setReferWrites(false)` to reject it with `unwillingToPerform` instead.
 Reads, binds, compares, and StartTLS are served normally.
 
 ### Storage Requirement

--- a/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
@@ -40,6 +40,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterfac
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeRecorder;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\FileChangeJournal;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\InMemoryChangeJournal;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
@@ -172,6 +173,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
     {
         $config = $container->get(ServerOptions::class)->getStorageConfig();
         $journalConfig = $this->journalConfig($container);
+        $origin = $this->journalOrigin($container);
 
         return match (true) {
             $config instanceof PdoConfig => $container->get(PdoBackendBuilder::class)->storage(),
@@ -183,7 +185,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
             $config instanceof InMemoryStorageConfig => new InMemoryStorage(
                 $config->entries(),
                 $journalConfig === null ? null : AuditingChangeJournal::wrap(
-                    new InMemoryChangeJournal($journalConfig->origin),
+                    new InMemoryChangeJournal($origin),
                     $journalConfig,
                 ),
             ),
@@ -215,7 +217,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
                     $lock,
                     $config->path() . self::JOURNAL_SUFFIX,
                     $config->path() . self::SEQ_SUFFIX,
-                    $journalConfig->origin,
+                    $this->journalOrigin($container),
                 ),
                 $journalConfig,
             ),
@@ -224,15 +226,22 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
     }
 
     /**
-     * The journal settings to build storage against, or null when journaling is off.
+     * The journal settings to build storage against, or null when nothing is recorded.
      */
     private function journalConfig(Container $container): ?ChangeJournalConfig
     {
-        $options = $container->get(ServerOptions::class);
+        return $container->get(ServerOptions::class)
+            ->getChangeJournalConfig();
+    }
 
-        return $options->isSyncEnabled()
-            ? $options->getChangeJournalConfig()
-            : null;
+    /**
+     * The identity stamped on changes this server authors.
+     */
+    private function journalOrigin(Container $container): ReplicaId
+    {
+        return $container->get(ServerOptions::class)
+            ->getReplicationConfig()
+            ->getId();
     }
 
     /**
@@ -262,6 +271,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
         return new PdoBackendBuilder(
             $config,
             $options->getRunnerConfig()->getMode(),
+            $this->journalOrigin($container),
             $container->get(SleeperInterface::class),
             $this->journalConfig($container),
         );
@@ -345,7 +355,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
     ): ?ChangeRecorder {
         $options = $container->get(ServerOptions::class);
 
-        if (!$options->isSyncEnabled() || !$storage instanceof ChangeJournalingInterface) {
+        if ($options->getChangeJournalConfig() === null || !$storage instanceof ChangeJournalingInterface) {
             return null;
         }
 
@@ -391,7 +401,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
     {
         $storageConfig = $options->getStorageConfig();
 
-        if ($options->getReplicaConfig() === null || $storageConfig instanceof PdoConfig) {
+        if ($options->getConsumerConfig() === null || $storageConfig instanceof PdoConfig) {
             return;
         }
 
@@ -430,7 +440,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
     {
         $options = $container->get(ServerOptions::class);
 
-        if (!$options->isSyncEnabled()) {
+        if ($options->getChangeJournalConfig() === null) {
             return null;
         }
 
@@ -533,7 +543,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
         }
 
         $longLivedTasks = [];
-        if ($options->getReplicaConfig() !== null) {
+        if ($options->getConsumerConfig() !== null) {
             $longLivedTasks[] = new LongLivedTask(
                 LdapReplica::TASK_NAME,
                 function () use ($container): void {
@@ -566,7 +576,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
         bool $useCoroutineSleeper,
     ): ?PasswordPolicyForwardWorker {
         $options = $container->get(ServerOptions::class);
-        $config = $options->getReplicaConfig();
+        $config = $options->getConsumerConfig();
 
         if ($config === null) {
             return null;
@@ -576,6 +586,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
             $container->get(ReplicaPasswordStateStoreInterface::class),
             new LdapClientForwardStateSender(new PrimaryConnectionFactory($config)),
             $container->get(SleeperInterface::class),
+            interval: $config->getForwardInterval(),
             signals: $useCoroutineSleeper
                 ? null
                 : new PcntlShutdownSignals(),
@@ -593,7 +604,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
         bool $hostManagedShutdown,
     ): ?LdapReplica {
         $options = $container->get(ServerOptions::class);
-        $config = $options->getReplicaConfig();
+        $config = $options->getConsumerConfig();
 
         if ($config === null) {
             return null;

--- a/src/FreeDSx/Ldap/Container/Provider/HandlerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/HandlerContainerProvider.php
@@ -183,13 +183,16 @@ final class HandlerContainerProvider implements ContainerProviderInterface
         $streamer = null;
         $persistSupported = false;
 
-        if ($journal !== null) {
+        $provider = $options->getReplicationConfig()->getProvider();
+
+        if ($journal !== null && $provider !== null) {
             $stream = new ChangeStream($journal);
             $streamer = new SyncPersistStreamer(
                 backend: $backend,
                 projector: $projector,
                 stream: $stream,
                 sleeper: $container->get(SleeperInterface::class),
+                pollInterval: $provider->getPollInterval(),
             );
             // Persist can only deliver writes made on other connections: one process shares them in memory,
             // otherwise the journal itself must be cross-process.
@@ -262,9 +265,18 @@ final class HandlerContainerProvider implements ContainerProviderInterface
         );
     }
 
+    /**
+     * The journal to serve sync from, or null when this server is not a provider.
+     *
+     * A journal may exist purely for auditing, which does not by itself expose sync to clients.
+     */
     private function syncJournalFor(Container $container): ?ChangeJournalInterface
     {
-        if (!$container->get(ServerOptions::class)->isSyncEnabled()) {
+        $isProvider = $container->get(ServerOptions::class)
+            ->getReplicationConfig()
+            ->isProvider();
+
+        if (!$isProvider) {
             return null;
         }
 

--- a/src/FreeDSx/Ldap/Container/Provider/PasswordPolicyContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/PasswordPolicyContainerProvider.php
@@ -77,7 +77,7 @@ final class PasswordPolicyContainerProvider implements ContainerProviderInterfac
             changeConstraints: $chain,
             uniqueTimes: new UniquePolicyTimeFactory(
                 $clock,
-                $options->getChangeJournalConfig()->origin,
+                $options->getReplicationConfig()->getId(),
             ),
         );
     }

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSyncHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientSyncHandler.php
@@ -115,7 +115,11 @@ class ClientSyncHandler extends ClientBasicHandler
                 }
             } while (!$this->isSyncComplete($searchDone));
 
-            return $searchDone;
+            // The loop only recognises the codes that continue or end a sync, so anything else is still an error.
+            return parent::handleResponse(
+                $messageTo,
+                $searchDone,
+            );
         } catch (ConnectionException $e) {
             if (!$this->wasCancelHandled) {
                 throw $e;

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoBackendBuilder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoBackendBuilder.php
@@ -22,6 +22,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Writer\SwooleWriterQueue;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Writer\WriteSerializingStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
 use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
 use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
@@ -44,10 +45,12 @@ final class PdoBackendBuilder
     /**
      * @param SleeperInterface $sleeper Paces a retried transaction.
      * @param ?ChangeJournalConfig $journalConfig Attaches a change journal when journaling is enabled.
+     * @param ReplicaId $origin Stamped on the changes this server authors.
      */
     public function __construct(
         private readonly PdoConfig $config,
         RunnerMode $runner,
+        private readonly ReplicaId $origin,
         private readonly SleeperInterface $sleeper = new BlockingSleeper(),
         private readonly ?ChangeJournalConfig $journalConfig = null,
     ) {
@@ -78,6 +81,7 @@ final class PdoBackendBuilder
         $this->storage = PdoStorageFactory::storageOn(
             $this->config,
             $provider,
+            $this->origin,
             $this->sleeper,
             $this->journalConfig,
         );
@@ -95,12 +99,14 @@ final class PdoBackendBuilder
         $writeStorage = PdoStorageFactory::storageOn(
             $this->config,
             $writes,
+            $this->origin,
             $this->sleeper,
             $this->journalConfig,
         );
         $readStorage = PdoStorageFactory::storageOn(
             $this->config,
             $reads,
+            $this->origin,
             $this->sleeper,
             $this->journalConfig,
         );

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoStorageFactory.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/PdoStorageFactory.php
@@ -22,6 +22,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Statement\PdoStatementPool;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\PdoStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Audit\AuditingChangeJournal;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\PdoChangeJournal;
 use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
 use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
@@ -36,11 +37,15 @@ use PDO;
  */
 final class PdoStorageFactory
 {
+    /**
+     * Storage without a journal, so it authors no changes an identity would be stamped on.
+     */
     public static function forPcntl(PdoConfig $config): PdoStorage
     {
         return self::storageOn(
             $config,
             self::sharedProvider($config),
+            new ReplicaId(),
         );
     }
 
@@ -61,10 +66,12 @@ final class PdoStorageFactory
 
     /**
      * @param ?ChangeJournalConfig $journalConfig Attaches a journal on this connection when journaling is enabled.
+     * @param ReplicaId $origin Stamped on the changes this server authors.
      */
     public static function storageOn(
         PdoConfig $config,
         PdoConnectionProviderInterface $provider,
+        ReplicaId $origin,
         ?SleeperInterface $sleeper = null,
         ?ChangeJournalConfig $journalConfig = null,
     ): PdoStorage {
@@ -93,7 +100,7 @@ final class PdoStorageFactory
                     $transactor,
                     $config->getDialect(),
                     $statements,
-                    $journalConfig->origin,
+                    $origin,
                 ),
                 $journalConfig,
             ),

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ChangeJournalConfig.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ChangeJournalConfig.php
@@ -18,6 +18,8 @@ use FreeDSx\Ldap\Server\Backend\Storage\Journal\Audit\AuditSinkInterface;
 /**
  * Central change-journal settings a storage backend builder assembles its journal from.
  *
+ * Recording changes stands on its own for auditing; replication reads the same journal when configured.
+ *
  * @api
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
@@ -25,7 +27,6 @@ use FreeDSx\Ldap\Server\Backend\Storage\Journal\Audit\AuditSinkInterface;
 final readonly class ChangeJournalConfig
 {
     public function __construct(
-        public ReplicaId $origin = new ReplicaId('local'),
         public RetentionPolicy $retention = new RetentionPolicy(),
         public ?AuditSinkInterface $auditSink = null,
     ) {}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/FileChangeJournal.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/FileChangeJournal.php
@@ -55,7 +55,7 @@ final readonly class FileChangeJournal implements ChangeJournalInterface
         private StorageLockInterface $lock,
         private string $journalPath,
         private string $seqPath,
-        private ReplicaId $origin = new ReplicaId('local'),
+        private ReplicaId $origin = new ReplicaId(),
         private ClockInterface $clock = new SystemClock(),
         private RowSerializerInterface $serializer = new JsonlRowSerializer(),
         private ChangeRecordRowMapper $mapper = new ChangeRecordRowMapper(),

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/InMemoryChangeJournal.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/InMemoryChangeJournal.php
@@ -33,7 +33,7 @@ final class InMemoryChangeJournal implements ChangeJournalInterface
     private int $seq = 0;
 
     public function __construct(
-        private readonly ReplicaId $origin = new ReplicaId('local'),
+        private readonly ReplicaId $origin = new ReplicaId(),
         private readonly ClockInterface $clock = new SystemClock(),
     ) {}
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/PdoChangeJournal.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/PdoChangeJournal.php
@@ -39,7 +39,7 @@ final readonly class PdoChangeJournal implements ChangeJournalInterface
         private PdoTransactor $transactor,
         private PdoJournalDialectInterface $dialect,
         private PdoStatementPool $statements,
-        private ReplicaId $origin = new ReplicaId('local'),
+        private ReplicaId $origin = new ReplicaId(),
         private ClockInterface $clock = new SystemClock(),
     ) {}
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ReplicaId.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Journal/ReplicaId.php
@@ -22,12 +22,20 @@ use FreeDSx\Ldap\Exception\InvalidArgumentException;
  */
 final readonly class ReplicaId
 {
-    public function __construct(
-        private string $value,
-    ) {
-        if ($this->value === '') {
+    private const LOCAL = 'local';
+
+    private string $value;
+
+    /**
+     * @param ?string $value The identity, or null for the default single-master one.
+     */
+    public function __construct(?string $value = null)
+    {
+        if ($value === '') {
             throw new InvalidArgumentException('A replica id cannot be empty.');
         }
+
+        $this->value = $value ?? self::LOCAL;
     }
 
     public function __toString(): string
@@ -40,7 +48,7 @@ final readonly class ReplicaId
      */
     public static function local(): self
     {
-        return new self('local');
+        return new self();
     }
 
     public function equals(self $other): bool

--- a/src/FreeDSx/Ldap/Server/Config/Replication/ConsumerConfig.php
+++ b/src/FreeDSx/Ldap/Server/Config/Replication/ConsumerConfig.php
@@ -11,8 +11,11 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap;
+namespace FreeDSx\Ldap\Server\Config\Replication;
 
+use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\LdapUrl;
 use FreeDSx\Ldap\Operation\Request\BindRequest;
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
 use FreeDSx\Ldap\Sync\Consumer\Checkpoint\InMemoryReplicationCheckpoint;
@@ -20,16 +23,23 @@ use FreeDSx\Ldap\Sync\Consumer\Checkpoint\ReplicationCheckpointInterface;
 use FreeDSx\Ldap\Sync\Consumer\ReconnectBackoff;
 
 /**
- * Configures a server as a replica of an upstream primary.
+ * How a server mirrors an upstream primary over RFC 4533.
  *
- * Replicas currently act as read-only.
+ * Consumers currently act as read-only.
  *
  * @api
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final class ReplicaConfig
+final class ConsumerConfig
 {
+    /**
+     * Seconds between drains of the queue forwarding local bind state to the primary.
+     */
+    public const DEFAULT_FORWARD_INTERVAL = 5.0;
+
+    private float $forwardInterval = self::DEFAULT_FORWARD_INTERVAL;
+
     private ?ReconnectBackoff $reconnectBackoff = null;
 
     public function __construct(
@@ -50,7 +60,7 @@ final class ReplicaConfig
     }
 
     /**
-     * How the replica authenticates to the primary (via Operations::bind() or Operations::bindSasl()), or null for none.
+     * How the consumer authenticates to the primary (via Operations::bind() or Operations::bindSasl()), or null for none.
      */
     public function getBind(): ?BindRequest
     {
@@ -65,7 +75,7 @@ final class ReplicaConfig
     }
 
     /**
-     * Whether the replica issues StartTLS on the primary connection before binding (LDAPS is set on the primary options).
+     * Whether the consumer issues StartTLS on the primary connection before binding (LDAPS is set on the primary options).
      */
     public function getUseStartTls(): bool
     {
@@ -75,6 +85,28 @@ final class ReplicaConfig
     public function setUseStartTls(bool $useStartTls): self
     {
         $this->useStartTls = $useStartTls;
+
+        return $this;
+    }
+
+    /**
+     * How long queued bind state waits before the next attempt to forward it to the primary.
+     */
+    public function getForwardInterval(): float
+    {
+        return $this->forwardInterval;
+    }
+
+    /**
+     * @throws InvalidArgumentException when the interval is not positive, which would drain without pause.
+     */
+    public function setForwardInterval(float $forwardInterval): self
+    {
+        if ($forwardInterval <= 0) {
+            throw new InvalidArgumentException('The forward interval must be greater than zero.');
+        }
+
+        $this->forwardInterval = $forwardInterval;
 
         return $this;
     }
@@ -95,7 +127,7 @@ final class ReplicaConfig
     }
 
     /**
-     * Where the sync cookie is persisted so the replica resumes across restarts.
+     * Where the sync cookie is persisted so the consumer resumes across restarts.
      */
     public function getCheckpoint(): ReplicationCheckpointInterface
     {

--- a/src/FreeDSx/Ldap/Server/Config/Replication/ProviderConfig.php
+++ b/src/FreeDSx/Ldap/Server/Config/Replication/ProviderConfig.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Config\Replication;
+
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+
+/**
+ * How a server serves RFC 4533 sync to downstream consumers.
+ *
+ * @api
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class ProviderConfig
+{
+    /**
+     * Seconds between journal polls; also bounds change-delivery latency and dead-peer detection.
+     */
+    public const DEFAULT_POLL_INTERVAL = 1.0;
+
+    private float $pollInterval = self::DEFAULT_POLL_INTERVAL;
+
+    public function getPollInterval(): float
+    {
+        return $this->pollInterval;
+    }
+
+    /**
+     * @throws InvalidArgumentException when the interval is not positive, which would poll without pause.
+     */
+    public function setPollInterval(float $pollInterval): self
+    {
+        if ($pollInterval <= 0) {
+            throw new InvalidArgumentException('The sync poll interval must be greater than zero.');
+        }
+
+        $this->pollInterval = $pollInterval;
+
+        return $this;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Config/ReplicationConfig.php
+++ b/src/FreeDSx/Ldap/Server/Config/ReplicationConfig.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Config;
+
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
+use FreeDSx\Ldap\Server\Config\Replication\ConsumerConfig;
+use FreeDSx\Ldap\Server\Config\Replication\ProviderConfig;
+
+/**
+ * The replication role a server plays, and its identity within the topology.
+ *
+ * Note: Serving sync from a consumer is not supported.
+ *
+ * @api
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class ReplicationConfig
+{
+    public function __construct(
+        private ReplicaId $id = new ReplicaId(),
+        private ?ProviderConfig $provider = null,
+        private ?ConsumerConfig $consumer = null,
+    ) {}
+
+    /**
+     * A primary that serves sync to downstream consumers.
+     */
+    public static function forProvider(?ProviderConfig $provider = null): self
+    {
+        return new self(provider: $provider ?? new ProviderConfig());
+    }
+
+    /**
+     * A read-only replica that mirrors an upstream primary.
+     */
+    public static function forReplica(ConsumerConfig $consumer): self
+    {
+        return new self(consumer: $consumer);
+    }
+
+    /**
+     * This server's identity, stamped on the changes it authors and carried in the sync cookie.
+     */
+    public function getId(): ReplicaId
+    {
+        return $this->id;
+    }
+
+    public function setId(ReplicaId $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getProvider(): ?ProviderConfig
+    {
+        return $this->provider;
+    }
+
+    public function setProvider(?ProviderConfig $provider): self
+    {
+        $this->provider = $provider;
+
+        return $this;
+    }
+
+    public function getConsumer(): ?ConsumerConfig
+    {
+        return $this->consumer;
+    }
+
+    public function setConsumer(?ConsumerConfig $consumer): self
+    {
+        $this->consumer = $consumer;
+
+        return $this;
+    }
+
+    /**
+     * Whether this server serves sync to downstream consumers.
+     */
+    public function isProvider(): bool
+    {
+        return $this->provider !== null;
+    }
+
+    /**
+     * Whether this server mirrors an upstream primary.
+     */
+    public function isConsumer(): bool
+    {
+        return $this->consumer !== null;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
+++ b/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
@@ -376,7 +376,7 @@ final class ConnectionHandlerBuilder implements ConnectionHandlerBuilderInterfac
         ProtocolHandlerProviderInterface $handlerProvider,
     ): MiddlewareChain {
         $options = $this->serverOptions();
-        $replicaConfig = $options->getReplicaConfig();
+        $consumerConfig = $options->getConsumerConfig();
 
         return new MiddlewareChain(
             [
@@ -414,8 +414,8 @@ final class ConnectionHandlerBuilder implements ConnectionHandlerBuilderInterfac
                 ),
                 // Only present on a read-only replica; sits below the writer so its referral is drained,
                 // and before the ACL loop so a write short-circuits early.
-                ...($replicaConfig !== null
-                    ? [new ReadOnlyMiddleware($replicaConfig)]
+                ...($consumerConfig !== null
+                    ? [new ReadOnlyMiddleware($consumerConfig)]
                     : []),
                 $this->container->get(CriticalControlMiddleware::class),
                 $this->container->get(OperationAuthorizationMiddleware::class),

--- a/src/FreeDSx/Ldap/Server/Middleware/ReadOnlyMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/ReadOnlyMiddleware.php
@@ -29,7 +29,7 @@ use FreeDSx\Ldap\Operation\Response\ModifyResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
-use FreeDSx\Ldap\ReplicaConfig;
+use FreeDSx\Ldap\Server\Config\Replication\ConsumerConfig;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
@@ -58,7 +58,7 @@ final readonly class ReadOnlyMiddleware implements MiddlewareInterface
         OperationType::PasswordModify,
     ];
 
-    public function __construct(private ReplicaConfig $replicaConfig) {}
+    public function __construct(private ConsumerConfig $consumerConfig) {}
 
     public function process(
         ServerRequestContext $context,
@@ -76,7 +76,7 @@ final readonly class ReadOnlyMiddleware implements MiddlewareInterface
             return $next->handle($context);
         }
 
-        if (!$this->replicaConfig->shouldReferWrites()) {
+        if (!$this->consumerConfig->shouldReferWrites()) {
             throw new OperationException(
                 self::DIAGNOSTIC,
                 ResultCode::UNWILLING_TO_PERFORM,
@@ -96,7 +96,7 @@ final readonly class ReadOnlyMiddleware implements MiddlewareInterface
         RequestInterface $request,
         int $messageId,
     ): LdapMessageResponse {
-        $referrals = $this->replicaConfig->referralUrls();
+        $referrals = $this->consumerConfig->referralUrls();
 
         // The default covers PasswordModify (an extended operation); the write gate guarantees no other type reaches here.
         $response = match (true) {

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyEngine.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyEngine.php
@@ -42,7 +42,7 @@ final readonly class PasswordPolicyEngine
     ) {
         // The Container injects the configured factory; the fallback reuses this engine's clock so tests stay in sync.
         $this->uniqueTimes = $uniqueTimes
-            ?? new UniquePolicyTimeFactory($this->clock, new ReplicaId('local'));
+            ?? new UniquePolicyTimeFactory($this->clock, ReplicaId::local());
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwardWorker.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwardWorker.php
@@ -42,6 +42,7 @@ class PasswordPolicyForwardWorker
         private readonly ReplicaPasswordStateStoreInterface $store,
         private readonly ForwardStateSenderInterface $sender,
         private readonly SleeperInterface $sleeper,
+        private readonly float $interval = self::DEFAULT_INTERVAL_SECONDS,
         private readonly ReconnectBackoff $backoff = new ReconnectBackoff(),
         private readonly ?ShutdownSignalsInterface $signals = null,
         private readonly ?LoggerInterface $logger = null,
@@ -60,7 +61,7 @@ class PasswordPolicyForwardWorker
             try {
                 $this->forwardOnce();
                 $delay = $this->backoff->initial();
-                $this->sleeper->sleep(self::DEFAULT_INTERVAL_SECONDS);
+                $this->sleeper->sleep($this->interval);
             } catch (ForwardStateException $e) {
                 $this->logger?->warning(
                     'Password-policy forwarding failed; retrying after backoff.',

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -27,7 +27,6 @@ use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashScheme;
 use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\DefaultPasswordQualityChecker;
 use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\PasswordQualityCheckerInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Config\InMemoryStorageConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Config\StorageConfigInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
@@ -37,6 +36,8 @@ use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\AccessControl\Subject\SubjectMatcherInterface;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
+use FreeDSx\Ldap\Server\Config\Replication\ConsumerConfig;
+use FreeDSx\Ldap\Server\Config\ReplicationConfig;
 use FreeDSx\Ldap\Server\Config\RunnerConfig;
 use FreeDSx\Ldap\Server\Config\SchemaConfig;
 use FreeDSx\Ldap\Server\Configuration\ConfigReloaderInterface;
@@ -120,8 +121,6 @@ final class ServerOptions implements ServerListenerOptionsInterface
 
     private ?ExternalCredentialMapperInterface $externalCredentialMapper = null;
 
-    private SchemaConfig $schemaConfig;
-
     private ?AccessControlInterface $accessControl = null;
 
     private ?AclRules $aclRules = null;
@@ -143,11 +142,7 @@ final class ServerOptions implements ServerListenerOptionsInterface
 
     private ?ServerRunnerInterface $serverRunner = null;
 
-    private bool $syncEnabled = false;
-
     private ?ChangeJournalConfig $changeJournalConfig = null;
-
-    private ?ReplicaConfig $replicaConfig = null;
 
     private int $maxSearchSize = 1000;
 
@@ -170,19 +165,18 @@ final class ServerOptions implements ServerListenerOptionsInterface
 
     /**
      * @param ?StorageConfigInterface $storageConfig Storage backend; a transient in-memory directory when omitted.
-     * @param ?NetworkConfig $networkConfig Listener and TLS settings; defaults to a plaintext listener on 0.0.0.0:389.
-     * @param ?SchemaConfig $schemaConfig Schema sources and validation; defaults to the schemas this package ships.
+     * @param NetworkConfig $networkConfig Listener and TLS settings; defaults to a plaintext listener on 0.0.0.0:389.
+     * @param SchemaConfig $schemaConfig Schema sources and validation; defaults to the schemas this package ships.
+     * @param ReplicationConfig $replicationConfig Replication role; defaults to playing none.
      */
     public function __construct(
         ?StorageConfigInterface $storageConfig = null,
-        ?NetworkConfig $networkConfig = null,
-        ?RunnerConfig $runnerConfig = null,
-        ?SchemaConfig $schemaConfig = null,
+        private NetworkConfig $networkConfig = new NetworkConfig(),
+        private RunnerConfig $runnerConfig = new RunnerConfig(),
+        private SchemaConfig $schemaConfig = new SchemaConfig(),
+        private ReplicationConfig $replicationConfig = new ReplicationConfig(),
     ) {
         $this->storageConfig = $storageConfig ?? InMemoryStorageConfig::withEntries();
-        $this->networkConfig = $networkConfig ?? new NetworkConfig();
-        $this->runnerConfig = $runnerConfig ?? new RunnerConfig();
-        $this->schemaConfig = $schemaConfig ?? new SchemaConfig();
     }
 
     public function getDseAltServer(): ?string
@@ -467,21 +461,20 @@ final class ServerOptions implements ServerListenerOptionsInterface
         return $this->serverRunner;
     }
 
-    public function isSyncEnabled(): bool
+    /**
+     * The journal settings for recording changes, or null when nothing is recorded.
+     *
+     * A configured provider records regardless, since it streams from the journal.
+     */
+    public function getChangeJournalConfig(): ?ChangeJournalConfig
     {
-        return $this->syncEnabled;
-    }
+        if ($this->changeJournalConfig !== null) {
+            return $this->changeJournalConfig;
+        }
 
-    public function setSyncEnabled(bool $syncEnabled): self
-    {
-        $this->syncEnabled = $syncEnabled;
-
-        return $this;
-    }
-
-    public function getChangeJournalConfig(): ChangeJournalConfig
-    {
-        return $this->changeJournalConfig ??= new ChangeJournalConfig();
+        return $this->getReplicationConfig()->isProvider()
+            ? $this->changeJournalConfig = new ChangeJournalConfig()
+            : null;
     }
 
     public function setChangeJournalConfig(ChangeJournalConfig $changeJournalConfig): self
@@ -492,35 +485,35 @@ final class ServerOptions implements ServerListenerOptionsInterface
     }
 
     /**
-     * Named constructor for a read-only replica that mirrors an upstream primary over RFC 4533.
-     *
-     * @param PdoConfig $storageConfig Persistent storage for the replica; PDO is required.
+     * A server playing no replication role holds one with both roles empty.
      */
-    public static function forReplica(
-        ReplicaConfig $replicaConfig,
-        PdoConfig $storageConfig,
-    ): self {
-        return (new self($storageConfig))->setReplicaConfig($replicaConfig);
+    public function getReplicationConfig(): ReplicationConfig
+    {
+        return $this->replicationConfig;
     }
 
-    public function getReplicaConfig(): ?ReplicaConfig
+    public function setReplicationConfig(ReplicationConfig $replicationConfig): self
     {
-        return $this->replicaConfig;
-    }
-
-    public function setReplicaConfig(ReplicaConfig $replicaConfig): self
-    {
-        $this->replicaConfig = $replicaConfig;
+        $this->replicationConfig = $replicationConfig;
 
         return $this;
     }
 
     /**
-     * Whether this server is a read-only replica, derived from having a replica config.
+     * The upstream this server mirrors, or null when it mirrors nothing.
+     */
+    public function getConsumerConfig(): ?ConsumerConfig
+    {
+        return $this->getReplicationConfig()
+            ->getConsumer();
+    }
+
+    /**
+     * Whether this server refuses client writes, which today follows from mirroring an upstream.
      */
     public function isReadOnly(): bool
     {
-        return $this->replicaConfig !== null;
+        return $this->getConsumerConfig() !== null;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Sync/Consumer/LdapReplica.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/LdapReplica.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Sync\Consumer;
 
 use FreeDSx\Ldap\Exception\CancelRequestException;
-use FreeDSx\Ldap\ReplicaConfig;
+use FreeDSx\Ldap\Server\Config\Replication\ConsumerConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
 use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
@@ -57,7 +57,7 @@ final class LdapReplica
     ) {}
 
     public static function forPcntl(
-        ReplicaConfig $config,
+        ConsumerConfig $config,
         EntryStorageInterface $storage,
         ?LoggerInterface $logger = null,
         ?PrimaryConnectionFactory $connectionFactory = null,
@@ -78,7 +78,7 @@ final class LdapReplica
      * @param ?ShutdownSignalsInterface $signals null when a host server owns SIGTERM and drives {@see stop()} instead
      */
     public static function forSwoole(
-        ReplicaConfig $config,
+        ConsumerConfig $config,
         EntryStorageInterface $storage,
         ?LoggerInterface $logger = null,
         ?ShutdownSignalsInterface $signals = new SwooleShutdownSignals(),
@@ -139,7 +139,7 @@ final class LdapReplica
     }
 
     private static function create(
-        ReplicaConfig $config,
+        ConsumerConfig $config,
         EntryStorageInterface $storage,
         SleeperInterface $sleeper,
         ?ShutdownSignalsInterface $signals,

--- a/src/FreeDSx/Ldap/Sync/Consumer/PrimaryConnectionFactory.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/PrimaryConnectionFactory.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Sync\Consumer;
 
 use FreeDSx\Ldap\LdapClient;
-use FreeDSx\Ldap\ReplicaConfig;
+use FreeDSx\Ldap\Server\Config\Replication\ConsumerConfig;
 use FreeDSx\Ldap\Sync\SyncRepl;
 
 /**
@@ -25,7 +25,7 @@ use FreeDSx\Ldap\Sync\SyncRepl;
  */
 readonly class PrimaryConnectionFactory
 {
-    public function __construct(private ReplicaConfig $config) {}
+    public function __construct(private ConsumerConfig $config) {}
 
     public function connectLdapClient(): LdapClient
     {

--- a/tests/integration/Journal/FileChangeJournalConcurrencyTest.php
+++ b/tests/integration/Journal/FileChangeJournalConcurrencyTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Integration\FreeDSx\Ldap\Server\Backend\Storage\Journal;
+namespace Tests\Integration\FreeDSx\Ldap\Journal;
 
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock\FileLock;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;

--- a/tests/integration/Journal/LdapAuditJournalTest.php
+++ b/tests/integration/Journal/LdapAuditJournalTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Journal;
+
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+use Tests\Support\FreeDSx\Ldap\TestWorker;
+
+/**
+ * A journal kept purely for auditing, which must not also turn the server into a sync provider.
+ */
+final class LdapAuditJournalTest extends ServerTestCase
+{
+    private static string $auditLog;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::$auditLog = TestWorker::path('audit.jsonl');
+        self::removeAuditLog();
+
+        if (!extension_loaded('pcntl')) {
+            return;
+        }
+
+        static::initSharedServer(
+            'ldap-backend-storage',
+            'tcp',
+            ['--journal=audit'],
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        static::tearDownSharedServer();
+        self::removeAuditLog();
+    }
+
+    public function setUp(): void
+    {
+        $this->setServerMode('ldap-backend-storage');
+
+        parent::setUp();
+    }
+
+    public function test_a_write_is_recorded_to_the_audit_log(): void
+    {
+        $this->authenticateAdmin();
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=audited,dc=foo,dc=bar',
+            [
+                'cn' => 'audited',
+                'sn' => 'Audited',
+                'objectClass' => 'person',
+            ],
+        ));
+
+        self::assertStringContainsString(
+            'cn=audited,dc=foo,dc=bar',
+            $this->readAuditLog(),
+        );
+    }
+
+    public function test_sync_is_not_served_while_only_auditing(): void
+    {
+        $this->authenticateAdmin();
+
+        $syncRepl = $this->ldapClient()->syncRepl();
+        $syncRepl->request()
+            ->base('dc=foo,dc=bar')
+            ->useSubtreeScope();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
+
+        $syncRepl->poll(static fn() => null);
+    }
+
+    private static function removeAuditLog(): void
+    {
+        if (file_exists(self::$auditLog)) {
+            unlink(self::$auditLog);
+        }
+    }
+
+    /**
+     * The sink writes from the server process, so the record may not have landed the moment the write returns.
+     */
+    private function readAuditLog(float $timeoutSeconds = 5.0): string
+    {
+        $deadline = microtime(true) + $timeoutSeconds;
+
+        do {
+            clearstatcache();
+            $contents = file_exists(self::$auditLog)
+                ? (string) file_get_contents(self::$auditLog)
+                : '';
+
+            if ($contents !== '') {
+                return $contents;
+            }
+
+            usleep(25_000);
+        } while (microtime(true) < $deadline);
+
+        return '';
+    }
+}

--- a/tests/integration/Journal/PdoChangeJournalConcurrencyTest.php
+++ b/tests/integration/Journal/PdoChangeJournalConcurrencyTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Integration\FreeDSx\Ldap\Server\Backend\Storage\Journal;
+namespace Tests\Integration\FreeDSx\Ldap\Journal;
 
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SqliteDialect;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Statement\PdoStatementPool;

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -25,6 +25,7 @@ use FreeDSx\Ldap\Ldif\Loader\FileLdifLoader;
 use FreeDSx\Ldap\Schema\LdifSchemaSource;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
+use FreeDSx\Ldap\Server\Config\Replication\ProviderConfig;
 use FreeDSx\Ldap\Server\Config\ReplicationConfig;
 use FreeDSx\Ldap\Server\Config\RunnerConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Audit\JsonLinesAuditSink;
@@ -48,8 +49,10 @@ final class LdapBackendStorageCommand extends Command
     public const MANAGER_PASSWORD = 'manager-pass';
 
     /**
-     * The fixed directory content every suite using this harness starts from.
+     * Tests assert on replicated state, so they should not wait a production poll for it.
      */
+    private const SYNC_POLL_INTERVAL = 0.05;
+
     /**
      * Serve sync to consumers, which records every write to the journal as a side effect.
      */
@@ -65,6 +68,9 @@ final class LdapBackendStorageCommand extends Command
      */
     private const JOURNAL_OFF = 'off';
 
+    /**
+     * The fixed directory content every suite using this harness starts from.
+     */
     private const SEED_LDIF = __DIR__ . '/../resources/seed/backend-storage-seed.ldif';
 
     protected function configure(): void
@@ -435,7 +441,9 @@ final class LdapBackendStorageCommand extends Command
         $mode = $input->getOption('journal') ?? self::JOURNAL_SYNC;
 
         match ($mode) {
-            self::JOURNAL_SYNC => $serverOptions->setReplicationConfig(ReplicationConfig::forProvider()),
+            self::JOURNAL_SYNC => $serverOptions->setReplicationConfig(ReplicationConfig::forProvider(
+                (new ProviderConfig())->setPollInterval(self::SYNC_POLL_INTERVAL),
+            )),
             self::JOURNAL_AUDIT => $serverOptions->setChangeJournalConfig(new ChangeJournalConfig(
                 auditSink: new JsonLinesAuditSink(TestWorker::path('audit.jsonl')),
             )),

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -25,10 +25,14 @@ use FreeDSx\Ldap\Ldif\Loader\FileLdifLoader;
 use FreeDSx\Ldap\Schema\LdifSchemaSource;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
+use FreeDSx\Ldap\Server\Config\ReplicationConfig;
 use FreeDSx\Ldap\Server\Config\RunnerConfig;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\Audit\JsonLinesAuditSink;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
 use FreeDSx\Ldap\Server\Config\SchemaConfig;
 use FreeDSx\Ldap\ServerOptions;
 use PDO;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -46,6 +50,21 @@ final class LdapBackendStorageCommand extends Command
     /**
      * The fixed directory content every suite using this harness starts from.
      */
+    /**
+     * Serve sync to consumers, which records every write to the journal as a side effect.
+     */
+    private const JOURNAL_SYNC = 'sync';
+
+    /**
+     * Record every write for auditing, without serving sync.
+     */
+    private const JOURNAL_AUDIT = 'audit';
+
+    /**
+     * The value when --journal is absent; passing it without one means {@see self::JOURNAL_SYNC}.
+     */
+    private const JOURNAL_OFF = 'off';
+
     private const SEED_LDIF = __DIR__ . '/../resources/seed/backend-storage-seed.ldif';
 
     protected function configure(): void
@@ -161,8 +180,13 @@ final class LdapBackendStorageCommand extends Command
             ->addOption(
                 'journal',
                 null,
-                InputOption::VALUE_NONE,
-                'Enable sync so every write appends a change-journal record',
+                InputOption::VALUE_OPTIONAL,
+                sprintf(
+                    'Record writes to the change journal: "%s" also serves them to consumers, "%s" only logs them',
+                    self::JOURNAL_SYNC,
+                    self::JOURNAL_AUDIT,
+                ),
+                self::JOURNAL_OFF,
             )
             ->addOption(
                 'max-search-lookthrough',
@@ -260,9 +284,10 @@ final class LdapBackendStorageCommand extends Command
         ))
             ->setAdministrators(Subject::group('cn=admins,dc=foo,dc=bar'))
             ->setMonitorEnabled((bool) $input->getOption('monitor'))
-            ->setSyncEnabled((bool) $input->getOption('journal'))
             ->setMaxSearchLookthrough((int) $this->getStringOption($input, 'max-search-lookthrough'))
             ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL));
+
+        $this->applyJournalMode($serverOptions, $input);
 
         if ($input->getOption('allow-relax')) {
             $serverOptions->setAclRules(
@@ -397,6 +422,29 @@ final class LdapBackendStorageCommand extends Command
         $server->run();
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Audit mode journals without a replication role, so nothing is served to consumers.
+     */
+    private function applyJournalMode(
+        ServerOptions $serverOptions,
+        InputInterface $input,
+    ): void {
+        // Symfony hands back null when the option is passed without a value.
+        $mode = $input->getOption('journal') ?? self::JOURNAL_SYNC;
+
+        match ($mode) {
+            self::JOURNAL_SYNC => $serverOptions->setReplicationConfig(ReplicationConfig::forProvider()),
+            self::JOURNAL_AUDIT => $serverOptions->setChangeJournalConfig(new ChangeJournalConfig(
+                auditSink: new JsonLinesAuditSink(TestWorker::path('audit.jsonl')),
+            )),
+            self::JOURNAL_OFF => $serverOptions,
+            default => throw new RuntimeException(sprintf(
+                'Unknown --journal mode "%s".',
+                is_string($mode) ? $mode : gettype($mode),
+            )),
+        };
     }
 
     private function buildSchemaConfig(

--- a/tests/support/LdapReplicaCommand.php
+++ b/tests/support/LdapReplicaCommand.php
@@ -8,11 +8,12 @@ use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Operations;
-use FreeDSx\Ldap\ReplicaConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoConfig;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\Server\Config\RunnerConfig;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\Config\Replication\ConsumerConfig;
+use FreeDSx\Ldap\Server\Config\ReplicationConfig;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
 use FreeDSx\Ldap\ServerOptions;
 use Symfony\Component\Console\Command\Command;
@@ -72,13 +73,13 @@ final class LdapReplicaCommand extends Command
         );
         register_shutdown_function(static fn() => $provider->stop());
 
-        $replicaConfig = new ReplicaConfig(
+        $consumerConfig = new ConsumerConfig(
             (new ClientOptions())
                 ->setServers(['127.0.0.1'])
                 ->setPort($providerPort)
                 ->setBaseDn('dc=foo,dc=bar'),
         );
-        $replicaConfig->setBind(Operations::bind(
+        $consumerConfig->setBind(Operations::bind(
             'cn=user,dc=foo,dc=bar',
             '12345',
         ));
@@ -90,12 +91,12 @@ final class LdapReplicaCommand extends Command
             ->setShutdownTimeout(0);
 
         $server = new LdapServer(
-            ServerOptions::forReplica(
-                $replicaConfig,
-                $this->createReplicaStorageConfig(),
-            )
-                ->setNetworkConfig($network)
-                ->setRunnerConfig(new RunnerConfig($runner === 'swoole' ? RunnerMode::Swoole : RunnerMode::Pcntl))
+            (new ServerOptions(
+                storageConfig: $this->createReplicaStorageConfig(),
+                networkConfig: $network,
+                runnerConfig: new RunnerConfig($runner === 'swoole' ? RunnerMode::Swoole : RunnerMode::Pcntl),
+                replicationConfig: ReplicationConfig::forReplica($consumerConfig),
+            ))
                 ->setPasswordPolicy(new PasswordPolicy(
                     lockout: new PasswordLockoutRules(
                         enabled: true,

--- a/tests/support/LdapReplicaCommand.php
+++ b/tests/support/LdapReplicaCommand.php
@@ -30,6 +30,11 @@ final class LdapReplicaCommand extends Command
 {
     use ConsoleOptionsTrait;
 
+    /**
+     * Tests assert on forwarded bind state, so they should not wait a production drain for it.
+     */
+    private const FORWARD_INTERVAL = 0.05;
+
     private const SEED = __DIR__ . '/../resources/seed/sync-seed.ldif';
 
     protected function configure(): void
@@ -83,6 +88,7 @@ final class LdapReplicaCommand extends Command
             'cn=user,dc=foo,dc=bar',
             '12345',
         ));
+        $consumerConfig->setForwardInterval(self::FORWARD_INTERVAL);
 
         $network = (new NetworkConfig())
             ->setPort($port)

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -33,6 +33,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
 use FreeDSx\Ldap\Server\Config\ConfidentialityRequirement;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
+use FreeDSx\Ldap\Server\Config\ReplicationConfig;
 use FreeDSx\Ldap\Server\Config\RunnerConfig;
 use FreeDSx\Ldap\ServerOptions;
 use Tests\Support\FreeDSx\Ldap\Server\Configuration\FileFlagConfigReloader;
@@ -295,7 +296,7 @@ final class LdapServerCommand extends Command
             ->setAdministrators(Subject::dn(self::ADMIN_DN))
             ->setMaxSearchLookthrough((int) $this->getStringOption($input, 'max-search-lookthrough'))
             ->setMaxSearchPagedLookthrough((int) $this->getStringOption($input, 'max-search-paged-lookthrough'))
-            ->setSyncEnabled(true)
+            ->setReplicationConfig(ReplicationConfig::forProvider())
             ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL));
 
         $authenticatedLookthrough = (int) $this->getStringOption($input, 'authenticated-lookthrough');

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -33,6 +33,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
 use FreeDSx\Ldap\Server\Config\ConfidentialityRequirement;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
+use FreeDSx\Ldap\Server\Config\Replication\ProviderConfig;
 use FreeDSx\Ldap\Server\Config\ReplicationConfig;
 use FreeDSx\Ldap\Server\Config\RunnerConfig;
 use FreeDSx\Ldap\ServerOptions;
@@ -53,6 +54,11 @@ final class LdapServerCommand extends Command
     public const MANAGER_DN = 'cn=manager';
 
     public const MANAGER_PASSWORD = 'manager-pass';
+
+    /**
+     * Tests assert on replicated state, so they should not wait a production poll for it.
+     */
+    private const SYNC_POLL_INTERVAL = 0.05;
 
     /**
      * Writes are denied by default, so tests that write bind as this identity.
@@ -296,7 +302,9 @@ final class LdapServerCommand extends Command
             ->setAdministrators(Subject::dn(self::ADMIN_DN))
             ->setMaxSearchLookthrough((int) $this->getStringOption($input, 'max-search-lookthrough'))
             ->setMaxSearchPagedLookthrough((int) $this->getStringOption($input, 'max-search-paged-lookthrough'))
-            ->setReplicationConfig(ReplicationConfig::forProvider())
+            ->setReplicationConfig(ReplicationConfig::forProvider(
+                (new ProviderConfig())->setPollInterval(self::SYNC_POLL_INTERVAL),
+            ))
             ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL));
 
         $authenticatedLookthrough = (int) $this->getStringOption($input, 'authenticated-lookthrough');

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap;
 
+use FreeDSx\Ldap\Server\Config\ReplicationConfig;
 use FreeDSx\Ldap\Server\Config\RunnerConfig;
 use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Container;
@@ -428,7 +429,7 @@ class ContainerTest extends TestCase
     private function journalingOptions(): ServerOptions
     {
         return (new ServerOptions())
-            ->setSyncEnabled(true)
+            ->setReplicationConfig(ReplicationConfig::forProvider())
             ->setChangeJournalConfig(new ChangeJournalConfig(
                 retention: new RetentionPolicy(maxRecords: 100),
             ));

--- a/tests/unit/LdapServerTest.php
+++ b/tests/unit/LdapServerTest.php
@@ -29,7 +29,8 @@ use FreeDSx\Ldap\Server\Backend\Storage\Export\DumpOptions;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\Server\Config\RunnerConfig;
 use FreeDSx\Ldap\ClientOptions;
-use FreeDSx\Ldap\ReplicaConfig;
+use FreeDSx\Ldap\Server\Config\Replication\ConsumerConfig;
+use FreeDSx\Ldap\Server\Config\ReplicationConfig;
 use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
 use FreeDSx\Ldap\ServerOptions;
@@ -96,7 +97,7 @@ class LdapServerTest extends TestCase
         }
 
         $options = (new ServerOptions(networkConfig: NetworkConfig::withPort(33389)))
-            ->setReplicaConfig(new ReplicaConfig(new ClientOptions()))
+            ->setReplicationConfig(ReplicationConfig::forReplica(new ConsumerConfig(new ClientOptions())))
             ->setStorageConfig($storageConfig)
             ->setRunnerConfig(new RunnerConfig($runner));
 
@@ -108,7 +109,7 @@ class LdapServerTest extends TestCase
     public function test_run_does_not_throw_for_a_replica_on_pdo_storage(): void
     {
         $this->options
-            ->setReplicaConfig(new ReplicaConfig(new ClientOptions()))
+            ->setReplicationConfig(ReplicationConfig::forReplica(new ConsumerConfig(new ClientOptions())))
             ->setStorageConfig(PdoConfig::forSqlite(':memory:'));
 
         $this->mockServerRunner

--- a/tests/unit/Protocol/ClientProtocolHandler/ClientSyncHandlerTest.php
+++ b/tests/unit/Protocol/ClientProtocolHandler/ClientSyncHandlerTest.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Control\Sync\SyncRequestControl;
 use FreeDSx\Ldap\Control\Sync\SyncStateControl;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\CancelRequestException;
+use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\LdapUrl;
 use FreeDSx\Ldap\Operation\LdapResult;
@@ -540,6 +541,31 @@ final class ClientSyncHandlerTest extends TestCase
         self::assertSame(
             [$referral],
             $referralsProcessed,
+        );
+    }
+
+    public function test_a_refused_sync_surfaces_as_an_operation_exception(): void
+    {
+        $messageTo = new LdapMessageRequest(
+            1,
+            new SyncRequest(),
+            new SyncRequestControl(),
+        );
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
+
+        // A refusal carries no SyncDoneControl, so the loop reads it as complete and must not return it as a result.
+        $this->subject->handleResponse(
+            $messageTo,
+            new LdapMessageResponse(
+                1,
+                new SearchResultDone(
+                    ResultCode::UNWILLING_TO_PERFORM,
+                    '',
+                    'Content synchronization is not supported.',
+                ),
+            ),
         );
     }
 

--- a/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
@@ -37,6 +37,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Statement\PdoStatementPool;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoStorageFactory;
 use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
@@ -1391,6 +1392,7 @@ final class PdoStorageTest extends TestCase
         $storage = PdoStorageFactory::storageOn(
             $config = PdoConfig::forSqlite(':memory:'),
             PdoStorageFactory::sharedProvider($config),
+            new ReplicaId(),
             journalConfig: new ChangeJournalConfig(),
         );
         $journal = $storage->changeJournal() ?? self::fail('Expected the storage to have a journal.');

--- a/tests/unit/Server/Config/Replication/ConsumerConfigTest.php
+++ b/tests/unit/Server/Config/Replication/ConsumerConfigTest.php
@@ -11,22 +11,22 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Unit\FreeDSx\Ldap;
+namespace Tests\Unit\FreeDSx\Ldap\Server\Config\Replication;
 
 use FreeDSx\Ldap\ClientOptions;
-use FreeDSx\Ldap\ReplicaConfig;
+use FreeDSx\Ldap\Server\Config\Replication\ConsumerConfig;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Sync\Consumer\Checkpoint\InMemoryReplicationCheckpoint;
 use FreeDSx\Ldap\Sync\Consumer\Checkpoint\ReplicationCheckpointInterface;
 use PHPUnit\Framework\TestCase;
 
-final class ReplicaConfigTest extends TestCase
+final class ConsumerConfigTest extends TestCase
 {
-    private ReplicaConfig $subject;
+    private ConsumerConfig $subject;
 
     protected function setUp(): void
     {
-        $this->subject = new ReplicaConfig(
+        $this->subject = new ConsumerConfig(
             (new ClientOptions())
                 ->setServers(['primary.example.com'])
                 ->setPort(636)
@@ -98,7 +98,7 @@ final class ReplicaConfigTest extends TestCase
     {
         $checkpoint = $this->createMock(ReplicationCheckpointInterface::class);
 
-        $config = new ReplicaConfig(
+        $config = new ConsumerConfig(
             new ClientOptions(),
             $checkpoint,
         );

--- a/tests/unit/Server/Middleware/ReadOnlyMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/ReadOnlyMiddlewareTest.php
@@ -29,7 +29,7 @@ use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
-use FreeDSx\Ldap\ReplicaConfig;
+use FreeDSx\Ldap\Server\Config\Replication\ConsumerConfig;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
@@ -44,19 +44,19 @@ final class ReadOnlyMiddlewareTest extends TestCase
 {
     private MiddlewareHandlerInterface&MockObject $next;
 
-    private ReplicaConfig $replicaConfig;
+    private ConsumerConfig $consumerConfig;
 
     private ReadOnlyMiddleware $subject;
 
     protected function setUp(): void
     {
         $this->next = $this->createMock(MiddlewareHandlerInterface::class);
-        $this->replicaConfig = new ReplicaConfig(
+        $this->consumerConfig = new ConsumerConfig(
             (new ClientOptions())
                 ->setServers(['primary.example.com'])
                 ->setPort(389),
         );
-        $this->subject = new ReadOnlyMiddleware($this->replicaConfig);
+        $this->subject = new ReadOnlyMiddleware($this->consumerConfig);
     }
 
     /**
@@ -146,7 +146,7 @@ final class ReadOnlyMiddlewareTest extends TestCase
 
     public function test_a_write_is_rejected_when_referral_is_disabled(): void
     {
-        $this->replicaConfig->setReferWrites(false);
+        $this->consumerConfig->setReferWrites(false);
         $this->next
             ->expects(self::never())
             ->method('handle');

--- a/tests/unit/ServerOptionsTest.php
+++ b/tests/unit/ServerOptionsTest.php
@@ -21,6 +21,9 @@ use FreeDSx\Ldap\Schema\Definition\Nis\AttributeTypeOid as NisAttributeTypeOid;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
 use FreeDSx\Ldap\Schema\SchemaResource;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashScheme;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
+use FreeDSx\Ldap\Server\Config\Replication\ConsumerConfig;
+use FreeDSx\Ldap\Server\Config\ReplicationConfig;
 use FreeDSx\Ldap\Server\Config\RunnerConfig;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\PasswordPolicy\QualityCheck\DefaultPasswordQualityChecker;
@@ -42,7 +45,6 @@ use FreeDSx\Ldap\Server\SearchLimit\SearchLimitRule;
 use FreeDSx\Ldap\Server\SearchLimit\SearchLimitRules;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\ClientOptions;
-use FreeDSx\Ldap\ReplicaConfig;
 use FreeDSx\Ldap\ServerOptions;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -56,24 +58,26 @@ final class ServerOptionsTest extends TestCase
         $this->subject = new ServerOptions();
     }
 
-    public function test_a_default_server_is_not_a_read_only_replica(): void
+    public function test_a_default_server_plays_no_replication_role(): void
     {
         self::assertFalse($this->subject->isReadOnly());
-        self::assertNull($this->subject->getReplicaConfig());
+        self::assertNull($this->subject->getConsumerConfig());
+        self::assertFalse($this->subject->getReplicationConfig()->isProvider());
+        self::assertFalse($this->subject->getReplicationConfig()->isConsumer());
     }
 
-    public function test_for_replica_configures_a_read_only_replica(): void
+    public function test_a_consumer_role_makes_the_server_read_only(): void
     {
-        $config = new ReplicaConfig(new ClientOptions());
-        $options = ServerOptions::forReplica(
-            $config,
-            PdoConfig::forSqlite(':memory:'),
+        $config = new ConsumerConfig(new ClientOptions());
+        $options = new ServerOptions(
+            storageConfig: PdoConfig::forSqlite(':memory:'),
+            replicationConfig: ReplicationConfig::forReplica($config),
         );
 
         self::assertTrue($options->isReadOnly());
         self::assertSame(
             $config,
-            $options->getReplicaConfig(),
+            $options->getConsumerConfig(),
         );
     }
 
@@ -159,33 +163,45 @@ final class ServerOptionsTest extends TestCase
         );
     }
 
-    public function test_sync_is_disabled_by_default(): void
+    public function test_a_provider_role_journals_without_the_journal_being_configured(): void
     {
-        self::assertFalse($this->subject->isSyncEnabled());
+        $this->subject->setReplicationConfig(ReplicationConfig::forProvider());
+
+        self::assertNotNull($this->subject->getChangeJournalConfig());
     }
 
-    public function test_it_can_enable_sync(): void
+    public function test_nothing_is_journaled_by_default(): void
     {
-        $this->subject->setSyncEnabled(true);
-
-        self::assertTrue($this->subject->isSyncEnabled());
+        self::assertNull($this->subject->getChangeJournalConfig());
     }
 
-    public function test_the_change_journal_config_defaults_to_a_usable_config(): void
+    public function test_a_journal_can_be_configured_without_a_replication_role(): void
     {
-        self::assertTrue(
-            $this->subject->getChangeJournalConfig()->origin->equals(new ReplicaId('local')),
-        );
-    }
-
-    public function test_it_can_override_the_change_journal_config(): void
-    {
-        $config = new ChangeJournalConfig(new ReplicaId('node-a'));
+        $config = new ChangeJournalConfig();
         $this->subject->setChangeJournalConfig($config);
 
         self::assertSame(
             $config,
             $this->subject->getChangeJournalConfig(),
+        );
+        self::assertFalse($this->subject->getReplicationConfig()->isProvider());
+    }
+
+    public function test_the_replica_id_defaults_to_the_local_identity(): void
+    {
+        self::assertTrue(
+            $this->subject->getReplicationConfig()->getId()->equals(ReplicaId::local()),
+        );
+    }
+
+    public function test_it_can_override_the_network_config(): void
+    {
+        $config = NetworkConfig::withPort(1389);
+        $this->subject->setNetworkConfig($config);
+
+        self::assertSame(
+            $config,
+            $this->subject->getNetworkConfig(),
         );
     }
 

--- a/tests/unit/Sync/Consumer/LdapReplicaTest.php
+++ b/tests/unit/Sync/Consumer/LdapReplicaTest.php
@@ -15,7 +15,7 @@ namespace Tests\Unit\FreeDSx\Ldap\Sync\Consumer;
 
 use Closure;
 use FreeDSx\Ldap\ClientOptions;
-use FreeDSx\Ldap\ReplicaConfig;
+use FreeDSx\Ldap\Server\Config\Replication\ConsumerConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
 use FreeDSx\Ldap\Server\Process\Signals\ShutdownSignalsInterface;
@@ -200,7 +200,7 @@ final class LdapReplicaTest extends TestCase
         $this->expectNotToPerformAssertions();
 
         LdapReplica::forPcntl(
-            new ReplicaConfig(new ClientOptions()),
+            new ConsumerConfig(new ClientOptions()),
             new InMemoryStorage(),
         );
     }
@@ -214,7 +214,7 @@ final class LdapReplicaTest extends TestCase
         $this->expectNotToPerformAssertions();
 
         LdapReplica::forSwoole(
-            new ReplicaConfig(new ClientOptions()),
+            new ConsumerConfig(new ClientOptions()),
             new InMemoryStorage(),
         );
     }


### PR DESCRIPTION
This refactors replication config to leave us in a better future state (where a read-only replica may to be the only possible topology). It also decouples the journaling from the replication such that you can enable journaling for the purpose of the auditing changelog but also not have sync / replication explicitly enabled. It's useful on its own for auditing purposes and it was meant to be separated like that. 

This also exposes some tunable settings which could be legitimately wanted (sync poll interval and a password policy batch forward interval). These are currently most useful in the integration tests, as there is not need for the higher times there (and cuts the integration test time just about in half again (now 7s for all integration tests to run locally).