### PR TITLE
[1.0.0] Several password policy implementations updates.

### DIFF
--- a/docs/Server/Password-Policy.md
+++ b/docs/Server/Password-Policy.md
@@ -207,18 +207,20 @@ map to `CONSTRAINT_VIOLATION`.
 
 ### History
 
-With `pwdInHistory` set, the server retains that many previous values in `pwdHistory` and rejects a new password that
-matches any retained value with `passwordInHistory` (`CONSTRAINT_VIOLATION`).
+With `pwdInHistory` set, the server retains that many superseded values in `pwdHistory` and rejects a new password that
+matches any of them, or the current password, with `passwordInHistory` (`CONSTRAINT_VIOLATION`). The value recorded is
+the one being replaced, so the window is the current password plus that many previous ones.
 
 ### Minimum Age
 
 `pwdMinAge` rejects a change attempted within that many seconds of the last change (`pwdChangedTime`) with
-`passwordTooYoung` (`CONSTRAINT_VIOLATION`).
+`passwordTooYoung` (`CONSTRAINT_VIOLATION`). An entry that must change its password is exempt, since the reset
+restriction would otherwise leave it no permitted operation.
 
 ### Safe Modify
 
 When `pwdSafeModify` is `TRUE`, a change must supply the current password. A missing existing password returns
-`mustSupplyOldPassword` (`CONSTRAINT_VIOLATION`). A supplied-but-incorrect one returns `INVALID_CREDENTIALS`.
+`mustSupplyOldPassword` (`INSUFFICIENT_ACCESS_RIGHTS`). A supplied-but-incorrect one returns `INVALID_CREDENTIALS`.
 
 ### Self-Service Changes
 
@@ -272,10 +274,16 @@ bind), falling back to `pwdChangedTime` when no successful bind has been recorde
 ### Change After Reset
 
 When `pwdMustChange` is `TRUE` and an administrator changes another user's password, the server sets `pwdReset`. At the
-user's next bind the response control reports `changeAfterReset`, and the session is restricted to bind, unbind, the
-RFC 3062 Password Modify, and a modify of the user's own password. Any other operation is rejected
-`UNWILLING_TO_PERFORM` with `changeAfterReset` until the password is changed. A successful self-change clears
+user's next bind the response control reports `changeAfterReset`, and the session is restricted to bind, unbind,
+StartTLS, the RFC 3062 Password Modify, and a modify of the user's own password. Any other operation is rejected
+`INSUFFICIENT_ACCESS_RIGHTS` with `changeAfterReset` until the password is changed. A successful self-change clears
 `pwdReset` and lifts the restriction without a rebind.
+
+StartTLS is permitted so a client that bound in the clear can protect the connection before changing its password.
+
+Both flags are required, so an entry marked `pwdReset` is only held to a change while `pwdMustChange` is `TRUE`.
+Clearing the policy flag releases entries already marked, and leaving it unset turns the feature off entirely: nothing
+sets `pwdReset` and nothing enforces it.
 
 ### Validity Window
 

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordPolicyAwareAuthenticator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordPolicyAwareAuthenticator.php
@@ -94,7 +94,7 @@ final readonly class PasswordPolicyAwareAuthenticator implements PasswordAuthent
 
         $this->guard->recordSuccess($attempt);
 
-        if ($attempt->state->mustChange) {
+        if ($attempt->state->mustChangeUnder($policy)) {
             $token->markMustChangePassword();
         }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Write/PasswordPolicyWriteHandler.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/PasswordPolicyWriteHandler.php
@@ -91,6 +91,7 @@ final readonly class PasswordPolicyWriteHandler implements WriteHandlerInterface
             $newPasswords,
             null,
             $this->isSelf($context, $request->entry->getDn()),
+            isNewEntry: true,
         ));
 
         // Carried on the command rather than written after, so the entry is never stored without the state governing
@@ -160,15 +161,16 @@ final readonly class PasswordPolicyWriteHandler implements WriteHandlerInterface
         array $newPasswords,
         ?string $oldPassword,
         bool $isSelf,
+        bool $isNewEntry = false,
     ): array {
         return array_map(
             fn(string $newPassword): PasswordModifyAttempt => new PasswordModifyAttempt(
                 target: $target,
                 newPassword: $newPassword,
-                hashedNewPassword: $newPassword,
                 oldPassword: $oldPassword,
                 isSelf: $isSelf,
                 passwordIsCleartext: !$this->hashService->isHashed($newPassword),
+                isNewEntry: $isNewEntry,
             ),
             $newPasswords,
         );

--- a/src/FreeDSx/Ldap/Server/Middleware/AuthorizationResolutionMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/AuthorizationResolutionMiddleware.php
@@ -64,18 +64,20 @@ final readonly class AuthorizationResolutionMiddleware implements MiddlewareInte
 
     /**
      * The response control rides out via {@see \FreeDSx\Ldap\Protocol\Queue\Response\PasswordPolicyResponseInterceptor}.
+     *
+     * draft-behera-11 §8.3 pairs changeAfterReset with insufficientAccessRights.
      */
     private function passwordChangeRequired(): OperationException
     {
         $this->passwordPolicyContext?->setOutcome(PasswordPolicyOutcome::deny(
             PwdPolicyError::CHANGE_AFTER_RESET,
-            ResultCode::UNWILLING_TO_PERFORM,
+            ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
             self::PASSWORD_CHANGE_REQUIRED,
         ));
 
         return new OperationException(
             self::PASSWORD_CHANGE_REQUIRED,
-            ResultCode::UNWILLING_TO_PERFORM,
+            ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
         );
     }
 }

--- a/src/FreeDSx/Ldap/Server/PasswordModify/PasswordModifyService.php
+++ b/src/FreeDSx/Ldap/Server/PasswordModify/PasswordModifyService.php
@@ -105,7 +105,6 @@ final readonly class PasswordModifyService
         $deltas = $this->changeGuard?->enforce(new PasswordModifyAttempt(
             target: $entry,
             newPassword: $newPassword,
-            hashedNewPassword: $hashed,
             oldPassword: $request->getOldPassword(),
             isSelf: $isSelf,
             passwordIsCleartext: true,

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Attempt/PasswordModifyAttempt.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Attempt/PasswordModifyAttempt.php
@@ -21,14 +21,18 @@ use SensitiveParameter;
  */
 final readonly class PasswordModifyAttempt
 {
+    /**
+     * @param bool $isNewEntry Whether the target is being created here, so its password values are the new ones
+     *                         rather than any it previously held.
+     */
     public function __construct(
         public Entry $target,
         #[SensitiveParameter]
         public string $newPassword,
-        public string $hashedNewPassword,
         #[SensitiveParameter]
         public ?string $oldPassword,
         public bool $isSelf,
         public bool $passwordIsCleartext = true,
+        public bool $isNewEntry = false,
     ) {}
 }

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/HistoryConstraint.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/HistoryConstraint.php
@@ -19,33 +19,47 @@ use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\PasswordPolicyOutcome;
 
 /**
- * Denies a change whose new value matches any retained pwdHistory entry.
+ * Denies a change whose new value matches the current password or any retained pwdHistory entry.
  */
 final readonly class HistoryConstraint implements PasswordChangeConstraint
 {
     public function __construct(private PasswordHashService $hashService) {}
 
     /**
+     * draft-behera-11 §8.2.6 checks the history and the current password attribute, since history holds only
+     * superseded values.
+     *
      * Comparison goes through {@see PasswordHashService}; entries stored under a no-longer-supported
      * scheme silently fail to match and effectively drop out of the history set (draft-behera-10 §5.3.7).
      */
     public function check(PasswordChangeAttempt $attempt): ?PasswordPolicyOutcome
     {
         $depth = $attempt->policy->quality->inHistory;
-        if ($depth === null || $depth === 0 || $attempt->state->history === []) {
+        if ($depth === null || $depth === 0) {
             return null;
+        }
+
+        foreach ($attempt->currentPasswords as $current) {
+            if ($this->hashService->verify($attempt->newPassword, $current)) {
+                return $this->reused();
+            }
         }
 
         foreach ($attempt->state->history as $entry) {
             if ($this->hashService->verify($attempt->newPassword, $entry->data)) {
-                return PasswordPolicyOutcome::deny(
-                    PwdPolicyError::PASSWORD_IN_HISTORY,
-                    ResultCode::CONSTRAINT_VIOLATION,
-                    'Password matches a recently used password.',
-                );
+                return $this->reused();
             }
         }
 
         return null;
+    }
+
+    private function reused(): PasswordPolicyOutcome
+    {
+        return PasswordPolicyOutcome::deny(
+            PwdPolicyError::PASSWORD_IN_HISTORY,
+            ResultCode::CONSTRAINT_VIOLATION,
+            'Password matches a recently used password.',
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/MinAgeConstraint.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/MinAgeConstraint.php
@@ -35,6 +35,12 @@ final readonly class MinAgeConstraint implements PasswordChangeConstraint
             return null;
         }
 
+        // draft-behera-11 §7.8: an identity that must change its password is exempt, since the reset gate
+        // leaves it no other operation and the two rules would otherwise trap the account.
+        if ($attempt->state->mustChangeUnder($attempt->policy)) {
+            return null;
+        }
+
         $age = $this->clock->now()->getTimestamp() - $changedAt->getTimestamp();
         if ($age >= $minAge) {
             return null;

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/PasswordChangeAttempt.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/PasswordChangeAttempt.php
@@ -22,6 +22,9 @@ use SensitiveParameter;
  */
 final readonly class PasswordChangeAttempt
 {
+    /**
+     * @param list<string> $currentPasswords Stored values the entry holds before the change, empty when it holds none.
+     */
     public function __construct(
         #[SensitiveParameter]
         public string $newPassword,
@@ -31,5 +34,7 @@ final readonly class PasswordChangeAttempt
         public PasswordPolicy $policy,
         public bool $isSelf,
         public bool $passwordIsCleartext = true,
+        #[SensitiveParameter]
+        public array $currentPasswords = [],
     ) {}
 }

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/SafeModifyConstraint.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Constraint/SafeModifyConstraint.php
@@ -24,6 +24,9 @@ use FreeDSx\Ldap\Server\PasswordPolicy\Decision\PasswordPolicyOutcome;
  */
 final readonly class SafeModifyConstraint implements PasswordChangeConstraint
 {
+    /**
+     * draft-behera-11 §8.2.1 pairs mustSupplyOldPassword with insufficientAccessRights.
+     */
     public function check(PasswordChangeAttempt $attempt): ?PasswordPolicyOutcome
     {
         if (!$attempt->isSelf || $attempt->policy->change->safeModify !== true || ($attempt->oldPassword ?? '') !== '') {
@@ -32,7 +35,7 @@ final readonly class SafeModifyConstraint implements PasswordChangeConstraint
 
         return PasswordPolicyOutcome::deny(
             PwdPolicyError::MUST_SUPPLY_OLD_PASSWORD,
-            ResultCode::CONSTRAINT_VIOLATION,
+            ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
             'The existing password must be supplied.',
         );
     }

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Guard/PasswordPolicyChangeGuard.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Guard/PasswordPolicyChangeGuard.php
@@ -21,6 +21,7 @@ use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
 use FreeDSx\Ldap\Server\PasswordPolicy\Attempt\PasswordModifyAttempt;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeAttempt;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\PasswordPolicyOutcome;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
@@ -65,16 +66,22 @@ final readonly class PasswordPolicyChangeGuard
         }
 
         $state = UserPasswordState::fromEntry($primary->target);
+        // The values being replaced serve both §8.2.6's current-password check and §8.2.7's history rotation.
+        // An entry created by this same operation holds the new values, not superseded ones.
+        $replaced = $primary->isNewEntry
+            ? []
+            : array_values($primary->target->get($policy->pwdAttribute)?->getValues() ?? []);
 
         foreach ($attempts as $attempt) {
-            $outcome = $this->engine->evaluatePasswordChange(
-                $attempt->newPassword,
-                $attempt->oldPassword,
-                $state,
-                $policy,
-                $attempt->isSelf,
-                $attempt->passwordIsCleartext,
-            );
+            $outcome = $this->engine->evaluatePasswordChange(new PasswordChangeAttempt(
+                newPassword: $attempt->newPassword,
+                oldPassword: $attempt->oldPassword,
+                state: $state,
+                policy: $policy,
+                isSelf: $attempt->isSelf,
+                passwordIsCleartext: $attempt->passwordIsCleartext,
+                currentPasswords: $replaced,
+            ));
             if ($outcome->denied) {
                 $this->reject(
                     $outcome,
@@ -89,10 +96,7 @@ final readonly class PasswordPolicyChangeGuard
         );
 
         return $this->engine->recordPasswordChange(
-            array_map(
-                static fn(PasswordModifyAttempt $attempt): string => $attempt->hashedNewPassword,
-                $attempts,
-            ),
+            $replaced,
             $state,
             $policy,
             $primary->isSelf,

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyEngine.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyEngine.php
@@ -26,7 +26,6 @@ use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\PasswordPolicyOutcome;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\RecordedOutcome;
-use SensitiveParameter;
 
 /**
  * Core decision / tracking engine for draft-behera-10 password policy.
@@ -216,25 +215,8 @@ final readonly class PasswordPolicyEngine
     /**
      * Evaluate a password change against the configured constraint chain.
      */
-    public function evaluatePasswordChange(
-        #[SensitiveParameter]
-        string $newPassword,
-        #[SensitiveParameter]
-        ?string $oldPassword,
-        UserPasswordState $state,
-        PasswordPolicy $policy,
-        bool $isSelf,
-        bool $passwordIsCleartext = true,
-    ): PasswordPolicyOutcome {
-        $attempt = new PasswordChangeAttempt(
-            newPassword: $newPassword,
-            oldPassword: $oldPassword,
-            state: $state,
-            policy: $policy,
-            isSelf: $isSelf,
-            passwordIsCleartext: $passwordIsCleartext,
-        );
-
+    public function evaluatePasswordChange(PasswordChangeAttempt $attempt): PasswordPolicyOutcome
+    {
         return $this->changeConstraints->evaluate($attempt)
             ?? PasswordPolicyOutcome::allow();
     }
@@ -243,10 +225,10 @@ final readonly class PasswordPolicyEngine
      * Stamp pwdChangedTime, rotate pwdHistory, set/clear pwdReset, and clear pwdFailureTime / pwdAccountLockedTime /
      * pwdGraceUseTime.
      *
-     * @param non-empty-list<string> $hashedNewPasswords stored values being set (newest first - one per password value)
+     * @param list<string> $replacedPasswords stored values the entry held before this change, empty when it held none
      */
     public function recordPasswordChange(
-        array $hashedNewPasswords,
+        array $replacedPasswords,
         UserPasswordState $state,
         PasswordPolicy $policy,
         bool $isSelf = true,
@@ -258,7 +240,7 @@ final readonly class PasswordPolicyEngine
         )];
 
         $historyChange = $this->buildHistoryChange(
-            $hashedNewPasswords,
+            $replacedPasswords,
             $state,
             $policy,
             $now,
@@ -392,17 +374,15 @@ final readonly class PasswordPolicyEngine
         PasswordPolicy $policy,
     ): ?PasswordPolicyOutcome {
         $maxIdle = $policy->expiration->maxIdle;
-        // Use the most recent activity, which is one of these.
-        $since = $this->latestOf(
-            $state->lastSuccess,
-            $state->changedAt,
-        );
+        // draft-behera-11 §7.1 counts from the last successful bind, falling back to the change time only when
+        // no bind has been recorded, so a password change does not itself refresh idleness.
+        $since = $state->lastSuccess ?? $state->changedAt;
         if ($maxIdle === null || $maxIdle === 0 || $since === null) {
             return null;
         }
 
         $idleSeconds = $this->clock->now()->getTimestamp() - $since->getTimestamp();
-        if ($idleSeconds <= $maxIdle) {
+        if ($idleSeconds < $maxIdle) {
             return null;
         }
 
@@ -427,7 +407,8 @@ final readonly class PasswordPolicyEngine
                 diagnostic: 'Password is not yet valid.',
             );
         }
-        if ($state->endTime !== null && $now > $state->endTime) {
+        // draft-behera-11 §7.1 locks at the instant pwdEndTime is reached, not the second after it.
+        if ($state->endTime !== null && $now >= $state->endTime) {
             return PasswordPolicyOutcome::deny(
                 PwdPolicyError::PASSWORD_EXPIRED,
                 ResultCode::INVALID_CREDENTIALS,
@@ -631,7 +612,7 @@ final readonly class PasswordPolicyEngine
         ?int $secondsRemaining,
         bool $isExpired,
     ): PasswordPolicyOutcome {
-        $errorCode = $state->mustChange ? PwdPolicyError::CHANGE_AFTER_RESET : null;
+        $errorCode = $state->mustChangeUnder($policy) ? PwdPolicyError::CHANGE_AFTER_RESET : null;
         $graceWarning = $isExpired
             ? $this->graceRemaining($state, $policy) - 1
             : null;
@@ -684,10 +665,13 @@ final readonly class PasswordPolicyEngine
     }
 
     /**
-     * @param non-empty-list<string> $hashedNewPasswords
+     * draft-behera-11 §8.2.7 retains the password being replaced, not the one being set, so the window holds
+     * pwdInHistory superseded values alongside the current one.
+     *
+     * @param list<string> $replacedPasswords
      */
     private function buildHistoryChange(
-        array $hashedNewPasswords,
+        array $replacedPasswords,
         UserPasswordState $state,
         PasswordPolicy $policy,
         DateTimeImmutable $now,
@@ -702,7 +686,7 @@ final readonly class PasswordPolicyEngine
                 $now,
                 $hash,
             ),
-            $hashedNewPasswords,
+            $replacedPasswords,
         );
         $retained = array_slice(
             [...$newest, ...$state->history],

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordResetGate.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordResetGate.php
@@ -27,6 +27,14 @@ use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 final class PasswordResetGate
 {
     /**
+     * StartTLS is named by §8.1.2.2, and RFC 3062 §4 wants password modify run under confidentiality.
+     */
+    private const PERMITTED_EXTENDED_OIDS = [
+        ExtendedRequest::OID_PWD_MODIFY,
+        ExtendedRequest::OID_START_TLS,
+    ];
+
+    /**
      * Whether the request is permitted while the bound identity must change its password (draft-behera-10 §8.1.2).
      */
     public function isPermitted(
@@ -37,7 +45,11 @@ final class PasswordResetGate
             return true;
         }
         if ($request instanceof ExtendedRequest) {
-            return $request->getName() === ExtendedRequest::OID_PWD_MODIFY;
+            return in_array(
+                $request->getName(),
+                self::PERMITTED_EXTENDED_OIDS,
+                true,
+            );
         }
 
         return $request instanceof ModifyRequest

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/UserPasswordState.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/UserPasswordState.php
@@ -73,6 +73,15 @@ final readonly class UserPasswordState
     }
 
     /**
+     * draft-behera-11 §7.2 needs pwdMustChange and pwdReset both true, so clearing the policy flag releases the entry.
+     */
+    public function mustChangeUnder(PasswordPolicy $policy): bool
+    {
+        return $this->mustChange
+            && $policy->change->mustChange === true;
+    }
+
+    /**
      * True when $authoritative (the primary's replicated entry) supersedes this local volatile state so it can be
      * dropped, which holds when the entry:
      *

--- a/tests/integration/Security/AclIntegrationTest.php
+++ b/tests/integration/Security/AclIntegrationTest.php
@@ -732,6 +732,23 @@ final class AclIntegrationTest extends ServerTestCase
         );
     }
 
+    /**
+     * Authenticating by Compare is not supported, so the password is never comparable and policy cannot be bypassed.
+     */
+    public function testComparingYourOwnPasswordIsDenied(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->ldapClient()->compare(
+            'cn=user,dc=foo,dc=bar',
+            'userPassword',
+            '12345',
+        );
+    }
+
     public function testACustomConfidentialAttributeIsHiddenWithoutAGrant(): void
     {
         $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');

--- a/tests/integration/Security/LdapPasswordPolicyServerTest.php
+++ b/tests/integration/Security/LdapPasswordPolicyServerTest.php
@@ -19,8 +19,10 @@ use FreeDSx\Ldap\Control\PwdPolicyResponseControl;
 use FreeDSx\Ldap\Controls;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\BindException;
+use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
 use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Search\Filters;
 use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
@@ -65,6 +67,55 @@ final class LdapPasswordPolicyServerTest extends ServerTestCase
         $this->assertSame(
             PwdPolicyError::CHANGE_AFTER_RESET,
             $control->getError(),
+        );
+    }
+
+    /**
+     * draft-behera-11 §8.3 pairs changeAfterReset with insufficientAccessRights, not unwillingToPerform.
+     */
+    public function testAnOperationUnderResetIsRefusedWithInsufficientAccessRights(): void
+    {
+        $client = $this->ldapClient();
+        $client->bind('cn=reset-user,dc=foo,dc=bar', self::PASSWORD);
+
+        try {
+            $client->search(
+                Operations::search(Filters::equal('cn', 'reset-user'))
+                    ->base('dc=foo,dc=bar')
+                    ->useSubtreeScope(),
+                Controls::pwdPolicy(),
+            );
+            $this->fail('Expected the reset gate to refuse the search.');
+        } catch (OperationException $e) {
+            $this->assertSame(
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+                $e->getCode(),
+            );
+        }
+    }
+
+    /**
+     * draft-behera-11 §8.1.2.2 names StartTLS among the operations a pwdReset identity may still perform.
+     */
+    public function testStartTlsIsPermittedUnderResetSoTheIdentityCanComply(): void
+    {
+        $dn = 'cn=reset-user,dc=foo,dc=bar';
+        $client = $this->ldapClient();
+        $client->bind($dn, self::PASSWORD);
+
+        $client->startTls();
+        $client->send(Operations::passwordModify(
+            $dn,
+            self::PASSWORD,
+            'a-fresh-password',
+        ));
+
+        // Binding with the new password proves StartTLS was permitted and the change it protects went through.
+        $client->bind($dn, 'a-fresh-password');
+
+        $this->assertSame(
+            'dn:' . $dn,
+            $client->whoami(),
         );
     }
 

--- a/tests/integration/Security/PasswordPolicyBindEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyBindEnforcementTest.php
@@ -37,6 +37,7 @@ use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
 use Tests\Support\FreeDSx\Ldap\Server\Clock\RecordingSleeper;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordChangeRules;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordExpirationRules;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
 use PHPUnit\Framework\TestCase;
@@ -391,11 +392,44 @@ final class PasswordPolicyBindEnforcementTest extends TestCase
         }
     }
 
-    public function test_recent_password_change_recovers_an_idle_locked_account(): void
+    /**
+     * draft-behera-11 §7.1 counts idleness from pwdLastSuccess, so a password change does not refresh it.
+     */
+    public function test_a_recent_password_change_does_not_recover_an_idle_locked_account(): void
     {
         $authenticator = $this->authenticatorFor(
             $this->user([
                 PasswordPolicyOid::NAME_PWD_LAST_SUCCESS => $this->minutesAgo(120),
+                PasswordPolicyOid::NAME_PWD_CHANGED_TIME => $this->minutesAgo(1),
+            ]),
+            new PasswordPolicy(
+                expiration: new PasswordExpirationRules(maxIdle: 3600),
+            ),
+        );
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
+
+        try {
+            $authenticator->authenticate(
+                self::USER_DN,
+                self::PASSWORD,
+            );
+        } finally {
+            self::assertSame(
+                PwdPolicyError::ACCOUNT_LOCKED,
+                $this->context->getOutcome()?->errorCode,
+            );
+        }
+    }
+
+    /**
+     * §7.1 falls back to pwdChangedTime only when no successful bind has been recorded.
+     */
+    public function test_idle_falls_back_to_the_change_time_when_no_bind_was_recorded(): void
+    {
+        $authenticator = $this->authenticatorFor(
+            $this->user([
                 PasswordPolicyOid::NAME_PWD_CHANGED_TIME => $this->minutesAgo(1),
             ]),
             new PasswordPolicy(
@@ -478,7 +512,9 @@ final class PasswordPolicyBindEnforcementTest extends TestCase
             $this->user([
                 PasswordPolicyOid::NAME_PWD_RESET => 'TRUE',
             ]),
-            new PasswordPolicy(),
+            new PasswordPolicy(
+                change: new PasswordChangeRules(mustChange: true),
+            ),
         );
 
         $authenticator->authenticate(
@@ -493,13 +529,36 @@ final class PasswordPolicyBindEnforcementTest extends TestCase
         $this->assertEventRecorded(ServerEvent::PasswordPolicyMustChange);
     }
 
-    public function test_pwd_reset_marks_token_for_required_change(): void
+    /**
+     * draft-behera-11 §7.2 needs both flags, so clearing pwdMustChange releases an entry still marked pwdReset.
+     */
+    public function test_pwd_reset_is_ignored_when_the_policy_does_not_require_a_change(): void
     {
         $authenticator = $this->authenticatorFor(
             $this->user([
                 PasswordPolicyOid::NAME_PWD_RESET => 'TRUE',
             ]),
             new PasswordPolicy(),
+        );
+
+        $token = $authenticator->authenticate(
+            self::USER_DN,
+            self::PASSWORD,
+        );
+
+        self::assertFalse($token->mustChangePassword());
+        self::assertNull($this->context->getOutcome()?->errorCode);
+    }
+
+    public function test_pwd_reset_marks_token_for_required_change(): void
+    {
+        $authenticator = $this->authenticatorFor(
+            $this->user([
+                PasswordPolicyOid::NAME_PWD_RESET => 'TRUE',
+            ]),
+            new PasswordPolicy(
+                change: new PasswordChangeRules(mustChange: true),
+            ),
         );
 
         $token = $authenticator->authenticate(

--- a/tests/integration/Security/PasswordPolicyChangeEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyChangeEnforcementTest.php
@@ -100,6 +100,51 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
         $this->assertControlError(PwdPolicyError::PASSWORD_IN_HISTORY);
     }
 
+    /**
+     * draft-behera-11 §8.2.6 checks the current password attribute as well as the history.
+     */
+    public function test_setting_the_current_password_again_is_rejected(): void
+    {
+        $handler = $this->handlerFor(
+            new PasswordPolicy(quality: new PasswordQualityRules(inHistory: 5)),
+        );
+
+        $this->handle(
+            $handler,
+            $this->request(self::OLD_PASSWORD, self::OLD_PASSWORD),
+            $this->selfToken(),
+        );
+
+        $this->assertResultCode(ResultCode::CONSTRAINT_VIOLATION);
+        $this->assertControlError(PwdPolicyError::PASSWORD_IN_HISTORY);
+    }
+
+    /**
+     * §8.2.7 retains the replaced password, so the immediately previous one cannot come straight back.
+     */
+    public function test_the_password_being_replaced_is_what_enters_history(): void
+    {
+        $handler = $this->handlerFor(
+            new PasswordPolicy(quality: new PasswordQualityRules(inHistory: 3)),
+        );
+
+        $this->handle(
+            $handler,
+            $this->request(self::OLD_PASSWORD, 'a-fresh-password'),
+            $this->selfToken(),
+        );
+        $this->assertResultCode(ResultCode::SUCCESS);
+
+        $this->handle(
+            $handler,
+            $this->request('a-fresh-password', self::OLD_PASSWORD),
+            $this->selfToken(),
+        );
+
+        $this->assertResultCode(ResultCode::CONSTRAINT_VIOLATION);
+        $this->assertControlError(PwdPolicyError::PASSWORD_IN_HISTORY);
+    }
+
     public function test_change_within_min_age_is_rejected(): void
     {
         $handler = $this->handlerFor(
@@ -117,6 +162,32 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
         $this->assertControlError(PwdPolicyError::PASSWORD_TOO_YOUNG);
     }
 
+    /**
+     * draft-behera-11 §7.8: an administrative reset stamps pwdChangedTime, so without the waiver pwdMinAge
+     * refuses the one operation §8.1.2.2 leaves the account.
+     */
+    public function test_a_must_change_identity_may_change_within_min_age(): void
+    {
+        $handler = $this->handlerFor(
+            new PasswordPolicy(change: new PasswordChangeRules(
+                minAge: 3600,
+                mustChange: true,
+            )),
+            [
+                PasswordPolicyOid::NAME_PWD_CHANGED_TIME => $this->minutesAgo(30),
+                PasswordPolicyOid::NAME_PWD_RESET => 'TRUE',
+            ],
+        );
+
+        $this->handle(
+            $handler,
+            $this->request(self::OLD_PASSWORD, 'a-fresh-password'),
+            $this->selfToken(),
+        );
+
+        $this->assertResultCode(ResultCode::SUCCESS);
+    }
+
     public function test_safe_modify_without_old_password_is_rejected(): void
     {
         $handler = $this->handlerFor(
@@ -129,7 +200,7 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
             $this->selfToken(),
         );
 
-        $this->assertResultCode(ResultCode::CONSTRAINT_VIOLATION);
+        $this->assertResultCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
         $this->assertControlError(PwdPolicyError::MUST_SUPPLY_OLD_PASSWORD);
     }
 

--- a/tests/support/LdapPasswordPolicyCommand.php
+++ b/tests/support/LdapPasswordPolicyCommand.php
@@ -9,6 +9,7 @@ use FreeDSx\Ldap\Ldif\Loader\FileLdifLoader;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordChangeRules;
 use FreeDSx\Ldap\ServerOptions;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,6 +21,10 @@ final class LdapPasswordPolicyCommand extends Command
     use ConsoleOptionsTrait;
 
     private const ADMIN_DN = 'cn=admin,dc=foo,dc=bar';
+
+    private const SSL_KEY = __DIR__ . '/../resources/cert/slapd.key';
+
+    private const SSL_CERT = __DIR__ . '/../resources/cert/slapd.crt';
 
     private const POLICY_SEED_LDIF = __DIR__ . '/../resources/seed/password-policy-seed.ldif';
 
@@ -63,6 +68,9 @@ final class LdapPasswordPolicyCommand extends Command
         $network = (new NetworkConfig())
             ->setPort($port)
             ->setTransport($transport)
+            // StartTLS has to be reachable, since the reset gate is required to permit it.
+            ->setSslCert(self::SSL_CERT)
+            ->setSslCertKey(self::SSL_KEY)
             ->setSocketAcceptTimeout(0.1);
 
         $options = (new ServerOptions(networkConfig: $network))
@@ -73,7 +81,10 @@ final class LdapPasswordPolicyCommand extends Command
         // Left unset for the subentry run, so any enforcement observed can only come from the DIT.
         if (!$useSubentries) {
             $options->getPasswordConfig()
-                ->setPolicy(new PasswordPolicy());
+                // pwdMustChange is what makes the seeded pwdReset binding, per draft-behera-11 7.2.
+                ->setPolicy(new PasswordPolicy(
+                    change: new PasswordChangeRules(mustChange: true),
+                ));
         }
 
         $server = new LdapServer($options);

--- a/tests/unit/Server/Backend/Auth/SaslBindPolicyEnforcerTest.php
+++ b/tests/unit/Server/Backend/Auth/SaslBindPolicyEnforcerTest.php
@@ -34,6 +34,7 @@ use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
 use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordChangeRules;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
 use PHPUnit\Framework\TestCase;
 use Tests\Support\FreeDSx\Ldap\ServerContainerTrait;
@@ -126,7 +127,9 @@ final class SaslBindPolicyEnforcerTest extends TestCase
     public function test_must_change_flags_the_context_and_surfaces_a_control(): void
     {
         $enforcer = $this->enforcer(
-            new PasswordPolicy(),
+            new PasswordPolicy(
+                change: new PasswordChangeRules(mustChange: true),
+            ),
             [PasswordPolicyOid::NAME_PWD_RESET => 'TRUE'],
         );
 

--- a/tests/unit/Server/Backend/Write/PasswordPolicyWriteHandlerTest.php
+++ b/tests/unit/Server/Backend/Write/PasswordPolicyWriteHandlerTest.php
@@ -186,7 +186,10 @@ final class PasswordPolicyWriteHandlerTest extends TestCase
         );
     }
 
-    public function test_multi_value_set_records_each_new_value_in_history(): void
+    /**
+     * draft-behera-11 §8.2.7 retains the password being replaced, so a multi-valued set records what it superseded.
+     */
+    public function test_multi_value_set_records_the_replaced_values_in_history(): void
     {
         $handler = $this->handler(new PasswordPolicy(
             quality: new PasswordQualityRules(inHistory: 5),
@@ -206,14 +209,35 @@ final class PasswordPolicyWriteHandlerTest extends TestCase
             static fn(string $value): string => HistoryEntry::decode($value)->data,
             $entry->get(PasswordPolicyOid::NAME_PWD_HISTORY)?->getValues() ?? [],
         );
-        // Both new values must be retained so neither can be reused after a multi-valued set.
-        self::assertContains(
-            'first-new-pass',
+        self::assertSame(
+            ['original-pass'],
             $stored,
         );
-        self::assertContains(
-            'second-new-pass',
-            $stored,
+    }
+
+    /**
+     * The new values are not in history, so §8.2.6's current-password clause is what stops either being reused.
+     */
+    public function test_a_value_just_set_cannot_be_set_again(): void
+    {
+        $handler = $this->handler(new PasswordPolicy(
+            quality: new PasswordQualityRules(inHistory: 5),
+        ));
+        $handler->handle(
+            new UpdateCommand(
+                new Dn(self::USER_DN),
+                [Change::replace('userPassword', 'first-new-pass')],
+            ),
+            $this->writeContext(),
+        );
+
+        $this->expectException(OperationException::class);
+        $handler->handle(
+            new UpdateCommand(
+                new Dn(self::USER_DN),
+                [Change::replace('userPassword', 'first-new-pass')],
+            ),
+            $this->writeContext(),
         );
     }
 
@@ -257,7 +281,7 @@ final class PasswordPolicyWriteHandlerTest extends TestCase
             self::fail('Expected an OperationException.');
         } catch (OperationException $e) {
             self::assertSame(
-                ResultCode::CONSTRAINT_VIOLATION,
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
                 $e->getCode(),
             );
         }

--- a/tests/unit/Server/Middleware/AuthorizationResolutionMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/AuthorizationResolutionMiddlewareTest.php
@@ -76,7 +76,7 @@ final class AuthorizationResolutionMiddlewareTest extends TestCase
             self::fail('Expected an OperationException.');
         } catch (OperationException $e) {
             self::assertSame(
-                ResultCode::UNWILLING_TO_PERFORM,
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
                 $e->getCode(),
             );
         }

--- a/tests/unit/Server/PasswordPolicy/Constraint/MinAgeConstraintTest.php
+++ b/tests/unit/Server/PasswordPolicy/Constraint/MinAgeConstraintTest.php
@@ -104,6 +104,22 @@ final class MinAgeConstraintTest extends TestCase
         );
     }
 
+    /**
+     * draft-behera-11 §7.8: the reset gate permits only a password change, so pwdMinAge must not refuse it too.
+     */
+    public function test_a_must_change_identity_is_exempt_from_min_age(): void
+    {
+        self::assertNull(
+            $this->subject->check(
+                $this->attempt(
+                    minAge: 3600,
+                    changedAt: $this->utc('2026-05-20T11:30:00Z'),
+                    mustChange: true,
+                ),
+            ),
+        );
+    }
+
     public function test_age_exactly_at_boundary_passes(): void
     {
         self::assertNull(
@@ -135,13 +151,20 @@ final class MinAgeConstraintTest extends TestCase
         ?int $minAge,
         ?DateTimeImmutable $changedAt,
         bool $isSelf = true,
+        bool $mustChange = false,
     ): PasswordChangeAttempt {
         return new PasswordChangeAttempt(
             newPassword: 'newpw',
             oldPassword: null,
-            state: new UserPasswordState(changedAt: $changedAt),
+            state: new UserPasswordState(
+                changedAt: $changedAt,
+                mustChange: $mustChange,
+            ),
             policy: new PasswordPolicy(
-                change: new PasswordChangeRules(minAge: $minAge),
+                change: new PasswordChangeRules(
+                    minAge: $minAge,
+                    mustChange: $mustChange,
+                ),
             ),
             isSelf: $isSelf,
         );

--- a/tests/unit/Server/PasswordPolicy/Guard/PasswordPolicyBindGuardTest.php
+++ b/tests/unit/Server/PasswordPolicy/Guard/PasswordPolicyBindGuardTest.php
@@ -34,6 +34,7 @@ use FreeDSx\Ldap\Server\PasswordPolicy\Attempt\PasswordBindAttempt;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordChangeRules;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordExpirationRules;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
 use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
@@ -281,7 +282,12 @@ final class PasswordPolicyBindGuardTest extends TestCase
 
     public function test_recordSuccess_surfaces_must_change(): void
     {
-        $this->subject->recordSuccess($this->attempt(new UserPasswordState(mustChange: true)));
+        $this->subject->recordSuccess($this->attempt(
+            new UserPasswordState(mustChange: true),
+            new PasswordPolicy(
+                change: new PasswordChangeRules(mustChange: true),
+            ),
+        ));
 
         self::assertSame(
             PwdPolicyError::CHANGE_AFTER_RESET,

--- a/tests/unit/Server/PasswordPolicy/Guard/PasswordPolicyChangeGuardTest.php
+++ b/tests/unit/Server/PasswordPolicy/Guard/PasswordPolicyChangeGuardTest.php
@@ -119,7 +119,7 @@ final class PasswordPolicyChangeGuardTest extends TestCase
     {
         $this->assertRejectedWith(
             PwdPolicyError::MUST_SUPPLY_OLD_PASSWORD,
-            ResultCode::CONSTRAINT_VIOLATION,
+            ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
             fn(): mixed => $this->guard(new PasswordPolicy(
                 change: new PasswordChangeRules(safeModify: true),
             ))->enforce($this->attempt($this->entry(), 'a-fresh-password')),
@@ -218,14 +218,12 @@ final class PasswordPolicyChangeGuardTest extends TestCase
     private function attempt(
         Entry $target,
         string $newPassword,
-        string $hashedNewPassword = '{BCRYPT}hash',
         ?string $oldPassword = null,
         bool $isSelf = true,
     ): PasswordModifyAttempt {
         return new PasswordModifyAttempt(
             target: $target,
             newPassword: $newPassword,
-            hashedNewPassword: $hashedNewPassword,
             oldPassword: $oldPassword,
             isSelf: $isSelf,
         );

--- a/tests/unit/Server/PasswordPolicy/PasswordPolicyEngineTest.php
+++ b/tests/unit/Server/PasswordPolicy/PasswordPolicyEngineTest.php
@@ -21,12 +21,14 @@ use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeAttempt;
 use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraint;
 use FreeDSx\Ldap\Server\PasswordPolicy\Constraint\PasswordChangeConstraintChain;
 use FreeDSx\Ldap\Server\PasswordPolicy\HistoryEntry;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyEngine;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\PasswordPolicyOutcome;
+use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordChangeRules;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordExpirationRules;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
@@ -163,13 +165,63 @@ final class PasswordPolicyEngineTest extends TestCase
         );
     }
 
-    public function test_evaluatePreBind_idle_baseline_uses_most_recent_activity(): void
+    /**
+     * §7.1 locks on reaching pwdMaxIdle, so the boundary second is already too idle.
+     */
+    public function test_evaluatePreBind_idle_locks_exactly_at_max_idle(): void
+    {
+        $outcome = $this->subject->evaluatePreBind(
+            new UserPasswordState(lastSuccess: $this->minutesAgo(60)),
+            new PasswordPolicy(
+                expiration: new PasswordExpirationRules(maxIdle: 3600),
+            ),
+        );
+
+        self::assertTrue($outcome->denied);
+    }
+
+    /**
+     * §7.1 locks when the current time reaches pwdEndTime, not the second after it.
+     */
+    public function test_evaluatePreBind_denies_exactly_at_the_end_time(): void
+    {
+        $outcome = $this->subject->evaluatePreBind(
+            new UserPasswordState(endTime: $this->clock->now()),
+            new PasswordPolicy(),
+        );
+
+        self::assertTrue($outcome->denied);
+        self::assertSame(
+            PwdPolicyError::PASSWORD_EXPIRED,
+            $outcome->errorCode,
+        );
+    }
+
+    /**
+     * draft-behera-11 §7.1 counts idleness from pwdLastSuccess, so changing the password does not refresh it.
+     */
+    public function test_evaluatePreBind_idle_baseline_ignores_a_recent_password_change(): void
     {
         $outcome = $this->subject->evaluatePreBind(
             new UserPasswordState(
                 changedAt: $this->minutesAgo(1),
                 lastSuccess: $this->minutesAgo(120),
             ),
+            new PasswordPolicy(
+                expiration: new PasswordExpirationRules(maxIdle: 3600),
+            ),
+        );
+
+        self::assertTrue($outcome->denied);
+    }
+
+    /**
+     * §7.1 falls back to pwdChangedTime only when no successful bind has been recorded.
+     */
+    public function test_evaluatePreBind_idle_baseline_falls_back_to_the_change_time(): void
+    {
+        $outcome = $this->subject->evaluatePreBind(
+            new UserPasswordState(changedAt: $this->minutesAgo(1)),
             new PasswordPolicy(
                 expiration: new PasswordExpirationRules(maxIdle: 3600),
             ),
@@ -564,7 +616,9 @@ final class PasswordPolicyEngineTest extends TestCase
     {
         $result = $this->subject->recordBindSuccess(
             new UserPasswordState(mustChange: true),
-            new PasswordPolicy(),
+            new PasswordPolicy(
+                change: new PasswordChangeRules(mustChange: true),
+            ),
         );
 
         self::assertFalse($result->outcome->denied);
@@ -572,6 +626,19 @@ final class PasswordPolicyEngineTest extends TestCase
             PwdPolicyError::CHANGE_AFTER_RESET,
             $result->outcome->errorCode,
         );
+    }
+
+    /**
+     * draft-behera-11 §7.2 needs both flags, so clearing pwdMustChange releases an entry still marked pwdReset.
+     */
+    public function test_recordBindSuccess_ignores_pwd_reset_when_the_policy_does_not_require_a_change(): void
+    {
+        $result = $this->subject->recordBindSuccess(
+            new UserPasswordState(mustChange: true),
+            new PasswordPolicy(),
+        );
+
+        self::assertNull($result->outcome->errorCode);
     }
 
     public function test_evaluatePasswordChange_delegates_to_constraint_chain(): void
@@ -583,13 +650,7 @@ final class PasswordPolicyEngineTest extends TestCase
         );
         $engine = $this->engineWith($this->stubConstraint($deny));
 
-        $outcome = $engine->evaluatePasswordChange(
-            newPassword: 'newpw',
-            oldPassword: null,
-            state: new UserPasswordState(),
-            policy: new PasswordPolicy(),
-            isSelf: true,
-        );
+        $outcome = $engine->evaluatePasswordChange($this->changeAttempt());
 
         self::assertSame(
             $deny,
@@ -601,13 +662,7 @@ final class PasswordPolicyEngineTest extends TestCase
     {
         $outcome = $this
             ->engineWith($this->stubConstraint(null))
-            ->evaluatePasswordChange(
-                newPassword: 'newpw',
-                oldPassword: null,
-                state: new UserPasswordState(),
-                policy: new PasswordPolicy(),
-                isSelf: true,
-            );
+            ->evaluatePasswordChange($this->changeAttempt());
 
         self::assertFalse($outcome->denied);
     }
@@ -618,36 +673,19 @@ final class PasswordPolicyEngineTest extends TestCase
         $policy = new PasswordPolicy();
         $constraint = new RecordingPasswordChangeConstraint();
 
-        $this->engineWith($constraint)->evaluatePasswordChange(
-            newPassword: 'newpw',
-            oldPassword: 'oldpw',
+        $given = $this->changeAttempt(
             state: $state,
             policy: $policy,
+            oldPassword: 'oldpw',
             isSelf: false,
         );
 
-        self::assertCount(
-            1,
+        $this->engineWith($constraint)->evaluatePasswordChange($given);
+
+        self::assertSame(
+            [$given],
             $constraint->invocations,
         );
-        $attempt = $constraint->invocations[0];
-        self::assertSame(
-            'newpw',
-            $attempt->newPassword,
-        );
-        self::assertSame(
-            'oldpw',
-            $attempt->oldPassword,
-        );
-        self::assertSame(
-            $state,
-            $attempt->state,
-        );
-        self::assertSame(
-            $policy,
-            $attempt->policy,
-        );
-        self::assertFalse($attempt->isSelf);
     }
 
     public function test_recordPasswordChange_stamps_changed_time(): void
@@ -696,7 +734,7 @@ final class PasswordPolicyEngineTest extends TestCase
         );
 
         $changes = $this->subject->recordPasswordChange(
-            ['{BCRYPT}brand-new'],
+            ['{BCRYPT}replaced'],
             new UserPasswordState(history: [
                 $newer,
                 $oldest,
@@ -716,7 +754,7 @@ final class PasswordPolicyEngineTest extends TestCase
             $values,
         );
         self::assertStringContainsString(
-            '{BCRYPT}brand-new',
+            '{BCRYPT}replaced',
             $values[0],
         );
         self::assertStringContainsString(
@@ -926,6 +964,21 @@ final class PasswordPolicyEngineTest extends TestCase
         );
 
         self::assertTrue($changes->isEmpty());
+    }
+
+    private function changeAttempt(
+        ?UserPasswordState $state = null,
+        ?PasswordPolicy $policy = null,
+        ?string $oldPassword = null,
+        bool $isSelf = true,
+    ): PasswordChangeAttempt {
+        return new PasswordChangeAttempt(
+            newPassword: 'newpw',
+            oldPassword: $oldPassword,
+            state: $state ?? new UserPasswordState(),
+            policy: $policy ?? new PasswordPolicy(),
+            isSelf: $isSelf,
+        );
     }
 
     private function engineWith(PasswordChangeConstraint $constraint): PasswordPolicyEngine

--- a/tests/unit/Server/PasswordPolicy/PasswordResetGateTest.php
+++ b/tests/unit/Server/PasswordPolicy/PasswordResetGateTest.php
@@ -60,6 +60,17 @@ final class PasswordResetGateTest extends TestCase
         ));
     }
 
+    /**
+     * draft-behera-11 §8.1.2.2 names StartTLS, and RFC 3062 §4 wants password modify run under confidentiality.
+     */
+    public function test_start_tls_extended_op_is_permitted(): void
+    {
+        self::assertTrue($this->subject->isPermitted(
+            new ExtendedRequest(ExtendedRequest::OID_START_TLS),
+            $this->token(),
+        ));
+    }
+
     public function test_other_extended_op_is_not_permitted(): void
     {
         self::assertFalse($this->subject->isPermitted(


### PR DESCRIPTION
This further aligns the password policy implementation with the RFC by fixing some behavior and adding more integration tests around it:

* Fix pwdMinAge check on the reset gate.
* Allow StartTLS on the reset gate.
* Make history constraint check current password too.
* Fix status codes to match the RFC.
* Compare pwdEndTime and pwdMaxIdle per the RFC.
* Correctly enforce pwdReset (missed this completely in the original implementation).