### PR TITLE
[1.0.0] Fix some minor server RFC conformance issues.

### DIFF
--- a/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Protocol\Factory;
 
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
@@ -60,10 +61,11 @@ readonly class ServerProtocolHandlerFactory implements HandlerRouteResolverInter
         if (!$request instanceof SearchRequest) {
             return false;
         }
-        $subschemaEntry = $this->options->getSubschemaEntry()->toString();
 
-        return $request->getScope() === SearchRequest::SCOPE_BASE_OBJECT
-            && strtolower((string) $request->getBaseDn()) === strtolower($subschemaEntry);
+        return $this->isBaseSearchFor(
+            $request,
+            $this->options->getSubschemaEntry(),
+        );
     }
 
     private function isMonitorSearch(RequestInterface $request): bool
@@ -72,8 +74,24 @@ readonly class ServerProtocolHandlerFactory implements HandlerRouteResolverInter
             return false;
         }
 
+        return $this->isBaseSearchFor(
+            $request,
+            new Dn(ServerMonitorHandler::DN),
+        );
+    }
+
+    /**
+     * Compared as names rather than as text, so a client spelling the DN differently still reaches the handler.
+     */
+    private function isBaseSearchFor(
+        SearchRequest $request,
+        Dn $dn,
+    ): bool {
+        $baseDn = $request->getBaseDn();
+
         return $request->getScope() === SearchRequest::SCOPE_BASE_OBJECT
-            && strtolower((string) $request->getBaseDn()) === ServerMonitorHandler::DN;
+            && $baseDn !== null
+            && $baseDn->equals($dn);
     }
 
     private function isRootDseSearch(RequestInterface $request): bool

--- a/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
@@ -66,6 +66,15 @@ class ServerAuthorization
     }
 
     /**
+     * RFC 4513 5.1.2: a name of non-zero length with an empty password, which the RFC refuses by its own result code.
+     */
+    public function isUnauthenticatedBind(RequestInterface $request): bool
+    {
+        return $request instanceof AnonBindRequest
+            && $request->getUsername() !== '';
+    }
+
+    /**
      * Determine if the bind type is actually supported. Anonymous binding may be disabled.
      */
     public function isAuthenticationTypeSupported(RequestInterface $request): bool

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnsupportedExtendedHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerUnsupportedExtendedHandler.php
@@ -43,13 +43,13 @@ final readonly class ServerUnsupportedExtendedHandler implements ServerProtocolH
         return ResponseStream::reply(
             $message,
             OperationOutcomeResult::failed(ResultCode::PROTOCOL_ERROR),
+            // RFC 4511 4.12: the response names no OID when the request's own name was not recognized.
             new ExtendedResponse(
                 new LdapResult(
                     ResultCode::PROTOCOL_ERROR,
                     '',
                     sprintf('The extended operation "%s" is not supported.', $request->getName()),
                 ),
-                $request->getName(),
             ),
         );
     }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -418,7 +418,10 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             );
             $normNew = $newEntry->getDn()->normalize();
 
-            if ($storage->exists($normNew)) {
+            // Respelling the RDN resolves to the entry being renamed, which is not a collision with another one.
+            $isRespelling = $normNew->toString() === $normOld->toString();
+
+            if (!$isRespelling && $storage->exists($normNew)) {
                 $this->throwEntryAlreadyExists($newEntry->getDn());
             }
 

--- a/src/FreeDSx/Ldap/Server/Middleware/BindMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/BindMiddleware.php
@@ -59,10 +59,17 @@ final readonly class BindMiddleware implements MiddlewareInterface
         $this->criticalControls->assertSupportedForBind($context->message->controls());
 
         if (!$this->authorization->isAuthenticationTypeSupported($request)) {
-            throw new OperationException(
-                'The requested authentication type is not supported.',
-                ResultCode::AUTH_METHOD_UNSUPPORTED,
-            );
+            // RFC 4513 5.1.2 names unwillingToPerform for a bind carrying a name but no password, which is a
+            // different refusal than the method itself being unavailable.
+            throw $this->authorization->isUnauthenticatedBind($request)
+                ? new OperationException(
+                    'Unauthenticated bind is not supported.',
+                    ResultCode::UNWILLING_TO_PERFORM,
+                )
+                : new OperationException(
+                    'The requested authentication type is not supported.',
+                    ResultCode::AUTH_METHOD_UNSUPPORTED,
+                );
         }
 
         // The authenticator writes the bind response itself (an interactive sub-protocol); carry only the outcome.

--- a/src/FreeDSx/Ldap/Server/Middleware/ServerControlRegistry.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/ServerControlRegistry.php
@@ -31,6 +31,8 @@ final class ServerControlRegistry
      * RFC 4370 eligibility gate runs upstream in ProxiedAuthorizationResolver, not here. ManageDsaIT is global
      * because it is recognized server-wide and treated as inert (no referral entries to reinterpret). The password
      * policy request control is global because it may accompany any request, and its criticality may be TRUE.
+     *
+     * A content sync carries ManageDsaIT critically, so dropping it here would refuse every replication request.
      */
     private const GLOBAL_CONTROLS = [
         Control::OID_PROXY_AUTHORIZATION,

--- a/tests/integration/LdapServerTest.php
+++ b/tests/integration/LdapServerTest.php
@@ -752,6 +752,23 @@ final class LdapServerTest extends ServerTestCase
         );
     }
 
+    /**
+     * RFC 4513 5.1.2 names unwillingToPerform for a bind supplying a name but no password.
+     */
+    public function testABindWithANameAndNoPasswordIsRefusedAsUnwillingToPerform(): void
+    {
+        // Built directly, since the client refuses to send a simple bind carrying an empty password.
+        try {
+            $this->ldapClient()->send(Operations::bindAnonymously('cn=admin,dc=foo,dc=bar'));
+            $this->fail('A name with an empty password should not have been accepted.');
+        } catch (BindException $e) {
+            $this->assertSame(
+                ResultCode::UNWILLING_TO_PERFORM,
+                $e->getCode(),
+            );
+        }
+    }
+
     public function testRenameWithoutDeleteKeepsOldRdn(): void
     {
         $this->authenticateAdmin();

--- a/tests/integration/Schema/LdapSchemaConstraintTest.php
+++ b/tests/integration/Schema/LdapSchemaConstraintTest.php
@@ -94,6 +94,24 @@ final class LdapSchemaConstraintTest extends ServerTestCase
         );
     }
 
+    /**
+     * RFC 4514 permits optional whitespace around the separator, so the same name may be spelled several ways.
+     */
+    public function test_the_subschema_is_reachable_by_an_equivalent_spelling_of_its_dn(): void
+    {
+        $this->authenticateAdmin();
+
+        $subschema = $this->ldapClient()->read(
+            'cn = Subschema',
+            ['subschemaSubentry'],
+        );
+
+        self::assertSame(
+            ['cn=Subschema'],
+            $subschema?->get('subschemaSubentry')?->getValues(),
+        );
+    }
+
     public function test_the_subschema_entry_names_itself_as_its_own_subschema(): void
     {
         $this->authenticateAdmin();

--- a/tests/integration/Storage/Concern/WriteTestsTrait.php
+++ b/tests/integration/Storage/Concern/WriteTestsTrait.php
@@ -932,6 +932,29 @@ trait WriteTestsTrait
         $this->ldapClient()->delete('cn=kept,dc=foo,dc=bar');
     }
 
+    public function testRenameCanRespellTheRdnInADifferentCase(): void
+    {
+        $this->authenticateAdmin();
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=Recase,dc=foo,dc=bar',
+            ['cn' => 'Recase', 'sn' => 'Recase', 'objectClass' => 'inetOrgPerson'],
+        ));
+
+        $this->ldapClient()->rename('cn=Recase,dc=foo,dc=bar', 'cn=recase', true);
+
+        $found = $this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'), 'cn')
+                ->base('cn=recase,dc=foo,dc=bar')
+                ->useBaseScope(),
+        );
+        self::assertSame(
+            ['recase'],
+            $found->first()?->get('cn')?->getValues(),
+        );
+
+        $this->ldapClient()->delete('cn=recase,dc=foo,dc=bar');
+    }
+
     public function testRenameChangesRdn(): void
     {
         $this->authenticateAdmin();

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerUnsupportedExtendedHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerUnsupportedExtendedHandlerTest.php
@@ -37,7 +37,7 @@ final class ServerUnsupportedExtendedHandlerTest extends TestCase
         $this->subject = new ServerUnsupportedExtendedHandler();
     }
 
-    public function test_it_returns_protocol_error_with_response_name_echoing_the_request(): void
+    public function test_it_returns_protocol_error_without_naming_a_response(): void
     {
         $oid = '1.2.3.4.5.6.7.8.9';
         $request = new LdapMessageRequest(
@@ -59,7 +59,6 @@ final class ServerUnsupportedExtendedHandlerTest extends TestCase
                         '',
                         sprintf('The extended operation "%s" is not supported.', $oid),
                     ),
-                    $oid,
                 ),
             )],
             [...$stream->messages],

--- a/tests/unit/Server/Middleware/BindMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/BindMiddlewareTest.php
@@ -182,7 +182,7 @@ final class BindMiddlewareTest extends TestCase
             $this->subject()->process(
                 new ServerRequestContext(new LdapMessageRequest(
                     1,
-                    new AnonBindRequest('foo'),
+                    new AnonBindRequest(),
                 )),
                 $this->next,
             );
@@ -190,6 +190,29 @@ final class BindMiddlewareTest extends TestCase
         } catch (OperationException $e) {
             self::assertSame(
                 ResultCode::AUTH_METHOD_UNSUPPORTED,
+                $e->getCode(),
+            );
+        }
+    }
+
+    public function test_a_name_with_an_empty_password_is_refused_as_unwilling_to_perform(): void
+    {
+        $this->authenticator
+            ->expects(self::never())
+            ->method('bind');
+
+        try {
+            $this->subject()->process(
+                new ServerRequestContext(new LdapMessageRequest(
+                    1,
+                    new AnonBindRequest('cn=foo,dc=foo,dc=bar'),
+                )),
+                $this->next,
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::UNWILLING_TO_PERFORM,
                 $e->getCode(),
             );
         }


### PR DESCRIPTION
Another round of small RFC related conformance fixes. Nothing really major here. Biggest is maybe the respelling change for RDNs and the result code change per the RFC for a specific anon bind.