### PR TITLE
[1.00] Server protocol handling RFC conformance.

### DIFF
--- a/src/FreeDSx/Ldap/Container/Provider/ConnectionGraphContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/ConnectionGraphContainerProvider.php
@@ -27,6 +27,7 @@ use FreeDSx\Ldap\Server\AccessControl\ConfidentialFilterRewriter;
 use FreeDSx\Ldap\Server\Middleware\AssertionMiddleware;
 use FreeDSx\Ldap\Server\Middleware\ConfidentialAttributeMiddleware;
 use FreeDSx\Ldap\Server\Middleware\CriticalControlMiddleware;
+use FreeDSx\Ldap\Server\Middleware\CriticalControlValidator;
 use FreeDSx\Ldap\Server\Middleware\MetricsMiddleware;
 use FreeDSx\Ldap\Server\Middleware\OperationAuthorizationMiddleware;
 use FreeDSx\Ldap\Server\Middleware\ResourceLimitMiddleware;
@@ -57,6 +58,7 @@ final class ConnectionGraphContainerProvider implements ContainerProviderInterfa
             AssertionEvaluator::class => $this->makeAssertionEvaluator(...),
             MetricsResponseInterceptor::class => $this->makeMetricsResponseInterceptor(...),
             MetricsMiddleware::class => $this->makeMetricsMiddleware(...),
+            CriticalControlValidator::class => $this->makeCriticalControlValidator(...),
             CriticalControlMiddleware::class => $this->makeCriticalControlMiddleware(...),
             OperationAuthorizationMiddleware::class => $this->makeOperationAuthorizationMiddleware(...),
             ConfidentialAttributeMiddleware::class => $this->makeConfidentialAttributeMiddleware(...),
@@ -126,7 +128,15 @@ final class ConnectionGraphContainerProvider implements ContainerProviderInterfa
 
     private function makeCriticalControlMiddleware(Container $container): CriticalControlMiddleware
     {
-        return new CriticalControlMiddleware($container->get(ServerProtocolHandlerFactory::class));
+        return new CriticalControlMiddleware(
+            $container->get(ServerProtocolHandlerFactory::class),
+            $container->get(CriticalControlValidator::class),
+        );
+    }
+
+    private function makeCriticalControlValidator(Container $container): CriticalControlValidator
+    {
+        return new CriticalControlValidator();
     }
 
     private function makeOperationAuthorizationMiddleware(Container $container): OperationAuthorizationMiddleware

--- a/src/FreeDSx/Ldap/Exception/MessageDecodeException.php
+++ b/src/FreeDSx/Ldap/Exception/MessageDecodeException.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Exception;
+
+use Throwable;
+
+/**
+ * A message whose envelope parsed but whose contents did not, so it can still be answered by its ID.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class MessageDecodeException extends ProtocolException
+{
+    public function __construct(
+        private readonly int $messageId,
+        private readonly int $protocolOpTag,
+        string $message,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct(
+            $message,
+            0,
+            $previous,
+        );
+    }
+
+    public function getMessageId(): int
+    {
+        return $this->messageId;
+    }
+
+    /**
+     * The tag of the operation that failed, which fixes the response type owed to the client.
+     */
+    public function getProtocolOpTag(): int
+    {
+        return $this->protocolOpTag;
+    }
+}

--- a/src/FreeDSx/Ldap/Operation/Request/AddRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/AddRequest.php
@@ -102,6 +102,14 @@ class AddRequest implements RequestInterface
                 throw new ProtocolException('The add request is malformed.');
             }
 
+            // An Attribute constrains its values to SIZE(1..MAX), unlike the PartialAttribute a Modify carries.
+            if (count($vals->getChildren()) === 0) {
+                throw new ProtocolException(sprintf(
+                    'No values for attribute type "%s".',
+                    (string) $attrType->getValue(),
+                ));
+            }
+
             $attrValues = [];
             foreach ($vals->getChildren() as $val) {
                 if (!$val instanceof OctetStringType) {

--- a/src/FreeDSx/Ldap/Operation/Request/SearchRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/SearchRequest.php
@@ -103,6 +103,26 @@ class SearchRequest implements RequestInterface
      */
     public const DEREF_ALWAYS = 3;
 
+    /**
+     * Every scope this server performs; the RFC 4511 4.5.1 enumeration is extensible, so others are well formed
+     * but name a scope it cannot answer.
+     */
+    public const SUPPORTED_SCOPES = [
+        self::SCOPE_BASE_OBJECT,
+        self::SCOPE_SINGLE_LEVEL,
+        self::SCOPE_WHOLE_SUBTREE,
+    ];
+
+    /**
+     * The RFC 4511 4.5.1 alias dereferencing enumeration, which unlike scope is closed.
+     */
+    public const DEREF_VALUES = [
+        self::DEREF_NEVER,
+        self::DEREF_IN_SEARCHING,
+        self::DEREF_FINDING_BASE_OBJECT,
+        self::DEREF_ALWAYS,
+    ];
+
     protected const APP_TAG = 3;
 
     private ?Dn $baseDn = null;

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientAbandonHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientAbandonHandler.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol\ClientProtocolHandler;
+
+use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\ClientQueue;
+use FreeDSx\Socket\Exception\ConnectionException;
+
+/**
+ * Logic for handling an abandon operation, which RFC 4511 §4.11 defines no response for.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class ClientAbandonHandler implements RequestHandlerInterface
+{
+    use MessageCreationTrait;
+
+    public function __construct(private readonly ClientQueue $queue) {}
+
+    /**
+     * {@inheritDoc}
+     * @throws EncoderException
+     * @throws ConnectionException
+     */
+    public function handleRequest(LdapMessageRequest $message): ?LdapMessageResponse
+    {
+        // Waiting for a reply would block until the read timeout, since a conformant server sends nothing.
+        $this->queue->sendMessage($message);
+
+        return null;
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientBasicHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler/ClientBasicHandler.php
@@ -89,10 +89,15 @@ class ClientBasicHandler implements RequestHandlerInterface, ResponseHandlerInte
                 $result->getResultCode(),
             );
         }
+        // RFC 4511 §4.1.9 fills matchedDN only when the target could not be named, so an empty one carries nothing.
+        $matchedDn = $result->getDn();
 
         throw new OperationException(
             $result->getDiagnosticMessage(),
             $result->getResultCode(),
+            matchedDn: $matchedDn->toString() === ''
+                ? null
+                : $matchedDn,
         );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/Factory/ClientProtocolHandlerFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ClientProtocolHandlerFactory.php
@@ -52,6 +52,8 @@ class ClientProtocolHandlerFactory
             );
         } elseif ($request instanceof Request\UnbindRequest) {
             return new ClientProtocolHandler\ClientUnbindHandler($this->queue());
+        } elseif ($request instanceof Request\AbandonRequest) {
+            return new ClientProtocolHandler\ClientAbandonHandler($this->queue());
         } elseif ($request instanceof Request\SaslBindRequest) {
             return new ClientProtocolHandler\ClientSaslBindHandler(
                 $this->queue(),

--- a/src/FreeDSx/Ldap/Protocol/Factory/ResponseFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ResponseFactory.php
@@ -123,6 +123,37 @@ class ResponseFactory
     }
 
     /**
+     * The response owed to a message whose contents could not be decoded, keyed by its protocolOp tag.
+     *
+     * The request object never existed, so the tag alone has to pick the response type the client is waiting on.
+     */
+    public function getDecodeFailureResponse(
+        int $messageId,
+        int $protocolOpTag,
+        string $diagnostic,
+    ): ?LdapMessageResponse {
+        $response = match ($protocolOpTag) {
+            0 => new BindResponse(new LdapResult(ResultCode::PROTOCOL_ERROR, '', $diagnostic)),
+            3 => new SearchResultDone(ResultCode::PROTOCOL_ERROR, '', $diagnostic),
+            6 => new ModifyResponse(ResultCode::PROTOCOL_ERROR, '', $diagnostic),
+            8 => new AddResponse(ResultCode::PROTOCOL_ERROR, '', $diagnostic),
+            10 => new DeleteResponse(ResultCode::PROTOCOL_ERROR, '', $diagnostic),
+            12 => new ModifyDnResponse(ResultCode::PROTOCOL_ERROR, '', $diagnostic),
+            14 => new CompareResponse(ResultCode::PROTOCOL_ERROR, '', $diagnostic),
+            23 => new ExtendedResponse(new LdapResult(ResultCode::PROTOCOL_ERROR, '', $diagnostic)),
+            // Unbind and Abandon have no response, and a response tag is not a request at all.
+            default => null,
+        };
+
+        return $response === null
+            ? null
+            : new LdapMessageResponse(
+                $messageId,
+                $response,
+            );
+    }
+
+    /**
      * Retrieve an extended error, which has a message ID of zero.
      *
      * @param Control ...$controls Response controls to attach to the resulting message.

--- a/src/FreeDSx/Ldap/Protocol/LdapMessage.php
+++ b/src/FreeDSx/Ldap/Protocol/LdapMessage.php
@@ -24,6 +24,7 @@ use FreeDSx\Asn1\Type\SequenceOfType;
 use FreeDSx\Asn1\Type\SequenceType;
 use FreeDSx\Ldap\Control;
 use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Exception\MessageDecodeException;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Operation\Request;
@@ -74,6 +75,35 @@ abstract class LdapMessage implements ProtocolElementInterface, PduInterface
      * The upper bound every RFC 4511 INTEGER (0 .. maxInt) field shares.
      */
     public const MAX_INT = 2147483647;
+
+    /**
+     * Every protocolOp tag this implementation decodes, keyed by tag.
+     *
+     * @var array<int, class-string<ProtocolElementInterface>>
+     */
+    private const PROTOCOL_OPS = [
+        0 => Request\BindRequest::class,
+        1 => Response\BindResponse::class,
+        2 => Request\UnbindRequest::class,
+        3 => Request\SearchRequest::class,
+        4 => Response\SearchResultEntry::class,
+        5 => Response\SearchResultDone::class,
+        6 => Request\ModifyRequest::class,
+        7 => Response\ModifyResponse::class,
+        8 => Request\AddRequest::class,
+        9 => Response\AddResponse::class,
+        10 => Request\DeleteRequest::class,
+        11 => Response\DeleteResponse::class,
+        12 => Request\ModifyDnRequest::class,
+        13 => Response\ModifyDnResponse::class,
+        14 => Request\CompareRequest::class,
+        15 => Response\CompareResponse::class,
+        16 => Request\AbandonRequest::class,
+        19 => Response\SearchResultReference::class,
+        23 => Request\ExtendedRequest::class,
+        24 => Response\ExtendedResponse::class,
+        25 => Response\IntermediateResponse::class,
+    ];
 
     private ControlBag $controls;
 
@@ -146,37 +176,19 @@ abstract class LdapMessage implements ProtocolElementInterface, PduInterface
             ));
         }
 
-        $controls = [];
-        if ($count > 2) {
-            for ($i = 2; $i < $count; $i++) {
-                $child = $type->getChild($i);
-                if ($child !== null && $child->getTagClass() === AbstractType::TAG_CLASS_CONTEXT_SPECIFIC && $child->getTagNumber() === 0) {
-                    if (!$child instanceof IncompleteType) {
-                        throw new ProtocolException('The ASN1 structure for the controls is malformed.');
-                    }
-                    $child = (new LdapEncoder())->complete(
-                        $child,
-                        AbstractType::TAG_TYPE_SEQUENCE,
-                    );
-
-                    foreach ($child->getChildren() as $control) {
-                        if (!($control instanceof SequenceType && $control->getChild(0) !== null && $control->getChild(0) instanceof OctetStringType)) {
-                            throw new ProtocolException('The control either is not a sequence or has no OID value attached.');
-                        }
-                        $controls[] = static::controlFromAsn1($control);
-                    }
-                }
-            }
-        }
-
         $messageId = $type->getChild(0);
         if (!($messageId instanceof IntegerType)) {
             throw new ProtocolException('Expected an LDAP message ID as an ASN.1 integer type. None received.');
         }
 
+        $messageIdValue = $messageId->getValue();
+        if (!is_int($messageIdValue)) {
+            throw new ProtocolException('Expected an LDAP message ID as an ASN.1 integer type. None received.');
+        }
+
         // A value outside the range MessageID constrains is not an encoding of that type, so it cannot be parsed
         // as one. Answering it would mean echoing an ID no conformant peer can accept.
-        if ($messageId->getValue() < 0 || $messageId->getValue() > self::MAX_INT) {
+        if ($messageIdValue < 0 || $messageIdValue > self::MAX_INT) {
             throw new ProtocolException('The LDAP message ID is outside the range it is permitted to use.');
         }
         /** @var SequenceType|null $opAsn1 */
@@ -185,36 +197,36 @@ abstract class LdapMessage implements ProtocolElementInterface, PduInterface
             throw new ProtocolException('The LDAP message is malformed.');
         }
 
-        $operation = match ($opAsn1->getTagNumber()) {
-            0 => Request\BindRequest::fromAsn1($opAsn1),
-            1 => Response\BindResponse::fromAsn1($opAsn1),
-            2 => Request\UnbindRequest::fromAsn1($opAsn1),
-            3 => Request\SearchRequest::fromAsn1($opAsn1),
-            4 => Response\SearchResultEntry::fromAsn1($opAsn1),
-            5 => Response\SearchResultDone::fromAsn1($opAsn1),
-            6 => Request\ModifyRequest::fromAsn1($opAsn1),
-            7 => Response\ModifyResponse::fromAsn1($opAsn1),
-            8 => Request\AddRequest::fromAsn1($opAsn1),
-            9 => Response\AddResponse::fromAsn1($opAsn1),
-            10 => Request\DeleteRequest::fromAsn1($opAsn1),
-            11 => Response\DeleteResponse::fromAsn1($opAsn1),
-            12 => Request\ModifyDnRequest::fromAsn1($opAsn1),
-            13 => Response\ModifyDnResponse::fromAsn1($opAsn1),
-            14 => Request\CompareRequest::fromAsn1($opAsn1),
-            15 => Response\CompareResponse::fromAsn1($opAsn1),
-            16 => Request\AbandonRequest::fromAsn1($opAsn1),
-            19 => Response\SearchResultReference::fromAsn1($opAsn1),
-            23 => Request\ExtendedRequest::fromAsn1($opAsn1),
-            24 => Response\ExtendedResponse::fromAsn1($opAsn1),
-            25 => Response\IntermediateResponse::fromAsn1($opAsn1),
-            default => throw new ProtocolException(sprintf(
+        $opTag = $opAsn1->getTagNumber();
+
+        // Resolved before anything is decoded: an unrecognized operation ends the session (RFC 4511 4.1.1),
+        // so it must not reach the answerable path below.
+        if (!is_int($opTag) || !isset(self::PROTOCOL_OPS[$opTag])) {
+            throw new ProtocolException(sprintf(
                 'The tag %s for the LDAP operation is not supported.',
-                $opAsn1->getTagNumber(),
-            )),
-        };
+                (string) $opTag,
+            ));
+        }
+
+        // Past this point the message can be answered by its ID, so a failure inside is reported as one that
+        // names the message rather than one that ends the session.
+        try {
+            $operation = self::PROTOCOL_OPS[$opTag]::fromAsn1($opAsn1);
+            $controls = self::controlsFromAsn1(
+                $type,
+                $count,
+            );
+        } catch (ProtocolException|EncoderException $e) {
+            throw new MessageDecodeException(
+                $messageIdValue,
+                $opTag,
+                $e->getMessage(),
+                $e,
+            );
+        }
 
         return new static(
-            $messageId->getValue(),
+            $messageIdValue,
             $operation,
             ...$controls,
         );
@@ -247,4 +259,43 @@ abstract class LdapMessage implements ProtocolElementInterface, PduInterface
      * @return AbstractType<mixed>
      */
     abstract protected function getOperationAsn1(): AbstractType;
+
+    /**
+     * @param SequenceType<mixed> $type
+     *
+     * @return list<Control\Control>
+     *
+     * @throws ProtocolException
+     * @throws EncoderException
+     */
+    private static function controlsFromAsn1(
+        SequenceType $type,
+        int $count,
+    ): array {
+        $controls = [];
+
+        for ($i = 2; $i < $count; $i++) {
+            $child = $type->getChild($i);
+            if ($child === null || $child->getTagClass() !== AbstractType::TAG_CLASS_CONTEXT_SPECIFIC || $child->getTagNumber() !== 0) {
+                continue;
+            }
+            if (!$child instanceof IncompleteType) {
+                throw new ProtocolException('The ASN1 structure for the controls is malformed.');
+            }
+
+            $child = (new LdapEncoder())->complete(
+                $child,
+                AbstractType::TAG_TYPE_SEQUENCE,
+            );
+
+            foreach ($child->getChildren() as $control) {
+                if (!($control instanceof SequenceType && $control->getChild(0) !== null && $control->getChild(0) instanceof OctetStringType)) {
+                    throw new ProtocolException('The control either is not a sequence or has no OID value attached.');
+                }
+                $controls[] = static::controlFromAsn1($control);
+            }
+        }
+
+        return $controls;
+    }
 }

--- a/src/FreeDSx/Ldap/Protocol/LdapMessage.php
+++ b/src/FreeDSx/Ldap/Protocol/LdapMessage.php
@@ -70,6 +70,11 @@ use function count;
  */
 abstract class LdapMessage implements ProtocolElementInterface, PduInterface
 {
+    /**
+     * The upper bound every RFC 4511 INTEGER (0 .. maxInt) field shares.
+     */
+    public const MAX_INT = 2147483647;
+
     private ControlBag $controls;
 
     public function __construct(
@@ -167,6 +172,12 @@ abstract class LdapMessage implements ProtocolElementInterface, PduInterface
         $messageId = $type->getChild(0);
         if (!($messageId instanceof IntegerType)) {
             throw new ProtocolException('Expected an LDAP message ID as an ASN.1 integer type. None received.');
+        }
+
+        // A value outside the range MessageID constrains is not an encoding of that type, so it cannot be parsed
+        // as one. Answering it would mean echoing an ID no conformant peer can accept.
+        if ($messageId->getValue() < 0 || $messageId->getValue() > self::MAX_INT) {
+            throw new ProtocolException('The LDAP message ID is outside the range it is permitted to use.');
         }
         /** @var SequenceType|null $opAsn1 */
         $opAsn1 = $type->getChild(1);

--- a/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Protocol;
 
+use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\AnonBindRequest;
 use FreeDSx\Ldap\Operation\Request\BindRequest;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
@@ -52,6 +53,8 @@ class ServerAuthorization
         } elseif ($request instanceof ExtendedRequest && $request->getName() === ExtendedRequest::OID_START_TLS) {
             return false;
         } elseif ($request instanceof UnbindRequest) {
+            return false;
+        } elseif ($request instanceof AbandonRequest) {
             return false;
         } elseif ($request instanceof BindRequest) {
             return false;

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol;
 
 use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Ldap\Exception\MessageDecodeException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Exception\RequestSizeExceededException;
@@ -62,7 +63,22 @@ readonly class ServerProtocolHandler
         $closeReason = null;
 
         try {
-            while ($message = $this->queue->getMessage()) {
+            while (true) {
+                try {
+                    $message = $this->queue->getMessage();
+                } catch (MessageDecodeException $e) {
+                    # The envelope parsed, so this message can be answered by its ID and the session continues. The
+                    # PDU was consumed before its contents were decoded, so the stream is already past it.
+                    if (!$this->answerDecodeFailure($e)) {
+                        $this->sendNoticeOfDisconnect('The message could not be processed.');
+                        $closeReason = ConnectionObservation::ProtocolError;
+
+                        break;
+                    }
+
+                    continue;
+                }
+
                 $this->dispatchRequest($message);
                 # If a protocol handler closed the TCP connection, then just break here...
                 if (!$this->queue->isConnected()) {
@@ -161,6 +177,33 @@ readonly class ServerProtocolHandler
                 $e->getMessage(),
             ));
         }
+    }
+
+    /**
+     * Answers a decode failure with the response its operation owes, reporting whether one could be framed.
+     *
+     * @throws EncoderException
+     */
+    private function answerDecodeFailure(MessageDecodeException $e): bool
+    {
+        $response = $this->responseFactory->getDecodeFailureResponse(
+            $e->getMessageId(),
+            $e->getProtocolOpTag(),
+            $e->getMessage(),
+        );
+
+        // An operation with no response, or a response tag masquerading as a request, leaves nothing to answer with.
+        if ($response === null) {
+            return false;
+        }
+
+        $this->eventLogger->record(
+            ServerEvent::MessageDecodeFailed,
+            [EventContext::REASON_MESSAGE => $e->getMessage()],
+        );
+        $this->queue->sendMessage($response);
+
+        return true;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/SearchResult.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/SearchResult.php
@@ -17,15 +17,15 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Operation\ResultCode;
 
-final class SearchResult
+final readonly class SearchResult
 {
     /**
      * @param iterable<Entry> $entries
      */
     private function __construct(
-        private readonly iterable $entries,
-        private readonly SearchResultState $state,
-        private readonly string $baseDn = '',
+        private iterable $entries,
+        private SearchResultState $state,
+        private string $matchedDn = '',
     ) {}
 
     /**
@@ -36,13 +36,11 @@ final class SearchResult
      */
     public static function makeSuccessResult(
         iterable $entries,
-        string $baseDn = '',
         ?SearchResultState $state = null,
     ): self {
         return new self(
             $entries,
             $state ?? new SearchResultState(),
-            $baseDn,
         );
     }
 
@@ -53,7 +51,7 @@ final class SearchResult
      */
     public static function makeErrorResult(
         int $resultCode,
-        string $baseDn = '',
+        string $matchedDn = '',
         string $diagnosticMessage = '',
         ?iterable $entries = null,
     ): self {
@@ -67,7 +65,7 @@ final class SearchResult
                 resultCode: $resultCode,
                 diagnosticMessage: $diagnosticMessage,
             ),
-            $baseDn,
+            $matchedDn,
         );
     }
 
@@ -76,14 +74,11 @@ final class SearchResult
      *
      * @param iterable<Entry> $entries
      */
-    public static function makeSizeLimitResult(
-        iterable $entries,
-        string $baseDn = '',
-    ): self {
+    public static function makeSizeLimitResult(iterable $entries): self
+    {
         return new self(
             $entries,
             new SearchResultState(resultCode: ResultCode::SIZE_LIMIT_EXCEEDED),
-            $baseDn,
         );
     }
 
@@ -100,8 +95,11 @@ final class SearchResult
         return $this->state;
     }
 
-    public function getBaseDn(): string
+    /**
+     * Empty unless the target could not be named, which is the only case RFC 4511 §4.1.9 fills matchedDN for.
+     */
+    public function getMatchedDn(): string
     {
-        return $this->baseDn;
+        return $this->matchedDn;
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -256,7 +256,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         if ($generator === null) {
             throw new OperationException(
                 'The paging session could not be resumed.',
-                ResultCode::OPERATIONS_ERROR,
+                ResultCode::UNWILLING_TO_PERFORM,
             );
         }
 
@@ -456,9 +456,10 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
                 ->pagingRequest()
                 ->findByNextCookie($cookie);
         } catch (ProtocolException $e) {
+            // An aged-out session leaves no record, so a resumed one and an invented one answer alike.
             throw new OperationException(
                 $e->getMessage(),
-                ResultCode::OPERATIONS_ERROR,
+                ResultCode::UNWILLING_TO_PERFORM,
             );
         }
     }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -85,16 +85,10 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
                 $token,
             );
             if ($response->isSizeLimitExceeded()) {
-                $searchResult = SearchResult::makeSizeLimitResult(
-                    $response->getEntries(),
-                    (string) $searchRequest->getBaseDn(),
-                );
+                $searchResult = SearchResult::makeSizeLimitResult($response->getEntries());
                 $controls[] = new PagingControl(0, '');
             } else {
-                $searchResult = SearchResult::makeSuccessResult(
-                    $response->getEntries(),
-                    (string) $searchRequest->getBaseDn(),
-                );
+                $searchResult = SearchResult::makeSuccessResult($response->getEntries());
                 $controls[] = new PagingControl(
                     $response->getRemaining(),
                     $response->isComplete()

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -354,6 +354,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
 
                 $page[] = $projection->project($filtered);
 
+                // Deliberate: the limit bounds each page rather than the whole paged operation.
                 if ($sizeLimit > 0 && count($page) >= $sizeLimit) {
                     $generator->next();
                     break;

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -62,6 +62,22 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
 
         $this->assertBaseDnProvided($request);
 
+        $sortControl = $this->sortingControl($message);
+        $sortResponse = $this->sortingResponseControl(
+            $sortControl,
+            $this->schema,
+        );
+
+        $refusal = $this->refuseUnsortableCriticalSearch(
+            $message,
+            $sortControl,
+            $sortResponse,
+        );
+
+        if ($refusal !== null) {
+            return $refusal;
+        }
+
         $backendResult = $this->backend->search(
             $request,
             $this->subentryVisibility($message->controls()),
@@ -85,10 +101,6 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
             $state,
         );
 
-        $sortResponse = $this->sortingResponseControl(
-            $this->sortingControl($message),
-            $this->schema,
-        );
         $responseControls = $sortResponse !== null
             ? [$sortResponse]
             : [];

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -82,7 +82,6 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
                 $token,
                 $projection,
             ),
-            (string) $request->getBaseDn(),
             $state,
         );
 

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
@@ -32,6 +32,8 @@ use FreeDSx\Ldap\Protocol\LdapMessage;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\Response\Cancellation;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
+use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\Subentry\SubentryVisibility;
 use Generator;
@@ -260,6 +262,35 @@ trait ServerSearchTrait
     }
 
     /**
+     * RFC 2891 §1.2: a critical sort the server cannot honor fails the search and returns no entries.
+     */
+    private function refuseUnsortableCriticalSearch(
+        LdapMessageRequest $message,
+        ?SortingControl $sortControl,
+        ?SortingResponseControl $sortResponse,
+    ): ?ResponseStream {
+        if ($sortControl === null || !$sortControl->getCriticality()) {
+            return null;
+        }
+
+        if ($sortResponse === null || $sortResponse->getResult() === ResultCode::SUCCESS) {
+            return null;
+        }
+
+        return ResponseStream::of(
+            [new LdapMessageResponse(
+                $message->getMessageId(),
+                new SearchResultDone(
+                    ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
+                    diagnosticMessage: 'The requested sort could not be performed.',
+                ),
+                $sortResponse,
+            )],
+            OperationOutcomeResult::failed(ResultCode::UNAVAILABLE_CRITICAL_EXTENSION),
+        );
+    }
+
+    /**
      * The RFC 2891 sort response control, with the result code per §1.2 (first unsortable key wins).
      */
     private function sortingResponseControl(
@@ -270,9 +301,20 @@ trait ServerSearchTrait
             return null;
         }
 
+        $seen = [];
+
         foreach ($sortControl->getSortKeys() as $sortKey) {
             $attribute = $sortKey->getAttribute();
             $attributeType = $schema->getAttributeType($attribute);
+
+            // RFC 2891 §1.1: an attribute type should occur in the key list only once.
+            if (isset($seen[strtolower($attribute)])) {
+                return new SortingResponseControl(
+                    ResultCode::UNWILLING_TO_PERFORM,
+                    $attribute,
+                );
+            }
+            $seen[strtolower($attribute)] = true;
 
             if ($attributeType === null) {
                 return new SortingResponseControl(

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
@@ -71,10 +71,7 @@ trait ServerSearchTrait
         if ($cancelSignal !== null && $cancellation->isCanceled()) {
             yield new LdapMessageResponse(
                 $messageId,
-                new SearchResultDone(
-                    ResultCode::CANCELED,
-                    $searchResult->getBaseDn(),
-                ),
+                new SearchResultDone(ResultCode::CANCELED),
             );
             yield new LdapMessageResponse(
                 $cancelSignal->getMessageId(),
@@ -88,7 +85,7 @@ trait ServerSearchTrait
             $messageId,
             new SearchResultDone(
                 $state->resultCode,
-                $searchResult->getBaseDn(),
+                $searchResult->getMatchedDn(),
                 $state->diagnosticMessage,
             ),
             ...$controls,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
@@ -28,6 +28,7 @@ use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessage;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\Response\Cancellation;
@@ -94,6 +95,9 @@ trait ServerSearchTrait
         );
     }
 
+    /**
+     * @throws OperationException
+     */
     private function getSearchRequestFromMessage(LdapMessageRequest $message): SearchRequest
     {
         $request = $message->getRequest();
@@ -104,7 +108,61 @@ trait ServerSearchTrait
                 get_class($request),
             ));
         }
+
+        $this->assertSearchParametersInRange($request);
+
         return $request;
+    }
+
+    /**
+     * Rejects RFC 4511 4.5.1 field values the decoder admits but the ASN.1 constraints do not.
+     *
+     * The decoder checks each field's type and stops there, so an out-of-range value would otherwise be coerced
+     * into a working request: an unknown scope reads as one level, and a negative sizeLimit defeats the server
+     * maximum entirely.
+     *
+     * @throws OperationException
+     */
+    private function assertSearchParametersInRange(SearchRequest $request): void
+    {
+        // An unknown scope must not silently become a scope the client did not ask for.
+        if (!in_array($request->getScope(), SearchRequest::SUPPORTED_SCOPES, true)) {
+            throw new OperationException(
+                'The search scope requested is not supported.',
+                ResultCode::PROTOCOL_ERROR,
+            );
+        }
+
+        if (!in_array($request->getDereferenceAliases(), SearchRequest::DEREF_VALUES, true)) {
+            throw new OperationException(
+                'The alias dereferencing value requested is not valid.',
+                ResultCode::PROTOCOL_ERROR,
+            );
+        }
+
+        $this->assertWithinMaxInt(
+            $request->getSizeLimit(),
+            'size limit',
+        );
+        $this->assertWithinMaxInt(
+            $request->getTimeLimit(),
+            'time limit',
+        );
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function assertWithinMaxInt(
+        int $value,
+        string $field,
+    ): void {
+        if ($value < 0 || $value > LdapMessage::MAX_INT) {
+            throw new OperationException(
+                sprintf('The %s requested is outside the permitted range.', $field),
+                ResultCode::PROTOCOL_ERROR,
+            );
+        }
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSyncHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSyncHandler.php
@@ -185,10 +185,7 @@ final class ServerSyncHandler implements ServerProtocolHandlerInterface
 
         yield new LdapMessageResponse(
             $messageId,
-            new SearchResultDone(
-                ResultCode::SUCCESS,
-                $baseDn->toString(),
-            ),
+            new SearchResultDone(ResultCode::SUCCESS),
             $doneControl,
         );
     }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/UpdateOperation.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/UpdateOperation.php
@@ -54,6 +54,15 @@ final class UpdateOperation
         Change $change,
     ): void {
         $attribute = $change->getAttribute();
+
+        // Legal to encode, but it would leave an attribute holding no values, which an entry cannot carry.
+        if ($attribute->getValues() === []) {
+            throw new OperationException(
+                sprintf('The add of attribute "%s" requires values.', $attribute->getName()),
+                ResultCode::PROTOCOL_ERROR,
+            );
+        }
+
         $existing = $entry->get($attribute, true);
 
         if ($existing === null) {

--- a/src/FreeDSx/Ldap/Server/Backend/Write/WriteCommandFactory.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/WriteCommandFactory.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Text;
 use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\MoveCommand;
@@ -63,6 +64,14 @@ final class WriteCommandFactory
         if ($request->getNewRdn()->hasUnescapedComma()) {
             throw new OperationException(
                 'The new RDN contains an unescaped comma.',
+                ResultCode::INVALID_DN_SYNTAX,
+            );
+        }
+
+        // A RelativeLDAPDN is an LDAPString, so bytes that do not spell one cannot name an entry.
+        if (!Text::isUtf8($request->getNewRdn()->toString())) {
+            throw new OperationException(
+                'The new RDN is not encoded as UTF-8.',
                 ResultCode::INVALID_DN_SYNTAX,
             );
         }

--- a/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
+++ b/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
@@ -58,6 +58,7 @@ use FreeDSx\Ldap\Server\Middleware\BindMiddleware;
 use FreeDSx\Ldap\Server\Middleware\ConfidentialAttributeMiddleware;
 use FreeDSx\Ldap\Server\Middleware\ConfidentialityMiddleware;
 use FreeDSx\Ldap\Server\Middleware\CriticalControlMiddleware;
+use FreeDSx\Ldap\Server\Middleware\CriticalControlValidator;
 use FreeDSx\Ldap\Server\Middleware\MetricsMiddleware;
 use FreeDSx\Ldap\Server\Middleware\OperationAuditMiddleware;
 use FreeDSx\Ldap\Server\Middleware\OperationAuthorizationMiddleware;
@@ -397,6 +398,7 @@ final class ConnectionHandlerBuilder implements ConnectionHandlerBuilderInterfac
                 new BindMiddleware(
                     $authorization,
                     new Authenticator($authenticators),
+                    $this->container->get(CriticalControlValidator::class),
                 ),
                 new AuthorizationResolutionMiddleware(
                     $dispatchAuthorizer,

--- a/src/FreeDSx/Ldap/Server/Logging/ServerEvent.php
+++ b/src/FreeDSx/Ldap/Server/Logging/ServerEvent.php
@@ -48,6 +48,7 @@ enum ServerEvent: string
     case PagingSessionEvicted           = 'paging.session_evicted';
     case JournalPruned                  = 'journal.pruned';
     case JournalPruneFailed             = 'journal.prune_failed';
+    case MessageDecodeFailed            = 'message.decode_failed';
     case NoticeOfDisconnectSent         = 'session.disconnect_notice';
     case WriteTimeout                   = 'session.write_timeout';
     case IdleTimeout                    = 'session.idle_timeout';
@@ -73,6 +74,7 @@ enum ServerEvent: string
             self::CriticalControlRejected,
             self::OperationRefused,
             self::SchemaViolation,
+            self::MessageDecodeFailed,
             self::NoticeOfDisconnectSent,
             self::WriteTimeout,
             self::IdleTimeout,

--- a/src/FreeDSx/Ldap/Server/Middleware/BindMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/BindMiddleware.php
@@ -35,6 +35,7 @@ final readonly class BindMiddleware implements MiddlewareInterface
     public function __construct(
         private ServerAuthorization $authorization,
         private Authenticator $authenticator,
+        private CriticalControlValidator $criticalControls,
     ) {}
 
     /**
@@ -52,6 +53,10 @@ final readonly class BindMiddleware implements MiddlewareInterface
 
         // RFC 4511 §4.2.1: a bind discards any prior authentication; a failed bind leaves the session anonymous.
         $this->authorization->setToken(new AnonToken());
+
+        // Checked here because the authenticator writes the response itself.
+        // RFC 4511 §4.1.11 refuses the operation before it is performed.
+        $this->criticalControls->assertSupportedForBind($context->message->controls());
 
         if (!$this->authorization->isAuthenticationTypeSupported($request)) {
             throw new OperationException(

--- a/src/FreeDSx/Ldap/Server/Middleware/CriticalControlMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/CriticalControlMiddleware.php
@@ -13,20 +13,17 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Middleware;
 
-use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Exception\OperationException;
-use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Factory\HandlerRouteResolverInterface;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
 
-use function in_array;
-use function sprintf;
-
 /**
  * Rejects requests carrying a critical control the resolved handler does not support (RFC 4511 §4.1.11).
+ *
+ * Note: A bind never reaches here, since it answers above this point. It runs the same check itself.
  *
  * @internal
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
@@ -35,7 +32,7 @@ final readonly class CriticalControlMiddleware implements MiddlewareInterface
 {
     public function __construct(
         private HandlerRouteResolverInterface $routeResolver,
-        private ServerControlRegistry $controlRegistry = new ServerControlRegistry(),
+        private CriticalControlValidator $validator = new CriticalControlValidator(),
     ) {}
 
     /**
@@ -46,40 +43,15 @@ final readonly class CriticalControlMiddleware implements MiddlewareInterface
         MiddlewareHandlerInterface $next,
     ): ResponseStream {
         $controls = $context->message->controls();
-        $routeId = $this->routeResolver->routeIdFor(
-            $context->message->getRequest(),
+
+        $this->validator->assertSupportedForRoute(
+            $this->routeResolver->routeIdFor(
+                $context->message->getRequest(),
+                $controls,
+            ),
             $controls,
         );
 
-        if ($this->controlRegistry->appliesTo($routeId)) {
-            $this->assertNoCriticalUnsupportedControls(
-                $controls,
-                $this->controlRegistry->supportedControlsFor($routeId),
-            );
-        }
-
         return $next->handle($context);
-    }
-
-    /**
-     * @param list<string> $supported
-     * @throws OperationException
-     */
-    private function assertNoCriticalUnsupportedControls(
-        ControlBag $controls,
-        array $supported,
-    ): void {
-        foreach ($controls as $control) {
-            if (!$control->getCriticality()) {
-                continue;
-            }
-
-            if (!in_array($control->getTypeOid(), $supported, true)) {
-                throw new OperationException(
-                    sprintf('Critical control %s is not supported.', $control->getTypeOid()),
-                    ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
-                );
-            }
-        }
     }
 }

--- a/src/FreeDSx/Ldap/Server/Middleware/CriticalControlValidator.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/CriticalControlValidator.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Middleware;
+
+use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Factory\HandlerId;
+
+use function in_array;
+use function sprintf;
+
+/**
+ * The RFC 4511 §4.1.11 check, shared by the pipeline and by the bind.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class CriticalControlValidator
+{
+    public function __construct(private ServerControlRegistry $controlRegistry = new ServerControlRegistry()) {}
+
+    /**
+     * @throws OperationException
+     */
+    public function assertSupportedForRoute(
+        HandlerId $routeId,
+        ControlBag $controls,
+    ): void {
+        if (!$this->controlRegistry->appliesTo($routeId)) {
+            return;
+        }
+
+        $this->assertNoCriticalUnsupportedControls(
+            $controls,
+            $this->controlRegistry->supportedControlsFor($routeId),
+        );
+    }
+
+    /**
+     * @throws OperationException
+     */
+    public function assertSupportedForBind(ControlBag $controls): void
+    {
+        $this->assertNoCriticalUnsupportedControls(
+            $controls,
+            $this->controlRegistry->supportedControlsForBind(),
+        );
+    }
+
+    /**
+     * @param list<string> $supported
+     *
+     * @throws OperationException
+     */
+    private function assertNoCriticalUnsupportedControls(
+        ControlBag $controls,
+        array $supported,
+    ): void {
+        foreach ($controls as $control) {
+            if (!$control->getCriticality()) {
+                continue;
+            }
+
+            if (!in_array($control->getTypeOid(), $supported, true)) {
+                throw new OperationException(
+                    sprintf('Critical control %s is not supported.', $control->getTypeOid()),
+                    ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
+                );
+            }
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Middleware/ServerControlRegistry.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/ServerControlRegistry.php
@@ -46,6 +46,22 @@ final class ServerControlRegistry
         HandlerId::Unbind,
     ];
 
+    /**
+     * A bind is answered in middleware rather than routed to a handler, so it has no HandlerId to look up.
+     *
+     * Proxied authorization is absent deliberately: RFC 4370 §3 does not list Bind among the operations it may
+     * accompany, and its criticality must be TRUE, so it can only ever be refused here.
+     *
+     * @return list<string>
+     */
+    public function supportedControlsForBind(): array
+    {
+        return [
+            Control::OID_MANAGE_DSA_IT,
+            Control::OID_PWD_POLICY,
+        ];
+    }
+
     public function appliesTo(HandlerId $id): bool
     {
         return !in_array(

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyProtocolFactory.php
@@ -26,6 +26,7 @@ use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Middleware\AuthorizationResolutionMiddleware;
 use FreeDSx\Ldap\Server\Middleware\BindMiddleware;
 use FreeDSx\Ldap\Server\Middleware\ConfidentialityMiddleware;
+use FreeDSx\Ldap\Server\Middleware\CriticalControlValidator;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareChain;
 use FreeDSx\Ldap\Server\Middleware\RequestValidationMiddleware;
 use FreeDSx\Ldap\Server\ServerConnectionScaffoldingTrait;
@@ -85,6 +86,7 @@ final class ProxyProtocolFactory implements ServerProtocolFactoryInterface
                 new BindMiddleware(
                     $serverAuthorization,
                     new Authenticator($authenticators),
+                    new CriticalControlValidator(),
                 ),
                 new AuthorizationResolutionMiddleware(
                     new DispatchAuthorizer($serverAuthorization),

--- a/src/FreeDSx/Ldap/Sync/Provider/SyncPersistStreamer.php
+++ b/src/FreeDSx/Ldap/Sync/Provider/SyncPersistStreamer.php
@@ -200,10 +200,7 @@ final readonly class SyncPersistStreamer
     ): Generator {
         yield new LdapMessageResponse(
             $messageId,
-            new SearchResultDone(
-                ResultCode::CANCELED,
-                $baseDn->toString(),
-            ),
+            new SearchResultDone(ResultCode::CANCELED),
             new SyncDoneControl(
                 (new SyncCookie($origin, $lastSeq))->encode(),
                 true,

--- a/tests/integration/Storage/Concern/BindTestsTrait.php
+++ b/tests/integration/Storage/Concern/BindTestsTrait.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Tests\Integration\FreeDSx\Ldap\Storage\Concern;
 
+use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Exception\BindException;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
 
 /**
  * Authentication against the backend.
@@ -42,5 +45,40 @@ trait BindTestsTrait
         $this->expectException(BindException::class);
 
         $this->ldapClient()->bind('cn=nobody,dc=foo,dc=bar', '12345');
+    }
+
+    public function testBindCarryingAnUnsupportedCriticalControlIsRefused(): void
+    {
+        try {
+            $this->ldapClient()->bind(
+                'cn=user,dc=foo,dc=bar',
+                '12345',
+                new Control('1.2.3.4.5', criticality: true),
+            );
+            self::fail('The unsupported critical control should have been refused.');
+        } catch (BindException $e) {
+            self::assertSame(
+                ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
+                $e->getCode(),
+            );
+        }
+
+        // The bind must not have taken effect, so the session is still anonymous.
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+        $this->ldapClient()->compare('cn=user,dc=foo,dc=bar', 'cn', 'user');
+    }
+
+    public function testBindCarryingANonCriticalUnsupportedControlSucceeds(): void
+    {
+        $this->ldapClient()->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+            new Control('1.2.3.4.5', criticality: false),
+        );
+
+        self::assertTrue(
+            $this->ldapClient()->compare('cn=user,dc=foo,dc=bar', 'cn', 'user'),
+        );
     }
 }

--- a/tests/integration/Storage/Concern/BindTestsTrait.php
+++ b/tests/integration/Storage/Concern/BindTestsTrait.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Operations;
 
 /**
  * Authentication against the backend.
@@ -45,6 +46,18 @@ trait BindTestsTrait
         $this->expectException(BindException::class);
 
         $this->ldapClient()->bind('cn=nobody,dc=foo,dc=bar', '12345');
+    }
+
+    public function testAnUnauthenticatedAbandonDrawsNoResponse(): void
+    {
+        self::assertNull($this->ldapClient()->send(Operations::abandon(99)));
+
+        // A response to the abandon would be read here instead of the bind's own, so this proves none was sent.
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        self::assertTrue(
+            $this->ldapClient()->compare('cn=user,dc=foo,dc=bar', 'cn', 'user'),
+        );
     }
 
     public function testBindCarryingAnUnsupportedCriticalControlIsRefused(): void

--- a/tests/integration/Storage/Concern/ControlTestsTrait.php
+++ b/tests/integration/Storage/Concern/ControlTestsTrait.php
@@ -13,9 +13,12 @@ declare(strict_types=1);
 
 namespace Tests\Integration\FreeDSx\Ldap\Storage\Concern;
 
+use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\Sorting\SortingControl;
 use FreeDSx\Ldap\Control\Sorting\SortKey;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Search\Filters;
 
@@ -64,6 +67,70 @@ trait ControlTestsTrait
 
         // After abandonment, hasEntries() must return false
         self::assertFalse($paging->hasEntries());
+    }
+
+    /**
+     * RFC 2696 3 prescribes this when a client resumes a paged search the server aged out.
+     */
+    public function testResumingAnAgedOutPagingSessionIsUnwillingToPerform(): void
+    {
+        $this->stopServer();
+        $this->createServerProcess(
+            'tcp',
+            [
+                ...static::storageExtraArgs(),
+                '--max-paging-sessions=1',
+            ],
+        );
+        $this->authenticateUser();
+
+        $search = Operations::search(Filters::present('objectClass'))
+            ->base('dc=foo,dc=bar')
+            ->useSubtreeScope();
+
+        $first = $this->ldapClient()->paging($search, 1);
+        $first->getEntries();
+
+        // Starting a second session at the cap ages the first one out.
+        $second = $this->ldapClient()->paging($search, 1);
+        $second->getEntries();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
+
+        $first->getEntries();
+    }
+
+    public function testAMalformedControlValueIsAnsweredWithoutEndingTheSession(): void
+    {
+        $this->authenticateUser();
+
+        $search = Operations::search(Filters::present('objectClass'))
+            ->base('dc=foo,dc=bar')
+            ->useSubtreeScope();
+
+        try {
+            $this->ldapClient()->search(
+                $search,
+                new Control(
+                    Control::OID_PAGING,
+                    false,
+                    'not-a-paging-control',
+                ),
+            );
+            self::fail('The malformed control value should have been refused.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::PROTOCOL_ERROR,
+                $e->getCode(),
+            );
+        }
+
+        // The same connection must still serve requests, which is the whole point of answering rather than closing.
+        self::assertCount(
+            8,
+            $this->ldapClient()->search($search),
+        );
     }
 
     public function testSortControlAscendingOrdersResults(): void

--- a/tests/integration/Storage/Concern/ControlTestsTrait.php
+++ b/tests/integration/Storage/Concern/ControlTestsTrait.php
@@ -15,6 +15,7 @@ namespace Tests\Integration\FreeDSx\Ldap\Storage\Concern;
 
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\Sorting\SortingControl;
+use FreeDSx\Ldap\Control\Sorting\SortingResponseControl;
 use FreeDSx\Ldap\Control\Sorting\SortKey;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
@@ -99,6 +100,68 @@ trait ControlTestsTrait
         $this->expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
 
         $first->getEntries();
+    }
+
+    public function testACriticalSortThatCannotBePerformedFailsTheSearch(): void
+    {
+        $this->authenticateUser();
+
+        try {
+            $this->ldapClient()->search(
+                Operations::search(Filters::present('objectClass'))
+                    ->base('dc=foo,dc=bar')
+                    ->useSubtreeScope(),
+                (new SortingControl(SortKey::ascending('bogusAttr')))->setCriticality(true),
+            );
+            self::fail('The critical sort should have failed the search.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
+                $e->getCode(),
+            );
+        }
+    }
+
+    public function testANonCriticalSortThatCannotBePerformedStillReturnsEntries(): void
+    {
+        $this->authenticateUser();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+            new SortingControl(SortKey::ascending('bogusAttr')),
+        );
+
+        self::assertCount(
+            8,
+            $entries,
+        );
+    }
+
+    public function testARepeatedSortKeyAttributeIsRefusedInTheSortResult(): void
+    {
+        $this->authenticateUser();
+
+        $response = $this->ldapClient()->send(
+            Operations::search(Filters::present('objectClass'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+            new SortingControl(
+                SortKey::ascending('sn'),
+                SortKey::descending('sn'),
+            ),
+        );
+
+        $sortResponse = $response?->controls()->get(Control::OID_SORTING_RESPONSE);
+        self::assertInstanceOf(
+            SortingResponseControl::class,
+            $sortResponse,
+        );
+        self::assertSame(
+            ResultCode::UNWILLING_TO_PERFORM,
+            $sortResponse->getResult(),
+        );
     }
 
     public function testAMalformedControlValueIsAnsweredWithoutEndingTheSession(): void

--- a/tests/integration/Storage/Concern/QueryTestsTrait.php
+++ b/tests/integration/Storage/Concern/QueryTestsTrait.php
@@ -1010,4 +1010,73 @@ trait QueryTestsTrait
         $this->expectExceptionCode(ResultCode::ALIAS_DEREFERENCING_PROBLEM);
         $this->ldapClient()->search($derefRequest);
     }
+
+    /**
+     * RFC 4511 4.5.1 constrains these fields, and the decoder only checks their type, so an out-of-range value
+     * would otherwise be coerced into a request the client never made.
+     *
+     * @return iterable<string, array{SearchRequest}>
+     */
+    public static function outOfRangeSearchParameterProvider(): iterable
+    {
+        yield 'a scope above the enumeration' => [
+            self::rangeProbeRequest()->setScope(3),
+        ];
+        yield 'a negative scope' => [
+            self::rangeProbeRequest()->setScope(-1),
+        ];
+        yield 'an alias value above the enumeration' => [
+            self::rangeProbeRequest()->setDereferenceAliases(4),
+        ];
+        yield 'a negative size limit' => [
+            self::rangeProbeRequest()->setSizeLimit(-1),
+        ];
+        yield 'a negative time limit' => [
+            self::rangeProbeRequest()->setTimeLimit(-1),
+        ];
+    }
+
+    #[DataProvider('outOfRangeSearchParameterProvider')]
+    public function test_a_search_parameter_outside_its_range_is_a_protocol_error(SearchRequest $request): void
+    {
+        $this->authenticateUser();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::PROTOCOL_ERROR);
+
+        $this->ldapClient()->search($request);
+    }
+
+    /**
+     * The clamp is applied with min(), so a negative limit would win it and lift the ceiling entirely.
+     */
+    public function testANegativeSizeLimitCannotDefeatTheServerMaximum(): void
+    {
+        $this->stopServer();
+        $this->createServerProcess(
+            'tcp',
+            [
+                ...static::storageExtraArgs(),
+                '--seed-entries=10',
+                '--max-search-size=2',
+            ],
+        );
+        $this->authenticateUser();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::PROTOCOL_ERROR);
+
+        $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope()
+                ->setSizeLimit(-1),
+        );
+    }
+
+    private static function rangeProbeRequest(): SearchRequest
+    {
+        return Operations::search(Filters::present('objectClass'))
+            ->base('dc=foo,dc=bar');
+    }
 }

--- a/tests/integration/Storage/Concern/QueryTestsTrait.php
+++ b/tests/integration/Storage/Concern/QueryTestsTrait.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
@@ -1072,6 +1073,50 @@ trait QueryTestsTrait
                 ->useSubtreeScope()
                 ->setSizeLimit(-1),
         );
+    }
+
+    public function testMatchedDnIsEmptyOnASuccessfulSearch(): void
+    {
+        $this->authenticateUser();
+
+        $response = $this->ldapClient()->send(
+            Operations::search(Filters::present('objectClass'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+
+        $done = $response?->getResponse();
+        self::assertInstanceOf(
+            SearchResultDone::class,
+            $done,
+        );
+        self::assertSame(
+            '',
+            $done->getDn()->toString(),
+        );
+    }
+
+    public function testMatchedDnNamesTheClosestAncestorWhenTheBaseIsMissing(): void
+    {
+        $this->authenticateUser();
+
+        try {
+            $this->ldapClient()->search(
+                Operations::search(Filters::present('objectClass'))
+                    ->base('cn=nope,ou=people,dc=foo,dc=bar')
+                    ->useSubtreeScope(),
+            );
+            self::fail('The missing base should have been refused.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::NO_SUCH_OBJECT,
+                $e->getCode(),
+            );
+            self::assertSame(
+                'ou=people,dc=foo,dc=bar',
+                $e->getMatchedDn()?->toString(),
+            );
+        }
     }
 
     private static function rangeProbeRequest(): SearchRequest

--- a/tests/integration/Storage/Concern/WriteTestsTrait.php
+++ b/tests/integration/Storage/Concern/WriteTestsTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Integration\FreeDSx\Ldap\Storage\Concern;
 
 use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
@@ -71,6 +72,62 @@ trait WriteTestsTrait
         self::assertSame(
             ['tagged'],
             $tagged->get(new Attribute('cn'), true)?->getValues(),
+        );
+    }
+
+    public function testAddRejectsAnAttributeCarryingNoValues(): void
+    {
+        $this->authenticateAdmin();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::PROTOCOL_ERROR);
+
+        $this->ldapClient()->create(new Entry(
+            'cn=novalues,dc=foo,dc=bar',
+            new Attribute('objectClass', 'inetOrgPerson'),
+            new Attribute('cn', 'novalues'),
+            new Attribute('sn', 'Novalues'),
+            new Attribute('description'),
+        ));
+    }
+
+    public function testModifyRejectsAnAddCarryingNoValues(): void
+    {
+        $this->authenticateAdmin();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::PROTOCOL_ERROR);
+
+        $this->ldapClient()->send(Operations::modify(
+            'cn=alice,ou=people,dc=foo,dc=bar',
+            Change::add(new Attribute('description')),
+        ));
+    }
+
+    public function testRenameToANewRdnThatIsNotUtf8IsRefused(): void
+    {
+        $this->authenticateAdmin();
+
+        try {
+            $this->ldapClient()->rename(
+                'cn=alice,ou=people,dc=foo,dc=bar',
+                "cn=\xFF\xFE",
+            );
+            self::fail('The new RDN that is not UTF-8 should have been refused.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INVALID_DN_SYNTAX,
+                $e->getCode(),
+            );
+        }
+
+        self::assertCount(
+            1,
+            $this->ldapClient()->search(
+                Operations::search(Filters::equal('cn', 'alice'))
+                    ->base('dc=foo,dc=bar')
+                    ->useSubtreeScope(),
+            ),
         );
     }
 

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -207,6 +207,13 @@ final class LdapBackendStorageCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Maximum entries returned per search (0 = no limit)',
                 '0',
+            )
+            ->addOption(
+                'max-paging-sessions',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Maximum concurrent paging sessions before the oldest is aged out',
+                '25',
             );
     }
 
@@ -299,6 +306,7 @@ final class LdapBackendStorageCommand extends Command
             ->setMonitorEnabled((bool) $input->getOption('monitor'))
             ->setMaxSearchLookthrough((int) $this->getStringOption($input, 'max-search-lookthrough'))
             ->setMaxSearchSize((int) $this->getStringOption($input, 'max-search-size'))
+            ->setMaxPagingSessions((int) $this->getStringOption($input, 'max-paging-sessions'))
             ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL));
 
         $this->applyJournalMode($serverOptions, $input);

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -200,6 +200,13 @@ final class LdapBackendStorageCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Maximum entries examined per search before adminLimitExceeded (0 = no limit)',
                 '0',
+            )
+            ->addOption(
+                'max-search-size',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Maximum entries returned per search (0 = no limit)',
+                '0',
             );
     }
 
@@ -291,6 +298,7 @@ final class LdapBackendStorageCommand extends Command
             ->setAdministrators(Subject::group('cn=admins,dc=foo,dc=bar'))
             ->setMonitorEnabled((bool) $input->getOption('monitor'))
             ->setMaxSearchLookthrough((int) $this->getStringOption($input, 'max-search-lookthrough'))
+            ->setMaxSearchSize((int) $this->getStringOption($input, 'max-search-size'))
             ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL));
 
         $this->applyJournalMode($serverOptions, $input);

--- a/tests/unit/Protocol/LdapMessageRequestTest.php
+++ b/tests/unit/Protocol/LdapMessageRequestTest.php
@@ -17,9 +17,13 @@ use FreeDSx\Asn1\Asn1;
 use FreeDSx\Asn1\Type\IncompleteType;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
+use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Protocol\LdapEncoder;
+use FreeDSx\Ldap\Protocol\LdapMessage;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class LdapMessageRequestTest extends TestCase
@@ -80,5 +84,44 @@ final class LdapMessageRequestTest extends TestCase
 
         self::assertTrue($message->controls()->has(Control::OID_PWD_POLICY));
         self::assertNull($message->controls()->getByClass(PwdPolicyResponseControl::class));
+    }
+
+    #[DataProvider('outOfRangeMessageIdProvider')]
+    public function test_it_refuses_a_message_id_outside_the_permitted_range(int $messageId): void
+    {
+        self::expectException(ProtocolException::class);
+        self::expectExceptionMessage('The LDAP message ID is outside the range it is permitted to use.');
+
+        LdapMessageRequest::fromAsn1(Asn1::sequence(
+            Asn1::integer($messageId),
+            Asn1::application(10, Asn1::octetString('dc=foo,dc=bar')),
+        ));
+    }
+
+    public static function outOfRangeMessageIdProvider(): Generator
+    {
+        yield 'negative' => [-1];
+        yield 'above maxInt' => [LdapMessage::MAX_INT + 1];
+    }
+
+    #[DataProvider('inRangeMessageIdProvider')]
+    public function test_it_accepts_a_message_id_at_the_edge_of_the_permitted_range(int $messageId): void
+    {
+        $message = LdapMessageRequest::fromAsn1(Asn1::sequence(
+            Asn1::integer($messageId),
+            Asn1::application(10, Asn1::octetString('dc=foo,dc=bar')),
+        ));
+
+        self::assertSame(
+            $messageId,
+            $message->getMessageId(),
+        );
+    }
+
+    public static function inRangeMessageIdProvider(): Generator
+    {
+        // Zero is in range here; it is refused later as reserved rather than as an unparseable ID.
+        yield 'zero' => [0];
+        yield 'maxInt' => [LdapMessage::MAX_INT];
     }
 }

--- a/tests/unit/Protocol/LdapMessageRequestTest.php
+++ b/tests/unit/Protocol/LdapMessageRequestTest.php
@@ -17,6 +17,8 @@ use FreeDSx\Asn1\Asn1;
 use FreeDSx\Asn1\Type\IncompleteType;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
+use FreeDSx\Asn1\Type\SequenceType;
+use FreeDSx\Ldap\Exception\MessageDecodeException;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Protocol\LdapEncoder;
@@ -123,5 +125,83 @@ final class LdapMessageRequestTest extends TestCase
         // Zero is in range here; it is refused later as reserved rather than as an unparseable ID.
         yield 'zero' => [0];
         yield 'maxInt' => [LdapMessage::MAX_INT];
+    }
+
+    public function test_a_failure_inside_the_operation_names_the_message_it_belongs_to(): void
+    {
+        try {
+            LdapMessageRequest::fromAsn1(self::addRequestWithNoValues());
+            self::fail('The valueless attribute should have been refused.');
+        } catch (MessageDecodeException $e) {
+            self::assertSame(
+                4,
+                $e->getMessageId(),
+            );
+            self::assertSame(
+                8,
+                $e->getProtocolOpTag(),
+            );
+        }
+    }
+
+    public function test_a_failure_inside_a_control_names_the_message_it_belongs_to(): void
+    {
+        $encoder = new LdapEncoder();
+
+        try {
+            LdapMessageRequest::fromAsn1(Asn1::sequence(
+                Asn1::integer(7),
+                Asn1::application(10, Asn1::octetString('dc=foo,dc=bar')),
+                Asn1::context(0, (new IncompleteType($encoder->encode(
+                    (new Control(Control::OID_PAGING, false, 'not-a-paging-control'))->toAsn1(),
+                )))->setIsConstructed(true)),
+            ));
+            self::fail('The malformed control value should have been refused.');
+        } catch (MessageDecodeException $e) {
+            self::assertSame(
+                7,
+                $e->getMessageId(),
+            );
+            self::assertSame(
+                10,
+                $e->getProtocolOpTag(),
+            );
+        }
+    }
+
+    /**
+     * An unrecognized operation cannot be answered, so it must stay a plain failure that ends the session.
+     */
+    public function test_an_unrecognized_operation_is_not_answerable(): void
+    {
+        try {
+            LdapMessageRequest::fromAsn1(Asn1::sequence(
+                Asn1::integer(3),
+                Asn1::application(30, Asn1::octetString('nope')),
+            ));
+            self::fail('The unrecognized operation should have been refused.');
+        } catch (ProtocolException $e) {
+            self::assertNotInstanceOf(
+                MessageDecodeException::class,
+                $e,
+            );
+        }
+    }
+
+    /**
+     * @return SequenceType<mixed>
+     */
+    private static function addRequestWithNoValues(): SequenceType
+    {
+        return Asn1::sequence(
+            Asn1::integer(4),
+            Asn1::application(8, Asn1::sequence(
+                Asn1::octetString('cn=foo,dc=foo,dc=bar'),
+                Asn1::sequenceOf(Asn1::sequence(
+                    Asn1::octetString('cn'),
+                    Asn1::setOf(),
+                )),
+            )),
+        );
     }
 }

--- a/tests/unit/Protocol/ServerAuthorizationTest.php
+++ b/tests/unit/Protocol/ServerAuthorizationTest.php
@@ -83,6 +83,13 @@ final class ServerAuthorizationTest extends TestCase
         ));
     }
 
+    public function test_it_should_not_require_authentication_for_an_abandon_request(): void
+    {
+        self::assertFalse($this->subject->isAuthenticationRequired(
+            Operations::abandon(1),
+        ));
+    }
+
     public function test_it_should_not_require_authentication_for_a_rootdse_request(): void
     {
         self::assertFalse($this->subject->isAuthenticationRequired(
@@ -187,7 +194,6 @@ final class ServerAuthorizationTest extends TestCase
             [Operations::add(Entry::fromArray(''))],
             [Operations::delete('cn=foo')],
             [Operations::rename('cn=foo', 'cn=foo')],
-            [Operations::abandon(1)],
             [Operations::passwordModify('', '', '')],
             [Operations::modify('cn=foo', Change::reset('foo'))],
             [Operations::compare('cn=foo', 'foo', 'bar')],

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
@@ -259,7 +259,7 @@ class ServerPagingHandlerTest extends TestCase
         );
     }
 
-    public function test_it_sends_an_operations_error_when_the_paging_generator_has_expired(): void
+    public function test_it_is_unwilling_to_perform_when_the_paging_generator_has_expired(): void
     {
         // A paging request exists and has been processed, but its generator was never stored
         // (simulating a session that expired or was evicted).
@@ -291,7 +291,7 @@ class ServerPagingHandlerTest extends TestCase
         self::assertSame([], $this->entryMessages());
         $done = $this->doneMessage()->getResponse();
         self::assertInstanceOf(SearchResultDone::class, $done);
-        self::assertSame(ResultCode::OPERATIONS_ERROR, $done->getResultCode());
+        self::assertSame(ResultCode::UNWILLING_TO_PERFORM, $done->getResultCode());
         self::assertSame('', $this->donePagingControl()->getCookie());
         self::assertInstanceOf(SearchOperationResult::class, $result);
         self::assertSame(
@@ -308,7 +308,10 @@ class ServerPagingHandlerTest extends TestCase
             searchRequest: $this->makeSearchRequest('(oh=no)'),
         );
 
-        self::expectExceptionObject(new OperationException("The supplied cookie is invalid."));
+        self::expectExceptionObject(new OperationException(
+            'The supplied cookie is invalid.',
+            ResultCode::UNWILLING_TO_PERFORM,
+        ));
 
         $this->subject->handleRequest(
             $message,

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
@@ -791,6 +791,107 @@ final class ServerSearchHandlerTest extends TestCase
         );
     }
 
+    public function test_a_repeated_sort_key_attribute_reports_unwilling_to_perform(): void
+    {
+        $search = new LdapMessageRequest(
+            2,
+            (new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar'),
+            new SortingControl(
+                SortKey::ascending('cn'),
+                SortKey::descending('CN'),
+            ),
+        );
+
+        $this->mockBackend
+            ->method('search')
+            ->willReturn(new EntryStream($this->makeGenerator()));
+
+        $this->drive(
+            $this->subject,
+            $search,
+        );
+
+        $done = end($this->sentMessages);
+        self::assertInstanceOf(LdapMessageResponse::class, $done);
+        $sortControl = $done->controls()->get(Control::OID_SORTING_RESPONSE);
+        self::assertInstanceOf(
+            SortingResponseControl::class,
+            $sortControl,
+        );
+        self::assertSame(
+            ResultCode::UNWILLING_TO_PERFORM,
+            $sortControl->getResult(),
+        );
+    }
+
+    public function test_an_unsortable_critical_sort_fails_the_search_and_returns_no_entries(): void
+    {
+        $search = new LdapMessageRequest(
+            2,
+            (new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar'),
+            (new SortingControl(SortKey::ascending('bogusAttr')))->setCriticality(true),
+        );
+
+        $this->mockBackend
+            ->expects(self::never())
+            ->method('search');
+
+        $this->drive(
+            $this->subject,
+            $search,
+        );
+
+        self::assertCount(
+            1,
+            $this->sentMessages,
+            'No entries may be returned when a critical sort cannot be honored.',
+        );
+
+        $done = end($this->sentMessages);
+        self::assertInstanceOf(LdapMessageResponse::class, $done);
+        $response = $done->getResponse();
+        self::assertInstanceOf(
+            SearchResultDone::class,
+            $response,
+        );
+        self::assertSame(
+            ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
+            $response->getResultCode(),
+        );
+        self::assertInstanceOf(
+            SortingResponseControl::class,
+            $done->controls()->get(Control::OID_SORTING_RESPONSE),
+        );
+    }
+
+    public function test_an_unsortable_non_critical_sort_still_returns_entries(): void
+    {
+        $entry = Entry::create('dc=foo,dc=bar', ['cn' => 'foo']);
+
+        $search = new LdapMessageRequest(
+            2,
+            (new SearchRequest(Filters::present('cn')))->base('dc=foo,dc=bar'),
+            new SortingControl(SortKey::ascending('bogusAttr')),
+        );
+
+        $this->mockBackend
+            ->method('search')
+            ->willReturn(new EntryStream($this->makeGenerator($entry)));
+        $this->mockFilterEvaluator
+            ->method('evaluate')
+            ->willReturn(true);
+
+        $this->drive(
+            $this->subject,
+            $search,
+        );
+
+        self::assertCount(
+            2,
+            $this->sentMessages,
+        );
+    }
+
     public function test_no_sort_control_does_not_append_sorting_response_control(): void
     {
         $search = new LdapMessageRequest(

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
@@ -27,6 +27,7 @@ use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessage;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseWriter;
@@ -45,6 +46,7 @@ use FreeDSx\Ldap\Server\Operation\SearchOperationResult;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -138,6 +140,90 @@ final class ServerSearchHandlerTest extends TestCase
             OperationOutcome::Succeeded,
             $result->outcome(),
         );
+    }
+
+    #[DataProvider('outOfRangeParameterProvider')]
+    public function test_it_rejects_a_search_parameter_outside_its_permitted_range(
+        SearchRequest $request,
+        string $expectedMessage,
+    ): void {
+        $this->mockBackend
+            ->expects(self::never())
+            ->method('search');
+
+        self::expectExceptionObject(new OperationException(
+            $expectedMessage,
+            ResultCode::PROTOCOL_ERROR,
+        ));
+
+        $this->subject->handleRequest(
+            new LdapMessageRequest(
+                2,
+                $request,
+            ),
+            $this->mockToken,
+        );
+    }
+
+    public static function outOfRangeParameterProvider(): Generator
+    {
+        yield 'a scope above the enumeration' => [
+            self::searchRequest()->setScope(3),
+            'The search scope requested is not supported.',
+        ];
+        yield 'a negative scope' => [
+            self::searchRequest()->setScope(-1),
+            'The search scope requested is not supported.',
+        ];
+        yield 'an alias value above the enumeration' => [
+            self::searchRequest()->setDereferenceAliases(4),
+            'The alias dereferencing value requested is not valid.',
+        ];
+        yield 'a negative alias value' => [
+            self::searchRequest()->setDereferenceAliases(-1),
+            'The alias dereferencing value requested is not valid.',
+        ];
+        yield 'a negative size limit' => [
+            self::searchRequest()->setSizeLimit(-1),
+            'The size limit requested is outside the permitted range.',
+        ];
+        yield 'a size limit above maxInt' => [
+            self::searchRequest()->setSizeLimit(LdapMessage::MAX_INT + 1),
+            'The size limit requested is outside the permitted range.',
+        ];
+        yield 'a negative time limit' => [
+            self::searchRequest()->setTimeLimit(-1),
+            'The time limit requested is outside the permitted range.',
+        ];
+        yield 'a time limit above maxInt' => [
+            self::searchRequest()->setTimeLimit(LdapMessage::MAX_INT + 1),
+            'The time limit requested is outside the permitted range.',
+        ];
+    }
+
+    /**
+     * Scope 3 is the subordinate scope the extensible enumeration anticipates, so it is well formed but unsupported.
+     */
+    public function test_it_accepts_every_scope_it_supports(): void
+    {
+        $this->mockBackend
+            ->method('search')
+            ->willReturnCallback(fn(): EntryStream => new EntryStream($this->makeGenerator()));
+
+        foreach (SearchRequest::SUPPORTED_SCOPES as $scope) {
+            $result = $this->drive(
+                $this->subject,
+                new LdapMessageRequest(
+                    2,
+                    self::searchRequest()->setScope($scope),
+                ),
+            );
+
+            self::assertSame(
+                OperationOutcome::Succeeded,
+                $result->outcome(),
+            );
+        }
     }
 
     public function test_entry_stripped_by_acl_is_excluded_when_it_no_longer_matches_filter(): void
@@ -724,6 +810,12 @@ final class ServerSearchHandlerTest extends TestCase
         $done = end($this->sentMessages);
         self::assertInstanceOf(LdapMessageResponse::class, $done);
         self::assertNull($done->controls()->get(Control::OID_SORTING_RESPONSE));
+    }
+
+    private static function searchRequest(): SearchRequest
+    {
+        return (new SearchRequest(Filters::equal('foo', 'bar')))
+            ->base('dc=foo,dc=bar');
     }
 
     private function makeHandler(

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
@@ -132,7 +132,7 @@ final class ServerSearchHandlerTest extends TestCase
             new LdapMessageResponse(2, new SearchResultEntry($entry2)),
             new LdapMessageResponse(
                 2,
-                new SearchResultDone(0, 'dc=foo,dc=bar'),
+                new SearchResultDone(0),
             ),
         ]);
         self::assertInstanceOf(SearchOperationResult::class, $result);
@@ -257,7 +257,7 @@ final class ServerSearchHandlerTest extends TestCase
         $this->assertSentMessages([
             new LdapMessageResponse(
                 2,
-                new SearchResultDone(0, 'dc=foo,dc=bar'),
+                new SearchResultDone(0),
             ),
         ]);
     }
@@ -317,7 +317,7 @@ final class ServerSearchHandlerTest extends TestCase
             new LdapMessageResponse(2, new SearchResultEntry($entry1)),
             new LdapMessageResponse(
                 2,
-                new SearchResultDone(ResultCode::SIZE_LIMIT_EXCEEDED, 'dc=foo,dc=bar'),
+                new SearchResultDone(ResultCode::SIZE_LIMIT_EXCEEDED),
             ),
         ]);
     }
@@ -346,7 +346,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->assertSentMessages([
             new LdapMessageResponse(2, new SearchResultEntry($entry1)),
-            new LdapMessageResponse(2, new SearchResultDone(0, 'dc=foo,dc=bar')),
+            new LdapMessageResponse(2, new SearchResultDone(0)),
         ]);
     }
 
@@ -376,7 +376,7 @@ final class ServerSearchHandlerTest extends TestCase
         $this->assertSentMessages([
             new LdapMessageResponse(2, new SearchResultEntry($entry1)),
             new LdapMessageResponse(2, new SearchResultEntry($entry2)),
-            new LdapMessageResponse(2, new SearchResultDone(0, 'dc=foo,dc=bar')),
+            new LdapMessageResponse(2, new SearchResultDone(0)),
         ]);
     }
 
@@ -408,7 +408,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->assertSentMessages([
             new LdapMessageResponse(2, new SearchResultEntry($entry1)),
-            new LdapMessageResponse(2, new SearchResultDone(ResultCode::SIZE_LIMIT_EXCEEDED, 'dc=foo,dc=bar')),
+            new LdapMessageResponse(2, new SearchResultDone(ResultCode::SIZE_LIMIT_EXCEEDED)),
         ]);
     }
 
@@ -440,7 +440,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->assertSentMessages([
             new LdapMessageResponse(2, new SearchResultEntry($entry1)),
-            new LdapMessageResponse(2, new SearchResultDone(ResultCode::SIZE_LIMIT_EXCEEDED, 'dc=foo,dc=bar')),
+            new LdapMessageResponse(2, new SearchResultDone(ResultCode::SIZE_LIMIT_EXCEEDED)),
         ]);
     }
 
@@ -472,7 +472,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->assertSentMessages([
             new LdapMessageResponse(2, new SearchResultEntry($entry1)),
-            new LdapMessageResponse(2, new SearchResultDone(ResultCode::SIZE_LIMIT_EXCEEDED, 'dc=foo,dc=bar')),
+            new LdapMessageResponse(2, new SearchResultDone(ResultCode::SIZE_LIMIT_EXCEEDED)),
         ]);
     }
 
@@ -496,7 +496,7 @@ final class ServerSearchHandlerTest extends TestCase
         $this->assertSentMessages([
             new LdapMessageResponse(
                 2,
-                new SearchResultDone(0, 'dc=foo,dc=bar'),
+                new SearchResultDone(0),
             ),
         ]);
     }
@@ -542,7 +542,7 @@ final class ServerSearchHandlerTest extends TestCase
             new LdapMessageResponse(2, new SearchResultEntry($entry2)),
             new LdapMessageResponse(
                 2,
-                new SearchResultDone(0, 'dc=foo,dc=bar'),
+                new SearchResultDone(0),
             ),
         ]);
     }
@@ -582,7 +582,7 @@ final class ServerSearchHandlerTest extends TestCase
         $this->assertSentMessages([
             new LdapMessageResponse(
                 2,
-                new SearchResultDone(0, 'dc=foo,dc=bar'),
+                new SearchResultDone(0),
             ),
         ]);
     }
@@ -660,7 +660,7 @@ final class ServerSearchHandlerTest extends TestCase
             [
                 new LdapMessageResponse(
                     2,
-                    new SearchResultDone(ResultCode::CANCELED, 'dc=foo,dc=bar'),
+                    new SearchResultDone(ResultCode::CANCELED),
                 ),
                 new LdapMessageResponse(
                     3,
@@ -692,7 +692,7 @@ final class ServerSearchHandlerTest extends TestCase
         $this->assertSentMessages([
             new LdapMessageResponse(
                 2,
-                new SearchResultDone(ResultCode::SUCCESS, 'dc=foo,dc=bar'),
+                new SearchResultDone(ResultCode::SUCCESS),
             ),
         ]);
     }

--- a/tests/unit/Server/Backend/Write/WriteCommandFactoryTest.php
+++ b/tests/unit/Server/Backend/Write/WriteCommandFactoryTest.php
@@ -78,6 +78,18 @@ final class WriteCommandFactoryTest extends TestCase
         self::assertSame('ou=people,dc=bar', $command->newParent?->toString());
     }
 
+    public function test_it_rejects_a_new_rdn_that_is_not_utf8(): void
+    {
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INVALID_DN_SYNTAX);
+
+        $this->subject->fromRequest(new ModifyDnRequest(
+            'cn=foo,dc=bar',
+            "cn=\xFF\xFE",
+            true,
+        ));
+    }
+
     public function test_it_throws_for_unsupported_request(): void
     {
         self::expectException(OperationException::class);

--- a/tests/unit/Server/Middleware/BindMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/BindMiddlewareTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Server\Middleware;
 
+use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\AnonBindRequest;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
@@ -22,11 +23,13 @@ use FreeDSx\Ldap\Protocol\Authenticator;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Server\Middleware\BindMiddleware;
+use FreeDSx\Ldap\Server\Middleware\CriticalControlValidator;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
 use FreeDSx\Ldap\Server\Operation\OperationOutcome;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Ldap\ServerOptions;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Tests\Support\FreeDSx\Ldap\Middleware\CallLog;
@@ -62,6 +65,81 @@ final class BindMiddlewareTest extends TestCase
         );
 
         self::assertNotNull($this->next->received);
+    }
+
+    #[DataProvider('bindControlProvider')]
+    public function test_a_critical_control_the_bind_cannot_honor_is_refused(
+        Control $control,
+        bool $expectRefusal,
+    ): void {
+        $this->authenticator
+            ->method('bind')
+            ->willReturn(BindToken::fromDn('cn=user,dc=foo,dc=bar'));
+
+        $context = new ServerRequestContext(new LdapMessageRequest(
+            1,
+            new SimpleBindRequest('cn=user,dc=foo,dc=bar', 'secret'),
+            $control,
+        ));
+
+        if (!$expectRefusal) {
+            $this->subject()->process($context, $this->next);
+            self::assertInstanceOf(
+                BindToken::class,
+                $this->authorization->getToken(),
+            );
+
+            return;
+        }
+
+        try {
+            $this->subject()->process($context, $this->next);
+            self::fail('The critical control should have been refused.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
+                $e->getCode(),
+            );
+        }
+
+        self::assertInstanceOf(
+            AnonToken::class,
+            $this->authorization->getToken(),
+            'The prior identity is dropped even when the control refuses the bind (RFC 4511 §4.2.1).',
+        );
+    }
+
+    /**
+     * @return iterable<string, array{Control, bool}>
+     */
+    public static function bindControlProvider(): iterable
+    {
+        yield 'an unrecognized critical control' => [
+            new Control('1.2.3.4.5', criticality: true),
+            true,
+        ];
+        // A bind is not among the operations RFC 4370 §3 lists, and the control's criticality is always TRUE.
+        yield 'proxied authorization, which a bind may never carry' => [
+            new Control(Control::OID_PROXY_AUTHORIZATION, criticality: true),
+            true,
+        ];
+        // Controls the dispatch route allows, which a bind is not routed through.
+        yield 'a critical assertion control' => [
+            new Control(Control::OID_ASSERTION, criticality: true),
+            true,
+        ];
+        yield 'a critical pre-read control' => [
+            new Control(Control::OID_PRE_READ, criticality: true),
+            true,
+        ];
+        yield 'the password policy control, which accompanies a bind' => [
+            new Control(Control::OID_PWD_POLICY, criticality: true),
+            false,
+        ];
+        yield 'an unrecognized control that is not critical' => [
+            new Control('1.2.3.4.5', criticality: false),
+            false,
+        ];
     }
 
     public function test_a_successful_bind_stores_the_token_and_short_circuits(): void
@@ -151,6 +229,7 @@ final class BindMiddlewareTest extends TestCase
         return new BindMiddleware(
             $this->authorization,
             $this->authenticator,
+            new CriticalControlValidator(),
         );
     }
 }

--- a/tests/unit/Server/Middleware/CriticalControlMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/CriticalControlMiddlewareTest.php
@@ -21,6 +21,7 @@ use FreeDSx\Ldap\Protocol\Factory\HandlerId;
 use FreeDSx\Ldap\Protocol\Factory\HandlerRouteResolverInterface;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Server\Middleware\CriticalControlMiddleware;
+use FreeDSx\Ldap\Server\Middleware\CriticalControlValidator;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
 use FreeDSx\Ldap\Server\Middleware\ServerControlRegistry;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -42,7 +43,7 @@ final class CriticalControlMiddlewareTest extends TestCase
         $this->resolver = $this->createMock(HandlerRouteResolverInterface::class);
         $this->subject = new CriticalControlMiddleware(
             $this->resolver,
-            new ServerControlRegistry(),
+            new CriticalControlValidator(new ServerControlRegistry()),
         );
         $this->next = new RecordingMiddlewareHandler(new CallLog());
     }


### PR DESCRIPTION
This corrects a cluster of RFC related handling in the server. Some pre-existing, some just in the main unreleased code. The two pre-existing ones are around matchedDn handling in search responses and message ID handling (tracking / validation). Others are related to specific protocol error handling correctness that needs to align with the various RFCs they fall under (paging and handling non-existent sessions, server side sort keys, etc). Will have other follow-ups as I make sure the server conforms to the various RFCs for behavior. All of these now get integration tests so the behavior is actually checked end to end.