### PR TITLE
[1.0.0] Server RFC conformance fixes.

### DIFF
--- a/src/FreeDSx/Ldap/Entry/Attribute.php
+++ b/src/FreeDSx/Ldap/Entry/Attribute.php
@@ -198,6 +198,24 @@ class Attribute implements IteratorAggregate, Countable, Stringable
     }
 
     /**
+     * Whether a description matches the RFC 4512 2.5 grammar:
+     *
+     *   attributedescription = attributetype options
+     *   attributetype        = oid            ; descr / numericoid
+     *   options              = *( ";" option )
+     *   option               = 1*keychar
+     *
+     * The D modifier matters: without it a trailing newline slips past the whitelist and into an identifier.
+     */
+    public static function isValidDescription(string $description): bool
+    {
+        return preg_match(
+            '/^([a-z][a-z0-9-]*|\d+(\.\d+)+)(;[a-z0-9-]+)*$/D',
+            strtolower($description),
+        ) === 1;
+    }
+
+    /**
      * Gets the name (AttributeType) portion of the AttributeDescription, which excludes the options.
      */
     public function getName(): string

--- a/src/FreeDSx/Ldap/Entry/DnNormalizer.php
+++ b/src/FreeDSx/Ldap/Entry/DnNormalizer.php
@@ -114,9 +114,17 @@ final class DnNormalizer
         return Rdn::escape($folded);
     }
 
+    /**
+     * Applies the same RFC 4518 2.2 mapping the prep profile would.
+     */
     private function canonicalizeAsciiValue(string $value): string
     {
-        $folded = strtolower($value);
+        $lowered = strtolower($value);
+        $folded = preg_replace(
+            '/[\x00-\x08\x0E-\x1F\x7F]/',
+            '',
+            $lowered,
+        ) ?? $lowered;
         $collapsed = preg_replace(
             '/[\x09-\x0D ]+/',
             ' ',

--- a/src/FreeDSx/Ldap/LdapUrl.php
+++ b/src/FreeDSx/Ldap/LdapUrl.php
@@ -24,6 +24,7 @@ use function count;
 use function end;
 use function explode;
 use function implode;
+use function in_array;
 use function key;
 use function ltrim;
 use function parse_url;
@@ -227,7 +228,6 @@ class LdapUrl implements Stringable
      * Given a string LDAP URL, get its object representation.
      *
      * @throws UrlParseException
-     * @throws InvalidArgumentException
      */
     public static function parse(string $ldapUrl): LdapUrl
     {
@@ -239,21 +239,85 @@ class LdapUrl implements Stringable
         $url->setDn((isset($pieces['path']) && $pieces['path'] !== '/') ? self::decode(ltrim($pieces['path'], '/')) : null);
 
         $query = explode('?', $pieces['query'] ?? '');
-        if (count($query) !== 0) {
-            $url->setAttributes(...($query[0] === '' ? [] : explode(',', $query[0])));
-            $url->setScope(isset($query[1]) && $query[1] !== '' ? $query[1] : null);
-            $url->setFilter(isset($query[2]) && $query[2] !== '' ? self::decode($query[2]) : null);
 
-            $extensions = [];
-            if (isset($query[3]) && $query[3] !== '') {
-                $extensions = array_map(function ($ext) {
-                    return LdapUrlExtension::parse($ext);
-                }, explode(',', $query[3]));
-            }
-            $url->setExtensions(...$extensions);
+        # RFC 4516 2 admits four query components at most: attributes, scope, filter and extensions.
+        if (count($query) > 4) {
+            throw new UrlParseException(sprintf(
+                'The LDAP URL has too many query components: %s',
+                $ldapUrl,
+            ));
         }
 
+        $url->setAttributes(...self::parseAttributes(
+            $query[0] ?? '',
+            $ldapUrl,
+        ));
+        self::applyScope(
+            $url,
+            isset($query[1]) && $query[1] !== '' ? $query[1] : null,
+            $ldapUrl,
+        );
+        $url->setFilter(isset($query[2]) && $query[2] !== '' ? self::decode($query[2]) : null);
+
+        $extensions = [];
+        if (isset($query[3]) && $query[3] !== '') {
+            $extensions = array_map(
+                fn(string $ext): LdapUrlExtension => LdapUrlExtension::parse($ext),
+                explode(',', $query[3]),
+            );
+        }
+        $url->setExtensions(...$extensions);
+
         return $url;
+    }
+
+    /**
+     * @return string[]
+     * @throws UrlParseException
+     */
+    private static function parseAttributes(
+        string $attributes,
+        string $ldapUrl,
+    ): array {
+        if ($attributes === '') {
+            return [];
+        }
+
+        $selectors = explode(',', $attributes);
+        if (in_array('', $selectors, true)) {
+            throw new UrlParseException(sprintf(
+                'The LDAP URL has an empty attribute selector: %s',
+                $ldapUrl,
+            ));
+        }
+
+        return array_map(
+            fn(string $attribute): string => self::decode($attribute),
+            $selectors,
+        );
+    }
+
+    /**
+     * A scope outside the RFC 4516 2 set makes the URL malformed, not the caller's argument invalid.
+     *
+     * @throws UrlParseException
+     */
+    private static function applyScope(
+        LdapUrl $url,
+        ?string $scope,
+        string $ldapUrl,
+    ): void {
+        try {
+            $url->setScope($scope);
+        } catch (InvalidArgumentException $e) {
+            throw new UrlParseException(
+                sprintf(
+                    'The LDAP URL has an invalid scope: %s',
+                    $ldapUrl,
+                ),
+                previous: $e,
+            );
+        }
     }
 
     /**

--- a/src/FreeDSx/Ldap/LdapUrlExtension.php
+++ b/src/FreeDSx/Ldap/LdapUrlExtension.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap;
 
 use FreeDSx\Ldap\Exception\UrlParseException;
+use FreeDSx\Ldap\Schema\Validation\Syntax\OidSyntaxValidator;
 use Stringable;
 
 use function explode;
-use function str_ireplace;
 use function str_replace;
 use function substr;
 
@@ -109,12 +109,6 @@ class LdapUrlExtension implements Stringable
      */
     public static function parse(string $extension): LdapUrlExtension
     {
-        if (preg_match('/!?\w+(=.*)?/', $extension) !== 1) {
-            throw new UrlParseException(sprintf(
-                'The LDAP URL extension is malformed: %s',
-                $extension,
-            ));
-        }
         $pieces = explode(
             separator: '=',
             string: $extension,
@@ -129,13 +123,17 @@ class LdapUrlExtension implements Stringable
             );
         }
 
-        $name = str_ireplace('%2c', ',', self::decode($pieces[0]));
+        $name = self::decode($pieces[0]);
+        # RFC 4516 2.1 defines extype as an oid, so it shares the schema OID grammar.
+        if (!(new OidSyntaxValidator())->isValid($name)) {
+            throw new UrlParseException(sprintf(
+                'The LDAP URL extension is malformed: %s',
+                $extension,
+            ));
+        }
+
         $value = isset($pieces[1])
-            ? str_ireplace(
-                search: '%2c',
-                replace: ',',
-                subject: self::decode($pieces[1]),
-            )
+            ? self::decode($pieces[1])
             : null;
 
         return new self(

--- a/src/FreeDSx/Ldap/LdapUrlTrait.php
+++ b/src/FreeDSx/Ldap/LdapUrlTrait.php
@@ -13,10 +13,9 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap;
 
-use function array_keys;
-use function array_values;
-use function str_ireplace;
-use function str_replace;
+use function bin2hex;
+use function hex2bin;
+use function preg_replace_callback;
 
 /**
  * Some common methods for LDAP URLs and URL Extensions.
@@ -26,47 +25,30 @@ use function str_replace;
 trait LdapUrlTrait
 {
     /**
-     * @var array<string, string>
+     * Anything outside printable ASCII, plus the printable characters that would otherwise read as structure.
      */
-    private static array $escapeMap = [
-        '%' => '%25',
-        '?' => '%3f',
-        ' ' => '%20',
-        '<' => '%3c',
-        '>' => '%3e',
-        '"' => '%22',
-        '#' => '%23',
-        '{' => '%7b',
-        '}' => '%7d',
-        '|' => '%7c',
-        '\\' => '%5c',
-        '^' => '%5e',
-        '~' => '%7e',
-        '[' => '%5b',
-        ']' => '%5d',
-        '`' => '%60',
-    ];
+    private const MUST_ENCODE = '/[^\x21-\x7E]|[%?<>"#{}|\\\\^~\[\]`]/';
 
     /**
-     * Percent-encode certain values in the URL.
+     * Percent-encode the octets a generated URL may not carry (RFC 4516 2.1).
      */
     protected static function encode(?string $value): string
     {
-        return str_replace(
-            search: array_keys(self::$escapeMap),
-            replace: array_values(self::$escapeMap),
+        return (string) preg_replace_callback(
+            pattern: self::MUST_ENCODE,
+            callback: static fn(array $matches): string => '%' . bin2hex($matches[0]),
             subject: (string) $value,
         );
     }
 
     /**
-     * Percent-decode values from the URL.
+     * Percent-decode in a single pass, so an encoded percent yields text rather than decoding a second time.
      */
     protected static function decode(string $value): string
     {
-        return str_ireplace(
-            search: array_values(self::$escapeMap),
-            replace: array_keys(self::$escapeMap),
+        return (string) preg_replace_callback(
+            pattern: '/%([0-9A-Fa-f]{2})/',
+            callback: static fn(array $matches): string => (string) hex2bin($matches[1]),
             subject: $value,
         );
     }

--- a/src/FreeDSx/Ldap/Operation/LdapResult.php
+++ b/src/FreeDSx/Ldap/Operation/LdapResult.php
@@ -209,11 +209,17 @@ class LdapResult implements ResponseInterface
                         if (!$ldapUrl instanceof OctetStringType) {
                             throw new ProtocolException('The ASN1 structure for a referral is malformed.');
                         }
+
                         try {
                             $referrals[] = LdapUrl::parse($ldapUrl->getValue());
-                        } catch (UrlParseException $e) {
-                            throw new ProtocolException($e->getMessage());
+                        } catch (UrlParseException) {
+                            # RFC 4511 4.1.10 makes the URIs alternatives, so an unusable one is ignored.
                         }
+                    }
+
+                    # The field is only sent when it holds a URI, so losing every one would hide the continuation.
+                    if ($referrals === []) {
+                        throw new ProtocolException('The LDAP result holds no usable referral URI.');
                     }
                 }
             }

--- a/src/FreeDSx/Ldap/Operation/Response/SearchResultReference.php
+++ b/src/FreeDSx/Ldap/Operation/Response/SearchResultReference.php
@@ -68,9 +68,13 @@ class SearchResultReference implements ResponseInterface
             }
             try {
                 $referrals[] = LdapUrl::parse($referral->getValue());
-            } catch (UrlParseException $e) {
-                throw new ProtocolException($e->getMessage());
+            } catch (UrlParseException) {
+                # RFC 4511 4.1.10 makes the URIs alternatives, so an unusable one is ignored.
             }
+        }
+
+        if ($referrals === []) {
+            throw new ProtocolException('The search result reference holds no usable URI.');
         }
 
         return new self(...$referrals);

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -459,9 +459,6 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
     }
 
     /**
-     * @throws OperationException
-     */
-    /**
      * @param list<Entry> $page
      */
     private function pageHasCapacity(

--- a/src/FreeDSx/Ldap/Schema/Definition/GeneralizedTime.php
+++ b/src/FreeDSx/Ldap/Schema/Definition/GeneralizedTime.php
@@ -24,17 +24,25 @@ use FreeDSx\Ldap\Exception\InvalidArgumentException;
  */
 final class GeneralizedTime
 {
+    /**
+     * The RFC 4517 3.3.13 ranges, since the offset never reaches the calendar check below.
+     */
     private const PATTERN = '/^
         (?<year>\d{4})
-        (?<month>\d{2})
-        (?<day>\d{2})
-        (?<hour>\d{2})
-        (?:(?<minute>\d{2})
-            (?:(?<second>\d{2}))?
+        (?<month>0[1-9]|1[0-2])
+        (?<day>0[1-9]|[12]\d|3[01])
+        (?<hour>[01]\d|2[0-3])
+        (?:(?<minute>[0-5]\d)
+            (?:(?<second>[0-5]\d|60))?
         )?
         (?:[.,](?<fraction>\d+))?
-        (?<zone>Z|[+\-]\d{2}(?:\d{2})?)
+        (?<zone>Z|[+\-](?:[01]\d|2[0-3])(?:[0-5]\d)?)
     $/xD';
+
+    /**
+     * RFC 4517 3.3.13 admits "60" as a leap second, which no calendar holds.
+     */
+    private const LEAP_SECOND = '60';
 
     private function __construct() {}
 
@@ -65,7 +73,8 @@ final class GeneralizedTime
             ));
         }
 
-        return $parsed->setTimezone(new DateTimeZone('UTC'));
+        return self::applyLeapSecond($parsed, $matches)
+            ->setTimezone(new DateTimeZone('UTC'));
     }
 
     /**
@@ -90,12 +99,30 @@ final class GeneralizedTime
     }
 
     /**
+     * A leap second is parsed as second 59, so the instant it names is one second later.
+     *
+     * @param array<int|string, string> $components named capture groups
+     */
+    private static function applyLeapSecond(
+        DateTimeImmutable $parsed,
+        array $components,
+    ): DateTimeImmutable {
+        if (($components['second'] ?? '') !== self::LEAP_SECOND) {
+            return $parsed;
+        }
+
+        return $parsed->modify('+1 second');
+    }
+
+    /**
      * @param array<int|string, string> $components named capture groups
      */
     private static function componentsToIso8601(array $components): string
     {
         $minute = ($components['minute'] ?? '') !== '' ? $components['minute'] : '00';
         $second = ($components['second'] ?? '') !== '' ? $components['second'] : '00';
+        // No calendar holds :60, so it is parsed as :59 and stepped forward once the instant exists.
+        $second = $second === self::LEAP_SECOND ? '59' : $second;
         $fraction = ($components['fraction'] ?? '') !== '' ? '.' . $components['fraction'] : '';
         $zone = $components['zone'] === 'Z'
             ? '+0000'

--- a/src/FreeDSx/Ldap/Schema/Matching/StringPrep.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/StringPrep.php
@@ -22,14 +22,28 @@ use Normalizer;
 final readonly class StringPrep
 {
     /**
-     * Code points removed by the Map step (RFC 4518 §2.2): soft hyphen, zero-width, variation selectors, NULL.
+     * Code points removed by the Map step (RFC 4518 §2.2).
      */
-    private const MAP_TO_NOTHING = '/[\x{00AD}\x{034F}\x{200B}\x{200C}\x{200D}\x{2060}\x{FEFF}\x{180B}-\x{180D}\x{FE00}-\x{FE0F}\x{0000}]/u';
+    private const MAP_TO_NOTHING = '/['
+        // Controls, less the line breaking ones mapped to SPACE below.
+        . '\x{0000}-\x{0008}\x{000E}-\x{001F}\x{007F}-\x{0084}\x{0086}-\x{009F}'
+        // Soft hyphens, combining grapheme joiner, variation selectors.
+        . '\x{00AD}\x{034F}\x{06DD}\x{070F}\x{1806}\x{180B}-\x{180E}\x{FE00}-\x{FE0F}'
+        // Zero width space and the bidi formatting points, which otherwise render identically to nothing.
+        . '\x{200B}-\x{200F}\x{202A}-\x{202E}\x{2060}-\x{2063}\x{206A}-\x{206F}\x{FEFF}'
+        // Annotation marks, object replacement, and the musical and tag formatting points.
+        . '\x{FFF9}-\x{FFFC}\x{1D173}-\x{1D17A}\x{E0001}\x{E0020}-\x{E007F}'
+        . ']/u';
 
     /**
-     * Whitespace variants folded to SPACE by the Map step (RFC 4518 §2.2).
+     * Whitespace folded to SPACE by the Map step (RFC 4518 §2.2).
      */
-    private const MAP_TO_SPACE = '/[\x{0009}-\x{000D}\x{0085}\x{00A0}\x{1680}\x{2000}-\x{200A}\x{2028}\x{2029}\x{202F}\x{205F}\x{3000}]/u';
+    private const MAP_TO_SPACE = '/['
+        // Line breaking controls.
+        . '\x{0009}-\x{000D}\x{0085}'
+        // Every code point carrying a Separator property.
+        . '\x{00A0}\x{1680}\x{2000}-\x{200A}\x{2028}-\x{2029}\x{202F}\x{205F}\x{3000}'
+        . ']/u';
 
     private bool $canFoldUnicode;
 

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/OidSyntaxValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/OidSyntaxValidator.php
@@ -20,7 +20,13 @@ namespace FreeDSx\Ldap\Schema\Validation\Syntax;
  */
 final class OidSyntaxValidator implements SyntaxValidatorInterface
 {
-    private const PATTERN = '/^([0-9]+(\.[0-9]+)*|[A-Za-z][A-Za-z0-9-]*)$/D';
+    /**
+     * RFC 4512 1.4: an arc carries no leading zero, and a numericoid needs at least one dot.
+     */
+    private const PATTERN = '/^('
+        . '(?:0|[1-9][0-9]*)(?:\.(?:0|[1-9][0-9]*))+'
+        . '|[A-Za-z][A-Za-z0-9-]*'
+        . ')$/D';
 
     public function isValid(string $value): bool
     {

--- a/src/FreeDSx/Ldap/Search/Filter/AttributeValueAssertionTrait.php
+++ b/src/FreeDSx/Ldap/Search/Filter/AttributeValueAssertionTrait.php
@@ -77,7 +77,7 @@ trait AttributeValueAssertionTrait
     public function toString(): string
     {
         return self::PAREN_LEFT
-            . $this->attribute
+            . $this->attributeToString()
             . self::FILTER_TYPE
             . Attribute::escape($this->value)
             . self::PAREN_RIGHT;

--- a/src/FreeDSx/Ldap/Search/Filter/FilterAttributeTrait.php
+++ b/src/FreeDSx/Ldap/Search/Filter/FilterAttributeTrait.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Search\Filter;
 
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Exception\FilterParseException;
+
 /**
  * Common methods for filters using attributes.
  *
@@ -42,5 +45,22 @@ trait FilterAttributeTrait
         $this->attribute = $attribute;
 
         return $this;
+    }
+
+    /**
+     * The attribute as a filter string names it.
+     *
+     * @throws FilterParseException
+     */
+    private function attributeToString(): string
+    {
+        if (!Attribute::isValidDescription($this->attribute)) {
+            throw new FilterParseException(sprintf(
+                'The attribute "%s" has no valid filter string representation.',
+                $this->attribute,
+            ));
+        }
+
+        return $this->attribute;
     }
 }

--- a/src/FreeDSx/Ldap/Search/Filter/MatchingRuleFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/MatchingRuleFilter.php
@@ -21,6 +21,7 @@ use FreeDSx\Asn1\Type\IncompleteType;
 use FreeDSx\Asn1\Type\OctetStringType;
 use FreeDSx\Asn1\Type\SequenceType;
 use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Exception\FilterParseException;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Protocol\LdapEncoder;
 use Stringable;
@@ -164,10 +165,7 @@ class MatchingRuleFilter implements FilterInterface, FilterAttributeInterface, S
     public function toString(): string
     {
         // RFC 4515 3: attr [":dn"] [":" matchingrule] ":=" value.
-        $filter = '';
-        if ($this->attribute !== null) {
-            $filter = $this->attribute;
-        }
+        $filter = $this->attributeToString();
         if ($this->useDnAttributes) {
             $filter .= ':dn';
         }
@@ -242,5 +240,26 @@ class MatchingRuleFilter implements FilterInterface, FilterAttributeInterface, S
             $matchValue->getValue(),
             $useDnAttr,
         );
+    }
+
+    /**
+     * The attribute as a filter string names it, empty when the assertion carries none.
+     *
+     * @throws FilterParseException
+     */
+    private function attributeToString(): string
+    {
+        if ($this->attribute === null) {
+            return '';
+        }
+
+        if (!Attribute::isValidDescription($this->attribute)) {
+            throw new FilterParseException(sprintf(
+                'The attribute "%s" has no valid filter string representation.',
+                $this->attribute,
+            ));
+        }
+
+        return $this->attribute;
     }
 }

--- a/src/FreeDSx/Ldap/Search/Filter/PresentFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/PresentFilter.php
@@ -51,7 +51,7 @@ class PresentFilter implements FilterInterface, FilterAttributeInterface, String
     public function toString(): string
     {
         return self::PAREN_LEFT
-            . $this->attribute
+            . $this->attributeToString()
             . self::FILTER_EQUAL
             . '*'
             . self::PAREN_RIGHT;

--- a/src/FreeDSx/Ldap/Search/Filter/SubstringFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/SubstringFilter.php
@@ -168,7 +168,7 @@ class SubstringFilter implements FilterInterface, FilterAttributeInterface, Stri
      */
     public function toString(): string
     {
-        $filter = self::PAREN_LEFT . $this->attribute . self::FILTER_EQUAL;
+        $filter = self::PAREN_LEFT . $this->attributeToString() . self::FILTER_EQUAL;
 
         $value = '';
         if (count($this->contains) !== 0) {

--- a/src/FreeDSx/Ldap/Search/FilterParser.php
+++ b/src/FreeDSx/Ldap/Search/FilterParser.php
@@ -434,13 +434,40 @@ class FilterParser
         ));
     }
 
+    /**
+     * @throws FilterParseException
+     */
     private function unescapeValue(string $value): string
     {
+        $this->assertValueEncoding($value);
+
         return (string) preg_replace_callback(
             '/\\\\([0-9A-Fa-f]{2})/',
             fn(array $matches) => (string) hex2bin($matches[1]),
             $value,
         );
+    }
+
+    /**
+     * RFC 4515 3: an assertion value is UTF1SUBSET, UTFMB, or an escape of exactly two hex digits.
+     *
+     * UTF1SUBSET excludes NUL, the parentheses, the asterisk and the backslash.
+     *
+     * @throws FilterParseException
+     */
+    private function assertValueEncoding(string $value): void
+    {
+        if (preg_match('/\\\\(?![0-9A-Fa-f]{2})/', $value) === 1) {
+            throw new FilterParseException(
+                'A "\" in an assertion value must be followed by two hex digits.',
+            );
+        }
+
+        if (preg_match('/[\x00()*]/', $value) === 1) {
+            throw new FilterParseException(
+                'An assertion value cannot hold an unescaped NUL, parenthesis or asterisk.',
+            );
+        }
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/EntryIndexWriter.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/EntryIndexWriter.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo;
 
 use FreeDSx\Ldap\Entry\Entry;
-use FreeDSx\Ldap\Schema\Text;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoEntryDialectInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Statement\PdoStatementPool;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterUtility;
@@ -223,15 +222,6 @@ final readonly class EntryIndexWriter
 
     private function valueLower(string $value): string
     {
-        if (!Text::isUtf8($value)) {
-            return '';
-        }
-
-        return mb_substr(
-            mb_strtolower($value, 'UTF-8'),
-            0,
-            SqlFilterUtility::MAX_INDEXED_VALUE_CHARS,
-            'UTF-8',
-        );
+        return SqlFilterUtility::normalize($value);
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -414,9 +414,6 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
     }
 
     /**
-     * @return Generator<Entry>
-     */
-    /**
      * Resolves each sort key against the schema here, since the query layer has no view of it.
      *
      * @return list<SortKeySpec>

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
@@ -342,7 +342,8 @@ trait SqlFilterTranslatorTrait
         $alias = $this->valueAlias();
 
         if ($startsWith !== null) {
-            $prefix = $this->prepareMatchValue($startsWith);
+            // A fragment keeps its edge spaces, which a whole value would have trimmed.
+            $prefix = SqlFilterUtility::normalizeFragment($startsWith);
             $inner = "$alias LIKE ? ESCAPE '!'";
             $sql = $this->buildValueExists(
                 $attribute,
@@ -472,20 +473,11 @@ trait SqlFilterTranslatorTrait
     }
 
     /**
-     * Pre-lower + truncate to match sidecar's value_lower; non-UTF-8 returns '' (matches binary-syntax rows only).
+     * Prepared the same way the sidecar's value_lower was written, so SQL and the evaluator agree.
      */
     private function prepareMatchValue(string $value): string
     {
-        if (!Text::isUtf8($value)) {
-            return '';
-        }
-
-        return mb_substr(
-            mb_strtolower($value, 'UTF-8'),
-            0,
-            SqlFilterUtility::MAX_INDEXED_VALUE_CHARS,
-            'UTF-8',
-        );
+        return SqlFilterUtility::normalize($value);
     }
 
     private function translateAnd(AndFilter $filter): ?SqlFilterResult

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterTranslatorTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter;
 
+use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Schema\Text;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\InvalidAttributeException;
 use FreeDSx\Ldap\Search\Filter\AndFilter;
@@ -606,24 +607,13 @@ trait SqlFilterTranslatorTrait
     }
 
     /**
-     * Validates an LDAP attribute description against the RFC 4512 syntax:
-     *
-     *   attributedescription = attributetype options
-     *   attributetype        = oid
-     *   oid                  = descr / numericoid
-     *   descr                = keystring (e.g. "cn", "userCertificate")
-     *   numericoid           = number 1*( DOT number ) (e.g. "2.5.4.3")
-     *   options              = *( ";" option )
-     *   option               = 1*keychar
+     * The lowercased attribute type an identifier may carry, once the RFC 4512 2.5 grammar admits it.
      *
      * @throws InvalidAttributeException
      */
     private function validateAttribute(string $attribute): string
     {
-        $lower = strtolower($attribute);
-
-        // The D modifier matters here: without it a trailing newline slips past the whitelist and into an identifier.
-        if (preg_match('/^([a-z][a-z0-9-]*|\d+(\.\d+)+)(;[a-z0-9-]+)*$/D', $lower) !== 1) {
+        if (!Attribute::isValidDescription($attribute)) {
             throw new InvalidAttributeException(sprintf(
                 'Attribute description "%s" is not a valid RFC 4512 attribute description.',
                 $attribute,
@@ -632,7 +622,7 @@ trait SqlFilterTranslatorTrait
 
         return explode(
             ';',
-            $lower,
+            strtolower($attribute),
             2,
         )[0];
     }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterUtility.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SqlFilter/SqlFilterUtility.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter;
 
+use FreeDSx\Ldap\Schema\Matching\StringPrep;
+use FreeDSx\Ldap\Schema\Text;
+
 /**
  * Shared utilities for SQL-based storage adapters.
  *
@@ -25,6 +28,27 @@ final class SqlFilterUtility
      */
     public const MAX_INDEXED_VALUE_CHARS = 255;
 
+    private static ?StringPrep $prep = null;
+
+    /**
+     * The sidecar form of a value, for the write side and the query side alike.
+     *
+     * Both must prepare identically or SQL answers a question the evaluator would answer differently, so this is
+     * the one definition of it.
+     */
+    public static function normalize(string $value): string
+    {
+        return self::truncate(self::prep()->prepareForEquality($value));
+    }
+
+    /**
+     * The sidecar form of a substring fragment, which keeps its edge spaces where a whole value would not.
+     */
+    public static function normalizeFragment(string $fragment): string
+    {
+        return self::truncate(self::prep()->prepareFragment($fragment));
+    }
+
     /**
      * Escape LIKE specials using `!` as the escape char.
      */
@@ -34,6 +58,28 @@ final class SqlFilterUtility
             ['!', '%', '_'],
             ['!!', '!%', '!_'],
             $value,
+        );
+    }
+
+    private static function prep(): StringPrep
+    {
+        return self::$prep ??= new StringPrep(foldCase: true);
+    }
+
+    /**
+     * Non-UTF-8 returns '', which matches binary-syntax rows only.
+     */
+    private static function truncate(string $value): string
+    {
+        if (!Text::isUtf8($value)) {
+            return '';
+        }
+
+        return mb_substr(
+            $value,
+            0,
+            self::MAX_INDEXED_VALUE_CHARS,
+            'UTF-8',
         );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStorageInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStorageInterface.php
@@ -48,8 +48,7 @@ interface EntryStorageInterface
 
     /**
      * Persist the entry keyed by its normalised DN, replacing any existing entry at the same DN.
-     */
-    /**
+     *
      * @param bool $rebuildIndexes Rewrite every secondary-index row rather than only those whose values changed.
      */
     public function store(

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
@@ -122,8 +122,7 @@ final readonly class StorageListOptions implements FilterAttributeContextInterfa
 
     /**
      * Match-all options for internal callers (e.g. hasChildren) and tests that do not need a meaningful filter.
-     */
-    /**
+     *
      * @param list<string>|null $attributes Lowercase base attribute names to materialize, or null for all.
      */
     public static function matchAll(

--- a/tests/integration/ServerTestCase.php
+++ b/tests/integration/ServerTestCase.php
@@ -109,8 +109,7 @@ class ServerTestCase extends LdapTestCase
 
     /**
      * Shared-server lifecycle — called from setUpBeforeClass / tearDownAfterClass
-     */
-    /**
+     *
      * @param list<string> $extraArgs
      */
     protected static function initSharedServer(

--- a/tests/integration/Storage/Concern/QueryTestsTrait.php
+++ b/tests/integration/Storage/Concern/QueryTestsTrait.php
@@ -186,6 +186,34 @@ trait QueryTestsTrait
             1,
         ];
 
+        // RFC 4518 2.2 maps these to nothing, so an assertion carrying one still matches the stored value.
+        yield 'an assertion carrying a left to right mark still matches' => [
+            Filters::equal('cn', "adm\u{200E}in"),
+            1,
+        ];
+        yield 'an assertion carrying a soft hyphen still matches' => [
+            Filters::equal('cn', "adm\u{00AD}in"),
+            1,
+        ];
+        yield 'an assertion carrying a zero width space still matches' => [
+            Filters::equal('cn', "adm\u{200B}in"),
+            1,
+        ];
+        yield 'an assertion carrying an ascii control still matches' => [
+            Filters::equal('cn', "adm\x01in"),
+            1,
+        ];
+
+        // RFC 4518 2.3 folds per RFC 3454 B.2 rather than lowercasing, so sharp s and "ss" are one value.
+        yield 'sharp s folds to a double s' => [
+            Filters::equal('displayName', 'strasse'),
+            1,
+        ];
+        yield 'the spelled out form matches the sharp s whatever its case' => [
+            Filters::equal('displayName', 'STRASSE'),
+            1,
+        ];
+
         // No approximate rule is implemented, so it must answer as the type's equality rule does.
         yield 'approximate on a case exact type rejects a case difference' => [
             Filters::approximate('labeledURI', 'a1b2c3'),
@@ -591,13 +619,27 @@ trait QueryTestsTrait
      */
     public static function refusedBaseDnProvider(): iterable
     {
-        yield 'attribute type outside the grammar' => ['!!!=bar,dc=foo,dc=bar'];
-        yield 'attribute type with an inner space' => ['cn foo=bar,dc=foo,dc=bar'];
-        yield 'empty attribute type' => ['=bar,dc=foo,dc=bar'];
-        yield 'attribute option in an rdn' => ['cn;lang-en=alice,dc=foo,dc=bar'];
-        yield 'oid arc with a leading zero' => ['2.05.4.3=alice,dc=foo,dc=bar'];
-        yield 'hexstring value form' => ['cn=#0C03616263,dc=foo,dc=bar'];
-        yield 'raw null byte in a value' => ["cn=a\0b,dc=foo,dc=bar"];
+        yield 'attribute type outside the grammar' => [
+            '!!!=bar,dc=foo,dc=bar',
+        ];
+        yield 'attribute type with an inner space' => [
+            'cn foo=bar,dc=foo,dc=bar',
+        ];
+        yield 'empty attribute type' => [
+            '=bar,dc=foo,dc=bar',
+        ];
+        yield 'attribute option in an rdn' => [
+            'cn;lang-en=alice,dc=foo,dc=bar',
+        ];
+        yield 'oid arc with a leading zero' => [
+            '2.05.4.3=alice,dc=foo,dc=bar',
+        ];
+        yield 'hexstring value form' => [
+            'cn=#0C03616263,dc=foo,dc=bar',
+        ];
+        yield 'raw null byte in a value' => [
+            "cn=a\0b,dc=foo,dc=bar",
+        ];
     }
 
     public function testAHexEscapeNamesTheSameEntryAsTheCharacterItEncodes(): void

--- a/tests/integration/Storage/Concern/WriteTestsTrait.php
+++ b/tests/integration/Storage/Concern/WriteTestsTrait.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Search\Filters;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Add, delete, modify, and rename against the backend.
@@ -317,6 +318,65 @@ trait WriteTestsTrait
         } finally {
             $this->ldapClient()->delete('labeledURI=CaseTest,dc=foo,dc=bar');
         }
+    }
+
+    /**
+     * @param non-empty-string $cn
+     */
+    #[DataProvider('invisiblyDifferentValueProvider')]
+    public function testAddIsRefusedForADnDifferingOnlyByACodePointThatRendersAsNothing(string $cn): void
+    {
+        $this->authenticateAdmin();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::ENTRY_ALREADY_EXISTS);
+
+        $this->ldapClient()->create(Entry::fromArray("cn=$cn,dc=foo,dc=bar", [
+            'cn' => $cn,
+            'sn' => 'Impostor',
+            'objectClass' => 'inetOrgPerson',
+        ]));
+    }
+
+    /**
+     * RFC 4518 2.2 maps these to nothing, so each names the seeded cn=admin and cannot be added beside it.
+     *
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function invisiblyDifferentValueProvider(): iterable
+    {
+        yield 'left to right mark' => [
+            "adm\u{200E}in",
+        ];
+        yield 'right to left mark' => [
+            "adm\u{200F}in",
+        ];
+        yield 'soft hyphen' => [
+            "adm\u{00AD}in",
+        ];
+        yield 'zero width space' => [
+            "adm\u{200B}in",
+        ];
+        yield 'object replacement character' => [
+            "adm\u{FFFC}in",
+        ];
+        yield 'ascii control' => [
+            "adm\x01in",
+        ];
+    }
+
+    public function testARenameOntoAnInvisiblyDifferentDnIsRefused(): void
+    {
+        $this->authenticateAdmin();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::ENTRY_ALREADY_EXISTS);
+
+        // Renaming keeps the parent, so this lands beside the seeded cn=admin under dc=foo,dc=bar.
+        $this->ldapClient()->rename(
+            'cn=nosn,dc=foo,dc=bar',
+            "cn=adm\u{200E}in",
+        );
     }
 
     public function testAddDuplicateDnFails(): void

--- a/tests/integration/Sync/SyncReplReplicaTestCase.php
+++ b/tests/integration/Sync/SyncReplReplicaTestCase.php
@@ -109,6 +109,58 @@ abstract class SyncReplReplicaTestCase extends ServerTestCase
         }
     }
 
+    /**
+     * The URL is generated on one side and parsed on the other, so only a round trip proves either.
+     */
+    public function test_the_referral_url_survives_the_round_trip_to_the_client(): void
+    {
+        self::assertNotNull($this->waitForReplica('cn=alice,ou=people,dc=foo,dc=bar'));
+
+        $client = $this->buildClient('tcp');
+        $client->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+
+        try {
+            $client->create(Entry::fromArray(
+                'cn=nope,ou=people,dc=foo,dc=bar',
+                [
+                    'objectClass' => 'inetOrgPerson',
+                    'cn' => 'nope',
+                    'sn' => 'Nope',
+                ],
+            ));
+
+            self::fail('The write should have been referred to the provider.');
+        } catch (ReferralException $e) {
+            $referrals = $e->getReferrals();
+
+            self::assertCount(
+                1,
+                $referrals,
+            );
+            self::assertSame(
+                sprintf(
+                    'ldap://127.0.0.1:%d/',
+                    TestWorker::port(TestWorker::OFFSET_PROVIDER),
+                ),
+                $referrals[0]->toString(),
+            );
+            self::assertSame(
+                '127.0.0.1',
+                $referrals[0]->getHost(),
+            );
+            self::assertSame(
+                TestWorker::port(TestWorker::OFFSET_PROVIDER),
+                $referrals[0]->getPort(),
+            );
+            self::assertFalse($referrals[0]->getUseSsl());
+        } finally {
+            $client->unbind();
+        }
+    }
+
     public function test_a_password_modify_on_the_replica_is_referred_to_the_provider(): void
     {
         $target = 'cn=user,dc=foo,dc=bar';

--- a/tests/resources/seed/backend-storage-seed.ldif
+++ b/tests/resources/seed/backend-storage-seed.ldif
@@ -43,6 +43,8 @@ uidNumber: 99
 employeeNumber: A1b2C3
 # Matched case-exactly by the schema, so searches on it prove the configured schema is in play.
 labeledURI: A1b2C3
+# Case folding maps the sharp s to "ss", which lowercasing alone would not.
+displayName: Straße
 
 dn: cn=nosn,dc=foo,dc=bar
 objectClass: groupOfNames

--- a/tests/unit/Entry/DnNormalizerTest.php
+++ b/tests/unit/Entry/DnNormalizerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Entry;
 
 use FreeDSx\Ldap\Entry\DnNormalizer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class DnNormalizerTest extends TestCase
@@ -98,11 +99,64 @@ final class DnNormalizerTest extends TestCase
         );
     }
 
-    public function test_a_null_byte_does_not_collapse_two_distinct_dns(): void
+    /**
+     * @param non-empty-string $dn
+     */
+    #[DataProvider('invisiblyDifferentDnProvider')]
+    public function test_a_dn_differing_only_by_a_code_point_that_renders_as_nothing_is_one_key(string $dn): void
     {
-        self::assertNotSame(
-            DnNormalizer::canonicalize("cn=a\\00b,dc=x"),
+        self::assertSame(
+            DnNormalizer::canonicalize('cn=admin,dc=x'),
+            DnNormalizer::canonicalize($dn),
+        );
+    }
+
+    /**
+     * The canonical form is the authorization key, so a second key here is an ACL rule that misses its entry.
+     *
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function invisiblyDifferentDnProvider(): iterable
+    {
+        yield 'left to right mark' => [
+            "cn=adm\u{200E}in,dc=x",
+        ];
+        yield 'right to left mark' => [
+            "cn=adm\u{200F}in,dc=x",
+        ];
+        yield 'left to right embedding' => [
+            "cn=adm\u{202A}in,dc=x",
+        ];
+        yield 'soft hyphen' => [
+            "cn=adm\u{00AD}in,dc=x",
+        ];
+        yield 'zero width space' => [
+            "cn=adm\u{200B}in,dc=x",
+        ];
+        yield 'object replacement character' => [
+            "cn=adm\u{FFFC}in,dc=x",
+        ];
+        // The ascii shortcut bypasses the prep profile, so it needs the same mapping.
+        yield 'ascii control below the line breaks' => [
+            "cn=adm\x01in,dc=x",
+        ];
+        yield 'ascii control above the line breaks' => [
+            "cn=adm\x1Fin,dc=x",
+        ];
+        yield 'delete' => [
+            "cn=adm\x7Fin,dc=x",
+        ];
+    }
+
+    /**
+     * RFC 4518 2.2 maps NUL to nothing, so the escaped form names the same entry. The raw byte is refused as
+     * invalid syntax instead, which is where the grammar draws the line.
+     */
+    public function test_an_escaped_null_byte_names_the_same_entry(): void
+    {
+        self::assertSame(
             DnNormalizer::canonicalize('cn=ab,dc=x'),
+            DnNormalizer::canonicalize("cn=a\\00b,dc=x"),
         );
     }
 

--- a/tests/unit/Entry/DnTest.php
+++ b/tests/unit/Entry/DnTest.php
@@ -92,14 +92,30 @@ class DnTest extends TestCase
      */
     public static function invalidAttributeTypeProvider(): iterable
     {
-        yield 'empty type' => ['=foo'];
-        yield 'punctuation only' => ['!!!=bar'];
-        yield 'inner space' => ['cn foo=bar'];
-        yield 'leading digit' => ['1cn=bar'];
-        yield 'underscore' => ['user_id=bar'];
-        yield 'attribute option' => ['cn;lang-en=bar'];
-        yield 'oid with a leading zero arc' => ['1.03.6=bar'];
-        yield 'undotted numeric oid' => ['2=bar'];
+        yield 'empty type' => [
+            '=foo',
+        ];
+        yield 'punctuation only' => [
+            '!!!=bar',
+        ];
+        yield 'inner space' => [
+            'cn foo=bar',
+        ];
+        yield 'leading digit' => [
+            '1cn=bar',
+        ];
+        yield 'underscore' => [
+            'user_id=bar',
+        ];
+        yield 'attribute option' => [
+            'cn;lang-en=bar',
+        ];
+        yield 'oid with a leading zero arc' => [
+            '1.03.6=bar',
+        ];
+        yield 'undotted numeric oid' => [
+            '2=bar',
+        ];
     }
 
     public function test_a_raw_null_byte_in_a_value_is_invalid(): void
@@ -136,10 +152,18 @@ class DnTest extends TestCase
      */
     public static function validAttributeTypeProvider(): iterable
     {
-        yield 'descr' => ['cn=bar'];
-        yield 'descr with a hyphen and digits' => ['x-my-attr2=bar'];
-        yield 'numeric oid' => ['2.5.4.3=bar'];
-        yield 'numeric oid with a zero arc' => ['2.5.0.3=bar'];
+        yield 'descr' => [
+            'cn=bar',
+        ];
+        yield 'descr with a hyphen and digits' => [
+            'x-my-attr2=bar',
+        ];
+        yield 'numeric oid' => [
+            '2.5.4.3=bar',
+        ];
+        yield 'numeric oid with a zero arc' => [
+            '2.5.0.3=bar',
+        ];
     }
 
     public function test_it_should_handle_a_rootdse_as_a_dn(): void

--- a/tests/unit/LdapUrlExtensionTest.php
+++ b/tests/unit/LdapUrlExtensionTest.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap;
 
+use FreeDSx\Ldap\Exception\UrlParseException;
 use FreeDSx\Ldap\LdapUrlExtension;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class LdapUrlExtensionTest extends TestCase
@@ -142,5 +144,51 @@ class LdapUrlExtensionTest extends TestCase
             'e-bindname=cn=Manager%2cdc=example%2cdc=com',
             $this->subject->toString(),
         );
+    }
+
+    public function test_it_should_parse_a_numeric_oid_extension_type(): void
+    {
+        self::assertEquals(
+            new LdapUrlExtension(
+                '1.3.6.1.4.1.1466.20037',
+                'v',
+            ),
+            LdapUrlExtension::parse('1.3.6.1.4.1.1466.20037=v'),
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function malformedExtensionProvider(): array
+    {
+        return [
+            'a repeated criticality marker' => [
+                '!!e-bindname',
+            ],
+            'a type with a leading hyphen' => [
+                '-bindname=v',
+            ],
+            'a type with a leading digit' => [
+                '1bindname=v',
+            ],
+            'an arc with a leading zero' => [
+                '1.03.6=v',
+            ],
+            'a type holding a space' => [
+                'e bindname=v',
+            ],
+            'an empty type' => [
+                '=v',
+            ],
+        ];
+    }
+
+    #[DataProvider('malformedExtensionProvider')]
+    public function test_it_should_reject_an_extension_type_that_is_not_an_oid(string $extension): void
+    {
+        $this->expectException(UrlParseException::class);
+
+        LdapUrlExtension::parse($extension);
     }
 }

--- a/tests/unit/LdapUrlTest.php
+++ b/tests/unit/LdapUrlTest.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Exception\UrlParseException;
 use FreeDSx\Ldap\LdapUrl;
 use FreeDSx\Ldap\LdapUrlExtension;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class LdapUrlTest extends TestCase
@@ -352,5 +353,131 @@ class LdapUrlTest extends TestCase
         $this->expectException(UrlParseException::class);
 
         LdapUrl::parse('ldap');
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function malformedUrlProvider(): array
+    {
+        return [
+            'more query components than exist' => [
+                'ldap://foo/dc=x????????',
+            ],
+            'empty attribute selector' => [
+                'ldap://foo/dc=x?cn,,sn?',
+            ],
+            'only an attribute separator' => [
+                'ldap://foo/dc=x?,?',
+            ],
+            'unrecognized scope' => [
+                'ldap://foo/dc=x??bogus',
+            ],
+            'extension type that is not an oid' => [
+                'ldap://foo/dc=x????!!bad',
+            ],
+            'extension type with a leading hyphen' => [
+                'ldap://foo/dc=x????-bad=v',
+            ],
+            'port beyond the valid range' => [
+                'ldap://foo:99999/dc=x',
+            ],
+        ];
+    }
+
+    #[DataProvider('malformedUrlProvider')]
+    public function test_it_should_reject_a_malformed_url(string $url): void
+    {
+        $this->expectException(UrlParseException::class);
+
+        LdapUrl::parse($url);
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function percentEncodingProvider(): array
+    {
+        return [
+            'a non ascii dn' => [
+                'ldap://foo/cn=caf%c3%a9,dc=x',
+                'cn=café,dc=x',
+            ],
+            'an uppercase escape' => [
+                'ldap://foo/cn=caf%C3%A9,dc=x',
+                'cn=café,dc=x',
+            ],
+            'an escape outside the reserved set' => [
+                'ldap://foo/cn=%41,dc=x',
+                'cn=A,dc=x',
+            ],
+            'an encoded percent stays text' => [
+                'ldap://foo/cn=%253f,dc=x',
+                'cn=%3f,dc=x',
+            ],
+            'a percent that escapes nothing' => [
+                'ldap://foo/cn=100%,dc=x',
+                'cn=100%,dc=x',
+            ],
+        ];
+    }
+
+    #[DataProvider('percentEncodingProvider')]
+    public function test_it_should_decode_any_percent_escape_exactly_once(
+        string $url,
+        string $expectedDn,
+    ): void {
+        self::assertSame(
+            $expectedDn,
+            (string) LdapUrl::parse($url)->getDn(),
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function roundTripProvider(): array
+    {
+        return [
+            'non ascii' => [
+                'cn=café,dc=x',
+            ],
+            'a literal percent' => [
+                'cn=100%,dc=x',
+            ],
+            'text that looks like an escape' => [
+                'cn=%3f,dc=x',
+            ],
+            'a space' => [
+                'cn=a b,dc=x',
+            ],
+            'a control character' => [
+                "cn=a\x01b,dc=x",
+            ],
+        ];
+    }
+
+    #[DataProvider('roundTripProvider')]
+    public function test_it_should_round_trip_a_dn_that_needs_escaping(string $dn): void
+    {
+        $url = (new LdapUrl('foo'))->setDn($dn);
+
+        self::assertSame(
+            $dn,
+            (string) LdapUrl::parse($url->toString())->getDn(),
+        );
+    }
+
+    /**
+     * RFC 4511 4.1.10 admits only the restricted set, so anything else survives by being escaped.
+     */
+    public function test_it_should_generate_a_url_with_no_octet_outside_the_restricted_set(): void
+    {
+        $url = (new LdapUrl('foo'))->setDn("cn=café\x01,dc=x");
+
+        self::assertSame(
+            'ldap://foo/cn=caf%c3%a9%01,dc=x',
+            $url->toString(),
+        );
     }
 }

--- a/tests/unit/Operation/LdapResultTest.php
+++ b/tests/unit/Operation/LdapResultTest.php
@@ -99,7 +99,27 @@ final class LdapResultTest extends TestCase
         );
     }
 
-    public function test_it_should_throw_a_protocol_exception_if_the_referral_cannot_be_parsed(): void
+    public function test_it_should_ignore_an_unparsable_referral_when_another_can_be_used(): void
+    {
+        $encoder = new LdapEncoder();
+
+        $result = LdapResult::fromAsn1(Asn1::sequence(
+            Asn1::enumerated(0),
+            Asn1::octetString('dc=foo,dc=bar'),
+            Asn1::octetString('foo'),
+            Asn1::context(3, (new IncompleteType(
+                $encoder->encode(Asn1::octetString('ldap://foo'))
+                . $encoder->encode(Asn1::octetString('bar')),
+            ))->setIsConstructed(true)),
+        ));
+
+        self::assertEquals(
+            [new LdapUrl('foo')],
+            $result->getReferrals(),
+        );
+    }
+
+    public function test_it_should_throw_a_protocol_exception_if_no_referral_can_be_parsed(): void
     {
         $encoder = new LdapEncoder();
 
@@ -110,8 +130,7 @@ final class LdapResultTest extends TestCase
             Asn1::octetString('dc=foo,dc=bar'),
             Asn1::octetString('foo'),
             Asn1::context(3, (new IncompleteType(
-                $encoder->encode(Asn1::octetString('ldap://foo'))
-                . $encoder->encode(Asn1::octetString('bar')),
+                $encoder->encode(Asn1::octetString('bar')),
             ))->setIsConstructed(true)),
         ));
     }

--- a/tests/unit/Operation/Response/SearchResultReferenceTest.php
+++ b/tests/unit/Operation/Response/SearchResultReferenceTest.php
@@ -69,12 +69,24 @@ final class SearchResultReferenceTest extends TestCase
         );
     }
 
-    public function test_it_should_throw_a_protocol_exception_if_the_referral_cannot_be_parsed(): void
+    public function test_it_should_ignore_an_unparsable_referral_when_another_can_be_used(): void
+    {
+        $this->subject = SearchResultReference::fromAsn1(Asn1::application(19, Asn1::sequence(
+            Asn1::octetString('ldap://foo/'),
+            Asn1::octetString('?bar'),
+        )));
+
+        self::assertEquals(
+            [new LdapUrl('foo')],
+            $this->subject->getReferrals(),
+        );
+    }
+
+    public function test_it_should_throw_a_protocol_exception_if_no_referral_can_be_parsed(): void
     {
         self::expectException(ProtocolException::class);
 
         SearchResultReference::fromAsn1(Asn1::application(19, Asn1::sequence(
-            Asn1::octetString('ldap://foo/'),
             Asn1::octetString('?bar'),
         )));
     }

--- a/tests/unit/Schema/Definition/GeneralizedTimeTest.php
+++ b/tests/unit/Schema/Definition/GeneralizedTimeTest.php
@@ -39,6 +39,17 @@ final class GeneralizedTimeTest extends TestCase
         );
     }
 
+    /**
+     * RFC 4517 3.3.13 admits "60" as a leap second, and it names the instant after 59.
+     */
+    public function test_parses_a_leap_second_as_the_instant_it_names(): void
+    {
+        self::assertSame(
+            '2017-01-01T00:00:00+00:00',
+            GeneralizedTime::parse('20161231235960Z')->format('c'),
+        );
+    }
+
     public function test_parses_hour_only_precision(): void
     {
         $parsed = GeneralizedTime::parse('2025041510Z');

--- a/tests/unit/Schema/Matching/StringPrepTest.php
+++ b/tests/unit/Schema/Matching/StringPrepTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Schema\Matching;
 
 use FreeDSx\Ldap\Schema\Matching\StringPrep;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class StringPrepTest extends TestCase
@@ -72,6 +73,93 @@ final class StringPrepTest extends TestCase
         self::assertSame(
             'foobar',
             $this->subject->prepareForEquality("foo\u{200B}bar"),
+        );
+    }
+
+    /**
+     * @param non-empty-string $value
+     */
+    #[DataProvider('mappedToNothingProvider')]
+    public function test_the_map_step_removes_a_code_point_that_renders_as_nothing(string $value): void
+    {
+        self::assertSame(
+            'admin',
+            $this->subject->prepareForEquality($value),
+        );
+    }
+
+    /**
+     * RFC 4518 2.2 enumerates these; left in place, each makes a value that renders as "admin" into a second,
+     * distinct value.
+     *
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function mappedToNothingProvider(): iterable
+    {
+        yield 'left to right mark' => [
+            "adm\u{200E}in",
+        ];
+        yield 'right to left mark' => [
+            "adm\u{200F}in",
+        ];
+        yield 'left to right embedding' => [
+            "adm\u{202A}in",
+        ];
+        yield 'pop directional formatting' => [
+            "adm\u{202C}in",
+        ];
+        yield 'mongolian todo soft hyphen' => [
+            "adm\u{1806}in",
+        ];
+        yield 'mongolian vowel separator' => [
+            "adm\u{180E}in",
+        ];
+        yield 'object replacement character' => [
+            "adm\u{FFFC}in",
+        ];
+        yield 'interlinear annotation anchor' => [
+            "adm\u{FFF9}in",
+        ];
+        yield 'word joiner' => [
+            "adm\u{2060}in",
+        ];
+        yield 'arabic end of ayah' => [
+            "adm\u{06DD}in",
+        ];
+        yield 'syriac abbreviation mark' => [
+            "adm\u{070F}in",
+        ];
+        yield 'control below the line breaks' => [
+            "adm\x01in",
+        ];
+        yield 'control above the line breaks' => [
+            "adm\x1Fin",
+        ];
+        yield 'delete' => [
+            "adm\x7Fin",
+        ];
+        yield 'c1 control' => [
+            "adm\u{009F}in",
+        ];
+        yield 'musical formatting' => [
+            "adm\u{1D173}in",
+        ];
+        yield 'language tag' => [
+            "adm\u{E0001}in",
+        ];
+        yield 'tag character' => [
+            "adm\u{E0041}in",
+        ];
+    }
+
+    /**
+     * The line breaking controls are the exception: RFC 4518 2.2 maps them to SPACE rather than to nothing.
+     */
+    public function test_the_map_step_folds_a_line_break_to_a_space_rather_than_removing_it(): void
+    {
+        self::assertSame(
+            'a b',
+            $this->subject->prepareForEquality("a\nb"),
         );
     }
 

--- a/tests/unit/Schema/Validation/Syntax/GeneralizedTimeSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/GeneralizedTimeSyntaxValidatorTest.php
@@ -48,6 +48,10 @@ final class GeneralizedTimeSyntaxValidatorTest extends TestCase
             'numeric offset' => ['20240101123000+0500'],
             'hour precision' => ['2024010112Z'],
             'fractional seconds' => ['20240101123000.5Z'],
+            'the largest offset the grammar admits' => ['20240101123000+2359'],
+            'a negative offset' => ['20240101123000-0500'],
+            // RFC 4517 3.3.13 defines leap-second as "60" alongside second, so this is a legal value.
+            'a leap second' => ['20161231235960Z'],
         ];
     }
 
@@ -63,6 +67,11 @@ final class GeneralizedTimeSyntaxValidatorTest extends TestCase
             'missing zone' => ['20240101123000'],
             'invalid month' => ['20241301010000Z'],
             'trailing newline' => ["20240101123000Z\n"],
+            // RFC 4517 3.3.13: g-differential reuses hour ("00" to "23") and minute ("00" to "59").
+            'offset hour above 23' => ['20240101123000+2400'],
+            'offset hour far above 23' => ['20240101123000+9900'],
+            'offset minute above 59' => ['20240101123000+0060'],
+            'a second above the leap second' => ['20240101123061Z'],
         ];
     }
 }

--- a/tests/unit/Schema/Validation/Syntax/OidSyntaxValidatorTest.php
+++ b/tests/unit/Schema/Validation/Syntax/OidSyntaxValidatorTest.php
@@ -48,6 +48,7 @@ final class OidSyntaxValidatorTest extends TestCase
             'short numeric oid' => ['2.5.4.3'],
             'descriptor' => ['cn'],
             'descriptor with digits and hyphen' => ['x-my-attr2'],
+            'a zero arc, which is a single digit rather than a leading zero' => ['1.0.6'],
         ];
     }
 
@@ -65,6 +66,11 @@ final class OidSyntaxValidatorTest extends TestCase
             'descriptor with underscore' => ['cn_x'],
             'with space' => ['1.2 3'],
             'trailing newline' => ["1.2.3\n"],
+            // RFC 4512 1.4: number is DIGIT / ( LDIGIT 1*DIGIT ), so 1.03.6 and 1.3.6 cannot both be spellings
+            // of one OID.
+            'leading zero in an arc' => ['1.03.6'],
+            'leading zeros in the first arc' => ['007.1'],
+            'a number carrying no dot is no numericoid' => ['1'],
         ];
     }
 }

--- a/tests/unit/Search/Filter/EqualityFilterTest.php
+++ b/tests/unit/Search/Filter/EqualityFilterTest.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Search\Filter;
 
 use FreeDSx\Asn1\Asn1;
+use FreeDSx\Ldap\Exception\FilterParseException;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class EqualityFilterTest extends TestCase
@@ -95,5 +97,74 @@ final class EqualityFilterTest extends TestCase
             '(foo=\29\28bar=foo)',
             $this->subject->toString(),
         );
+    }
+
+    /**
+     * @param non-empty-string $attribute
+     */
+    #[DataProvider('unrepresentableAttributeProvider')]
+    public function test_an_attribute_outside_the_grammar_has_no_string_representation(string $attribute): void
+    {
+        self::expectException(FilterParseException::class);
+
+        (new EqualityFilter($attribute, 'x'))->toString();
+    }
+
+    /**
+     * RFC 4515 3 takes attr from RFC 4512 2.5, and nothing escapes an attribute into shape.
+     *
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function unrepresentableAttributeProvider(): iterable
+    {
+        yield 'an opening parenthesis' => [
+            'cn(bad',
+        ];
+        yield 'a closing parenthesis' => [
+            'cn)bad',
+        ];
+        yield 'an equals sign' => [
+            'cn=bad',
+        ];
+        yield 'an asterisk' => [
+            'cn*bad',
+        ];
+        yield 'a leading digit' => [
+            '1cn',
+        ];
+        yield 'an underscore' => [
+            'user_id',
+        ];
+    }
+
+    /**
+     * @param non-empty-string $attribute
+     */
+    #[DataProvider('representableAttributeProvider')]
+    public function test_an_attribute_within_the_grammar_is_emitted_as_written(string $attribute): void
+    {
+        self::assertSame(
+            "($attribute=x)",
+            (new EqualityFilter($attribute, 'x'))->toString(),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function representableAttributeProvider(): iterable
+    {
+        yield 'a descr' => [
+            'cn',
+        ];
+        yield 'a descr with hyphens and digits' => [
+            'x-my-attr2',
+        ];
+        yield 'a numeric oid' => [
+            '2.5.4.3',
+        ];
+        yield 'a descr carrying an option' => [
+            'cn;lang-en',
+        ];
     }
 }

--- a/tests/unit/Search/FilterParserTest.php
+++ b/tests/unit/Search/FilterParserTest.php
@@ -286,6 +286,78 @@ final class FilterParserTest extends TestCase
         );
     }
 
+    /**
+     * @param non-empty-string $filter
+     */
+    #[DataProvider('malformedValueEncodingProvider')]
+    public function test_it_should_error_on_a_value_outside_the_rfc_4515_encoding(string $filter): void
+    {
+        self::expectException(FilterParseException::class);
+
+        FilterParser::parse($filter);
+    }
+
+    /**
+     * RFC 4515 3: escaped is ESC HEX HEX, and UTF1SUBSET excludes NUL, the parentheses and the asterisk.
+     *
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function malformedValueEncodingProvider(): iterable
+    {
+        yield 'a backslash followed by no hex digits' => [
+            '(cn=a\zz)',
+        ];
+        yield 'a backslash at the end of a value' => [
+            '(cn=a\)',
+        ];
+        yield 'a backslash followed by one hex digit' => [
+            '(cn=a\5)',
+        ];
+        yield 'an unescaped opening parenthesis' => [
+            '(cn=a(b)',
+        ];
+        yield 'a raw null byte' => [
+            "(cn=a\x00b)",
+        ];
+    }
+
+    /**
+     * @param non-empty-string $filter
+     */
+    #[DataProvider('wellFormedValueEncodingProvider')]
+    public function test_it_should_accept_a_value_within_the_rfc_4515_encoding(string $filter): void
+    {
+        self::assertSame(
+            $filter,
+            FilterParser::parse($filter)->toString(),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function wellFormedValueEncodingProvider(): iterable
+    {
+        yield 'an escaped backslash' => [
+            '(cn=a\5cb)',
+        ];
+        yield 'an escaped parenthesis' => [
+            '(cn=a\28b)',
+        ];
+        yield 'an escaped asterisk' => [
+            '(cn=a\2ab)',
+        ];
+        yield 'an escaped null' => [
+            '(cn=a\00b)',
+        ];
+        yield 'a substring, whose asterisks are structural' => [
+            '(cn=a*b*c)',
+        ];
+        yield 'a multibyte value' => [
+            '(cn=Ω)',
+        ];
+    }
+
     public function test_it_should_error_on_nested_unmatched_parenthesis(): void
     {
         self::expectException(FilterParseException::class);


### PR DESCRIPTION
Hopefully the last round of these for a bit. More fixes to DN handled (stringprep related weirdness around characters considered "nothing"), LDAP URL parsing fixes (original escaping I implemented was wrong, though this is really not used much server side here), edge cases around generalized time parsing, and string filter validation (specifically the attribute descriptions).