### PR TITLE
[1.0.0] Handle subtree moves / renames properly.

### DIFF
--- a/docs/Server/Access-Control.md
+++ b/docs/Server/Access-Control.md
@@ -217,6 +217,7 @@ The defaults are fixed rather than configurable:
 - Attribute writes that match no rule are denied.
 - Attribute reads that match no rule are allowed, so a search still returns attributes you wrote no rule for.
 - Controls and extended operations that match no rule are denied, so privileged controls are off unless granted.
+- Relocations that match no rule are denied. Moving an entry between containers needs a grant.
 
 Because writes are denied by default, granting an operation is not enough on its own. A rule that allows `Add` or
 `Modify` still needs a matching attribute rule for the attributes being written, otherwise the operation is
@@ -245,7 +246,7 @@ replacing them, so they compose on `secureDefault()` or on a policy built from `
 
 | Method                                                    | Grants                                                                            |
 |-----------------------------------------------------------|-----------------------------------------------------------------------------------|
-| `withFullAccess($subject, $target = new AnyTargetMatcher())`   | Every operation and every attribute write over the target                         |
+| `withFullAccess($subject, $target = new AnyTargetMatcher())`   | Every operation, every attribute write, and relocation over the target            |
 | `withSelfServiceWrites($attributes = AclRules::SELF_WRITABLE_ATTRIBUTES)` | Modify on an identity's own entry, limited to the given attributes |
 | `withCredentialProtection($administrators = null)`        | The `userPassword` and Password Modify rules, plus privileged controls and extended operations for the administrator |
 | `withReplicaGrants($replica, $target = new AnyTargetMatcher())` | The content-sync control, the ppolicy-forward extended operation, and the policy-state writes that forward needs |
@@ -253,8 +254,9 @@ replacing them, so they compose on `secureDefault()` or on a policy built from `
 `AclRules::secureDefault()` is built from the first three. `withFullAccess()` is what it applies to the configured
 [administrator](#administrators), so reaching for it directly is how you grant a second identity the same rights.
 
-It covers operations and attribute writes only. Controls, extended operations, and confidential attributes are gated
-separately, which is why an administrator gets those from `withCredentialProtection()` rather than from this method.
+It covers operations, attribute writes, and [relocation](#relocation-rules) only. Controls, extended operations, and
+confidential attributes are gated separately, which is why an administrator gets those from
+`withCredentialProtection()` rather than from this method.
 
 ```php
 // A provisioning account with full rights over one subtree.
@@ -496,6 +498,41 @@ AclRules::fromEmpty()->replaceControlRules(
 ```
 
 A client attaches the control with `Controls::relaxRules()`, e.g. `$client->create($entry, Controls::relaxRules())`.
+
+## Relocation Rules
+
+`RelocationRule`s gate whether entries may leave or arrive in a container. This is a separate question from whether an
+entry may be renamed, which the `ModifyDn` operation controls.
+
+Two things make these rules different:
+
+- The target matches the container, not the entry being moved. For `RelocationAccess::Out` it is tested against the
+  entry's current parent, for `RelocationAccess::In` against the new parent. A rule with no direction covers both.
+- They are only consulted when a move changes the parent. Renaming an entry in place never reaches them. You can
+  pin a container shut without preventing renames inside it.
+
+They are denied by default, so an identity granted `ModifyDn` also needs a relocation grant before it can move entries
+between containers. `withFullAccess()` includes one.
+
+```php
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationAccess;
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationRule;
+
+AclRules::secureDefault()->appendRelocationRules(
+    // Nothing may be moved out of ou=protected, though entries there may still be renamed in place.
+    RelocationRule::deny(
+        Subject::authenticated(),
+        Target::subtree('ou=protected,dc=example,dc=com'),
+        RelocationAccess::Out,
+    ),
+    // Everything else stays movable for this identity.
+    RelocationRule::allow(
+        Subject::group('cn=admins,dc=example,dc=com'),
+    ),
+);
+```
+
+Order matters: the deny is listed first so it matches before the grant.
 
 ## Extended Operation Rules
 

--- a/src/FreeDSx/Ldap/Server/AccessControl/AccessControlInterface.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/AccessControlInterface.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationAccess;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -48,6 +49,21 @@ interface AccessControlInterface
         Dn $dn,
         string $attribute,
         AttributeAccess $access,
+    ): void;
+
+    /**
+     * Assert that $token may move an entry out of, or into, the given container.
+     *
+     * Only consulted when a Modify DN changes the parent, so renaming an entry in place never reaches this.
+     *
+     * @param Dn $container The old parent for Out, the new parent for In.
+     *
+     * @throws OperationException with ResultCode::INSUFFICIENT_ACCESS_RIGHTS on denial
+     */
+    public function authorizeRelocation(
+        TokenInterface $token,
+        Dn $container,
+        RelocationAccess $direction,
     ): void;
 
     /**

--- a/src/FreeDSx/Ldap/Server/AccessControl/AclRules.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/AclRules.php
@@ -24,6 +24,7 @@ use FreeDSx\Ldap\Server\AccessControl\Rule\ConfidentialAccessRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ExtendedOperationRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\AccessControl\Subject\SubjectMatcherInterface;
 use FreeDSx\Ldap\Server\AccessControl\Target\AnyTargetMatcher;
@@ -61,6 +62,7 @@ final readonly class AclRules
      * @param ControlRule[] $controls Evaluated per control in order; first match wins.
      * @param ExtendedOperationRule[] $extendedOps Evaluated per extended operation in order; first match wins.
      * @param ConfidentialAccessRule[] $confidential Evaluated per confidential attribute in order; first match wins.
+     * @param RelocationRule[] $relocations Evaluated per container and direction in order; first match wins.
      */
     private function __construct(
         public array $operations = [],
@@ -68,6 +70,7 @@ final readonly class AclRules
         public array $controls = [],
         public array $extendedOps = [],
         public array $confidential = [],
+        public array $relocations = [],
     ) {}
 
     /**
@@ -80,6 +83,7 @@ final readonly class AclRules
      * @param ControlRule[] $controls
      * @param ExtendedOperationRule[] $extendedOps
      * @param ConfidentialAccessRule[] $confidential
+     * @param RelocationRule[] $relocations
      */
     public static function fromEmpty(
         array $operations = [],
@@ -87,6 +91,7 @@ final readonly class AclRules
         array $controls = [],
         array $extendedOps = [],
         array $confidential = [],
+        array $relocations = [],
     ): self {
         return new self(
             $operations,
@@ -94,6 +99,7 @@ final readonly class AclRules
             $controls,
             $extendedOps,
             $confidential,
+            $relocations,
         );
     }
 
@@ -108,6 +114,7 @@ final readonly class AclRules
             $this->controls,
             $this->extendedOps,
             $this->confidential,
+            $this->relocations,
         );
     }
 
@@ -122,6 +129,7 @@ final readonly class AclRules
             $this->controls,
             $this->extendedOps,
             $this->confidential,
+            $this->relocations,
         );
     }
 
@@ -136,6 +144,7 @@ final readonly class AclRules
             $controls,
             $this->extendedOps,
             $this->confidential,
+            $this->relocations,
         );
     }
 
@@ -150,6 +159,7 @@ final readonly class AclRules
             $this->controls,
             $extendedOps,
             $this->confidential,
+            $this->relocations,
         );
     }
 
@@ -166,6 +176,24 @@ final readonly class AclRules
             $this->controls,
             $this->extendedOps,
             $confidential,
+            $this->relocations,
+        );
+    }
+
+    /**
+     * Rules gating whether entries may leave or arrive in a container, consulted only when a move changes the parent.
+     *
+     * Discards every relocation rule already present.
+     */
+    public function replaceRelocationRules(RelocationRule ...$relocations): self
+    {
+        return new self(
+            $this->operations,
+            $this->attributes,
+            $this->controls,
+            $this->extendedOps,
+            $this->confidential,
+            $relocations,
         );
     }
 
@@ -221,6 +249,17 @@ final readonly class AclRules
         return $this->replaceConfidentialAccess(
             ...$this->confidential,
             ...$confidential,
+        );
+    }
+
+    /**
+     * Append relocation rules, so anything already present matches first.
+     */
+    public function appendRelocationRules(RelocationRule ...$relocations): self
+    {
+        return $this->replaceRelocationRules(
+            ...$this->relocations,
+            ...$relocations,
         );
     }
 
@@ -372,7 +411,11 @@ final readonly class AclRules
             ->appendAttributeRules(AttributeRule::allow(
                 $subject,
                 $target,
-            )->forWrite());
+            )->forWrite())
+            ->appendRelocationRules(RelocationRule::allow(
+                $subject,
+                $target,
+            ));
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/AccessControl/ConfidentialAttributeAccessControl.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/ConfidentialAttributeAccessControl.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationAccess;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
@@ -71,6 +72,18 @@ final readonly class ConfidentialAttributeAccessControl implements AccessControl
             $operation,
             $token,
             $dn,
+        );
+    }
+
+    public function authorizeRelocation(
+        TokenInterface $token,
+        Dn $container,
+        RelocationAccess $direction,
+    ): void {
+        $this->inner->authorizeRelocation(
+            $token,
+            $container,
+            $direction,
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/AccessControl/PrivilegedBypassAccessControl.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/PrivilegedBypassAccessControl.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationAccess;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Token\PrivilegedTokenInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -50,6 +51,22 @@ final readonly class PrivilegedBypassAccessControl implements AccessControlInter
             $operation,
             $token,
             $dn,
+        );
+    }
+
+    public function authorizeRelocation(
+        TokenInterface $token,
+        Dn $container,
+        RelocationAccess $direction,
+    ): void {
+        if ($token instanceof PrivilegedTokenInterface) {
+            return;
+        }
+
+        $this->inner->authorizeRelocation(
+            $token,
+            $container,
+            $direction,
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/AccessControl/Rule/RelocationAccess.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Rule/RelocationAccess.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Rule;
+
+/**
+ * The direction a relocation rule applies to, relative to the container it targets.
+ *
+ * A request is always Out or In, a rule may be Both.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+enum RelocationAccess
+{
+    /**
+     * Entries leaving the container.
+     */
+    case Out;
+
+    /**
+     * Entries arriving in the container.
+     */
+    case In;
+
+    case Both;
+
+    /**
+     * Whether a rule with this scope applies to the requested direction.
+     */
+    public function includes(self $requested): bool
+    {
+        return $this === self::Both
+            || $this === $requested;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/Rule/RelocationRule.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Rule/RelocationRule.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Rule;
+
+use FreeDSx\Ldap\Server\AccessControl\Subject\SubjectMatcherInterface;
+use FreeDSx\Ldap\Server\AccessControl\Target\AnyTargetMatcher;
+use FreeDSx\Ldap\Server\AccessControl\Target\TargetMatcherInterface;
+
+/**
+ * An ordered access control rule gating whether entries may leave or arrive in a container.
+ *
+ * Only consulted when a Modify DN changes the parent, so renaming an entry in place is never gated by these rules.
+ *
+ * @api
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class RelocationRule
+{
+    /**
+     * @param TargetMatcherInterface $target The container, being the old parent for Out and the new parent for In.
+     * @param RelocationAccess $access Whether this covers entries leaving the container, arriving in it, or both.
+     */
+    public function __construct(
+        public Effect $effect,
+        public SubjectMatcherInterface $subject,
+        public TargetMatcherInterface $target,
+        public RelocationAccess $access = RelocationAccess::Both,
+    ) {}
+
+    /**
+     * @param TargetMatcherInterface $target The container, being the old parent for Out and the new parent for In.
+     * @param RelocationAccess $access Whether this covers entries leaving the container, arriving in it, or both.
+     */
+    public static function allow(
+        SubjectMatcherInterface $subject,
+        TargetMatcherInterface $target = new AnyTargetMatcher(),
+        RelocationAccess $access = RelocationAccess::Both,
+    ): self {
+        return new self(
+            Effect::Allow,
+            $subject,
+            $target,
+            $access,
+        );
+    }
+
+    /**
+     * @param TargetMatcherInterface $target The container, being the old parent for Out and the new parent for In.
+     * @param RelocationAccess $access Whether this covers entries leaving the container, arriving in it, or both.
+     */
+    public static function deny(
+        SubjectMatcherInterface $subject,
+        TargetMatcherInterface $target = new AnyTargetMatcher(),
+        RelocationAccess $access = RelocationAccess::Both,
+    ): self {
+        return new self(
+            Effect::Deny,
+            $subject,
+            $target,
+            $access,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/RuleBasedAccessControl.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/RuleBasedAccessControl.php
@@ -26,6 +26,8 @@ use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ExtendedOperationRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationAccess;
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\SubjectMatcherInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
@@ -71,6 +73,19 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
         Dn $dn,
     ): void {
         if (!$this->isAllowed($operation, $token, $dn)) {
+            $this->deny();
+        }
+    }
+
+    /**
+     * @throws OperationException
+     */
+    public function authorizeRelocation(
+        TokenInterface $token,
+        Dn $container,
+        RelocationAccess $direction,
+    ): void {
+        if (!$this->isRelocationAllowed($token, $container, $direction)) {
             $this->deny();
         }
     }
@@ -263,6 +278,28 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
             || in_array($operation, $rule->operations, true);
     }
 
+    private function isRelocationAllowed(
+        TokenInterface $token,
+        Dn $container,
+        RelocationAccess $direction,
+    ): bool {
+        return $this->resolveEffect(
+            $this->rules->relocations,
+            $this->relocationMatches(...),
+            $direction,
+            $token,
+            $container,
+            Effect::Deny,
+        ) === Effect::Allow;
+    }
+
+    private function relocationMatches(
+        RelocationRule $rule,
+        RelocationAccess $direction,
+    ): bool {
+        return $rule->access->includes($direction);
+    }
+
     private function isControlAllowed(
         string $controlOid,
         TokenInterface $token,
@@ -366,7 +403,7 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
     /**
      * Returns the effect of the first rule whose selector, target, and subject all match; otherwise $default.
      *
-     * @template TRule of OperationRule|ControlRule
+     * @template TRule of OperationRule|ControlRule|RelocationRule
      * @template TValue
      * @param TRule[] $rules
      * @param callable(TRule, TValue): bool $selectorMatches

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/MysqlDialect.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/MysqlDialect.php
@@ -83,6 +83,42 @@ final class MysqlDialect implements PdoDialectInterface
         return 768;
     }
 
+    protected function charLength(string $column): string
+    {
+        return "CHAR_LENGTH($column)";
+    }
+
+    protected function concat(
+        string $left,
+        string $right,
+    ): string {
+        return "CONCAT($left, $right)";
+    }
+
+    /**
+     * The entry table's collation is case-insensitive, so the comparison is taken to bytes to match every other adapter.
+     */
+    protected function binaryCompare(
+        string $left,
+        string $right,
+    ): string {
+        return "CAST($left AS BINARY) = CAST($right AS BINARY)";
+    }
+
+    /**
+     * Wrapped in a derived table, which MySQL materializes.
+     *
+     * A subquery is otherwise refused for reading the table the statement is updating.
+     */
+    protected function scopedSubtreeIds(): string
+    {
+        $walk = $this->subtreeWalk();
+
+        return <<<SQL
+            SELECT scoped.entry_id FROM ($walk) AS scoped
+        SQL;
+    }
+
     protected function schemaName(): string
     {
         return 'mysql';

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
@@ -153,6 +153,46 @@ trait PdoDialectTrait
         SQL;
     }
 
+    public function queryRenameEntry(): string
+    {
+        return <<<SQL
+            UPDATE entries
+            SET dn = ?,
+                lc_dn = ?,
+                lc_parent_dn = ?
+            WHERE lc_dn = ?
+        SQL;
+    }
+
+    /**
+     * One pass, since the walk reaches a deep entry only through parent links this statement rewrites.
+     *
+     * The stored DN is assigned first, because MySQL evaluates each assignment against the preceding ones.
+     */
+    public function queryRenameDescendants(): string
+    {
+        $carriesSuffix = $this->binaryCompare(
+            'SUBSTR(dn, ' . $this->charLength('dn') . ' - ? + 1)',
+            '?',
+        );
+        $stored = $this->replaceDnSuffix('dn');
+        $canonical = $this->replaceDnSuffix('lc_dn');
+        $parent = $this->replaceDnSuffix('lc_parent_dn');
+        $scope = $this->scopedSubtreeIds();
+
+        return <<<SQL
+            UPDATE entries
+            SET dn = CASE
+                    WHEN $carriesSuffix
+                    THEN $stored
+                    ELSE $canonical
+                END,
+                lc_dn = $canonical,
+                lc_parent_dn = $parent
+            WHERE entry_id IN ($scope)
+        SQL;
+    }
+
     public function queryDelete(): string
     {
         return <<<SQL
@@ -249,5 +289,69 @@ trait PdoDialectTrait
     protected function listColumns(): string
     {
         return 'entry_id, lc_dn, dn, attributes';
+    }
+
+    /**
+     * Replaces the trailing characters of $column, the first marker naming how many and the second what replaces them.
+     */
+    protected function replaceDnSuffix(string $column): string
+    {
+        return $this->concat(
+            "SUBSTR($column, 1, {$this->charLength($column)} - ?)",
+            '?',
+        );
+    }
+
+    /**
+     * Character count, which the DN arithmetic needs: SQLite counts characters for TEXT, MySQL's LENGTH() counts bytes.
+     */
+    protected function charLength(string $column): string
+    {
+        return "LENGTH($column)";
+    }
+
+    protected function concat(
+        string $left,
+        string $right,
+    ): string {
+        return "$left || $right";
+    }
+
+    /**
+     * Byte-exact comparison, which SQLite already applies to text; a collated one would let a dialect keep a spelling
+     * the other adapters discard.
+     */
+    protected function binaryCompare(
+        string $left,
+        string $right,
+    ): string {
+        return "$left = $right";
+    }
+
+    /**
+     * Entry keys under a DN, which the rename scopes on. Parameters: [lc_dn]
+     */
+    protected function scopedSubtreeIds(): string
+    {
+        return $this->subtreeWalk();
+    }
+
+    /**
+     * Descends lc_parent_dn, so a rename costs its subtree rather than the whole table a DN suffix match would scan.
+     */
+    protected function subtreeWalk(): string
+    {
+        return <<<SQL
+            WITH RECURSIVE subtree AS (
+                SELECT entry_id, lc_dn
+                FROM entries
+                WHERE lc_parent_dn = ?
+                UNION ALL
+                SELECT e.entry_id, e.lc_dn
+                FROM entries e
+                INNER JOIN subtree s ON e.lc_parent_dn = s.lc_dn
+            )
+            SELECT entry_id FROM subtree
+        SQL;
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoEntryDialectInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoEntryDialectInterface.php
@@ -113,6 +113,22 @@ interface PdoEntryDialectInterface
     public function queryUpsert(): string;
 
     /**
+     * Re-key one entry in place.
+     *
+     * Parameters: [dn, lc_dn, lc_parent_dn, current lc_dn]
+     */
+    public function queryRenameEntry(): string;
+
+    /**
+     * Re-key every entry beneath a DN, keeping each stored DN's own leading RDNs where it carries the source's stored
+     * form. Lengths are counted in characters.
+     *
+     * Parameters: [from dn length, from dn, from dn length, to dn, from lc_dn length, to lc_dn, from lc_dn length,
+     * to lc_dn, from lc_dn length, to lc_dn, from lc_dn]
+     */
+    public function queryRenameDescendants(): string;
+
+    /**
      * `DELETE FROM entries WHERE lc_dn = ?`. Parameters: [lc_dn]
      */
     public function queryDelete(): string;
@@ -133,7 +149,7 @@ interface PdoEntryDialectInterface
     public function querySidecarDeleteNames(int $count): string;
 
     /**
-     * INSERT prefix for the sidecar; caller appends `(?, ?, ?, ?)` tuples for (entry_lc_dn, attr_name_lower, value_lower, value_original).
+     * INSERT prefix for the sidecar; caller appends `(?, ?, ?, ?)` tuples for (owner_entry_id, attr_name_lower, value_lower, value_original).
      */
     public function querySidecarInsertPrefix(): string;
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Support\ArrayEntryStorageTrait;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Support\SortKeyComparator;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Support\SubtreeRename;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
@@ -80,6 +81,30 @@ final class InMemoryStorage implements EntryStorageInterface, ChangeJournalingIn
         bool $rebuildIndexes = false,
     ): void {
         $this->entries[$entry->getDn()->normalize()->toString()] = $entry;
+    }
+
+    public function renameSubtree(
+        Dn $from,
+        Dn $to,
+    ): void {
+        $base = $this->find($from);
+        if ($base === null) {
+            return;
+        }
+
+        $rename = new SubtreeRename(
+            $from,
+            $to,
+            $base->getDn()->toString(),
+        );
+
+        $this->entries = $rename->applyTo(
+            $this->entries,
+            static fn(Entry $entry): Entry => Entry::raw(
+                $rename->storedFor($entry->getDn()),
+                $entry->getAttributes(),
+            ),
+        );
     }
 
     public function remove(Dn $dn): void

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonFileStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/JsonFileStorage.php
@@ -121,6 +121,21 @@ final class JsonFileStorage implements EntryStorageInterface, ChangeJournalingIn
     }
 
     /**
+     * Re-keys under the same lock the buffer already takes, so a partially renamed subtree is never published.
+     */
+    public function renameSubtree(
+        Dn $from,
+        Dn $to,
+    ): void {
+        $this->atomic(static function (EntryStorageInterface $storage) use ($from, $to): void {
+            $storage->renameSubtree(
+                $from,
+                $to,
+            );
+        });
+    }
+
+    /**
      * One mutation for the whole set, rather than rewriting the file once per DN.
      */
     public function removeAll(array $dns): void

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -29,6 +29,7 @@ use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Statement\PooledStatement;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query\SqlQuery;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SidecarLeaf;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Support\SubtreeRename;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterResult;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingTrait;
@@ -244,7 +245,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
             // stored; a second writer then repairs whatever the first left behind instead of drifting from it.
             $current = $rebuildIndexes
                 ? null
-                : $this->currentForDiff($normDn);
+                : $this->lockedEntry($normDn);
 
             $this->statements->execute($this->dialect->queryUpsert(), [
                 $lcDn,
@@ -267,6 +268,43 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
                 $entry,
                 $current,
             );
+        });
+    }
+
+    /**
+     * Re-keys the subtree without touching a single sidecar row, since those hang off entry_id rather than the DN.
+     */
+    public function renameSubtree(
+        Dn $from,
+        Dn $to,
+    ): void {
+        $this->assertDnFits($to->toString());
+
+        $this->atomic(function () use ($from, $to): void {
+            // Locked before the walk reads it, so a concurrent rename of the same base cannot interleave with this one.
+            $base = $this->lockedEntry($from->normalize());
+
+            if ($base === null) {
+                return;
+            }
+
+            $rename = new SubtreeRename(
+                $from,
+                $to,
+                $base->getDn()->toString(),
+            );
+
+            $this->statements->execute(
+                $this->dialect->queryRenameDescendants(),
+                $this->renameDescendantParams($rename),
+            );
+
+            $this->statements->execute($this->dialect->queryRenameEntry(), [
+                $rename->toDisplay,
+                $rename->lcTo,
+                $to->normalize()->getParent()?->toString() ?? '',
+                $rename->lcFrom,
+            ]);
         });
     }
 
@@ -468,9 +506,9 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
     }
 
     /**
-     * The stored entry, locked for the rest of this transaction, or null when there is nothing to diff against.
+     * The stored entry, locked for the rest of this transaction, or null when there is none.
      */
-    private function currentForDiff(Dn $normDn): ?Entry
+    private function lockedEntry(Dn $normDn): ?Entry
     {
         $this->dialect->lockRowForWrite(
             $this->transactor->pdo(),
@@ -480,6 +518,31 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
         );
 
         return $this->find($normDn);
+    }
+
+    /**
+     * The DN lengths are counted in characters, matching what the dialect's SUBSTR and length functions slice on.
+     *
+     * @return list<string|int>
+     */
+    private function renameDescendantParams(SubtreeRename $rename): array
+    {
+        $storedLength = mb_strlen($rename->fromDisplay, 'UTF-8');
+        $canonicalLength = mb_strlen($rename->lcFrom, 'UTF-8');
+
+        return [
+            $storedLength,
+            $rename->fromDisplay,
+            $storedLength,
+            $rename->toDisplay,
+            $canonicalLength,
+            $rename->lcTo,
+            $canonicalLength,
+            $rename->lcTo,
+            $canonicalLength,
+            $rename->lcTo,
+            $rename->lcFrom,
+        ];
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/JsonEntryBuffer.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/JsonEntryBuffer.php
@@ -59,7 +59,7 @@ final class JsonEntryBuffer implements EntryStorageInterface, ChangeAppenderInte
 
     public function find(Dn $dn): ?Entry
     {
-        $key = $dn->toString();
+        $key = $dn->normalize()->toString();
         if (!isset($this->data[$key])) {
             return null;
         }
@@ -69,7 +69,7 @@ final class JsonEntryBuffer implements EntryStorageInterface, ChangeAppenderInte
 
     public function exists(Dn $dn): bool
     {
-        return isset($this->data[$dn->toString()]);
+        return isset($this->data[$dn->normalize()->toString()]);
     }
 
     public function list(StorageListOptions $options): EntryStream
@@ -84,9 +84,30 @@ final class JsonEntryBuffer implements EntryStorageInterface, ChangeAppenderInte
         $this->data[$entry->getDn()->normalize()->toString()] = ($this->fromEntry)($entry);
     }
 
+    public function renameSubtree(
+        Dn $from,
+        Dn $to,
+    ): void {
+        $base = $this->find($from);
+        if ($base === null) {
+            return;
+        }
+
+        $rename = new SubtreeRename(
+            $from,
+            $to,
+            $base->getDn()->toString(),
+        );
+
+        $this->data = $rename->applyTo(
+            $this->data,
+            fn(mixed $row): array => ($this->fromEntry)($this->renamed($rename, $row)),
+        );
+    }
+
     public function remove(Dn $dn): void
     {
-        unset($this->data[$dn->toString()]);
+        unset($this->data[$dn->normalize()->toString()]);
     }
 
     public function removeAll(array $dns): void
@@ -136,6 +157,18 @@ final class JsonEntryBuffer implements EntryStorageInterface, ChangeAppenderInte
     public function getData(): array
     {
         return $this->data;
+    }
+
+    private function renamed(
+        SubtreeRename $rename,
+        mixed $row,
+    ): Entry {
+        $entry = ($this->toEntry)($row);
+
+        return Entry::raw(
+            $rename->storedFor($entry->getDn()),
+            $entry->getAttributes(),
+        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/SubtreeRename.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/SubtreeRename.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Support;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+
+/**
+ * The DN rewrite a subtree rename applies, shared so every adapter moves a subtree the same way.
+ *
+ * @internal
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class SubtreeRename
+{
+    /**
+     * Canonical form of the DN being moved.
+     */
+    public string $lcFrom;
+
+    /**
+     * Canonical form of the DN it moves to.
+     */
+    public string $lcTo;
+
+    /**
+     * Stored form of the DN it moves to.
+     */
+    public string $toDisplay;
+
+    /**
+     * @param Dn $from The DN being moved.
+     * @param Dn $to The DN it moves to.
+     * @param string $fromDisplay The stored form of $from, which descendants carry as their ancestor portion.
+     *
+     * @throws InvalidArgumentException when either DN is empty or the target sits at or under the source
+     */
+    public function __construct(
+        public Dn $from,
+        public Dn $to,
+        public string $fromDisplay,
+    ) {
+        $this->lcFrom = $from->normalize()->toString();
+        $this->lcTo = $to->normalize()->toString();
+        $this->toDisplay = $to->toString();
+
+        if ($this->lcFrom === '' || $this->lcTo === '') {
+            throw new InvalidArgumentException('A subtree rename requires a source and a target DN.');
+        }
+
+        if ($to->isDescendantOf($from)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Cannot move "%s" to "%s", which sits within its own subtree.',
+                    $from->toString(),
+                    $to->toString(),
+                ),
+            );
+        }
+    }
+
+    /**
+     * Whether the entry at the given DN moves with this rename.
+     */
+    public function covers(Dn $dn): bool
+    {
+        return $dn->isDescendantOf($this->from);
+    }
+
+    /**
+     * Re-keys every covered row of $rows, which are keyed by canonical DN.
+     *
+     * @template TRow
+     *
+     * @param array<string, TRow> $rows
+     * @param callable(TRow): TRow $rename Rewrites the row itself, which carries its own stored DN.
+     *
+     * @return array<string, TRow>
+     */
+    public function applyTo(
+        array $rows,
+        callable $rename,
+    ): array {
+        $renamed = [];
+
+        foreach ($rows as $lcDn => $row) {
+            $lcDn = (string) $lcDn;
+
+            if (!$this->covers(Dn::fromCanonical($lcDn))) {
+                $renamed[$lcDn] = $row;
+
+                continue;
+            }
+
+            $renamed[$this->canonicalFor($lcDn)] = $rename($row);
+        }
+
+        return $renamed;
+    }
+
+    /**
+     * The canonical DN an entry currently stored under $lcDn moves to.
+     */
+    public function canonicalFor(string $lcDn): string
+    {
+        return $this->replaceSuffix(
+            $lcDn,
+            $this->lcFrom,
+            $this->lcTo,
+        );
+    }
+
+    /**
+     * The stored DN an entry moves to, keeping its own leading RDNs and taking the ancestor portion from the target.
+     *
+     * Spelling is only carried over where the stored DN ends in the source's stored form verbatim; anything else has
+     * no prefix that can be split off reliably, so it takes the canonical DN.
+     */
+    public function storedFor(Dn $storedDn): Dn
+    {
+        $lcDn = $storedDn->normalize()->toString();
+        if ($lcDn === $this->lcFrom) {
+            return $this->to;
+        }
+
+        $stored = $storedDn->toString();
+        if (!str_ends_with($stored, $this->fromDisplay) || $stored === $this->fromDisplay) {
+            return Dn::fromCanonical($this->canonicalFor($lcDn));
+        }
+
+        return new Dn($this->replaceSuffix(
+            $stored,
+            $this->fromDisplay,
+            $this->toDisplay,
+        ));
+    }
+
+    private function replaceSuffix(
+        string $subject,
+        string $suffix,
+        string $replacement,
+    ): string {
+        return substr(
+            $subject,
+            0,
+            -strlen($suffix),
+        ) . $replacement;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/WriteSerializingStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/WriteSerializingStorage.php
@@ -67,6 +67,16 @@ final readonly class WriteSerializingStorage implements EntryStorageInterface, R
         ));
     }
 
+    public function renameSubtree(
+        Dn $from,
+        Dn $to,
+    ): void {
+        $this->queue->run(fn() => $this->writes->renameSubtree(
+            $from,
+            $to,
+        ));
+    }
+
     public function remove(Dn $dn): void
     {
         $this->queue->run(fn() => $this->writes->remove($dn));

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStorageInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStorageInterface.php
@@ -57,6 +57,16 @@ interface EntryStorageInterface
     ): void;
 
     /**
+     * Re-key the entry at $from and every descendant under $to, leaving attributes and secondary-index rows untouched.
+     *
+     * $to must be free, its parent must exist, and $to may not sit at or under $from.
+     */
+    public function renameSubtree(
+        Dn $from,
+        Dn $to,
+    ): void;
+
+    /**
      * Remove the entry for the given normalised DN. A no-op if the entry does not exist.
      */
     public function remove(Dn $dn): void;

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -390,30 +390,36 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
     }
 
     /**
+     * Moves whatever is under the entry along with it.
+     *
+     * The containers an entry leaves and arrives in are gated by the relocation rules the middleware consults.
+     *
      * @throws OperationException
      */
     public function move(
         MoveCommand $command,
         WriteContext $context,
     ): void {
-        $this->writeAtomic(function (EntryStorageInterface $storage) use ($command, $context): void {
-            $normOld = $command->dn->normalize();
+        $normOld = $command->dn->normalize();
+        $this->findOrFail(
+            $this->storage,
+            $normOld,
+        );
+        $this->assertNotNamingContext(
+            $this->storage,
+            $command->dn,
+        );
+        $this->assertNewSuperiorExists(
+            $this->storage,
+            $command,
+        );
+        $this->assertNotIntoOwnSubtree(
+            $command,
+            $normOld,
+        );
+
+        $this->writeAtomic(function (EntryStorageInterface $storage) use ($command, $context, $normOld): void {
             $entry = $this->findOrFail($storage, $normOld);
-
-            if ($storage->hasChildren($normOld)) {
-                throw new OperationException(
-                    sprintf('Entry "%s" has subordinate entries and cannot be moved.', $command->dn->toString()),
-                    ResultCode::NOT_ALLOWED_ON_NON_LEAF,
-                );
-            }
-
-            $this->assertNotNamingContext(
-                $storage,
-                $command->dn,
-            );
-
-            $this->assertNewSuperiorExists($storage, $command);
-
             $newEntry = $this->entryHandler->apply($entry, $command);
             $this->validateForMove(
                 $command,
@@ -425,8 +431,12 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             // Respelling the RDN resolves to the entry being renamed, which is not a collision with another one.
             $isRespelling = $normNew->toString() === $normOld->toString();
 
-            if (!$isRespelling && $storage->exists($normNew)) {
-                $this->throwEntryAlreadyExists($newEntry->getDn());
+            if (!$isRespelling) {
+                $this->assertMoveTargetIsFree(
+                    $storage,
+                    $normNew,
+                    $newEntry->getDn(),
+                );
             }
 
             $this->subentryGuard->assertPlacement(
@@ -440,16 +450,23 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
                 $newEntry,
                 $context,
             );
-            $storage->remove($normOld);
-            $storage->store(
-                $newEntry,
-                rebuildIndexes: true,
-            );
-            $this->changeRecorder?->recordModRdn(
+
+            // Re-keyed before the base is stored, so the upsert lands on the moved row rather than inserting a second.
+            if (!$isRespelling) {
+                $storage->renameSubtree(
+                    $normOld,
+                    $newEntry->getDn(),
+                );
+            }
+
+            $storage->store($newEntry);
+            $this->recordSubtreeMove(
                 $storage,
+                $context,
                 $newEntry,
                 $command->dn,
-                $context,
+                $normOld,
+                $normNew,
             );
         });
     }
@@ -476,6 +493,130 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         return $this->searchStream->buildForBaseObject(
             $entry,
             $request,
+        );
+    }
+
+    /**
+     * The target must hold no entry, and nothing may already sit beneath it.
+     *
+     * @throws OperationException
+     */
+    private function assertMoveTargetIsFree(
+        EntryStorageInterface $storage,
+        Dn $normNew,
+        Dn $newDn,
+    ): void {
+        // A system write may create an entry whose parent is absent, so the target can hold subordinates yet not exist.
+        if (!$storage->exists($normNew) && !$storage->hasChildren($normNew)) {
+            return;
+        }
+
+        $this->throwEntryAlreadyExists($newDn);
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function assertNotIntoOwnSubtree(
+        MoveCommand $command,
+        Dn $normOld,
+    ): void {
+        // Also what keeps the storage suffix rewrite well defined, so this is more than a sanity check.
+        if ($command->newParent === null || !$command->newParent->normalize()->isDescendantOf($normOld)) {
+            return;
+        }
+
+        throw new OperationException(
+            sprintf(
+                'Entry "%s" cannot be moved beneath itself.',
+                $command->dn->toString(),
+            ),
+            ResultCode::UNWILLING_TO_PERFORM,
+        );
+    }
+
+    /**
+     * One record per moved entry, since a consumer re-fetches by the DN each record carries and would otherwise never
+     * hear about a descendant.
+     */
+    private function recordSubtreeMove(
+        EntryStorageInterface $storage,
+        WriteContext $context,
+        Entry $newEntry,
+        Dn $previousDn,
+        Dn $normOld,
+        Dn $normNew,
+    ): void {
+        if ($this->changeRecorder === null) {
+            return;
+        }
+
+        $this->changeRecorder->recordModRdn(
+            $storage,
+            $newEntry,
+            $previousDn,
+            $context,
+        );
+
+        // Respelling the base leaves every DN beneath it exactly where it was.
+        if ($normNew->toString() === $normOld->toString()) {
+            return;
+        }
+
+        foreach ($this->movedDescendants($storage, $normNew) as $entry) {
+            $this->changeRecorder->recordModRdn(
+                $storage,
+                $entry,
+                $this->previousDnOf(
+                    $entry->getDn(),
+                    $normOld,
+                    $normNew,
+                ),
+                $context,
+            );
+        }
+    }
+
+    /**
+     * Read in full rather than streamed, so the journal writes below do not run against an open result set.
+     *
+     * @return list<Entry>
+     */
+    private function movedDescendants(
+        EntryStorageInterface $storage,
+        Dn $normNew,
+    ): array {
+        $descendants = [];
+        $options = StorageListOptions::matchAll(
+            $normNew,
+            subtree: true,
+        );
+
+        foreach ($storage->list($options)->entries as $entry) {
+            if ($entry->getDn()->normalize()->toString() !== $normNew->toString()) {
+                $descendants[] = $entry;
+            }
+        }
+
+        return $descendants;
+    }
+
+    /**
+     * Where a moved entry sat before, by swapping back the canonical suffix the move replaced.
+     */
+    private function previousDnOf(
+        Dn $movedDn,
+        Dn $normOld,
+        Dn $normNew,
+    ): Dn {
+        $lcDn = $movedDn->normalize()->toString();
+
+        return Dn::fromCanonical(
+            substr(
+                $lcDn,
+                0,
+                -strlen($normNew->toString()),
+            ) . $normOld->toString(),
         );
     }
 
@@ -571,13 +712,13 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
      */
     private function collectSubtreeDnsDeepestFirst(Dn $base): array
     {
-        $dns = [];
         $options = StorageListOptions::matchAll(
             $base,
             subtree: true,
             attributes: [],
         );
 
+        $dns = [];
         foreach ($this->storage->list($options)->entries as $entry) {
             $dns[] = $entry->getDn()->normalize();
         }
@@ -784,6 +925,8 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
     }
 
     /**
+     * A single-RDN superior is held to this too, so a move cannot strand the entry under a DN that holds nothing.
+     *
      * @throws OperationException
      */
     private function assertNewSuperiorExists(EntryStorageInterface $storage, MoveCommand $command): void
@@ -792,9 +935,7 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             return;
         }
 
-        $normNewParent = $command->newParent->normalize();
-
-        if ($normNewParent->getParent() !== null && !$storage->exists($normNewParent)) {
+        if (!$storage->exists($command->newParent->normalize())) {
             $this->throwNoSuchObject(
                 $storage,
                 $command->newParent,

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
@@ -35,6 +35,7 @@ use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerMonitorHandler;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationAccess;
 use FreeDSx\Ldap\Server\AccessControl\OperationTargetDn;
 use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
@@ -372,6 +373,42 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
             OperationType::ModifyDn,
             $token,
             $newParentDn,
+        );
+
+        $this->authorizeRelocation(
+            $request,
+            $token,
+            $newParentDn,
+        );
+    }
+
+    /**
+     * Gates the containers an entry leaves and arrives in.
+     *
+     * @throws OperationException
+     */
+    private function authorizeRelocation(
+        ModifyDnRequest $request,
+        TokenInterface $token,
+        Dn $newParentDn,
+    ): void {
+        $oldParentDn = $request->getDn()->getParent();
+        if ($oldParentDn === null) {
+            return;
+        }
+        if ($oldParentDn->normalize()->toString() === $newParentDn->normalize()->toString()) {
+            return;
+        }
+
+        $this->accessControl->authorizeRelocation(
+            $token,
+            $oldParentDn,
+            RelocationAccess::Out,
+        );
+        $this->accessControl->authorizeRelocation(
+            $token,
+            $newParentDn,
+            RelocationAccess::In,
         );
     }
 

--- a/tests/integration/Storage/Concern/SubtreeMoveTestsTrait.php
+++ b/tests/integration/Storage/Concern/SubtreeMoveTestsTrait.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Storage\Concern;
+
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\Search\Filters;
+use Tests\Support\FreeDSx\Ldap\LdapBackendStorageCommand;
+
+/**
+ * Renaming and moving an entry that has subordinates, which travel with it (RFC 4511 §4.9).
+ */
+trait SubtreeMoveTestsTrait
+{
+    public function testRenameMovesTheSubordinatesOfTheEntry(): void
+    {
+        $this->authenticateAdmin();
+        $this->seedSubtreeToMove();
+
+        $this->ldapClient()->rename('ou=dept,dc=foo,dc=bar', 'ou=division', true);
+
+        self::assertSame(
+            [
+                'cn=deep,cn=lead,ou=division,dc=foo,dc=bar',
+                'cn=lead,ou=division,dc=foo,dc=bar',
+                'ou=division,dc=foo,dc=bar',
+            ],
+            $this->dnsUnder('ou=division,dc=foo,dc=bar'),
+        );
+
+        $this->deleteSubtree('ou=division,dc=foo,dc=bar');
+    }
+
+    public function testRenameLeavesNothingBehindAtTheOldSubtree(): void
+    {
+        $this->authenticateAdmin();
+        $this->seedSubtreeToMove();
+
+        $this->ldapClient()->rename('ou=dept,dc=foo,dc=bar', 'ou=division', true);
+
+        self::assertCount(
+            0,
+            $this->ldapClient()->search(
+                Operations::search(Filters::equal('ou', 'dept'))
+                    ->base('dc=foo,dc=bar')
+                    ->useSubtreeScope(),
+            ),
+        );
+
+        $this->deleteSubtree('ou=division,dc=foo,dc=bar');
+    }
+
+    public function testMoveRelocatesTheEntryAndItsSubordinatesUnderANewSuperior(): void
+    {
+        $this->authenticateAdmin();
+        $this->seedSubtreeToMove();
+
+        $this->ldapClient()->move('ou=dept,dc=foo,dc=bar', 'ou=people,dc=foo,dc=bar');
+
+        self::assertSame(
+            [
+                'cn=deep,cn=lead,ou=dept,ou=people,dc=foo,dc=bar',
+                'cn=lead,ou=dept,ou=people,dc=foo,dc=bar',
+                'ou=dept,ou=people,dc=foo,dc=bar',
+            ],
+            $this->dnsUnder('ou=dept,ou=people,dc=foo,dc=bar'),
+        );
+
+        $this->deleteSubtree('ou=dept,ou=people,dc=foo,dc=bar');
+    }
+
+    public function testMovedSubordinatesAreStillFoundByAnIndexedFilter(): void
+    {
+        $this->authenticateAdmin();
+        $this->seedSubtreeToMove();
+
+        $this->ldapClient()->rename('ou=dept,dc=foo,dc=bar', 'ou=division', true);
+
+        $found = $this->ldapClient()->search(
+            Operations::search(Filters::equal('cn', 'deep'))
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        );
+        self::assertSame(
+            'cn=deep,cn=lead,ou=division,dc=foo,dc=bar',
+            $found->first()?->getDn()->toString(),
+        );
+
+        $this->deleteSubtree('ou=division,dc=foo,dc=bar');
+    }
+
+    public function testMoveIntoItsOwnSubtreeIsRefused(): void
+    {
+        $this->authenticateAdmin();
+        $this->seedSubtreeToMove();
+
+        try {
+            $this->ldapClient()->move('ou=dept,dc=foo,dc=bar', 'cn=lead,ou=dept,dc=foo,dc=bar');
+            self::fail('Moving an entry beneath itself should have been refused.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::UNWILLING_TO_PERFORM,
+                $e->getCode(),
+            );
+        }
+
+        $this->deleteSubtree('ou=dept,dc=foo,dc=bar');
+    }
+
+    public function testRenamingASubtreeIsRefusedForANormalUser(): void
+    {
+        $this->authenticateAdmin();
+        $this->seedSubtreeToMove();
+
+        $this->authenticateUser();
+
+        try {
+            $this->ldapClient()->rename('ou=dept,dc=foo,dc=bar', 'ou=division', true);
+            self::fail('A subtree rename should not be permitted under the default ACL.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+                $e->getCode(),
+            );
+        }
+
+        $this->authenticateAdmin();
+        self::assertSame(
+            [
+                'cn=deep,cn=lead,ou=dept,dc=foo,dc=bar',
+                'cn=lead,ou=dept,dc=foo,dc=bar',
+                'ou=dept,dc=foo,dc=bar',
+            ],
+            $this->dnsUnder('ou=dept,dc=foo,dc=bar'),
+        );
+
+        $this->deleteSubtree('ou=dept,dc=foo,dc=bar');
+    }
+
+    public function testAnIdentityGrantedModifyDnCanRenameASubtree(): void
+    {
+        $this->authenticateAdmin();
+        $this->seedMover();
+        $this->seedSubtreeToMove();
+
+        $this->authenticateMover();
+        $this->ldapClient()->rename('ou=dept,dc=foo,dc=bar', 'ou=division', true);
+
+        self::assertSame(
+            [
+                'cn=deep,cn=lead,ou=division,dc=foo,dc=bar',
+                'cn=lead,ou=division,dc=foo,dc=bar',
+                'ou=division,dc=foo,dc=bar',
+            ],
+            $this->dnsUnder('ou=division,dc=foo,dc=bar'),
+        );
+
+        $this->authenticateAdmin();
+        $this->deleteSubtree('ou=division,dc=foo,dc=bar');
+        $this->ldapClient()->delete(LdapBackendStorageCommand::MOVER_DN);
+    }
+
+    public function testRenamingInPlaceIsAllowedInsideAPinnedContainer(): void
+    {
+        $this->authenticateAdmin();
+        $this->seedMover();
+        $this->seedPinnedContainer();
+
+        $this->authenticateMover();
+        $this->ldapClient()->rename('cn=held,ou=pinned,dc=foo,dc=bar', 'cn=renamed', true);
+
+        self::assertSame(
+            [
+                'cn=renamed,ou=pinned,dc=foo,dc=bar',
+                'ou=pinned,dc=foo,dc=bar',
+            ],
+            $this->dnsUnder(LdapBackendStorageCommand::PINNED_CONTAINER_DN),
+        );
+
+        $this->authenticateAdmin();
+        $this->cleanUpRelocationFixtures();
+    }
+
+    public function testMovingOutOfAPinnedContainerIsRefused(): void
+    {
+        $this->authenticateAdmin();
+        $this->seedMover();
+        $this->seedPinnedContainer();
+
+        $this->authenticateMover();
+
+        try {
+            $this->ldapClient()->move('cn=held,ou=pinned,dc=foo,dc=bar', 'dc=foo,dc=bar');
+            self::fail('Moving out of a pinned container should have been refused.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+                $e->getCode(),
+            );
+        }
+
+        $this->authenticateAdmin();
+        self::assertNotNull($this->ldapClient()->read('cn=held,ou=pinned,dc=foo,dc=bar'));
+
+        $this->cleanUpRelocationFixtures();
+    }
+
+    public function testMovingIntoASealedContainerIsRefused(): void
+    {
+        $this->authenticateAdmin();
+        $this->seedMover();
+        $this->seedPinnedContainer();
+        $this->ldapClient()->create(Entry::fromArray(
+            LdapBackendStorageCommand::SEALED_CONTAINER_DN,
+            ['ou' => 'sealed', 'objectClass' => 'organizationalUnit'],
+        ));
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=loose,dc=foo,dc=bar',
+            ['cn' => 'loose', 'sn' => 'Loose', 'objectClass' => 'inetOrgPerson'],
+        ));
+
+        $this->authenticateMover();
+
+        try {
+            $this->ldapClient()->move('cn=loose,dc=foo,dc=bar', LdapBackendStorageCommand::SEALED_CONTAINER_DN);
+            self::fail('Moving into a sealed container should have been refused.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
+                $e->getCode(),
+            );
+        }
+
+        $this->authenticateAdmin();
+        self::assertNotNull($this->ldapClient()->read('cn=loose,dc=foo,dc=bar'));
+
+        $this->ldapClient()->delete('cn=loose,dc=foo,dc=bar');
+        $this->ldapClient()->delete(LdapBackendStorageCommand::SEALED_CONTAINER_DN);
+        $this->cleanUpRelocationFixtures();
+    }
+
+    /**
+     * Created per test rather than seeded, so the shared fixture's entry counts stay as every other case expects.
+     */
+    private function seedMover(): void
+    {
+        $this->ldapClient()->create(Entry::fromArray(
+            LdapBackendStorageCommand::MOVER_DN,
+            [
+                'cn' => 'mover',
+                'sn' => 'Mover',
+                'userPassword' => LdapBackendStorageCommand::MOVER_PASSWORD,
+                'objectClass' => 'inetOrgPerson',
+            ],
+        ));
+    }
+
+    private function authenticateMover(): void
+    {
+        $this->ldapClient()->bind(
+            LdapBackendStorageCommand::MOVER_DN,
+            LdapBackendStorageCommand::MOVER_PASSWORD,
+        );
+    }
+
+    /**
+     * The container cn=mover is denied moving entries out of, holding one entry to try it with.
+     */
+    private function seedPinnedContainer(): void
+    {
+        $this->ldapClient()->create(Entry::fromArray(
+            LdapBackendStorageCommand::PINNED_CONTAINER_DN,
+            ['ou' => 'pinned', 'objectClass' => 'organizationalUnit'],
+        ));
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=held,ou=pinned,dc=foo,dc=bar',
+            ['cn' => 'held', 'sn' => 'Held', 'objectClass' => 'inetOrgPerson'],
+        ));
+    }
+
+    private function cleanUpRelocationFixtures(): void
+    {
+        $this->deleteSubtree(LdapBackendStorageCommand::PINNED_CONTAINER_DN);
+        $this->ldapClient()->delete(LdapBackendStorageCommand::MOVER_DN);
+    }
+
+    /**
+     * A three-level subtree, so a rename has to reach past the entries directly beneath the base.
+     */
+    private function seedSubtreeToMove(): void
+    {
+        $this->ldapClient()->create(Entry::fromArray(
+            'ou=dept,dc=foo,dc=bar',
+            ['ou' => 'dept', 'objectClass' => 'organizationalUnit'],
+        ));
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=lead,ou=dept,dc=foo,dc=bar',
+            ['cn' => 'lead', 'sn' => 'Lead', 'objectClass' => 'inetOrgPerson'],
+        ));
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=deep,cn=lead,ou=dept,dc=foo,dc=bar',
+            ['cn' => 'deep', 'sn' => 'Deep', 'objectClass' => 'inetOrgPerson'],
+        ));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function dnsUnder(string $baseDn): array
+    {
+        $dns = [];
+
+        foreach ($this->ldapClient()->search(
+            Operations::search(Filters::present('objectClass'))
+                ->base($baseDn)
+                ->useSubtreeScope(),
+        ) as $entry) {
+            $dns[] = $entry->getDn()->toString();
+        }
+        sort($dns);
+
+        return $dns;
+    }
+
+    /**
+     * Deepest first, since an entry holding subordinates cannot be deleted.
+     */
+    private function deleteSubtree(string $baseDn): void
+    {
+        $dns = $this->dnsUnder($baseDn);
+        usort(
+            $dns,
+            static fn(string $a, string $b): int => substr_count($b, ',') <=> substr_count($a, ','),
+        );
+
+        foreach ($dns as $dn) {
+            $this->ldapClient()->delete($dn);
+        }
+    }
+}

--- a/tests/integration/Storage/LdapBackendStorageTest.php
+++ b/tests/integration/Storage/LdapBackendStorageTest.php
@@ -18,6 +18,7 @@ use Tests\Integration\FreeDSx\Ldap\Storage\Concern\BindTestsTrait;
 use Tests\Integration\FreeDSx\Ldap\Storage\Concern\ControlTestsTrait;
 use Tests\Integration\FreeDSx\Ldap\Storage\Concern\DefaultAclTestsTrait;
 use Tests\Integration\FreeDSx\Ldap\Storage\Concern\QueryTestsTrait;
+use Tests\Integration\FreeDSx\Ldap\Storage\Concern\SubtreeMoveTestsTrait;
 use Tests\Integration\FreeDSx\Ldap\Storage\Concern\WriteTestsTrait;
 
 /**
@@ -32,6 +33,7 @@ class LdapBackendStorageTest extends ServerTestCase
     use QueryTestsTrait;
     use DefaultAclTestsTrait;
     use WriteTestsTrait;
+    use SubtreeMoveTestsTrait;
     use ControlTestsTrait;
 
     public static function setUpBeforeClass(): void

--- a/tests/profile/docker-compose.yml
+++ b/tests/profile/docker-compose.yml
@@ -98,6 +98,40 @@ services:
     tmpfs:
       - /var/lib/ldap
 
+  389ds:
+    image: quay.io/389ds/dirsrv:latest
+    container_name: freedsx-profile-389ds
+    cpus: ${PROFILE_CPUS:-4}
+    # Pinned to the same cores as freedsx-server so a comparison measures the server, not core contention.
+    cpuset: ${SERVER_CPUSET:-}
+    ports:
+      - "10392:3389"
+    environment:
+      DS_DM_PASSWORD: "P@ssword12345"
+      DS_SUFFIX_NAME: "dc=example,dc=com"
+    healthcheck:
+      test: ["CMD-SHELL", "dsctl localhost status 2>/dev/null | grep -qi running"]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+      start_period: 20s
+
+  # The image creates the instance but not the suffix, so the backend is added once the instance answers.
+  389ds-init:
+    image: quay.io/389ds/dirsrv:latest
+    container_name: freedsx-profile-389ds-init
+    depends_on:
+      389ds:
+        condition: service_healthy
+    restart: on-failure
+    entrypoint:
+      - bash
+      - -lc
+      - >
+        dsconf -D "cn=Directory Manager" -w "P@ssword12345" ldap://389ds:3389 backend suffix list 2>/dev/null | grep -q "dc=example,dc=com"
+        || dsconf -D "cn=Directory Manager" -w "P@ssword12345" ldap://389ds:3389 backend create
+        --suffix "dc=example,dc=com" --be-name userRoot --create-suffix
+
   opendj:
     image: openidentityplatform/opendj:latest
     container_name: freedsx-profile-opendj

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -11,8 +11,12 @@ use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationAccess;
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\AccessControl\Target\Target;
 use FreeDSx\Ldap\Server\Backend\Auth\ManagerIdentity;
@@ -48,6 +52,25 @@ final class LdapBackendStorageCommand extends Command
     public const MANAGER_DN = 'cn=manager';
 
     public const MANAGER_PASSWORD = 'manager-pass';
+
+    public const ROOT_DN = 'dc=foo,dc=bar';
+
+    /**
+     * Holds ModifyDn without administrator rights, so a rename it performs is held to the per-entry rules.
+     */
+    public const MOVER_DN = 'cn=mover,dc=foo,dc=bar';
+
+    public const MOVER_PASSWORD = '12345';
+
+    /**
+     * Entries may be renamed inside this container but never moved out of it.
+     */
+    public const PINNED_CONTAINER_DN = 'ou=pinned,dc=foo,dc=bar';
+
+    /**
+     * Nothing may be moved into this container.
+     */
+    public const SEALED_CONTAINER_DN = 'ou=sealed,dc=foo,dc=bar';
 
     /**
      * Tests assert on replicated state, so they should not wait a production poll for it.
@@ -379,6 +402,8 @@ final class LdapBackendStorageCommand extends Command
             );
         }
 
+        $this->grantSubtreeMoves($serverOptions);
+
         if ($input->getOption('manager')) {
             $serverOptions->setManager(new ManagerIdentity(
                 new Dn(self::MANAGER_DN),
@@ -464,6 +489,50 @@ final class LdapBackendStorageCommand extends Command
         $server->run();
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Lets cn=mover rename entries without administrator rights, while pinning one container shut.
+     */
+    private function grantSubtreeMoves(ServerOptions $serverOptions): void
+    {
+        $mover = Subject::dn(self::MOVER_DN);
+
+        $serverOptions->setAclRules(
+            $serverOptions->getAclRules()
+                ->appendOperationRules(
+                    OperationRule::allow(
+                        $mover,
+                        Target::subtree(self::ROOT_DN),
+                        OperationType::ModifyDn,
+                    ),
+                )
+                ->appendAttributeRules(
+                    AttributeRule::allow(
+                        $mover,
+                        Target::subtree(self::ROOT_DN),
+                        'cn',
+                        'ou',
+                    )->forWrite(),
+                )
+                // Denies first, since the first match wins.
+                ->appendRelocationRules(
+                    RelocationRule::deny(
+                        $mover,
+                        Target::subtree(self::PINNED_CONTAINER_DN),
+                        RelocationAccess::Out,
+                    ),
+                    RelocationRule::deny(
+                        $mover,
+                        Target::subtree(self::SEALED_CONTAINER_DN),
+                        RelocationAccess::In,
+                    ),
+                    RelocationRule::allow(
+                        $mover,
+                        Target::subtree(self::ROOT_DN),
+                    ),
+                ),
+        );
     }
 
     /**

--- a/tests/support/Storage/SubtreeRenameStorageContractTests.php
+++ b/tests/support/Storage/SubtreeRenameStorageContractTests.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Support\FreeDSx\Ldap\Storage;
+
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
+
+/**
+ * Shared EntryStorageInterface::renameSubtree() contract, so every adapter moves a subtree the same way.
+ *
+ * @mixin \PHPUnit\Framework\TestCase
+ */
+trait SubtreeRenameStorageContractTests
+{
+    public function test_renaming_a_subtree_moves_the_base_entry(): void
+    {
+        $storage = $this->renameStorage();
+        $this->renamePeopleToStaff($storage);
+
+        self::assertNull($storage->find(new Dn('ou=people,dc=foo,dc=bar')));
+        self::assertSame(
+            'ou=Staff,dc=foo,dc=bar',
+            $storage->find(new Dn('ou=staff,dc=foo,dc=bar'))?->getDn()->toString(),
+        );
+    }
+
+    public function test_renaming_a_subtree_moves_every_child(): void
+    {
+        $storage = $this->renameStorage();
+        $this->renamePeopleToStaff($storage);
+
+        self::assertSame(
+            [
+                'cn=Alice,ou=Staff,dc=foo,dc=bar',
+                'cn=Bob,ou=Staff,dc=foo,dc=bar',
+                'cn=dave,ou=staff,dc=foo,dc=bar',
+            ],
+            $this->storedDnsUnder(
+                $storage,
+                'ou=staff,dc=foo,dc=bar',
+            ),
+        );
+    }
+
+    public function test_renaming_a_subtree_moves_a_descendant_nested_below_a_child(): void
+    {
+        $storage = $this->renameStorage();
+        $this->renamePeopleToStaff($storage);
+
+        self::assertSame(
+            'cn=Laptop,cn=Alice,ou=Staff,dc=foo,dc=bar',
+            $storage->find(new Dn('cn=laptop,cn=alice,ou=staff,dc=foo,dc=bar'))?->getDn()->toString(),
+        );
+    }
+
+    public function test_renaming_a_subtree_reparents_the_children_it_moves(): void
+    {
+        $storage = $this->renameStorage();
+        $this->renamePeopleToStaff($storage);
+
+        self::assertTrue($storage->hasChildren(new Dn('ou=staff,dc=foo,dc=bar')));
+        self::assertFalse($storage->hasChildren(new Dn('ou=people,dc=foo,dc=bar')));
+    }
+
+    public function test_renaming_a_subtree_leaves_entries_outside_it_alone(): void
+    {
+        $storage = $this->renameStorage();
+        $this->renamePeopleToStaff($storage);
+
+        self::assertSame(
+            'cn=Carol,ou=Groups,dc=foo,dc=bar',
+            $storage->find(new Dn('cn=carol,ou=groups,dc=foo,dc=bar'))?->getDn()->toString(),
+        );
+    }
+
+    public function test_renaming_a_subtree_keeps_the_attributes_of_a_moved_entry(): void
+    {
+        $storage = $this->renameStorage();
+        $this->renamePeopleToStaff($storage);
+
+        self::assertSame(
+            ['Alice'],
+            $storage->find(new Dn('cn=alice,ou=staff,dc=foo,dc=bar'))?->get('cn')?->getValues(),
+        );
+    }
+
+    public function test_renaming_a_subtree_canonicalizes_a_descendant_that_spells_the_source_differently(): void
+    {
+        $storage = $this->renameStorage();
+        $this->renamePeopleToStaff($storage);
+
+        self::assertSame(
+            'cn=dave,ou=staff,dc=foo,dc=bar',
+            $storage->find(new Dn('cn=dave,ou=staff,dc=foo,dc=bar'))?->getDn()->toString(),
+        );
+    }
+
+    public function test_renaming_a_subtree_slices_multibyte_dns_on_character_boundaries(): void
+    {
+        $storage = $this->makeRenameStorage(
+            new Entry(new Dn('dc=foo,dc=bar')),
+            new Entry(new Dn('ou=Москва,dc=foo,dc=bar')),
+            new Entry(new Dn('cn=Zoë,ou=Москва,dc=foo,dc=bar')),
+        );
+
+        $storage->renameSubtree(
+            new Dn('ou=москва,dc=foo,dc=bar'),
+            new Dn('ou=Ω,dc=foo,dc=bar'),
+        );
+
+        self::assertSame(
+            'cn=Zoë,ou=Ω,dc=foo,dc=bar',
+            $storage->find(new Dn('cn=zoë,ou=ω,dc=foo,dc=bar'))?->getDn()->toString(),
+        );
+    }
+
+    public function test_renaming_a_subtree_that_does_not_exist_changes_nothing(): void
+    {
+        $storage = $this->renameStorage();
+
+        $storage->renameSubtree(
+            new Dn('ou=missing,dc=foo,dc=bar'),
+            new Dn('ou=Staff,dc=foo,dc=bar'),
+        );
+
+        self::assertNull($storage->find(new Dn('ou=staff,dc=foo,dc=bar')));
+        self::assertNotNull($storage->find(new Dn('cn=alice,ou=people,dc=foo,dc=bar')));
+    }
+
+    public function test_renaming_a_subtree_into_its_own_subtree_is_refused(): void
+    {
+        $storage = $this->renameStorage();
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $storage->renameSubtree(
+            new Dn('ou=people,dc=foo,dc=bar'),
+            new Dn('ou=Staff,ou=people,dc=foo,dc=bar'),
+        );
+    }
+
+    /**
+     * @param Entry ...$entries Seeded before the rename runs.
+     */
+    abstract protected function makeRenameStorage(Entry ...$entries): EntryStorageInterface;
+
+    private function renameStorage(): EntryStorageInterface
+    {
+        return $this->makeRenameStorage(
+            new Entry(new Dn('dc=foo,dc=bar')),
+            new Entry(new Dn('ou=People,dc=foo,dc=bar')),
+            new Entry(new Dn('ou=Groups,dc=foo,dc=bar')),
+            new Entry(
+                new Dn('cn=Alice,ou=People,dc=foo,dc=bar'),
+                new Attribute('cn', 'Alice'),
+            ),
+            new Entry(new Dn('cn=Bob,ou=People,dc=foo,dc=bar')),
+            new Entry(new Dn('cn=Laptop,cn=Alice,ou=People,dc=foo,dc=bar')),
+            // Stored with a spelling of the parent that the base entry does not carry.
+            new Entry(new Dn('cn=dave,OU=people,dc=foo,dc=bar')),
+            new Entry(new Dn('cn=Carol,ou=Groups,dc=foo,dc=bar')),
+        );
+    }
+
+    private function renamePeopleToStaff(EntryStorageInterface $storage): void
+    {
+        $storage->renameSubtree(
+            new Dn('ou=people,dc=foo,dc=bar'),
+            new Dn('ou=Staff,dc=foo,dc=bar'),
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function storedDnsUnder(
+        EntryStorageInterface $storage,
+        string $baseDn,
+    ): array {
+        $dns = [];
+
+        $stream = $storage->list(StorageListOptions::matchAll(new Dn($baseDn), false));
+        foreach ($stream->entries as $entry) {
+            $dns[] = $entry->getDn()->toString();
+        }
+        sort($dns);
+
+        return $dns;
+    }
+}

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
@@ -21,6 +21,7 @@ use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Operation\Request\CompareRequest;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerDispatchHandler;
@@ -181,6 +182,24 @@ final class ServerDispatchHandlerTest extends TestCase
             ->with(self::isInstanceOf(WriteRequestInterface::class));
 
         $this->subject->handleRequest($delete, $this->mockToken);
+    }
+
+    public function test_it_sends_modify_dn_through_the_write_handler(): void
+    {
+        $modifyDn = new LdapMessageRequest(
+            1,
+            new ModifyDnRequest('cn=foo,dc=bar', 'cn=baz', true),
+        );
+
+        $this->mockWriteHandler
+            ->expects(self::once())
+            ->method('handle')
+            ->with(self::isInstanceOf(WriteRequestInterface::class));
+
+        $this->subject->handleRequest(
+            $modifyDn,
+            $this->mockToken,
+        );
     }
 
     public function test_non_critical_unsupported_control_does_not_cause_an_error(): void

--- a/tests/unit/Server/AccessControl/AclRulesTest.php
+++ b/tests/unit/Server/AccessControl/AclRulesTest.php
@@ -29,6 +29,8 @@ use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationAccess;
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationRule;
 use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\AccessControl\Target\Target;
@@ -604,6 +606,54 @@ final class AclRulesTest extends TestCase
             $this->user(),
             Control::OID_PROXY_AUTHORIZATION,
         ));
+    }
+
+    public function test_relocation_is_denied_under_the_secure_default(): void
+    {
+        $subject = new RuleBasedAccessControl(AclRules::secureDefault());
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $subject->authorizeRelocation(
+            $this->user(),
+            new Dn('ou=people,dc=foo,dc=bar'),
+            RelocationAccess::Out,
+        );
+    }
+
+    public function test_full_access_grants_relocation(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $rules = AclRules::secureDefault()
+            ->withFullAccess(Subject::dn(self::ADMIN_DN));
+
+        (new RuleBasedAccessControl($rules))->authorizeRelocation(
+            $this->admin(),
+            new Dn('ou=people,dc=foo,dc=bar'),
+            RelocationAccess::Out,
+        );
+    }
+
+    public function test_appended_relocation_rules_keep_the_ones_already_present(): void
+    {
+        $rules = AclRules::fromEmpty()
+            ->appendRelocationRules(RelocationRule::deny(Subject::anyone()))
+            ->appendRelocationRules(RelocationRule::allow(Subject::anyone()));
+
+        self::assertCount(
+            2,
+            $rules->relocations,
+        );
+
+        // The deny was appended first, so it matches first.
+        self::expectException(OperationException::class);
+        (new RuleBasedAccessControl($rules))->authorizeRelocation(
+            $this->user(),
+            new Dn('ou=people,dc=foo,dc=bar'),
+            RelocationAccess::Out,
+        );
     }
 
     private function user(): TokenInterface

--- a/tests/unit/Server/AccessControl/PrivilegedBypassAccessControlTest.php
+++ b/tests/unit/Server/AccessControl/PrivilegedBypassAccessControlTest.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\PrivilegedBypassAccessControl;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationAccess;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Ldap\Server\Token\ManagerToken;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -56,6 +57,9 @@ final class PrivilegedBypassAccessControlTest extends TestCase
         $this->inner
             ->expects(self::never())
             ->method('authorizeExtendedOperation');
+        $this->inner
+            ->expects(self::never())
+            ->method('authorizeRelocation');
 
         $dn = new Dn('cn=other,dc=foo,dc=bar');
         $this->subject->authorizeOperation(
@@ -77,6 +81,11 @@ final class PrivilegedBypassAccessControlTest extends TestCase
         $this->subject->authorizeExtendedOperation(
             $this->manager,
             '1.2.3.4',
+        );
+        $this->subject->authorizeRelocation(
+            $this->manager,
+            $dn,
+            RelocationAccess::Out,
         );
 
         $this->addToAssertionCount(1);

--- a/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
+++ b/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
@@ -25,6 +25,8 @@ use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ConfidentialAccessRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationAccess;
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationRule;
 use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
 use FreeDSx\Ldap\Server\AccessControl\BackendAwareInterface;
 use FreeDSx\Ldap\Server\AccessControl\Subject\AnySubjectMatcher;
@@ -932,5 +934,95 @@ final class RuleBasedAccessControlTest extends TestCase
             new AnonToken(),
             'userPassword',
         ));
+    }
+
+    public function test_relocation_is_denied_when_no_rule_matches(): void
+    {
+        $subject = new RuleBasedAccessControl(AclRules::fromEmpty());
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $subject->authorizeRelocation(
+            $this->bindToken,
+            $this->dn,
+            RelocationAccess::Out,
+        );
+    }
+
+    public function test_relocation_is_allowed_by_a_matching_rule(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $subject = new RuleBasedAccessControl(AclRules::fromEmpty(
+            relocations: [RelocationRule::allow(new AnySubjectMatcher())],
+        ));
+
+        $subject->authorizeRelocation(
+            $this->bindToken,
+            $this->dn,
+            RelocationAccess::Out,
+        );
+    }
+
+    public function test_relocation_rules_apply_only_to_their_own_direction(): void
+    {
+        $subject = new RuleBasedAccessControl(AclRules::fromEmpty(
+            relocations: [
+                RelocationRule::allow(
+                    new AnySubjectMatcher(),
+                    new AnyTargetMatcher(),
+                    RelocationAccess::In,
+                ),
+            ],
+        ));
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $subject->authorizeRelocation(
+            $this->bindToken,
+            $this->dn,
+            RelocationAccess::Out,
+        );
+    }
+
+    public function test_a_relocation_rule_for_both_directions_answers_either(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $subject = new RuleBasedAccessControl(AclRules::fromEmpty(
+            relocations: [RelocationRule::allow(new AnySubjectMatcher())],
+        ));
+
+        $subject->authorizeRelocation(
+            $this->bindToken,
+            $this->dn,
+            RelocationAccess::Out,
+        );
+        $subject->authorizeRelocation(
+            $this->bindToken,
+            $this->dn,
+            RelocationAccess::In,
+        );
+    }
+
+    public function test_the_first_matching_relocation_rule_wins(): void
+    {
+        $subject = new RuleBasedAccessControl(AclRules::fromEmpty(
+            relocations: [
+                RelocationRule::deny(new AnySubjectMatcher()),
+                RelocationRule::allow(new AnySubjectMatcher()),
+            ],
+        ));
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $subject->authorizeRelocation(
+            $this->bindToken,
+            $this->dn,
+            RelocationAccess::Out,
+        );
     }
 }

--- a/tests/unit/Server/Backend/Storage/Adapter/InMemoryStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/InMemoryStorageTest.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\InMemoryChangeJournal;
@@ -24,10 +25,13 @@ use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 use PHPUnit\Framework\TestCase;
 use Tests\Support\FreeDSx\Ldap\Journal\JournalingStorageContractTests;
+use Tests\Support\FreeDSx\Ldap\Storage\SubtreeRenameStorageContractTests;
 
 final class InMemoryStorageTest extends TestCase
 {
     use JournalingStorageContractTests;
+
+    use SubtreeRenameStorageContractTests;
 
     private InMemoryStorage $subject;
 
@@ -333,5 +337,10 @@ final class InMemoryStorageTest extends TestCase
             [],
             $journal,
         );
+    }
+
+    protected function makeRenameStorage(Entry ...$entries): EntryStorageInterface
+    {
+        return new InMemoryStorage($entries);
     }
 }

--- a/tests/unit/Server/Backend/Storage/Adapter/JsonFileStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/JsonFileStorageTest.php
@@ -44,12 +44,15 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 use Tests\Support\FreeDSx\Ldap\Journal\JournalingStorageContractTests;
+use Tests\Support\FreeDSx\Ldap\Storage\SubtreeRenameStorageContractTests;
 
 final class JsonFileStorageTest extends TestCase
 {
     use ServerContainerTrait;
 
     use JournalingStorageContractTests;
+
+    use SubtreeRenameStorageContractTests;
 
     private WritableStorageBackend $subject;
 
@@ -467,6 +470,19 @@ final class JsonFileStorageTest extends TestCase
             $this->registerTemp(),
             $journal,
         );
+    }
+
+    protected function makeRenameStorage(Entry ...$entries): EntryStorageInterface
+    {
+        $storage = $this->makeStorage($this->registerTemp());
+
+        $storage->atomic(static function (EntryStorageInterface $buffer) use ($entries): void {
+            foreach ($entries as $entry) {
+                $buffer->store($entry);
+            }
+        });
+
+        return $storage;
     }
 
     /**

--- a/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
@@ -45,6 +45,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\DnTooLongException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
@@ -64,12 +65,15 @@ use Tests\Support\FreeDSx\Ldap\ServerContainerTrait;
 use RuntimeException;
 use Tests\Support\FreeDSx\Ldap\Pdo\RecordingPdo;
 use Tests\Support\FreeDSx\Ldap\Journal\JournalingStorageContractTests;
+use Tests\Support\FreeDSx\Ldap\Storage\SubtreeRenameStorageContractTests;
 
 final class PdoStorageTest extends TestCase
 {
     use ServerContainerTrait;
 
     use JournalingStorageContractTests;
+
+    use SubtreeRenameStorageContractTests;
 
     private WritableStorageBackend $subject;
 
@@ -1506,6 +1510,17 @@ final class PdoStorageTest extends TestCase
             $statements,
             journal: $journal,
         );
+    }
+
+    protected function makeRenameStorage(Entry ...$entries): EntryStorageInterface
+    {
+        $storage = $this->pdoStorage(TestServerOptions::sqlite());
+
+        foreach ($entries as $entry) {
+            $storage->store($entry);
+        }
+
+        return $storage;
     }
 
     /**

--- a/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
@@ -617,19 +617,66 @@ final class WritableStorageBackendTest extends TestCase
         );
     }
 
-    public function test_move_throws_not_allowed_on_non_leaf_when_entry_has_children(): void
+    public function test_move_relocates_an_entry_that_has_children(): void
     {
-        self::expectException(OperationException::class);
-        self::expectExceptionCode(ResultCode::NOT_ALLOWED_ON_NON_LEAF);
+        $this->addPeopleOu();
 
-        // dc=example,dc=com has cn=Alice as a direct child — cannot be moved
+        $this->subject->move(
+            $this->renamePeopleToStaff(),
+            $this->context(),
+        );
+
+        self::assertNotNull($this->subject->get(new Dn('ou=staff,dc=example,dc=com')));
+        self::assertNull($this->subject->get(new Dn('ou=people,dc=example,dc=com')));
+    }
+
+    public function test_move_takes_the_descendants_of_the_entry_with_it(): void
+    {
+        $this->addPeopleOu();
+
+        $this->subject->move(
+            $this->renamePeopleToStaff(),
+            $this->context(),
+        );
+
+        self::assertNotNull($this->subject->get(new Dn('cn=bob,ou=staff,dc=example,dc=com')));
+        self::assertNull($this->subject->get(new Dn('cn=bob,ou=people,dc=example,dc=com')));
+    }
+
+    public function test_move_refuses_relocating_an_entry_beneath_itself(): void
+    {
+        $this->addPeopleOu();
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
+
         $this->subject->move(
             new MoveCommand(
-                new Dn('dc=example,dc=com'),
-                Rdn::create('dc=example'),
-                false,
-                null,
+                new Dn('ou=People,dc=example,dc=com'),
+                Rdn::create('ou=Staff'),
+                true,
+                new Dn('cn=Bob,ou=People,dc=example,dc=com'),
             ),
+            $this->context(),
+        );
+    }
+
+    public function test_move_refuses_a_target_that_already_holds_subordinates(): void
+    {
+        $this->addPeopleOu();
+        $this->subject->add(
+            new AddCommand(new Entry(
+                new Dn('cn=Orphan,ou=Staff,dc=example,dc=com'),
+                new Attribute('cn', 'Orphan'),
+            )),
+            $this->systemContext(),
+        );
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::ENTRY_ALREADY_EXISTS);
+
+        $this->subject->move(
+            $this->renamePeopleToStaff(),
             $this->context(),
         );
     }
@@ -969,6 +1016,13 @@ final class WritableStorageBackendTest extends TestCase
     {
         /** @var EntryStorageInterface&MockObject $storage */
         $storage = $this->createMock(EntryStorageInterface::class);
+        // The entry and its parent are read before the write opens, so both must resolve to reach atomic().
+        $storage->method('find')
+            ->willReturn($this->alice);
+        $storage->method('exists')
+            ->willReturn(true);
+        $storage->method('list')
+            ->willReturn(new EntryStream($this->makeGenerator($this->alice)));
         $storage->method('atomic')
             ->willThrowException(new StorageIoException('Unable to publish the storage update.'));
 
@@ -2053,6 +2107,30 @@ final class WritableStorageBackendTest extends TestCase
         return WriteContext::system(
             new AnonToken(),
             new ControlBag(),
+        );
+    }
+
+    /**
+     * The shared fixture puts cn=Bob under this, but leaves the OU itself out.
+     */
+    private function addPeopleOu(): void
+    {
+        $this->subject->add(
+            new AddCommand(new Entry(
+                new Dn('ou=People,dc=example,dc=com'),
+                new Attribute('ou', 'People'),
+            )),
+            $this->context(),
+        );
+    }
+
+    private function renamePeopleToStaff(): MoveCommand
+    {
+        return new MoveCommand(
+            new Dn('ou=People,dc=example,dc=com'),
+            Rdn::create('ou=Staff'),
+            true,
+            null,
         );
     }
 

--- a/tests/unit/Server/Backend/Storage/Adapter/WriteSerializingStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WriteSerializingStorageTest.php
@@ -170,6 +170,30 @@ final class WriteSerializingStorageTest extends TestCase
         );
     }
 
+    public function test_rename_subtree_routes_through_queue_to_writes(): void
+    {
+        $from = new Dn('ou=people,dc=example,dc=com');
+        $to = new Dn('ou=staff,dc=example,dc=com');
+
+        $this->writes
+            ->expects(self::once())
+            ->method('renameSubtree')
+            ->with($from, $to);
+        $this->reads
+            ->expects(self::never())
+            ->method('renameSubtree');
+
+        $this->subject->renameSubtree(
+            $from,
+            $to,
+        );
+
+        self::assertSame(
+            1,
+            $this->queue->ranCount,
+        );
+    }
+
     public function test_atomic_routes_through_queue_to_writes(): void
     {
         $callable = static function (EntryStorageInterface $s): void {

--- a/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
@@ -32,6 +32,7 @@ use FreeDSx\Ldap\Protocol\Factory\HandlerRouteResolverInterface;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
+use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationAccess;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\Middleware\OperationAuthorizationMiddleware;
@@ -259,6 +260,89 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
                 'ou=other,dc=bar',
             ],
             $this->authorizedModifyDnTargets(),
+        );
+    }
+
+    public function test_dispatch_route_authorizes_relocation_of_both_containers_when_the_parent_changes(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $relocations = [];
+        $this->accessControl
+            ->method('authorizeRelocation')
+            ->willReturnCallback(static function (
+                TokenInterface $token,
+                Dn $container,
+                RelocationAccess $direction,
+            ) use (&$relocations): void {
+                $relocations[] = $direction->name . ':' . $container->toString();
+            });
+
+        $this->subject->process(
+            $this->contextFor(new ModifyDnRequest('cn=foo,ou=here,dc=bar', 'cn=baz', true, 'ou=there,dc=bar')),
+            $this->next,
+        );
+
+        self::assertSame(
+            [
+                'Out:ou=here,dc=bar',
+                'In:ou=there,dc=bar',
+            ],
+            $relocations,
+        );
+    }
+
+    public function test_dispatch_route_skips_relocation_for_a_rename_in_place(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $this->accessControl
+            ->expects(self::never())
+            ->method('authorizeRelocation');
+
+        $this->subject->process(
+            $this->contextFor(new ModifyDnRequest('cn=foo,ou=here,dc=bar', 'cn=baz', true)),
+            $this->next,
+        );
+    }
+
+    public function test_dispatch_route_skips_relocation_when_the_new_superior_is_the_current_parent(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $this->accessControl
+            ->expects(self::never())
+            ->method('authorizeRelocation');
+
+        $this->subject->process(
+            $this->contextFor(new ModifyDnRequest('cn=foo,ou=here,dc=bar', 'cn=baz', true, 'OU=Here,DC=Bar')),
+            $this->next,
+        );
+    }
+
+    public function test_dispatch_route_skips_relocation_for_a_single_rdn_source(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $this->accessControl
+            ->expects(self::never())
+            ->method('authorizeRelocation');
+
+        $this->subject->process(
+            $this->contextFor(new ModifyDnRequest('dc=bar', 'dc=baz', true, 'ou=there,dc=bar')),
+            $this->next,
+        );
+    }
+
+    public function test_dispatch_route_relocation_denial_blocks_dispatch(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $this->accessControl
+            ->method('authorizeRelocation')
+            ->willThrowException($this->denied());
+
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+
+        $this->subject->process(
+            $this->contextFor(new ModifyDnRequest('cn=foo,ou=here,dc=bar', 'cn=baz', true, 'ou=there,dc=bar')),
+            $this->next,
         );
     }
 


### PR DESCRIPTION
This adds proper support for subtree renames. So that everything below it is properly handled and updated in PDO / across the other storage. This needed the prior PDO schema rework to do properly. I also need to follow up and refactor the WritableStorageBackend, as it is too large and doing too much. It's one of the older classes now since I implemented backend storage in general.

I also measured performance of this against a rename of an entry with many below it (10k+) and it is still quite fast. So at least that holds.

Edit: digging into this more made me realize I went about the authorization differently than others typically handle moving in / out as a subordinate. So I aligned the ACLs to match. I was actually a little surprised it was handled this way. But it works in my favor as it simplifies the design and actually made the operation even faster than it already was.