### PR TITLE
[1.0.0] Server RFC conformance fixes: write path / paging sorts

### DIFF
--- a/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Container\Contributor\DirectoryListenerContributor;
 use FreeDSx\Ldap\Container\Contributor\ListenerContributorInterface;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\Factory\ServerProtocolHandlerFactory;
+use FreeDSx\Ldap\Schema\Matching\EqualityComparatorResolver;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Schema\Validation\Syntax\AttributeSyntaxResolver;
@@ -50,6 +51,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Journal\InMemoryChangeJournal;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionPolicy;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\RetentionSweeper;
 use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Operation\WriteEntryOperationHandler;
 use FreeDSx\Ldap\Server\Backend\Storage\OperationalAttributeGenerator;
 use FreeDSx\Ldap\Server\Backend\Storage\SearchStreamBuilder;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptionsFactory;
@@ -172,6 +174,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
         return new FilterEvaluator(
             $container->get(ServerOptions::class)->getSchema(),
             $this->makeDerivedResolver($container),
+            $this->makeEqualityComparatorResolver($container),
             $this->makeAttributeSyntaxResolver($container),
         );
     }
@@ -179,6 +182,13 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
     private function makeAttributeSyntaxResolver(Container $container): AttributeSyntaxResolver
     {
         return new AttributeSyntaxResolver(
+            $container->get(ServerOptions::class)->getSchema(),
+        );
+    }
+
+    private function makeEqualityComparatorResolver(Container $container): EqualityComparatorResolver
+    {
+        return new EqualityComparatorResolver(
             $container->get(ServerOptions::class)->getSchema(),
         );
     }
@@ -332,6 +342,9 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
                 $options->makeSearchLimits(),
             ),
             filterEvaluator: $container->get(FilterEvaluatorInterface::class),
+            entryHandler: new WriteEntryOperationHandler(
+                $this->makeEqualityComparatorResolver($container),
+            ),
             operationalAttrs: $container->get(OperationalAttributeGenerator::class),
             changeRecorder: $this->changeRecorderFor($container, $storage),
         );

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -72,12 +72,22 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         $pagingRequest = $this->findOrMakePagingRequest($message);
         $searchRequest = $this->getSearchRequestFromMessage($message);
 
+        $sortControl = $this->sortingControl($message);
+        $sortResponse = $this->sortingResponseControl(
+            $sortControl,
+            $this->schema,
+        );
+
         $response = null;
         $controls = [];
         $entriesReturned = 0;
         $failure = null;
         try {
             $this->assertBaseDnProvided($searchRequest);
+            $this->assertSortIsSatisfiable(
+                $sortControl,
+                $sortResponse,
+            );
 
             $response = $this->handlePaging(
                 $pagingRequest,
@@ -115,10 +125,6 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
             $controls[] = new PagingControl(0, '');
         }
 
-        $sortResponse = $this->sortingResponseControl(
-            $this->sortingControl($message),
-            $this->schema,
-        );
         if ($sortResponse !== null) {
             $controls[] = $sortResponse;
         }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
@@ -282,6 +282,43 @@ trait ServerSearchTrait
     }
 
     /**
+     * RFC 2891 §1.2: the sort response for a sort demanded critically that the server cannot honor.
+     */
+    private function unsatisfiedCriticalSort(
+        ?SortingControl $sortControl,
+        ?SortingResponseControl $sortResponse,
+    ): ?SortingResponseControl {
+        if ($sortControl === null || !$sortControl->getCriticality()) {
+            return null;
+        }
+
+        if ($sortResponse === null || $sortResponse->getResult() === ResultCode::SUCCESS) {
+            return null;
+        }
+
+        return $sortResponse;
+    }
+
+    /**
+     * The refusal as an exception, for callers whose failure path already tears down per-request state.
+     *
+     * @throws OperationException
+     */
+    private function assertSortIsSatisfiable(
+        ?SortingControl $sortControl,
+        ?SortingResponseControl $sortResponse,
+    ): void {
+        if ($this->unsatisfiedCriticalSort($sortControl, $sortResponse) === null) {
+            return;
+        }
+
+        throw new OperationException(
+            'The requested sort could not be performed.',
+            ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
+        );
+    }
+
+    /**
      * RFC 2891 §1.2: a critical sort the server cannot honor fails the search and returns no entries.
      */
     private function refuseUnsortableCriticalSearch(
@@ -289,11 +326,11 @@ trait ServerSearchTrait
         ?SortingControl $sortControl,
         ?SortingResponseControl $sortResponse,
     ): ?ResponseStream {
-        if ($sortControl === null || !$sortControl->getCriticality()) {
-            return null;
-        }
-
-        if ($sortResponse === null || $sortResponse->getResult() === ResultCode::SUCCESS) {
+        $unsatisfied = $this->unsatisfiedCriticalSort(
+            $sortControl,
+            $sortResponse,
+        );
+        if ($unsatisfied === null) {
             return null;
         }
 
@@ -304,7 +341,7 @@ trait ServerSearchTrait
                     ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
                     diagnosticMessage: 'The requested sort could not be performed.',
                 ),
-                $sortResponse,
+                $unsatisfied,
             )],
             OperationOutcomeResult::failed(ResultCode::UNAVAILABLE_CRITICAL_EXTENSION),
         );

--- a/src/FreeDSx/Ldap/Schema/Matching/EqualityComparatorResolver.php
+++ b/src/FreeDSx/Ldap/Schema/Matching/EqualityComparatorResolver.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Schema\Matching;
+
+use FreeDSx\Ldap\Schema\Matching\Comparator\CaseIgnoreComparator;
+use FreeDSx\Ldap\Schema\Schema;
+
+/**
+ * Resolves the EQUALITY rule an attribute type declares, so every path deciding value equality asks the same question.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class EqualityComparatorResolver
+{
+    public function __construct(
+        private Schema $schema,
+        private MatchingRuleComparatorInterface $default = new CaseIgnoreComparator(),
+    ) {}
+
+    /**
+     * Falls back to the default when the type is undefined or declares a rule nothing implements.
+     */
+    public function for(string $attributeName): MatchingRuleComparatorInterface
+    {
+        $equalityOid = $this->schema->getAttributeType($attributeName)?->equalityOid;
+        $comparator = $equalityOid !== null
+            ? $this->schema->getComparator($equalityOid)
+            : null;
+
+        return $comparator ?? $this->default;
+    }
+}

--- a/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Schema\Validation;
 use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Entry\Rdn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Schema\Definition\AttributeUsage;
@@ -100,6 +101,52 @@ final class SchemaValidator
         $this->checkNoEquivalentValues($result);
         $this->checkStructuralClassUnchanged($result);
         $this->validateStructure($result);
+    }
+
+    /**
+     * Validates the entry resulting from a modifyDn, where the new RDN adds values and the old one may remove them.
+     *
+     * @param bool $isSystem Skip the NO-USER-MODIFICATION check for server-initiated writes.
+     * @throws OperationException
+     */
+    public function validateModifyDn(
+        Entry $result,
+        Rdn $newRdn,
+        bool $isSystem = false,
+    ): void {
+        if ($this->mode === SchemaValidationMode::Off) {
+            return;
+        }
+
+        // Checked first, since a caller relaxing an earlier violation would otherwise stop validation before this.
+        $this->checkAttributeSyntaxes($result);
+        if (!$isSystem) {
+            $this->checkNoUserModificationInRdn($newRdn);
+        }
+
+        $this->checkNoEquivalentValues($result);
+        $this->validateStructure($result);
+    }
+
+    /**
+     * The new RDN is client-supplied, so the values it puts on the entry face the same restriction as a modify.
+     *
+     * @throws OperationException
+     */
+    private function checkNoUserModificationInRdn(Rdn $rdn): void
+    {
+        foreach ($rdn->getAll() as $component) {
+            $attrType = $this->schema->getAttributeType($component->getName());
+
+            if ($attrType === null || !$attrType->noUserModification) {
+                continue;
+            }
+
+            $this->fail(
+                sprintf('Attribute "%s" cannot be set by users.', $component->getName()),
+                ResultCode::CONSTRAINT_VIOLATION,
+            );
+        }
     }
 
     /**

--- a/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
@@ -22,7 +22,7 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Schema\Definition\AttributeUsage;
 use FreeDSx\Ldap\Schema\Definition\ObjectClass;
 use FreeDSx\Ldap\Schema\Definition\ObjectClassType;
-use FreeDSx\Ldap\Schema\Matching\Comparator\CaseIgnoreComparator;
+use FreeDSx\Ldap\Schema\Matching\EqualityComparatorResolver;
 use FreeDSx\Ldap\Schema\Matching\MatchingRuleComparatorInterface;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
@@ -41,11 +41,16 @@ final class SchemaValidator
 
     private readonly AttributeSyntaxResolver $syntaxResolver;
 
+    private readonly EqualityComparatorResolver $equalityResolver;
+
     public function __construct(
         private readonly Schema $schema,
         private readonly SchemaValidationMode $mode,
+        ?AttributeSyntaxResolver $syntaxResolver = null,
+        ?EqualityComparatorResolver $equalityResolver = null,
     ) {
-        $this->syntaxResolver = new AttributeSyntaxResolver($schema);
+        $this->syntaxResolver = $syntaxResolver ?? new AttributeSyntaxResolver($schema);
+        $this->equalityResolver = $equalityResolver ?? new EqualityComparatorResolver($schema);
     }
 
     public function mode(): SchemaValidationMode
@@ -255,7 +260,7 @@ final class SchemaValidator
      */
     private function hasEquivalentValues(Attribute $attr): bool
     {
-        $comparator = $this->equalityComparatorFor($attr->getName());
+        $comparator = $this->equalityResolver->for($attr->getName());
         $seen = [];
 
         foreach ($attr->getValues() as $value) {
@@ -284,16 +289,6 @@ final class SchemaValidator
         }
 
         return false;
-    }
-
-    private function equalityComparatorFor(string $attribute): MatchingRuleComparatorInterface
-    {
-        $equalityOid = $this->schema->getAttributeType($attribute)?->equalityOid;
-        $comparator = $equalityOid !== null
-            ? $this->schema->getComparator($equalityOid)
-            : null;
-
-        return $comparator ?? new CaseIgnoreComparator();
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/MoveOperation.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/MoveOperation.php
@@ -36,14 +36,34 @@ final class MoveOperation
         $newEntry = new Entry($newDn, ...$entry->getAttributes());
 
         if ($command->deleteOldRdn) {
-            foreach ($command->dn->getRdn()->getAll() as $component) {
-                $newEntry->get($component->getName())?->removeValues(
-                    [Rdn::unescape($component->getValue())],
-                    caseSensitive: false,
-                );
-            }
+            $this->removeOldRdnValues(
+                $newEntry,
+                $command->dn->getRdn(),
+            );
         }
 
         return $newEntry->mergeRdnAttributes();
+    }
+
+    /**
+     * An attribute cannot remain on an entry with no values.
+     */
+    private function removeOldRdnValues(
+        Entry $entry,
+        Rdn $oldRdn,
+    ): void {
+        foreach ($oldRdn->getAll() as $component) {
+            $existing = $entry->get($component->getName());
+            if ($existing === null) {
+                continue;
+            }
+            $existing->removeValues(
+                [Rdn::unescape($component->getValue())],
+                caseSensitive: false,
+            );
+            if ($existing->getValues() === []) {
+                $entry->reset($existing);
+            }
+        }
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/UpdateOperation.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/UpdateOperation.php
@@ -171,6 +171,11 @@ final class UpdateOperation
             $values,
             caseSensitive: false,
         );
+
+        // RFC 4511 §4.6: listing every value an attribute currently holds removes the attribute itself.
+        if ($existing->getValues() === []) {
+            $entry->reset($existing);
+        }
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/UpdateOperation.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/UpdateOperation.php
@@ -18,6 +18,8 @@ use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Matching\EqualityComparatorResolver;
+use FreeDSx\Ldap\Schema\Matching\MatchingRuleComparatorInterface;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 
 /**
@@ -27,6 +29,10 @@ use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
  */
 final class UpdateOperation
 {
+    public function __construct(
+        private readonly EqualityComparatorResolver $equalityResolver,
+    ) {}
+
     /**
      * @throws OperationException
      */
@@ -69,9 +75,10 @@ final class UpdateOperation
             $entry->add($attribute);
             return;
         }
+        $comparator = $this->equalityResolver->for($attribute->getName());
 
         foreach ($attribute->getValues() as $value) {
-            if ($existing->has($value, caseSensitive: false)) {
+            if ($this->matchesAny($comparator, $existing->getValues(), $value)) {
                 throw new OperationException(
                     sprintf('Attribute "%s" already contains the given value.', $attribute->getName()),
                     ResultCode::ATTRIBUTE_OR_VALUE_EXISTS,
@@ -147,15 +154,17 @@ final class UpdateOperation
             $entry,
             $attribute->getName(),
         );
+        $comparator = $this->equalityResolver->for($attribute->getName());
 
         foreach ($values as $value) {
-            if (!$existing->has($value, caseSensitive: false)) {
+            if (!$this->matchesAny($comparator, $existing->getValues(), $value)) {
                 throw new OperationException(
                     sprintf('The given value does not exist in attribute "%s".', $attribute->getName()),
                     ResultCode::NO_SUCH_ATTRIBUTE,
                 );
             }
 
+            // Folded rather than matched by rule, so the value naming the entry is protected however it is spelled.
             if ($rdnValue !== null && strcasecmp($value, $rdnValue) === 0) {
                 throw new OperationException(
                     sprintf(
@@ -167,15 +176,56 @@ final class UpdateOperation
             }
         }
 
-        $existing->removeValues(
+        $existing->removeValues($this->valuesMatching(
+            $comparator,
+            $existing->getValues(),
             $values,
-            caseSensitive: false,
-        );
+        ));
 
         // RFC 4511 §4.6: listing every value an attribute currently holds removes the attribute itself.
         if ($existing->getValues() === []) {
             $entry->reset($existing);
         }
+    }
+
+    /**
+     * The stored values a delete names, resolved by the type's equality rule rather than by their spelling.
+     *
+     * @param string[] $stored
+     * @param string[] $requested
+     * @return list<string>
+     */
+    private function valuesMatching(
+        MatchingRuleComparatorInterface $comparator,
+        array $stored,
+        array $requested,
+    ): array {
+        $matched = [];
+
+        foreach ($stored as $value) {
+            if ($this->matchesAny($comparator, $requested, $value)) {
+                $matched[] = $value;
+            }
+        }
+
+        return $matched;
+    }
+
+    /**
+     * @param string[] $values
+     */
+    private function matchesAny(
+        MatchingRuleComparatorInterface $comparator,
+        array $values,
+        string $candidate,
+    ): bool {
+        foreach ($values as $value) {
+            if ($comparator->equals($value, $candidate)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/WriteEntryOperationHandler.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Operation/WriteEntryOperationHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Operation;
 
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Schema\Matching\EqualityComparatorResolver;
 use FreeDSx\Ldap\Server\Backend\Write\Command\MoveCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 use FreeDSx\Ldap\Server\Backend\Write\WriteRequestInterface;
@@ -26,6 +27,15 @@ use LogicException;
  */
 final class WriteEntryOperationHandler
 {
+    private readonly UpdateOperation $update;
+
+    public function __construct(
+        EqualityComparatorResolver $equalityResolver,
+        private readonly MoveOperation $move = new MoveOperation(),
+    ) {
+        $this->update = new UpdateOperation($equalityResolver);
+    }
+
     public function apply(
         Entry $entry,
         WriteRequestInterface $command,
@@ -34,8 +44,8 @@ final class WriteEntryOperationHandler
         $target = $entry->makeCopy();
 
         return match (true) {
-            $command instanceof UpdateCommand => (new UpdateOperation())->execute($target, $command),
-            $command instanceof MoveCommand => (new MoveOperation())->execute($target, $command),
+            $command instanceof UpdateCommand => $this->update->execute($target, $command),
+            $command instanceof MoveCommand => $this->move->execute($target, $command),
             default => throw new LogicException(
                 sprintf('No entry operation handler for %s', $command::class),
             ),

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Filter/FilterEvaluator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Filter/FilterEvaluator.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Schema\Definition\SyntaxOid;
 use FreeDSx\Ldap\Schema\Matching\Comparator\CaseIgnoreComparator;
+use FreeDSx\Ldap\Schema\Matching\EqualityComparatorResolver;
 use FreeDSx\Ldap\Schema\Matching\Comparator\IntegerComparator;
 use FreeDSx\Ldap\Schema\Matching\MatchingRuleComparatorInterface;
 use FreeDSx\Ldap\Schema\Matching\SubstringAssertion;
@@ -102,6 +103,7 @@ final class FilterEvaluator implements FilterEvaluatorInterface
     public function __construct(
         private readonly Schema $schema,
         private readonly DerivedResolver $derivedResolver,
+        private readonly EqualityComparatorResolver $equalityResolver,
         ?AttributeSyntaxResolver $syntaxResolver = null,
         private readonly CaseIgnoreComparator $defaultComparator = new CaseIgnoreComparator(),
         private readonly IntegerComparator $integerComparator = new IntegerComparator(),
@@ -236,7 +238,7 @@ final class FilterEvaluator implements FilterEvaluatorInterface
             return FilterResult::False;
         }
 
-        $comparator = $this->resolveEqualityComparator($filter->getAttribute());
+        $comparator = $this->equalityResolver->for($filter->getAttribute());
         $filterValue = $filter->getValue();
 
         foreach ($values as $value) {
@@ -333,7 +335,7 @@ final class FilterEvaluator implements FilterEvaluatorInterface
 
         // No approximate rule is implemented, so this falls back to the type's own equality rather than a case
         // insensitive default, which would answer differently than the equality filter for the same assertion.
-        $comparator = $this->resolveEqualityComparator($filter->getAttribute());
+        $comparator = $this->equalityResolver->for($filter->getAttribute());
         $filterValue = $filter->getValue();
 
         foreach ($values as $value) {
@@ -454,7 +456,7 @@ final class FilterEvaluator implements FilterEvaluatorInterface
         // RFC 4511 4.5.1.7.7: an absent matchingRule means the EQUALITY rule of the attribute type.
         if ($rule === null) {
             $comparator = $attribute !== null
-                ? $this->resolveEqualityComparator($attribute)
+                ? $this->equalityResolver->for($attribute)
                 : $this->defaultComparator;
 
             return $comparator->equals(...);
@@ -476,16 +478,6 @@ final class FilterEvaluator implements FilterEvaluatorInterface
                 => ((int) $v & (int) $a) !== 0,
             default => null,
         };
-    }
-
-    private function resolveEqualityComparator(string $attrName): MatchingRuleComparatorInterface
-    {
-        $attrType = $this->schema->getAttributeType($attrName);
-        $comparator = $attrType?->equalityOid !== null
-            ? $this->schema->getComparator($attrType->equalityOid)
-            : null;
-
-        return $comparator ?? $this->defaultComparator;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -68,8 +68,8 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         private readonly SchemaValidator $validator,
         private readonly StorageListOptionsFactory $listOptions,
         private readonly FilterEvaluatorInterface $filterEvaluator,
+        private readonly WriteEntryOperationHandler $entryHandler,
         private readonly OperationalAttributeGenerator $operationalAttrs = new OperationalAttributeGenerator(),
-        private readonly WriteEntryOperationHandler $entryHandler = new WriteEntryOperationHandler(),
         private readonly ?ChangeRecorder $changeRecorder = null,
         private readonly SubentryPlacementGuard $subentryGuard = new SubentryPlacementGuard(),
     ) {}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -411,6 +411,11 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             $this->assertNewSuperiorExists($storage, $command);
 
             $newEntry = $this->entryHandler->apply($entry, $command);
+            $this->validateForMove(
+                $command,
+                $newEntry,
+                $context,
+            );
             $normNew = $newEntry->getDn()->normalize();
 
             if ($storage->exists($normNew)) {
@@ -609,6 +614,28 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             $this->validator->validateModify(
                 $command,
                 $updated,
+                $context->isSystem(),
+            );
+        } catch (OperationException $e) {
+            $this->recordOrReject(
+                $e,
+                $context,
+            );
+        }
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function validateForMove(
+        MoveCommand $command,
+        Entry $moved,
+        WriteContext $context,
+    ): void {
+        try {
+            $this->validator->validateModifyDn(
+                $moved,
+                $command->newRdn,
                 $context->isSystem(),
             );
         } catch (OperationException $e) {

--- a/tests/integration/Storage/Concern/ControlTestsTrait.php
+++ b/tests/integration/Storage/Concern/ControlTestsTrait.php
@@ -122,6 +122,52 @@ trait ControlTestsTrait
         }
     }
 
+    public function testACriticalSortThatCannotBePerformedFailsAPagedSearch(): void
+    {
+        $this->authenticateUser();
+
+        $paging = $this->ldapClient()
+            ->paging(
+                Operations::search(Filters::present('objectClass'))
+                    ->base('dc=foo,dc=bar')
+                    ->useSubtreeScope(),
+                2,
+            )
+            ->useControls((new SortingControl(SortKey::ascending('bogusAttr')))->setCriticality(true));
+
+        try {
+            $entries = $paging->getEntries();
+            self::fail(sprintf(
+                'The critical sort should have failed the paged search, got %d entries.',
+                count($entries),
+            ));
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
+                $e->getCode(),
+            );
+        }
+    }
+
+    public function testANonCriticalSortThatCannotBePerformedStillReturnsPagedEntries(): void
+    {
+        $this->authenticateUser();
+
+        $paging = $this->ldapClient()
+            ->paging(
+                Operations::search(Filters::present('objectClass'))
+                    ->base('dc=foo,dc=bar')
+                    ->useSubtreeScope(),
+                2,
+            )
+            ->useControls(new SortingControl(SortKey::ascending('bogusAttr')));
+
+        self::assertCount(
+            2,
+            $paging->getEntries(),
+        );
+    }
+
     public function testANonCriticalSortThatCannotBePerformedStillReturnsEntries(): void
     {
         $this->authenticateUser();

--- a/tests/integration/Storage/Concern/WriteTestsTrait.php
+++ b/tests/integration/Storage/Concern/WriteTestsTrait.php
@@ -462,6 +462,133 @@ trait WriteTestsTrait
         );
     }
 
+    public function testModifyAddOfACaseVariantOnACaseExactAttributeIsANewValue(): void
+    {
+        $this->authenticateAdmin();
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=exactadd,dc=foo,dc=bar',
+            [
+                'cn' => 'exactadd',
+                'sn' => 'Exact',
+                'labeledURI' => 'http://Example.COM/A',
+                'objectClass' => 'inetOrgPerson',
+            ],
+        ));
+
+        $this->ldapClient()->send(Operations::modify(
+            'cn=exactadd,dc=foo,dc=bar',
+            Change::add(new Attribute('labeledURI', 'http://example.com/a')),
+        ));
+
+        $found = $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'), 'labeledURI')
+                ->base('cn=exactadd,dc=foo,dc=bar')
+                ->useBaseScope(),
+        );
+        self::assertCount(
+            2,
+            $found->first()?->get('labeledURI')?->getValues() ?? [],
+        );
+
+        $this->ldapClient()->delete('cn=exactadd,dc=foo,dc=bar');
+    }
+
+    public function testModifyDeleteOfACaseVariantOnACaseExactAttributeIsRefused(): void
+    {
+        $this->authenticateAdmin();
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=exactdel,dc=foo,dc=bar',
+            [
+                'cn' => 'exactdel',
+                'sn' => 'Exact',
+                'labeledURI' => 'http://Example.COM/A',
+                'objectClass' => 'inetOrgPerson',
+            ],
+        ));
+
+        try {
+            $this->ldapClient()->send(Operations::modify(
+                'cn=exactdel,dc=foo,dc=bar',
+                Change::delete(new Attribute('labeledURI', 'http://example.com/a')),
+            ));
+            self::fail('Deleting a value the entry does not hold should have been rejected.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::NO_SUCH_ATTRIBUTE,
+                $e->getCode(),
+            );
+        }
+
+        $found = $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'), 'labeledURI')
+                ->base('cn=exactdel,dc=foo,dc=bar')
+                ->useBaseScope(),
+        );
+        self::assertSame(
+            ['http://Example.COM/A'],
+            $found->first()?->get('labeledURI')?->getValues(),
+        );
+
+        $this->ldapClient()->delete('cn=exactdel,dc=foo,dc=bar');
+    }
+
+    public function testModifyDeleteOfACaseVariantOnACaseIgnoreAttributeSucceeds(): void
+    {
+        $this->authenticateAdmin();
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=ignoredel,dc=foo,dc=bar',
+            [
+                'cn' => 'ignoredel',
+                'sn' => 'Ignore',
+                'description' => 'Hello World',
+                'objectClass' => 'inetOrgPerson',
+            ],
+        ));
+
+        $this->ldapClient()->send(Operations::modify(
+            'cn=ignoredel,dc=foo,dc=bar',
+            Change::delete(new Attribute('description', 'hello world')),
+        ));
+
+        $found = $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'), 'description')
+                ->base('cn=ignoredel,dc=foo,dc=bar')
+                ->useBaseScope(),
+        );
+        self::assertNull($found->first()?->get('description'));
+
+        $this->ldapClient()->delete('cn=ignoredel,dc=foo,dc=bar');
+    }
+
+    public function testModifyDeleteFoldsInsignificantSpaceOnACaseIgnoreAttribute(): void
+    {
+        $this->authenticateAdmin();
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=spacedel,dc=foo,dc=bar',
+            [
+                'cn' => 'spacedel',
+                'sn' => 'Space',
+                'description' => 'Hello World',
+                'objectClass' => 'inetOrgPerson',
+            ],
+        ));
+
+        // RFC 4518 §2.6.1 folds inner whitespace, so the doubled space names the stored value.
+        $this->ldapClient()->send(Operations::modify(
+            'cn=spacedel,dc=foo,dc=bar',
+            Change::delete(new Attribute('description', 'Hello  World')),
+        ));
+
+        $found = $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'), 'description')
+                ->base('cn=spacedel,dc=foo,dc=bar')
+                ->useBaseScope(),
+        );
+        self::assertNull($found->first()?->get('description'));
+
+        $this->ldapClient()->delete('cn=spacedel,dc=foo,dc=bar');
+    }
+
     public function testModifyDeletingEveryValueRemovesTheAttribute(): void
     {
         $this->authenticateAdmin();

--- a/tests/integration/Storage/Concern/WriteTestsTrait.php
+++ b/tests/integration/Storage/Concern/WriteTestsTrait.php
@@ -462,6 +462,167 @@ trait WriteTestsTrait
         );
     }
 
+    public function testModifyDeletingEveryValueRemovesTheAttribute(): void
+    {
+        $this->authenticateAdmin();
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=dropmail,dc=foo,dc=bar',
+            [
+                'cn' => 'dropmail',
+                'sn' => 'Drop',
+                'mail' => ['one@foo.bar', 'two@foo.bar'],
+                'objectClass' => 'inetOrgPerson',
+            ],
+        ));
+
+        $this->ldapClient()->send(Operations::modify(
+            'cn=dropmail,dc=foo,dc=bar',
+            Change::delete(new Attribute('mail', 'one@foo.bar', 'two@foo.bar')),
+        ));
+
+        $found = $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'), 'mail')
+                ->base('cn=dropmail,dc=foo,dc=bar')
+                ->useBaseScope(),
+        );
+        self::assertNull($found->first()?->get('mail'));
+
+        $this->ldapClient()->delete('cn=dropmail,dc=foo,dc=bar');
+    }
+
+    public function testModifyDeletingTheLastValueOfARequiredAttributeIsRefused(): void
+    {
+        $this->authenticateAdmin();
+
+        // Naming every value is the same removal as deleting the attribute outright, so sn must not survive empty.
+        try {
+            $this->ldapClient()->send(Operations::modify(
+                'cn=user,dc=foo,dc=bar',
+                Change::delete(new Attribute('sn', 'Admin')),
+            ));
+            self::fail('The schema violating modify should have been rejected.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::OBJECT_CLASS_VIOLATION,
+                $e->getCode(),
+            );
+        }
+
+        $found = $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'), 'sn')
+                ->base('cn=user,dc=foo,dc=bar')
+                ->useBaseScope(),
+        );
+        self::assertSame(
+            ['Admin'],
+            $found->first()?->get('sn')?->getValues(),
+        );
+    }
+
+    public function testRenameRemovingTheLastValueOfARequiredAttributeIsRefused(): void
+    {
+        $this->authenticateAdmin();
+
+        // cn=user is an inetOrgPerson, so deleting the old cn leaves it without an attribute person requires.
+        try {
+            $this->ldapClient()->rename('cn=user,dc=foo,dc=bar', 'sn=Admin', true);
+            self::fail('The schema violating rename should have been rejected.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::OBJECT_CLASS_VIOLATION,
+                $e->getCode(),
+            );
+        }
+
+        $found = $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'), 'cn')
+                ->base('cn=user,dc=foo,dc=bar')
+                ->useBaseScope(),
+        );
+        self::assertSame(
+            ['user'],
+            $found->first()?->get('cn')?->getValues(),
+        );
+    }
+
+    public function testRenameToAnUndefinedAttributeTypeIsRefused(): void
+    {
+        $this->authenticateAdmin();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::UNDEFINED_ATTRIBUTE_TYPE);
+
+        $this->ldapClient()->rename('cn=user,dc=foo,dc=bar', 'undefinedType=user', false);
+    }
+
+    public function testRenameToAnAttributeNoObjectClassPermitsIsRefused(): void
+    {
+        $this->authenticateAdmin();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::OBJECT_CLASS_VIOLATION);
+
+        $this->ldapClient()->rename('cn=user,dc=foo,dc=bar', 'dc=user', false);
+    }
+
+    public function testRenameToANoUserModificationAttributeIsRefused(): void
+    {
+        $this->authenticateAdmin();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::CONSTRAINT_VIOLATION);
+
+        $this->ldapClient()->rename('cn=user,dc=foo,dc=bar', 'hasSubordinates=TRUE', false);
+    }
+
+    public function testRenameDropsAnRdnAttributeLeftWithNoValues(): void
+    {
+        $this->authenticateAdmin();
+        $this->ldapClient()->create(Entry::fromArray(
+            'employeeNumber=E1,dc=foo,dc=bar',
+            [
+                'cn' => 'pruneme',
+                'sn' => 'Prune',
+                'employeeNumber' => 'E1',
+                'objectClass' => 'inetOrgPerson',
+            ],
+        ));
+
+        $this->ldapClient()->rename('employeeNumber=E1,dc=foo,dc=bar', 'cn=pruneme', true);
+
+        $found = $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'), 'employeeNumber')
+                ->base('cn=pruneme,dc=foo,dc=bar')
+                ->useBaseScope(),
+        );
+        self::assertNull($found->first()?->get('employeeNumber'));
+
+        $this->ldapClient()->delete('cn=pruneme,dc=foo,dc=bar');
+    }
+
+    public function testRenameKeepsAnRdnAttributeHoldingOtherValues(): void
+    {
+        $this->authenticateAdmin();
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=keepme,dc=foo,dc=bar',
+            ['cn' => ['keepme', 'kept'], 'sn' => 'Keep', 'objectClass' => 'inetOrgPerson'],
+        ));
+
+        $this->ldapClient()->rename('cn=keepme,dc=foo,dc=bar', 'cn=kept', true);
+
+        $found = $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'), 'cn')
+                ->base('cn=kept,dc=foo,dc=bar')
+                ->useBaseScope(),
+        );
+        self::assertSame(
+            ['kept'],
+            $found->first()?->get('cn')?->getValues(),
+        );
+
+        $this->ldapClient()->delete('cn=kept,dc=foo,dc=bar');
+    }
+
     public function testRenameChangesRdn(): void
     {
         $this->authenticateAdmin();

--- a/tests/support/Backend/Storage/BackendFactoryTrait.php
+++ b/tests/support/Backend/Storage/BackendFactoryTrait.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 
 namespace Tests\Support\FreeDSx\Ldap\Backend\Storage;
 
+use FreeDSx\Ldap\Schema\Matching\EqualityComparatorResolver;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Schema\SchemaResource;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Operation\WriteEntryOperationHandler;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeRecorder;
 use FreeDSx\Ldap\Server\Backend\Storage\SearchStreamBuilder;
@@ -36,12 +39,13 @@ trait BackendFactoryTrait
      * attribute type from one an entry merely lacks, so an empty schema would make every assertion Undefined.
      */
     private function makeWritableBackend(
-        EntryStorageInterface $storage,
-        ?SchemaValidator $validator = null,
+        ?EntryStorageInterface $storage = null,
+        ?SchemaValidationMode $validationMode = null,
         ?Schema $schema = null,
         ?SearchLimits $limits = null,
         ?ChangeRecorder $changeRecorder = null,
     ): WritableStorageBackend {
+        $storage ??= new InMemoryStorage();
         $schema ??= SchemaResource::Core->load();
         $limits ??= new SearchLimits();
         $filterEvaluator = $this->makeFilterEvaluator(
@@ -56,15 +60,19 @@ trait BackendFactoryTrait
                 $filterEvaluator,
                 $this->makeDerivedResolver($storage),
             ),
-            validator: $validator ?? new SchemaValidator(
+            // Built from the same schema the rest of the backend reads, so the two cannot disagree.
+            validator: new SchemaValidator(
                 $schema,
-                SchemaValidationMode::Off,
+                $validationMode ?? SchemaValidationMode::Off,
             ),
             listOptions: new StorageListOptionsFactory(
                 $schema,
                 $limits,
             ),
             filterEvaluator: $filterEvaluator,
+            entryHandler: new WriteEntryOperationHandler(
+                new EqualityComparatorResolver($schema),
+            ),
             changeRecorder: $changeRecorder,
         );
     }

--- a/tests/support/Backend/Storage/FilterEvaluatorFactoryTrait.php
+++ b/tests/support/Backend/Storage/FilterEvaluatorFactoryTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Support\FreeDSx\Ldap\Backend\Storage;
 
 use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Schema\Matching\EqualityComparatorResolver;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Schema\SchemaResource;
 use FreeDSx\Ldap\Server\Backend\Storage\Derived\DerivedResolver;
@@ -33,9 +34,12 @@ trait FilterEvaluatorFactoryTrait
         ?Schema $schema = null,
         ?EntryStorageInterface $storage = null,
     ): FilterEvaluator {
+        $schema ??= SchemaResource::Core->load();
+
         return new FilterEvaluator(
-            $schema ?? SchemaResource::Core->load(),
+            $schema,
             $this->makeDerivedResolver($storage),
+            new EqualityComparatorResolver($schema),
         );
     }
 

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
@@ -851,6 +851,110 @@ class ServerPagingHandlerTest extends TestCase
         );
     }
 
+    public function test_an_unsortable_critical_sort_fails_the_paged_search_and_returns_no_entries(): void
+    {
+        $message = new LdapMessageRequest(
+            2,
+            $this->makeSearchRequest(),
+            new PagingControl(10, ''),
+            (new SortingControl(SortKey::ascending('bogusAttr')))->setCriticality(true),
+        );
+
+        $this->mockBackend
+            ->expects(self::never())
+            ->method('search');
+
+        $this->drive(
+            $this->subject,
+            $message,
+        );
+
+        self::assertCount(
+            1,
+            $this->sentMessages,
+            'No entries may be returned when a critical sort cannot be honored.',
+        );
+
+        $done = $this->doneMessage();
+        $response = $done->getResponse();
+        self::assertInstanceOf(
+            SearchResultDone::class,
+            $response,
+        );
+        self::assertSame(
+            ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
+            $response->getResultCode(),
+        );
+        self::assertInstanceOf(
+            SortingResponseControl::class,
+            $done->controls()->get(Control::OID_SORTING_RESPONSE),
+        );
+    }
+
+    public function test_an_unsortable_critical_sort_discards_the_paged_result_set(): void
+    {
+        $message = new LdapMessageRequest(
+            2,
+            $this->makeSearchRequest(),
+            new PagingControl(10, ''),
+            (new SortingControl(SortKey::ascending('bogusAttr')))->setCriticality(true),
+        );
+
+        $this->drive(
+            $this->subject,
+            $message,
+        );
+
+        $paging = $this->doneMessage()->controls()->get(Control::OID_PAGING);
+        self::assertInstanceOf(
+            PagingControl::class,
+            $paging,
+        );
+        self::assertSame(
+            '',
+            $paging->getCookie(),
+        );
+        self::assertSame(
+            0,
+            $this->requestHistory->pagingRequest()->count(),
+        );
+    }
+
+    public function test_an_unsortable_non_critical_paged_sort_still_returns_entries(): void
+    {
+        $message = new LdapMessageRequest(
+            2,
+            $this->makeSearchRequest(),
+            new PagingControl(10, ''),
+            new SortingControl(SortKey::ascending('bogusAttr')),
+        );
+
+        $this->mockBackend
+            ->method('search')
+            ->willReturn(new EntryStream($this->makeGenerator(
+                Entry::create('dc=foo,dc=bar', ['cn' => 'foo']),
+            )));
+
+        $this->drive(
+            $this->subject,
+            $message,
+        );
+
+        $response = $this->doneMessage()->getResponse();
+        self::assertInstanceOf(
+            SearchResultDone::class,
+            $response,
+        );
+        self::assertSame(
+            ResultCode::SUCCESS,
+            $response->getResultCode(),
+        );
+        self::assertGreaterThan(
+            1,
+            count($this->sentMessages),
+        );
+    }
+
     public function test_no_sort_control_does_not_append_sorting_response_control(): void
     {
         $message = $this->makeSearchMessage(size: 10);

--- a/tests/unit/Server/Backend/Storage/Adapter/Operation/UpdateOperationTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Operation/UpdateOperationTest.php
@@ -19,6 +19,8 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Schema\Matching\EqualityComparatorResolver;
+use FreeDSx\Ldap\Schema\SchemaResource;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Operation\UpdateOperation;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 use PHPUnit\Framework\TestCase;
@@ -31,7 +33,9 @@ final class UpdateOperationTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->subject = new UpdateOperation();
+        $this->subject = new UpdateOperation(
+            new EqualityComparatorResolver(SchemaResource::Core->load()),
+        );
         $this->entry = new Entry(
             new Dn('cn=alice,dc=example,dc=com'),
             new Attribute('cn', 'alice'),

--- a/tests/unit/Server/Backend/Storage/Adapter/Operation/WriteEntryOperationHandlerTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Operation/WriteEntryOperationHandlerTest.php
@@ -18,6 +18,8 @@ use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Entry\Rdn;
+use FreeDSx\Ldap\Schema\Matching\EqualityComparatorResolver;
+use FreeDSx\Ldap\Schema\SchemaResource;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Operation\WriteEntryOperationHandler;
 use FreeDSx\Ldap\Server\Backend\Write\Command\MoveCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
@@ -33,7 +35,9 @@ final class WriteEntryOperationHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->subject = new WriteEntryOperationHandler();
+        $this->subject = new WriteEntryOperationHandler(
+            new EqualityComparatorResolver(SchemaResource::Core->load()),
+        );
         $this->entry = new Entry(
             new Dn('cn=alice,dc=example,dc=com'),
             new Attribute('cn', 'alice'),

--- a/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
@@ -24,8 +24,6 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Search\Filter\PresentFilter;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
-use FreeDSx\Ldap\Schema\SchemaResource;
-use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
@@ -301,7 +299,7 @@ final class WritableStorageBackendTest extends TestCase
 
     public function test_add_allows_root_naming_context_entry_for_system_context(): void
     {
-        $backend = self::makeWritableBackend(new InMemoryStorage());
+        $backend = self::makeWritableBackend();
         $root = new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example'));
         $backend->add(
             new AddCommand($root),
@@ -313,7 +311,7 @@ final class WritableStorageBackendTest extends TestCase
 
     public function test_add_refuses_root_naming_context_entry_for_non_system_context(): void
     {
-        $backend = self::makeWritableBackend(new InMemoryStorage());
+        $backend = self::makeWritableBackend();
         $root = new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example'));
 
         self::expectException(OperationException::class);
@@ -327,7 +325,7 @@ final class WritableStorageBackendTest extends TestCase
 
     public function test_add_refuses_single_rdn_root_entry_for_non_system_context(): void
     {
-        $backend = self::makeWritableBackend(new InMemoryStorage());
+        $backend = self::makeWritableBackend();
         $root = new Entry(new Dn('dc=com'), new Attribute('dc', 'com'));
 
         self::expectException(OperationException::class);
@@ -1102,10 +1100,7 @@ final class WritableStorageBackendTest extends TestCase
     {
         $backend = self::makeWritableBackend(
             storage: new InMemoryStorage([$this->base]),
-            validator: new SchemaValidator(
-                SchemaResource::Core->load(),
-                SchemaValidationMode::Strict,
-            ),
+            validationMode: SchemaValidationMode::Strict,
         );
 
         self::expectException(OperationException::class);
@@ -1124,10 +1119,7 @@ final class WritableStorageBackendTest extends TestCase
     {
         $backend = self::makeWritableBackend(
             storage: new InMemoryStorage([$this->base]),
-            validator: new SchemaValidator(
-                SchemaResource::Core->load(),
-                SchemaValidationMode::Strict,
-            ),
+            validationMode: SchemaValidationMode::Strict,
         );
 
         $backend->add(
@@ -1153,10 +1145,7 @@ final class WritableStorageBackendTest extends TestCase
         );
         $backend = self::makeWritableBackend(
             storage: new InMemoryStorage([$this->base, $valid]),
-            validator: new SchemaValidator(
-                SchemaResource::Core->load(),
-                SchemaValidationMode::Strict,
-            ),
+            validationMode: SchemaValidationMode::Strict,
         );
 
         self::expectException(OperationException::class);
@@ -1175,10 +1164,7 @@ final class WritableStorageBackendTest extends TestCase
     {
         $backend = self::makeWritableBackend(
             storage: new InMemoryStorage([$this->base]),
-            validator: new SchemaValidator(
-                SchemaResource::Core->load(),
-                SchemaValidationMode::Lenient,
-            ),
+            validationMode: SchemaValidationMode::Lenient,
         );
         $violations = new SchemaViolations();
 
@@ -1221,10 +1207,7 @@ final class WritableStorageBackendTest extends TestCase
         );
         $backend = self::makeWritableBackend(
             storage: new InMemoryStorage([$this->base, $valid]),
-            validator: new SchemaValidator(
-                SchemaResource::Core->load(),
-                SchemaValidationMode::Lenient,
-            ),
+            validationMode: SchemaValidationMode::Lenient,
         );
         $violations = new SchemaViolations();
 
@@ -1263,10 +1246,7 @@ final class WritableStorageBackendTest extends TestCase
     {
         $backend = self::makeWritableBackend(
             storage: new InMemoryStorage([$this->base]),
-            validator: new SchemaValidator(
-                SchemaResource::Core->load(),
-                SchemaValidationMode::Strict,
-            ),
+            validationMode: SchemaValidationMode::Strict,
         );
         $violations = new SchemaViolations();
 
@@ -1295,10 +1275,7 @@ final class WritableStorageBackendTest extends TestCase
     {
         $backend = self::makeWritableBackend(
             storage: new InMemoryStorage([$this->base]),
-            validator: new SchemaValidator(
-                SchemaResource::Core->load(),
-                SchemaValidationMode::Strict,
-            ),
+            validationMode: SchemaValidationMode::Strict,
         );
         $violations = new SchemaViolations();
 
@@ -1339,10 +1316,7 @@ final class WritableStorageBackendTest extends TestCase
     {
         $backend = self::makeWritableBackend(
             storage: new InMemoryStorage([$this->base]),
-            validator: new SchemaValidator(
-                SchemaResource::Core->load(),
-                SchemaValidationMode::Lenient,
-            ),
+            validationMode: SchemaValidationMode::Lenient,
         );
         $violations = new SchemaViolations();
 
@@ -1389,10 +1363,7 @@ final class WritableStorageBackendTest extends TestCase
         );
         $backend = self::makeWritableBackend(
             storage: new InMemoryStorage([$this->base, $valid]),
-            validator: new SchemaValidator(
-                SchemaResource::Core->load(),
-                SchemaValidationMode::Strict,
-            ),
+            validationMode: SchemaValidationMode::Strict,
         );
 
         $backend->update(
@@ -1424,10 +1395,7 @@ final class WritableStorageBackendTest extends TestCase
         );
         $backend = self::makeWritableBackend(
             storage: new InMemoryStorage([$this->base, $valid]),
-            validator: new SchemaValidator(
-                SchemaResource::Core->load(),
-                SchemaValidationMode::Strict,
-            ),
+            validationMode: SchemaValidationMode::Strict,
         );
 
         self::expectException(OperationException::class);
@@ -1708,7 +1676,7 @@ final class WritableStorageBackendTest extends TestCase
 
     public function test_no_such_object_with_no_existing_ancestor_has_null_matched_dn(): void
     {
-        $backend = self::makeWritableBackend(new InMemoryStorage());
+        $backend = self::makeWritableBackend();
 
         $request = (new SearchRequest(new PresentFilter('objectClass')))
             ->base('cn=Missing,dc=example,dc=com')


### PR DESCRIPTION
The write paths for updates / moving an entry need some better schema handling. These paths existed prior to the schema being fully in place, so things got missed here. Also fixing an issue in sorting during pagination to make sure criticality is honored.