### PR TITLE
[1.0.0] Anchor searches to the entry_id.

### DIFF
--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -705,16 +705,14 @@ scans many entries to return few. Raise it above the largest legitimate subtree 
 **Default**: `5000`
 
 > It applies only to filters evaluated in PHP. That means the in-memory backend, and SQL backends when the filter cannot
-> be pushed to the index. Indexed equality and prefix filters are bounded by the database and are not counted. Paged
-> searches are subject to the lookthrough limit cumulatively across all pages (see `setMaxSearchPagedLookthrough` to set
-> a separate cap for paging).
+> be pushed to the index. Indexed equality and prefix filters are bounded by the database and are not counted. Each page
+> of a paged search is counted on its own (see `setMaxSearchPagedLookthrough`).
 
 ------------------
 #### setMaxSearchPagedLookthrough
 
-Set a lookthrough cap applied to paged searches, counted cumulatively across all pages. Paging is the standard way to retrieve
-large result sets, so this lets you allow large paged enumerations without loosening the regular `setMaxSearchLookthrough`
-for ordinary searches. A value of `0` falls back to the regular lookthrough limit.
+A separate lookthrough cap for paged searches, counted per page. Filling a page examines more candidates than an ordinary
+search, so this raises the cap for paging without loosening `setMaxSearchLookthrough`.
 
 **Default**: `0` (use the regular lookthrough limit)
 

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -719,9 +719,10 @@ search, so this raises the cap for paging without loosening `setMaxSearchLookthr
 ------------------
 #### setMaxPagingSessions
 
-Cap how many paged searches one connection may leave unfinished, since each holds its result state until the connection
-closes. Starting one past the cap discards the least recently started session, logged as `paging.session_evicted`. A
-client resuming a discarded session is refused with an invalid cookie. A value of `0` removes the cap.
+Cap how many paged searches one connection may leave unfinished, since each holds its place in the result until the
+connection closes. Starting one past the cap discards the least recently started session, logged as
+`paging.session_evicted`. A client resuming a discarded session is refused with an invalid cookie. A value of `0`
+removes the cap.
 
 **Default**: `25`
 

--- a/src/FreeDSx/Ldap/Container/Provider/StorageContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/StorageContainerProvider.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Container\Provider;
 
 use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\EntryIndexReindexer;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\MysqlDialect;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SqliteDialect;
@@ -61,10 +62,16 @@ final class StorageContainerProvider implements ContainerProviderInterface
             SortKeyComparator::class => $this->makeSortKeyComparator(...),
             StorageListOptionsFactory::class => $this->makeStorageListOptionsFactory(...),
             EntryStorageInterface::class => $this->makeStorage(...),
+            EntryIndexReindexer::class => $this->makeEntryIndexReindexer(...),
             PdoDialectInterface::class => $this->makePdoDialect(...),
             PdoStorageFactory::class => $this->makePdoStorageFactory(...),
             PdoBackend::class => $this->makePdoBackend(...),
         ];
+    }
+
+    private function makeEntryIndexReindexer(Container $container): EntryIndexReindexer
+    {
+        return new EntryIndexReindexer($container->get(EntryStorageInterface::class));
     }
 
     /**

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -27,6 +27,7 @@ use FreeDSx\Ldap\Ldif\Output\LdifOutputInterface;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\EntryIndexReindexer;
+use FreeDSx\Ldap\Server\Backend\Storage\DrainableWritesInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Export\DirectoryDumper;
 use FreeDSx\Ldap\Server\Backend\Storage\Export\DumpOptions;
@@ -89,11 +90,31 @@ class LdapServer
         LdifLoaderInterface $loader,
         SeedOptions $options = new SeedOptions(),
     ): self {
-        $this->container->get(LdapImporter::class)->importEntries(
+        return $this->seedEntries(
             $this->streamSeedEntries($loader, $options->getUrlResolver()),
+            $options,
+        );
+    }
+
+    /**
+     * Bulk-imports entries already in hand, for a caller building them rather than reading LDIF.
+     *
+     * @param iterable<Entry> $entries Depth-first, since a parent has to exist before the entries beneath it.
+     *
+     * @throws InvalidArgumentException when the creator DN is malformed or an entry's parent is missing
+     * @throws OperationException when an entry violates the schema and validation mode is strict
+     */
+    public function seedEntries(
+        iterable $entries,
+        SeedOptions $options = new SeedOptions(),
+    ): self {
+        $this->container->get(LdapImporter::class)->importEntries(
+            $entries,
             $options->getCreatorDn(),
             $options->isIgnoreValidation(),
         );
+
+        $this->drainWrites();
 
         return $this;
     }
@@ -140,10 +161,23 @@ class LdapServer
      */
     public function reindex(): self
     {
-        (new EntryIndexReindexer($this->container->get(EntryStorageInterface::class)))
-            ->reindex();
+        $this->container->get(EntryIndexReindexer::class)->reindex();
 
         return $this;
+    }
+
+    /**
+     * Releases whatever the write path keeps between writes, since seeding is a burst followed by silence.
+     *
+     * Under Swoole that helper is a coroutine, and one still waiting for work holds open the scope it was spawned in.
+     */
+    private function drainWrites(): void
+    {
+        $storage = $this->container->get(EntryStorageInterface::class);
+
+        if ($storage instanceof DrainableWritesInterface) {
+            $storage->drainWrites();
+        }
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/CollectedPage.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/CollectedPage.php
@@ -14,22 +14,26 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Server\Backend\Storage\PageCursor;
 
 /**
- * Holds the result of a single generator collection pass in a paging operation.
+ * One page of a paging operation, and where the result was left.
  *
  * @internal
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final class CollectedPage
+final readonly class CollectedPage
 {
     /**
      * @param Entry[] $entries
+     * @param bool $isResultExhausted Whether the result ran out, so no further page can exist.
+     * @param ?PageCursor $cursor Where to resume, or null when nothing was read.
      */
     public function __construct(
-        public readonly array $entries,
-        public readonly bool $isGeneratorExhausted,
-        public readonly bool $isSizeLimitExceeded,
+        public array $entries,
+        public bool $isResultExhausted,
+        public bool $isSizeLimitExceeded,
+        public ?PageCursor $cursor = null,
     ) {}
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -24,8 +24,12 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\Response\Cancellation;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Schema\Schema;
+use FreeDSx\Ldap\Search\Filter\FilterInterface;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
+use FreeDSx\Ldap\Server\Backend\Storage\PageCursor;
+use FreeDSx\Ldap\Server\Backend\Storage\PageSlice;
 use FreeDSx\Ldap\Server\Paging\PagingRequest;
 use FreeDSx\Ldap\Server\Paging\PagingRequestComparator;
 use FreeDSx\Ldap\Server\Paging\PagingResponse;
@@ -37,7 +41,6 @@ use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
-use Generator;
 use Throwable;
 
 /**
@@ -144,7 +147,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
          */
         if (($response && $response->isComplete()) || $searchResult->getState()->resultCode !== ResultCode::SUCCESS) {
             $this->requestHistory->pagingRequest()->remove($pagingRequest);
-            $this->requestHistory->removePagingGenerator($pagingRequest->getNextCookie());
+            $this->requestHistory->removePagingCursor($pagingRequest->getNextCookie());
         }
 
         $outcome = $failure !== null
@@ -198,32 +201,15 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         PagingRequest $pagingRequest,
         TokenInterface $token,
     ): PagingResponse {
-        $searchRequest = $pagingRequest->getSearchRequest();
-
-        // Paged searches use the paged lookthrough limit (falls back to the regular one when unset).
-        $result = $this->backend->search(
-            $searchRequest,
-            $this->subentryVisibility($pagingRequest->controls()),
-            $pagingRequest->controls(),
-            new SearchLimits(
-                maxSearchTimeLimit: $this->limits->maxSearchTimeLimit,
-                maxSearchLookthrough: $this->limits->effectivePagedLookthrough(),
-            ),
-        );
-        $generator = $result->entries;
-
-        $collected = $this->collectFromGenerator(
-            $generator,
-            $pagingRequest->getSize(),
-            $searchRequest,
+        $collected = $this->collectPage(
+            $pagingRequest,
             $token,
-            $this->projectionFor($searchRequest),
+            null,
         );
 
         return $this->buildPagingResponse(
             $collected,
             $pagingRequest,
-            $generator,
         );
     }
 
@@ -251,29 +237,26 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         }
 
         $currentCookie = $pagingRequest->getNextCookie();
-        $generator = $this->requestHistory->getPagingGenerator($currentCookie);
+        $resumeFrom = $this->requestHistory->getPagingCursor($currentCookie);
 
-        if ($generator === null) {
+        if ($resumeFrom === null) {
             throw new OperationException(
                 'The paging session could not be resumed.',
                 ResultCode::UNWILLING_TO_PERFORM,
             );
         }
 
-        $this->requestHistory->removePagingGenerator($currentCookie);
+        $this->requestHistory->removePagingCursor($currentCookie);
 
-        $collected = $this->collectFromGenerator(
-            $generator,
-            $pagingRequest->getSize(),
-            $pagingRequest->getSearchRequest(),
+        $collected = $this->collectPage(
+            $pagingRequest,
             $token,
-            $this->projectionFor($pagingRequest->getSearchRequest()),
+            $resumeFrom,
         );
 
         return $this->buildPagingResponse(
             $collected,
             $pagingRequest,
-            $generator,
         );
     }
 
@@ -283,7 +266,6 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
     private function buildPagingResponse(
         CollectedPage $collected,
         PagingRequest $pagingRequest,
-        Generator $generator,
     ): PagingResponse {
         if ($collected->isSizeLimitExceeded) {
             return PagingResponse::makeSizeLimitExceeded(new Entries(...$collected->entries));
@@ -292,13 +274,14 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         $nextCookie = $this->generateCookie();
         $pagingRequest->updateNextCookie($nextCookie);
 
-        if ($collected->isGeneratorExhausted) {
+        // Without a position there is nothing to resume from, so the result has to be treated as finished.
+        if ($collected->isResultExhausted || $collected->cursor === null) {
             return PagingResponse::makeFinal(new Entries(...$collected->entries));
         }
 
-        $this->requestHistory->storePagingGenerator(
+        $this->requestHistory->storePagingCursor(
             $nextCookie,
-            $generator,
+            $collected->cursor,
         );
 
         return PagingResponse::make(
@@ -307,73 +290,118 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
     }
 
     /**
-     * Advances the generator, collecting up to $pageSize entries that pass the filter.
+     * Fills one page from $resumeFrom, reading bounded slices to their end so each says where it stopped.
      *
-     * Also enforces the client's sizeLimit from the SearchRequest. When the sizeLimit is
-     * reached before the generator is exhausted, $isSizeLimitExceeded is true in the return.
+     * @throws OperationException
      */
-    private function collectFromGenerator(
-        Generator $generator,
-        int $pageSize,
-        SearchRequest $request,
+    private function collectPage(
+        PagingRequest $pagingRequest,
         TokenInterface $token,
-        AttributeProjection $projection,
+        ?PageCursor $resumeFrom,
     ): CollectedPage {
-        $page = [];
+        $request = $pagingRequest->getSearchRequest();
+        $projection = $this->projectionFor($request);
+        $filter = $request->getFilter();
         $effectivePageSize = $this->effectiveSizeLimit(
-            $pageSize,
+            $pagingRequest->getSize(),
             $this->limits->maxSearchPageSize,
         );
-        $pageLimit = $effectivePageSize > 0
-            ? $effectivePageSize
-            : null;
         $sizeLimit = $this->effectiveSizeLimit(
             $request->getSizeLimit(),
             $this->limits->maxSearchSize,
         );
-        $filter = $request->getFilter();
 
-        while ($generator->valid() && $this->pageHasCapacity($page, $pageLimit)) {
-            $entry = $generator->current();
+        // Deliberate: the size limit bounds each page rather than the whole paged operation.
+        $collectCap = $this->effectiveSizeLimit(
+            $effectivePageSize,
+            $sizeLimit,
+        );
+        $pageLimit = $collectCap > 0
+            ? $collectCap
+            : null;
 
-            if ($entry instanceof Entry) {
-                $filtered = $this->accessControl->filterEntry(
-                    $token,
+        $page = [];
+        $cursor = $resumeFrom;
+        $exhausted = false;
+        $sliceSize = $pageLimit ?? $this->limits->maxSearchPageSize;
+
+        while (!$exhausted && $this->pageHasCapacity($page, $pageLimit)) {
+            $stream = $this->readSlice(
+                $pagingRequest,
+                new PageSlice(
+                    max($sliceSize, 1),
+                    $cursor,
+                ),
+            );
+            foreach ($stream->entries as $entry) {
+                $kept = $this->keepForPage(
                     $entry,
+                    $token,
+                    $filter,
                 );
 
-                if ($filtered === null) {
-                    $generator->next();
-                    continue;
-                }
-
-                if ($filtered !== $entry && !$this->filterEvaluator->evaluate($filtered, $filter)) {
-                    $generator->next();
-                    continue;
-                }
-
-                $page[] = $projection->project($filtered);
-
-                // Deliberate: the limit bounds each page rather than the whole paged operation.
-                if ($sizeLimit > 0 && count($page) >= $sizeLimit) {
-                    $generator->next();
-                    break;
+                if ($kept !== null) {
+                    $page[] = $projection->project($kept);
                 }
             }
 
-            $generator->next();
+            // A stream that reports nothing cannot be resumed, so the result has to be taken as finished.
+            $read = $stream->entries->getReturn();
+            $exhausted = $read === null || !$read->hasMore || $read->cursor === null;
+            $cursor = $read->cursor ?? $cursor;
         }
-
-        $generatorExhausted = !$generator->valid();
-        $sizeLimitExceeded = !$generatorExhausted
-            && $sizeLimit > 0
-            && count($page) >= $sizeLimit;
 
         return new CollectedPage(
             $page,
-            $generatorExhausted,
-            $sizeLimitExceeded,
+            $exhausted,
+            !$exhausted && $sizeLimit > 0 && count($page) >= $sizeLimit,
+            $cursor,
         );
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function readSlice(
+        PagingRequest $pagingRequest,
+        PageSlice $slice,
+    ): EntryStream {
+        // Paged searches use the paged lookthrough limit (falls back to the regular one when unset), applied per page.
+        return $this->backend->search(
+            $pagingRequest->getSearchRequest(),
+            $this->subentryVisibility($pagingRequest->controls()),
+            $pagingRequest->controls(),
+            new SearchLimits(
+                maxSearchTimeLimit: $this->limits->maxSearchTimeLimit,
+                maxSearchLookthrough: $this->limits->effectivePagedLookthrough(),
+            ),
+            $slice,
+        );
+    }
+
+    /**
+     * The entry as this identity may see it, or null when it may not see it at all.
+     *
+     * @throws OperationException
+     */
+    private function keepForPage(
+        Entry $entry,
+        TokenInterface $token,
+        FilterInterface $filter,
+    ): ?Entry {
+        $filtered = $this->accessControl->filterEntry(
+            $token,
+            $entry,
+        );
+
+        if ($filtered === null) {
+            return null;
+        }
+
+        // Stripping an attribute can cost the entry its match, so a changed entry is judged against the filter again.
+        return $filtered !== $entry && !$this->filterEvaluator->evaluate($filtered, $filter)
+            ? null
+            : $filtered;
     }
 
     private function projectionFor(SearchRequest $request): AttributeProjection
@@ -423,7 +451,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         }
 
         $requests->remove($oldest);
-        $this->requestHistory->removePagingGenerator($oldest->getNextCookie());
+        $this->requestHistory->removePagingCursor($oldest->getNextCookie());
         $this->eventLogger?->record(
             ServerEvent::PagingSessionEvicted,
             [EventContext::LIMIT => $limit],

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -143,7 +143,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
          *     assume the paged result set is closed and no longer resumable.
          *
          * If a search result is anything other than success, or the paging is complete,
-         * remove the paging request and discard the generator.
+         * remove the paging request and discard the cursor.
          */
         if (($response && $response->isComplete()) || $searchResult->getState()->resultCode !== ResultCode::SUCCESS) {
             $this->requestHistory->pagingRequest()->remove($pagingRequest);

--- a/src/FreeDSx/Ldap/Server/Backend/LdapBackendInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/LdapBackendInterface.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
+use FreeDSx\Ldap\Server\Backend\Storage\PageSlice;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Subentry\SubentryVisibility;
 
@@ -33,12 +34,14 @@ interface LdapBackendInterface
     /**
      * @param SubentryVisibility $subentries Which entry population is in scope; callers state it, as no default is safe for all.
      * @param ?SearchLimits $effectiveLimits Per-request effective limits (time/lookthrough); null uses backend defaults.
+     * @param ?PageSlice $slice Read one bounded piece, so the stream reports where it stopped; null reads the result.
      */
     public function search(
         SearchRequest $request,
         SubentryVisibility $subentries,
         ControlBag $controls = new ControlBag(),
         ?SearchLimits $effectiveLimits = null,
+        ?PageSlice $slice = null,
     ): EntryStream;
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SqliteDialect.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/SqliteDialect.php
@@ -124,11 +124,11 @@ final class SqliteDialect implements PdoDialectInterface
     }
 
     /**
-     * Sorting reads entry_id straight off the row source rather than a derived table, so it need not be selected.
+     * Sorting reads entry_id straight off the row source, but a resumable list reads it off the row, so it is selected.
      */
     protected function listColumns(): string
     {
-        return 'dn, attributes';
+        return 'entry_id, dn, attributes';
     }
 
     protected function schemaName(): string

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
@@ -43,6 +43,15 @@ final class InMemoryStorage implements EntryStorageInterface, ChangeJournalingIn
     private array $entries = [];
 
     /**
+     * Assigned rather than derived from the DN, so a resumed walk is not disturbed by a rename.
+     *
+     * @var array<string, int> entry key, keyed by normalised DN string
+     */
+    private array $keys = [];
+
+    private int $nextKey = 1;
+
+    /**
      * @param Entry[] $entries pre-populated into the store
      */
     public function __construct(
@@ -54,7 +63,7 @@ final class InMemoryStorage implements EntryStorageInterface, ChangeJournalingIn
         $this->journal = $journal;
 
         foreach ($entries as $entry) {
-            $this->entries[$entry->getDn()->normalize()->toString()] = $entry;
+            $this->store($entry);
         }
     }
 
@@ -73,6 +82,7 @@ final class InMemoryStorage implements EntryStorageInterface, ChangeJournalingIn
         return $this->listFromArray(
             $options,
             $this->entries,
+            $this->keys,
         );
     }
 
@@ -80,7 +90,11 @@ final class InMemoryStorage implements EntryStorageInterface, ChangeJournalingIn
         Entry $entry,
         bool $rebuildIndexes = false,
     ): void {
-        $this->entries[$entry->getDn()->normalize()->toString()] = $entry;
+        $lcDn = $entry->getDn()->normalize()->toString();
+
+        // Overwriting an entry keeps its key, matching the upsert the database adapters do.
+        $this->keys[$lcDn] ??= $this->nextKey++;
+        $this->entries[$lcDn] = $entry;
     }
 
     public function renameSubtree(
@@ -105,11 +119,19 @@ final class InMemoryStorage implements EntryStorageInterface, ChangeJournalingIn
                 $entry->getAttributes(),
             ),
         );
+
+        // Re-keyed the same way and in the same order, so a walk in progress keeps both its position and its ordering.
+        $this->keys = $rename->applyTo(
+            $this->keys,
+            static fn(int $key): int => $key,
+        );
     }
 
     public function remove(Dn $dn): void
     {
-        unset($this->entries[$dn->normalize()->toString()]);
+        $lcDn = $dn->normalize()->toString();
+
+        unset($this->entries[$lcDn], $this->keys[$lcDn]);
     }
 
     public function removeAll(array $dns): void

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/Query/FetchedBatch.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/Query/FetchedBatch.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query;
+
+use FreeDSx\Ldap\Server\Backend\Storage\PageCursor;
+
+/**
+ * What one statement's worth of rows amounted to.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class FetchedBatch
+{
+    /**
+     * @param int $rows Rows read, which tells a caller whether the batch filled and so whether more may follow.
+     * @param ?PageCursor $cursor Where the rows ended, or null when none were read.
+     */
+    public function __construct(
+        public int $rows,
+        public ?PageCursor $cursor = null,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/Query/ListQuerySpec.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/Query/ListQuerySpec.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query;
+
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SortKeySpec;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterResult;
+use FreeDSx\Ldap\Server\Backend\Storage\PageCursor;
+use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
+use FreeDSx\Ldap\Server\Subentry\SubentryVisibility;
+
+/**
+ * The SQL-side view of a list request: the translated filter and normalized base.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ListQuerySpec
+{
+    /**
+     * @param list<SortKeySpec> $sortKeys
+     * @param ?int $limit Rows the query may return, or null for no bound.
+     */
+    public function __construct(
+        public string $base,
+        public bool $subtree,
+        public ?SqlFilterResult $filter,
+        public ?int $limit,
+        public array $sortKeys = [],
+        public SubentryVisibility $subentries = SubentryVisibility::All,
+        public ?PageCursor $after = null,
+    ) {}
+
+    /**
+     * @param list<SortKeySpec> $sortKeys
+     */
+    public static function fromOptions(
+        StorageListOptions $options,
+        ?SqlFilterResult $filter,
+        ?int $limit,
+        array $sortKeys,
+    ): self {
+        return new self(
+            base: $options->baseDn->normalize()->toString(),
+            subtree: $options->subtree,
+            filter: $filter,
+            limit: $limit,
+            sortKeys: $sortKeys,
+            subentries: $options->subentries,
+            after: $options->after,
+        );
+    }
+
+    /**
+     * The same spec seeking past $after, for the next batch of a walk.
+     */
+    public function resumingAfter(PageCursor $after): self
+    {
+        return new self(
+            base: $this->base,
+            subtree: $this->subtree,
+            filter: $this->filter,
+            limit: $this->limit,
+            sortKeys: $this->sortKeys,
+            subentries: $this->subentries,
+            after: $after,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/Query/PdoListQueryBuilder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/Query/PdoListQueryBuilder.php
@@ -51,7 +51,7 @@ final readonly class PdoListQueryBuilder
         $seek = $spec->after !== null && $spec->sortKeys === []
             ? new SqlQuery(
                 'entry_id > ?',
-                [$spec->after->entryKey],
+                [$spec->after->position],
             )
             : null;
 
@@ -85,6 +85,14 @@ final readonly class PdoListQueryBuilder
             $query = $query->appending(
                 ' LIMIT ?',
                 [$spec->limit],
+            );
+        }
+
+        // A sort orders by something the key says nothing about, so resuming it skips what was already handed over.
+        if ($spec->after?->isOrdinal === true && $spec->limit !== null) {
+            $query = $query->appending(
+                ' OFFSET ?',
+                [$spec->after->position],
             );
         }
 
@@ -153,7 +161,7 @@ final readonly class PdoListQueryBuilder
         }
 
         if ($after !== null) {
-            $params[] = $after->entryKey;
+            $params[] = $after->position;
         }
 
         $params[] = $limit;

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/Query/PdoListQueryBuilder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/Query/PdoListQueryBuilder.php
@@ -13,12 +13,14 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query;
 
+use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SortKeySpec;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterResult;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterUtility;
 use FreeDSx\Ldap\Server\Subentry\SubentryVisibility;
 
+use function array_merge;
 use function implode;
 
 /**
@@ -32,63 +34,57 @@ final readonly class PdoListQueryBuilder
         private PdoDialectInterface $dialect,
     ) {}
 
-    /**
-     * @param list<SortKeySpec> $sortKeys
-     */
-    public function build(
-        string $base,
-        bool $subtree,
-        ?SqlFilterResult $filterResult,
-        ?int $sqlLimit,
-        array $sortKeys,
-        SubentryVisibility $subentries = SubentryVisibility::All,
-    ): SqlQuery {
-        $streamed = $this->tryBuildStreamingQuery(
-            $base,
-            $subtree,
-            $filterResult,
-            $sqlLimit,
-            $sortKeys,
-            $subentries,
-        );
+    public function build(ListQuerySpec $spec): SqlQuery
+    {
+        $streamed = $this->tryBuildStreamingQuery($spec);
 
         if ($streamed !== null) {
             return $streamed;
         }
 
         $subentryCondition = $this->subentryCondition(
-            $subentries,
+            $spec->subentries,
             'entry_id',
         );
+        // Resuming an unsorted list seeks on the key directly; a sorted one seeks on the projected key, which only
+        // exists once the sort has wrapped the query.
+        $seek = $spec->after !== null && $spec->sortKeys === []
+            ? new SqlQuery(
+                'entry_id > ?',
+                [$spec->after->entryKey],
+            )
+            : null;
+
         $query = match (true) {
-            !$subtree => $this->buildChildQuery(
-                $base,
-                $filterResult,
+            !$spec->subtree => $this->buildChildQuery(
+                $spec->base,
+                $spec->filter,
                 $subentryCondition,
+                $seek,
             ),
-            $base === '' => $this->buildRootQuery(
-                $filterResult,
+            $spec->base === '' => $this->buildRootQuery(
+                $spec->filter,
                 $subentryCondition,
+                $seek,
             ),
             default => $this->buildSubtreeQuery(
-                $base,
-                $filterResult,
+                $spec->base,
+                $spec->filter,
                 $subentryCondition,
+                $seek,
             ),
         };
 
-        if ($sortKeys !== []) {
-            $query = $this->applySort(
-                $query,
-                $sortKeys,
-            );
-        }
+        // A resumable walk needs one deterministic order, so an unsorted list gets the key order it seeks in.
+        $query = $spec->sortKeys !== []
+            ? $this->applySort($query, $spec->sortKeys)
+            : $query->appending(' ORDER BY entry_id');
 
         // Bound rather than inlined: an inlined limit makes every distinct client size limit its own prepared statement.
-        if ($sqlLimit !== null) {
+        if ($spec->limit !== null) {
             $query = $query->appending(
                 ' LIMIT ?',
-                [$sqlLimit],
+                [$spec->limit],
             );
         }
 
@@ -96,28 +92,38 @@ final readonly class PdoListQueryBuilder
     }
 
     /**
-     * Bounds work to $sqlLimit by pushing DISTINCT + subtree scope + LIMIT into the sidecar sub-select, wrapped in a
-     * derived table (portable: MySQL/MariaDB reject LIMIT directly inside IN, and it still streams on SQLite).
+     * Bounds work to the spec's limit by pushing DISTINCT + subtree scope + LIMIT into the sidecar sub-select, wrapped
+     * in a derived table (portable: MySQL/MariaDB reject LIMIT directly inside IN, and it still streams on SQLite).
      *
      * @param list<string> $filterParams
      */
     public function buildStreamingQuery(
         string $sidecarCondition,
         array $filterParams,
-        string $base,
-        int $sqlLimit,
-        SubentryVisibility $subentries = SubentryVisibility::All,
+        ListQuerySpec $spec,
     ): SqlQuery {
         $fetchAll = $this->dialect->queryFetchAll();
         $params = $filterParams;
+        $base = $spec->base;
+        $after = $spec->after;
+
+        // This shape exists to bound the candidate scan, so it is only ever built with a bound to spend.
+        $limit = $spec->limit ?? throw new RuntimeException(
+            'A streaming list query requires a row bound.',
+        );
 
         // Applied inside the candidate select, since the limit below it would otherwise be spent on excluded rows.
         $subentryCondition = $this->subentryCondition(
-            $subentries,
+            $spec->subentries,
             's.owner_entry_id',
         );
         $subentryClause = $subentryCondition !== null
             ? "AND $subentryCondition"
+            : '';
+
+        // Seeks and orders inside the candidate select as well, so the limit is spent on rows the caller has not seen.
+        $seekClause = $after !== null
+            ? 'AND s.owner_entry_id > ?'
             : '';
 
         if ($base === '') {
@@ -125,6 +131,8 @@ final readonly class PdoListQueryBuilder
                 SELECT DISTINCT s.owner_entry_id AS d FROM entry_attribute_values s
                     WHERE $sidecarCondition
                     $subentryClause
+                    $seekClause
+                    ORDER BY s.owner_entry_id
                     LIMIT ?
                 SQL;
         } else {
@@ -136,16 +144,22 @@ final readonly class PdoListQueryBuilder
                     WHERE $sidecarCondition
                       AND (scope.lc_dn = ? OR scope.lc_dn LIKE ? ESCAPE '!')
                     $subentryClause
+                    $seekClause
+                    ORDER BY s.owner_entry_id
                     LIMIT ?
                 SQL;
             $params[] = $base;
             $params[] = '%,' . SqlFilterUtility::escape($base);
         }
 
-        $params[] = $sqlLimit;
+        if ($after !== null) {
+            $params[] = $after->entryKey;
+        }
+
+        $params[] = $limit;
 
         return new SqlQuery(
-            "$fetchAll WHERE entry_id IN (SELECT t.d FROM ($inner) t)",
+            "$fetchAll WHERE entry_id IN (SELECT t.d FROM ($inner) t) ORDER BY entry_id",
             $params,
         );
     }
@@ -155,31 +169,21 @@ final readonly class PdoListQueryBuilder
      *
      * A single drivable sidecar leaf under a bounded, unsorted subtree/root search drives off the sidecar index so the
      * limit short-circuits candidate scanning.
-     *
-     * @param list<SortKeySpec> $sortKeys
      */
-    private function tryBuildStreamingQuery(
-        string $base,
-        bool $subtree,
-        ?SqlFilterResult $filterResult,
-        ?int $sqlLimit,
-        array $sortKeys,
-        SubentryVisibility $subentries = SubentryVisibility::All,
-    ): ?SqlQuery {
-        if (!$subtree || $sqlLimit === null || $sortKeys !== []) {
+    private function tryBuildStreamingQuery(ListQuerySpec $spec): ?SqlQuery
+    {
+        if (!$spec->subtree || $spec->limit === null || $spec->sortKeys !== []) {
             return null;
         }
 
-        if ($filterResult === null || $filterResult->sidecarCondition === null) {
+        if ($spec->filter === null || $spec->filter->sidecarCondition === null) {
             return null;
         }
 
         return $this->buildStreamingQuery(
-            $filterResult->sidecarCondition,
-            $filterResult->params,
-            $base,
-            $sqlLimit,
-            $subentries,
+            $spec->filter->sidecarCondition,
+            $spec->filter->params,
+            $spec,
         );
     }
 
@@ -187,6 +191,7 @@ final readonly class PdoListQueryBuilder
         string $base,
         ?SqlFilterResult $filterResult,
         ?string $subentryCondition,
+        ?SqlQuery $seek,
     ): SqlQuery {
         $query = new SqlQuery(
             $this->dialect->queryFetchChildren(),
@@ -202,14 +207,21 @@ final readonly class PdoListQueryBuilder
             );
         }
 
-        return $subentryCondition !== null
-            ? $query->appending(' AND ' . $subentryCondition)
-            : $query;
+        if ($subentryCondition !== null) {
+            $query = $query->appending(' AND ' . $subentryCondition);
+        }
+
+        return $this->appendSeek(
+            $query,
+            $seek,
+            true,
+        );
     }
 
     private function buildRootQuery(
         ?SqlFilterResult $filterResult,
         ?string $subentryCondition,
+        ?SqlQuery $seek,
     ): SqlQuery {
         $conditions = [];
         $params = [];
@@ -221,6 +233,14 @@ final readonly class PdoListQueryBuilder
 
         if ($subentryCondition !== null) {
             $conditions[] = $subentryCondition;
+        }
+
+        if ($seek !== null) {
+            $conditions[] = $seek->sql;
+            $params = array_merge(
+                $params,
+                $seek->params,
+            );
         }
 
         if ($conditions === []) {
@@ -237,22 +257,31 @@ final readonly class PdoListQueryBuilder
         string $base,
         ?SqlFilterResult $filterResult,
         ?string $subentryCondition,
+        ?SqlQuery $seek,
     ): SqlQuery {
         if ($filterResult === null) {
             $query = new SqlQuery(
                 $this->dialect->querySubtree(),
                 [$base],
             );
+            $hasWhere = $subentryCondition !== null;
 
-            return $subentryCondition !== null
-                ? $query->appending(' WHERE ' . $subentryCondition)
-                : $query;
+            if ($subentryCondition !== null) {
+                $query = $query->appending(' WHERE ' . $subentryCondition);
+            }
+
+            return $this->appendSeek(
+                $query,
+                $seek,
+                $hasWhere,
+            );
         }
 
         return $this->buildFilteredSubtreeQuery(
             $base,
             $filterResult,
             $subentryCondition,
+            $seek,
         );
     }
 
@@ -263,6 +292,7 @@ final readonly class PdoListQueryBuilder
         string $base,
         SqlFilterResult $filterResult,
         ?string $subentryCondition,
+        ?SqlQuery $seek,
     ): SqlQuery {
         $fetchAll = $this->dialect->queryFetchAll();
         $filterSql = $filterResult->sql;
@@ -279,9 +309,31 @@ final readonly class PdoListQueryBuilder
         $params[] = $base;
         $params[] = '%,' . SqlFilterUtility::escape($base);
 
-        return new SqlQuery(
-            $sql,
-            $params,
+        return $this->appendSeek(
+            new SqlQuery(
+                $sql,
+                $params,
+            ),
+            $seek,
+            true,
+        );
+    }
+
+    /**
+     * Appended last so its bindings follow every condition already in the query.
+     */
+    private function appendSeek(
+        SqlQuery $query,
+        ?SqlQuery $seek,
+        bool $hasWhere,
+    ): SqlQuery {
+        if ($seek === null) {
+            return $query;
+        }
+
+        return $query->appending(
+            ($hasWhere ? ' AND ' : ' WHERE ') . $seek->sql,
+            $seek->params,
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -22,7 +22,6 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SortKeySpec;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\PdoConnectionProviderInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\EntryIndexWriter;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query\FetchedBatch;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query\ListQuerySpec;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query\PdoListQueryBuilder;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\PdoTransactor;
@@ -44,6 +43,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock\RowLockableInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
+use FreeDSx\Ldap\Server\Backend\Storage\FetchedBatch;
 use FreeDSx\Ldap\Server\Backend\Storage\PageCursor;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 use FreeDSx\Ldap\Server\Backend\ResettableInterface;
@@ -383,15 +383,24 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
         StorageListOptions $options,
         bool $isPreFiltered,
     ): ?int {
-        if ($isPreFiltered) {
-            return $options->sizeLimit > 0
+        $ceiling = match (true) {
+            $isPreFiltered => $options->sizeLimit > 0
                 ? $options->sizeLimit
-                : null;
+                : null,
+            $options->lookthroughLimit > 0 => $options->lookthroughLimit + 1,
+            default => null,
+        };
+
+        if ($options->maxCandidates === null) {
+            return $ceiling;
         }
 
-        return $options->lookthroughLimit > 0
-            ? $options->lookthroughLimit + 1
-            : null;
+        // One past what a slice will hand over, so it can say whether more remain without the caller reading on.
+        $sliceRead = $options->maxCandidates + 1;
+
+        return $ceiling === null
+            ? $sliceRead
+            : min($ceiling, $sliceRead);
     }
 
     /**
@@ -507,7 +516,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
     /**
      * Walks the result in bounded batches, seeking past the last row read rather than holding one cursor open.
      *
-     * @return Generator<Entry> Returns the cursor for the last row read, for a caller resuming later.
+     * @return Generator<int, Entry, mixed, FetchedBatch>
      */
     private function generateBatches(
         SqlQuery $query,
@@ -523,22 +532,40 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
         $cursor = $options->after;
         $read = 0;
 
+        // A sort orders by something the key says nothing about, so its walk resumes by count rather than by key.
+        $isSorted = $options->sortKeys !== [];
+        $delivered = $isSorted
+            ? $options->after->position ?? 0
+            : 0;
+
         while (true) {
+            $remaining = $options->maxCandidates === null
+                ? null
+                : $options->maxCandidates - $read;
             $batch = yield from $this->generateBatch(
                 $query,
                 $deadline,
                 $allowed,
+                $remaining,
             );
-            $cursor = $batch->cursor ?? $cursor;
             $read += $batch->rows;
+            $delivered += $batch->rows;
+            $cursor = $isSorted
+                ? PageCursor::afterSorted($delivered)
+                : $batch->cursor ?? $cursor;
 
             $isLast = $spec === null
                 || $cursor === null
+                || $batch->hasMore
                 || $batch->rows < $batchSize
                 || ($maxRows !== null && $read >= $maxRows);
 
             if ($isLast) {
-                return $cursor;
+                return new FetchedBatch(
+                    $read,
+                    $cursor,
+                    $batch->hasMore,
+                );
             }
 
             $query = $this->queryBuilder->build($spec->resumingAfter($cursor));
@@ -555,6 +582,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
         SqlQuery $query,
         ?float $deadline,
         ?array $allowed,
+        ?int $yieldCap = null,
     ): Generator {
         $stmt = $this->statements->execute(
             $query->sql,
@@ -562,10 +590,18 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
         );
         $rows = 0;
         $cursor = null;
+        $hasMore = false;
 
         while (($row = $stmt->fetch()) !== false) {
             if ($deadline !== null && microtime(true) >= $deadline) {
                 throw new TimeLimitExceededException();
+            }
+
+            // Read but not handed over: its only job is to prove the result did not end here.
+            if ($yieldCap !== null && $rows >= $yieldCap) {
+                $hasMore = true;
+
+                break;
             }
 
             $rows++;
@@ -583,6 +619,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
         return new FetchedBatch(
             $rows,
             $cursor,
+            $hasMore,
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -22,11 +22,12 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SortKeySpec;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\PdoConnectionProviderInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\EntryIndexWriter;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query\FetchedBatch;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query\ListQuerySpec;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query\PdoListQueryBuilder;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\PdoTransactor;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Statement\PdoStatementPool;
 use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Statement\PooledStatement;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query\SqlQuery;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SidecarLeaf;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Support\SubtreeRename;
@@ -43,6 +44,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Lock\RowLockableInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
+use FreeDSx\Ldap\Server\Backend\Storage\PageCursor;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 use FreeDSx\Ldap\Server\Backend\ResettableInterface;
 use Generator;
@@ -75,6 +77,11 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
      * DNs per batched delete, well inside the placeholder limits of every supported driver.
      */
     private const DELETE_BATCH_SIZE = 500;
+
+    /**
+     * Rows a single list statement may transfer before the walk seeks on and issues the next one.
+     */
+    private const FETCH_BATCH_SIZE = 1000;
 
     private readonly PdoListQueryBuilder $queryBuilder;
 
@@ -189,41 +196,36 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
         $composed = $this->tryComposedStreamingQuery($filterResult, $options);
         if ($composed !== null) {
             return new EntryStream(
-                $this->generateRows(
-                    $this->statements->execute(
-                        $composed->sql,
-                        $composed->params,
-                    ),
+                $this->generateBatches(
+                    $composed,
                     $deadline,
-                    $options->attributes,
+                    $options,
+                    self::COMPOSED_DRIVER_PROBE_LIMIT,
                 ),
                 false,
             );
         }
 
         $isPreFiltered = $filterResult !== null && $filterResult->isExact;
-
-        // Exact is bound by the client sizeLimit; otherwise cap candidate transfer at lookthrough+1.
-        $sqlLimit = match (true) {
-            $isPreFiltered && $options->sizeLimit > 0 => $options->sizeLimit,
-            $options->lookthroughLimit > 0 => $options->lookthroughLimit + 1,
-            default => null,
-        };
-
-        $query = $this->queryBuilder->build(
-            $options->baseDn->normalize()->toString(),
-            $options->subtree,
+        $maxRows = $this->maxRowsFor($options, $isPreFiltered);
+        $batchSize = $maxRows === null
+            ? self::FETCH_BATCH_SIZE
+            : min($maxRows, self::FETCH_BATCH_SIZE);
+        $spec = ListQuerySpec::fromOptions(
+            $options,
             $filterResult,
-            $sqlLimit,
+            $batchSize,
             $this->sortSpecs($options),
-            $options->subentries,
         );
 
         return new EntryStream(
-            $this->generateRows(
-                $this->statements->execute($query->sql, $query->params),
+            $this->generateBatches(
+                $this->queryBuilder->build($spec),
                 $deadline,
-                $options->attributes,
+                $options,
+                $batchSize,
+                $spec,
+                $maxRows,
             ),
             $isPreFiltered,
         );
@@ -373,6 +375,26 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
     }
 
     /**
+     * Rows worth reading at all, or null to walk the whole result.
+     *
+     * An exact filter makes the client size limit a real ceiling on the answer.
+     */
+    private function maxRowsFor(
+        StorageListOptions $options,
+        bool $isPreFiltered,
+    ): ?int {
+        if ($isPreFiltered) {
+            return $options->sizeLimit > 0
+                ? $options->sizeLimit
+                : null;
+        }
+
+        return $options->lookthroughLimit > 0
+            ? $options->lookthroughLimit + 1
+            : null;
+    }
+
+    /**
      * Records the schema the tables were created from, so a database states which revision it holds.
      */
     private static function stampSchemaVersion(PDO $pdo): void
@@ -406,12 +428,16 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
             return null;
         }
 
+        // The leaf was chosen for matching fewer rows than the probe cap, so this bound cannot truncate it.
         return $this->queryBuilder->buildStreamingQuery(
             $driver->condition,
             $driver->params,
-            $options->baseDn->normalize()->toString(),
-            self::COMPOSED_DRIVER_PROBE_LIMIT,
-            $options->subentries,
+            ListQuerySpec::fromOptions(
+                $options,
+                $filterResult,
+                self::COMPOSED_DRIVER_PROBE_LIMIT,
+                [],
+            ),
         );
     }
 
@@ -479,30 +505,101 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
     }
 
     /**
-     * @param list<string>|null $attributes
+     * Walks the result in bounded batches, seeking past the last row read rather than holding one cursor open.
+     *
+     * @return Generator<Entry> Returns the cursor for the last row read, for a caller resuming later.
      */
-    private function generateRows(
-        PooledStatement $stmt,
+    private function generateBatches(
+        SqlQuery $query,
         ?float $deadline,
-        ?array $attributes = null,
+        StorageListOptions $options,
+        int $batchSize,
+        ?ListQuerySpec $spec = null,
+        ?int $maxRows = null,
     ): Generator {
-        $allowed = $attributes === null
+        $allowed = $options->attributes === null
             ? null
-            : array_fill_keys($attributes, true);
+            : array_fill_keys($options->attributes, true);
+        $cursor = $options->after;
+        $read = 0;
+
+        while (true) {
+            $batch = yield from $this->generateBatch(
+                $query,
+                $deadline,
+                $allowed,
+            );
+            $cursor = $batch->cursor ?? $cursor;
+            $read += $batch->rows;
+
+            $isLast = $spec === null
+                || $cursor === null
+                || $batch->rows < $batchSize
+                || ($maxRows !== null && $read >= $maxRows);
+
+            if ($isLast) {
+                return $cursor;
+            }
+
+            $query = $this->queryBuilder->build($spec->resumingAfter($cursor));
+        }
+    }
+
+    /**
+     * One statement's worth of rows, released as this returns so only one is ever open.
+     *
+     * @param array<string, true>|null $allowed
+     * @return Generator<int, Entry, mixed, FetchedBatch>
+     */
+    private function generateBatch(
+        SqlQuery $query,
+        ?float $deadline,
+        ?array $allowed,
+    ): Generator {
+        $stmt = $this->statements->execute(
+            $query->sql,
+            $query->params,
+        );
+        $rows = 0;
+        $cursor = null;
 
         while (($row = $stmt->fetch()) !== false) {
             if ($deadline !== null && microtime(true) >= $deadline) {
                 throw new TimeLimitExceededException();
             }
 
+            $rows++;
+            $cursor = $this->cursorForRow($row) ?? $cursor;
             $entry = $this->rowToEntry(
                 $row,
                 $allowed,
             );
+
             if ($entry !== null) {
                 yield $entry;
             }
         }
+
+        return new FetchedBatch(
+            $rows,
+            $cursor,
+        );
+    }
+
+    /**
+     * The resume point a row represents, or null when the query did not project the key.
+     */
+    private function cursorForRow(mixed $row): ?PageCursor
+    {
+        if (!is_array($row)) {
+            return null;
+        }
+
+        $key = $row['entry_id'] ?? null;
+
+        return is_int($key) || is_string($key)
+            ? PageCursor::afterEntry((int) $key)
+            : null;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/ArrayEntryStorageTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/ArrayEntryStorageTrait.php
@@ -17,9 +17,10 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
+use FreeDSx\Ldap\Server\Backend\Storage\FetchedBatch;
+use FreeDSx\Ldap\Server\Backend\Storage\PageCursor;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 use FreeDSx\Ldap\Server\Subentry\SubentryDetector;
-use FreeDSx\Ldap\Server\Subentry\SubentryVisibility;
 use Generator;
 
 /**
@@ -35,52 +36,119 @@ trait ArrayEntryStorageTrait
 
     /**
      * @param array<string, Entry> $entries Entries keyed by normalised DN string
+     * @param array<string, int> $keys Entry key per normalised DN string
      */
     private function listFromArray(
         StorageListOptions $options,
         array $entries,
+        array $keys = [],
     ): EntryStream {
+        $scoped = $this->yieldByScope($options, $entries);
+
         if ($options->sortKeys === []) {
-            return new EntryStream(
-                $this->yieldByScope(
-                    $entries,
-                    $options->baseDn,
-                    $options->subtree,
-                    $options->timeLimit,
-                    $options->subentries,
-                ),
-            );
+            return new EntryStream($this->pageByKey(
+                $scoped,
+                $keys,
+                $options,
+            ));
         }
 
-        return new EntryStream($this->sortedStreamFromArray(
+        /** @var list<Entry> $collected */
+        $collected = iterator_to_array($scoped, false);
+
+        return new EntryStream($this->pageByCount(
+            $this->sortKeyComparator->sort($collected, $options->sortKeys),
             $options,
-            $entries,
         ));
     }
 
     /**
-     * @param array<string, Entry> $entries Entries keyed by normalised DN string
-     * @return Generator<Entry>
+     * Hands over the window $options asks for, resuming past the key it names.
+     *
+     * @param iterable<Entry> $entries
+     * @param array<string, int> $keys Entry key per normalised DN string
+     * @return Generator<int, Entry, mixed, FetchedBatch>
      */
-    private function sortedStreamFromArray(
+    private function pageByKey(
+        iterable $entries,
+        array $keys,
         StorageListOptions $options,
-        array $entries,
     ): Generator {
-        /** @var list<Entry> $collected */
-        $collected = iterator_to_array(
-            $this->yieldByScope(
-                $entries,
-                $options->baseDn,
-                $options->subtree,
-                $options->timeLimit,
-                $options->subentries,
-            ),
-            false,
-        );
+        $after = $options->after?->position;
+        $cursor = $options->after;
+        $taken = 0;
+        $hasMore = false;
 
-        yield from $this->sortKeyComparator->sort(
-            $collected,
-            $options->sortKeys,
+        foreach ($entries as $entry) {
+            $key = $keys[$entry->getDn()->normalize()->toString()] ?? null;
+
+            if ($after !== null && $key !== null && $key <= $after) {
+                continue;
+            }
+
+            // Seen but not handed over: its only job is to prove the result did not end here.
+            if ($options->maxCandidates !== null && $taken >= $options->maxCandidates) {
+                $hasMore = true;
+
+                break;
+            }
+
+            $taken++;
+
+            if ($key !== null) {
+                $cursor = PageCursor::afterEntry($key);
+            }
+
+            yield $entry;
+        }
+
+        return new FetchedBatch(
+            $taken,
+            $cursor,
+            $hasMore,
+        );
+    }
+
+    /**
+     * Hands over the window $options asks for, resuming by how much was already delivered.
+     *
+     * A sort defines its own order that the key says nothing about, so the count is the only position that means
+     * anything. The sort is recomputed identically for every page.
+     *
+     * @param iterable<Entry> $entries
+     * @return Generator<int, Entry, mixed, FetchedBatch>
+     */
+    private function pageByCount(
+        iterable $entries,
+        StorageListOptions $options,
+    ): Generator {
+        $delivered = $options->after->position ?? 0;
+        $skipped = 0;
+        $taken = 0;
+        $hasMore = false;
+
+        foreach ($entries as $entry) {
+            if ($skipped < $delivered) {
+                $skipped++;
+
+                continue;
+            }
+
+            if ($options->maxCandidates !== null && $taken >= $options->maxCandidates) {
+                $hasMore = true;
+
+                break;
+            }
+
+            $taken++;
+
+            yield $entry;
+        }
+
+        return new FetchedBatch(
+            $taken,
+            PageCursor::afterSorted($delivered + $taken),
+            $hasMore,
         );
     }
 
@@ -103,18 +171,18 @@ trait ArrayEntryStorageTrait
     }
 
     /**
+     * Entries in scope, in insertion order, which is ascending key order since keys are handed out on insert and a
+     * rename re-keys the array in place.
+     *
      * @param array<string, Entry> $entries Entries keyed by normalised DN string
-     * @return Generator<Entry>
+     * @return Generator<int, Entry>
      */
     private function yieldByScope(
+        StorageListOptions $options,
         array $entries,
-        Dn $baseDn,
-        bool $subtree,
-        int $timeLimit = 0,
-        SubentryVisibility $subentries = SubentryVisibility::All,
     ): Generator {
-        $deadline = $timeLimit > 0
-            ? microtime(true) + $timeLimit
+        $deadline = $options->timeLimit > 0
+            ? microtime(true) + $options->timeLimit
             : null;
 
         foreach ($entries as $normDn => $entry) {
@@ -124,11 +192,11 @@ trait ArrayEntryStorageTrait
 
             $entryDn = Dn::fromCanonical((string) $normDn);
 
-            $inScope = $subtree
-                ? $entryDn->isDescendantOf($baseDn)
-                : $entryDn->isChildOf($baseDn);
+            $inScope = $options->subtree
+                ? $entryDn->isDescendantOf($options->baseDn)
+                : $entryDn->isChildOf($options->baseDn);
 
-            if ($inScope && SubentryDetector::isVisibleUnder($entry, $subentries)) {
+            if ($inScope && SubentryDetector::isVisibleUnder($entry, $options->subentries)) {
                 yield $entry;
             }
         }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/SwooleWriterQueue.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/SwooleWriterQueue.php
@@ -74,6 +74,24 @@ final class SwooleWriterQueue implements WriterQueueInterface
     }
 
     /**
+     * Closing the channel wakes the writer out of its idle wait, so it exits now rather than a timeout later.
+     *
+     * Every accepted job has already been replied to by the time run() returns, so there is never one in flight here.
+     */
+    public function drain(): void
+    {
+        $jobs = $this->jobs;
+        if ($jobs === null) {
+            return;
+        }
+
+        $this->jobs = null;
+        $this->started = false;
+
+        $jobs->close();
+    }
+
+    /**
      * Executes a batch under a single outer transaction, isolating per-job failures via savepoints.
      *
      * @internal
@@ -138,7 +156,14 @@ final class SwooleWriterQueue implements WriterQueueInterface
     {
         $batchWrapper = $this->batchWrapper;
         $executeBatch = self::executeBatch(...);
-        $onExit = function (): void {
+
+        // Only the writer still holding the current channel may clear the state
+        $onExit = function () use ($jobs): void {
+            if ($this->jobs !== $jobs) {
+                return;
+            }
+
+            $this->jobs = null;
             $this->started = false;
         };
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/WriteSerializingStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/WriteSerializingStorage.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Server\Backend\ResettableInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\DrainableWritesInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
@@ -29,13 +30,22 @@ use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final readonly class WriteSerializingStorage implements EntryStorageInterface, ResettableInterface, ChangeJournalingInterface
+final readonly class WriteSerializingStorage implements
+    EntryStorageInterface,
+    ResettableInterface,
+    ChangeJournalingInterface,
+    DrainableWritesInterface
 {
     public function __construct(
         private EntryStorageInterface $reads,
         private EntryStorageInterface $writes,
         private WriterQueueInterface $queue,
     ) {}
+
+    public function drainWrites(): void
+    {
+        $this->queue->drain();
+    }
 
     public function find(Dn $dn): ?Entry
     {

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/WriterQueueInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Writer/WriterQueueInterface.php
@@ -27,4 +27,9 @@ interface WriterQueueInterface
      * @throws Throwable
      */
     public function run(Closure $job): void;
+
+    /**
+     * Release the writer now that no further job is coming, rather than leaving it to time out.
+     */
+    public function drain(): void;
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/DrainableWritesInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/DrainableWritesInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage;
+
+/**
+ * Storage that writes through a helper which outlives a single write.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+interface DrainableWritesInterface
+{
+    /**
+     * Release the write helper now that no further write is coming, rather than leaving it to time out.
+     *
+     * For a caller that writes in one burst and then stops, such as seeding. Not for one still serving requests.
+     */
+    public function drainWrites(): void;
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/FetchedBatch.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/FetchedBatch.php
@@ -11,23 +11,23 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query;
-
-use FreeDSx\Ldap\Server\Backend\Storage\PageCursor;
+namespace FreeDSx\Ldap\Server\Backend\Storage;
 
 /**
- * What one statement's worth of rows amounted to.
+ * What one bounded read amounted to, returned by the stream that performed it.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 final readonly class FetchedBatch
 {
     /**
-     * @param int $rows Rows read, which tells a caller whether the batch filled and so whether more may follow.
-     * @param ?PageCursor $cursor Where the rows ended, or null when none were read.
+     * @param int $rows Candidates read, which tells a caller whether its bound was reached.
+     * @param ?PageCursor $cursor The last one read, or null when there were none.
+     * @param bool $hasMore Whether a further candidate was seen beyond the bound, so a caller need not read to find out.
      */
     public function __construct(
         public int $rows,
         public ?PageCursor $cursor = null,
+        public bool $hasMore = false,
     ) {}
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/PageCursor.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/PageCursor.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage;
+
+/**
+ * Where a list resumes from, as a key the storage assigns rather than anything derived from the entry.
+ *
+ * A key survives a rename, so a walk is not disturbed by one landing between pages.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class PageCursor
+{
+    /**
+     * @param int $entryKey Identifies the last entry delivered.
+     */
+    private function __construct(public int $entryKey) {}
+
+    public static function afterEntry(int $entryKey): self
+    {
+        return new self($entryKey);
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/PageCursor.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/PageCursor.php
@@ -14,21 +14,33 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage;
 
 /**
- * Where a list resumes from, as a key the storage assigns rather than anything derived from the entry.
- *
- * A key survives a rename, so a walk is not disturbed by one landing between pages.
+ * Where a list resumes from: an assigned key, which a rename cannot disturb, or a count when a sort defines the order.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 final readonly class PageCursor
 {
     /**
-     * @param int $entryKey Identifies the last entry delivered.
+     * @param int $position The key of the last entry delivered, or the count already delivered when sorted.
      */
-    private function __construct(public int $entryKey) {}
+    private function __construct(
+        public int $position,
+        public bool $isOrdinal = false,
+    ) {}
 
     public static function afterEntry(int $entryKey): self
     {
         return new self($entryKey);
+    }
+
+    /**
+     * @param int $delivered Entries the sorted order has already handed over.
+     */
+    public static function afterSorted(int $delivered): self
+    {
+        return new self(
+            $delivered,
+            true,
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/PageSlice.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/PageSlice.php
@@ -13,21 +13,21 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage;
 
-use FreeDSx\Ldap\Entry\Entry;
-use Generator;
-
 /**
- * Lazy entry generator returned by storage list() / backend search(); $isPreFiltered marks an exact native filter match.
+ * A bounded piece of a result, for a caller that reads one page at a time.
+ *
+ * Bounded so the caller can read it to the end, which is the only point a stream will say where it stopped.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final readonly class EntryStream
+final readonly class PageSlice
 {
     /**
-     * @param Generator<int, Entry, mixed, ?FetchedBatch> $entries Returns what it read, once read to its end.
+     * @param int $limit Candidates this slice may examine.
+     * @param ?PageCursor $after Where to resume, or null to start from the beginning.
      */
     public function __construct(
-        public Generator $entries,
-        public bool $isPreFiltered = false,
+        public int $limit,
+        public ?PageCursor $after = null,
     ) {}
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/SearchStreamBuilder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/SearchStreamBuilder.php
@@ -96,6 +96,8 @@ final readonly class SearchStreamBuilder
         foreach ($generator as $entry) {
             yield $this->injectDerived($entry, $request);
         }
+
+        return $generator->getReturn();
     }
 
     /**
@@ -181,6 +183,8 @@ final readonly class SearchStreamBuilder
                 yield $entry;
             }
         }
+
+        return $generator->getReturn();
     }
 
     /**
@@ -205,6 +209,8 @@ final readonly class SearchStreamBuilder
 
             yield $entry;
         }
+
+        return $generator->getReturn();
     }
 
     /**
@@ -224,6 +230,8 @@ final readonly class SearchStreamBuilder
                 ResultCode::TIME_LIMIT_EXCEEDED,
             );
         }
+
+        return $generator->getReturn();
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/SearchStreamBuilder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/SearchStreamBuilder.php
@@ -86,8 +86,8 @@ final readonly class SearchStreamBuilder
     }
 
     /**
-     * @param Generator<Entry> $generator
-     * @return Generator<Entry>
+     * @param Generator<int, Entry, mixed, ?FetchedBatch> $generator
+     * @return Generator<int, Entry, mixed, ?FetchedBatch>
      */
     private function wrapWithDerived(
         Generator $generator,
@@ -170,8 +170,8 @@ final readonly class SearchStreamBuilder
     }
 
     /**
-     * @param Generator<Entry> $generator
-     * @return Generator<Entry>
+     * @param Generator<int, Entry, mixed, ?FetchedBatch> $generator
+     * @return Generator<int, Entry, mixed, ?FetchedBatch>
      * @throws OperationException
      */
     private function wrapWithFilterEvaluation(
@@ -188,8 +188,8 @@ final readonly class SearchStreamBuilder
     }
 
     /**
-     * @param Generator<Entry> $generator
-     * @return Generator<Entry>
+     * @param Generator<int, Entry, mixed, ?FetchedBatch> $generator
+     * @return Generator<int, Entry, mixed, ?FetchedBatch>
      * @throws OperationException
      */
     private function wrapWithLookthrough(
@@ -214,8 +214,8 @@ final readonly class SearchStreamBuilder
     }
 
     /**
-     * @param Generator<Entry> $generator
-     * @return Generator<Entry>
+     * @param Generator<int, Entry, mixed, ?FetchedBatch> $generator
+     * @return Generator<int, Entry, mixed, ?FetchedBatch>
      * @throws OperationException
      */
     private function wrapWithTimeLimitHandling(Generator $generator): Generator
@@ -235,10 +235,13 @@ final readonly class SearchStreamBuilder
     }
 
     /**
-     * @return Generator<Entry>
+     * @return Generator<int, Entry, mixed, ?FetchedBatch>
      */
     private function yieldSingle(Entry $entry): Generator
     {
         yield $entry;
+
+        // A base-object read is one entry, so there is never anywhere to resume from.
+        return null;
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
@@ -29,6 +29,7 @@ final readonly class StorageListOptions
     /**
      * @param SortKey[] $sortKeys
      * @param list<string>|null $attributes Lowercase base attribute names to materialize, or null for all.
+     * @param ?PageCursor $after Resume after this entry rather than starting from the beginning.
      */
     public function __construct(
         public Dn $baseDn,
@@ -40,6 +41,7 @@ final readonly class StorageListOptions
         public int $lookthroughLimit = 0,
         public ?array $attributes = null,
         public SubentryVisibility $subentries = SubentryVisibility::All,
+        public ?PageCursor $after = null,
     ) {}
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
@@ -30,6 +30,7 @@ final readonly class StorageListOptions
      * @param SortKey[] $sortKeys
      * @param list<string>|null $attributes Lowercase base attribute names to materialize, or null for all.
      * @param ?PageCursor $after Resume after this entry rather than starting from the beginning.
+     * @param ?int $maxCandidates Stop after examining this many, so the caller can read the result to its end.
      */
     public function __construct(
         public Dn $baseDn,
@@ -42,6 +43,7 @@ final readonly class StorageListOptions
         public ?array $attributes = null,
         public SubentryVisibility $subentries = SubentryVisibility::All,
         public ?PageCursor $after = null,
+        public ?int $maxCandidates = null,
     ) {}
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptionsFactory.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptionsFactory.php
@@ -44,6 +44,7 @@ final readonly class StorageListOptionsFactory
 
     /**
      * @param ?SearchLimits $effectiveLimits Per-request limits, or null for the ones this factory was configured with.
+     * @param ?PageSlice $slice Reads one bounded piece of the result rather than the whole of it.
      */
     public function make(
         SearchRequest $request,
@@ -51,6 +52,7 @@ final readonly class StorageListOptionsFactory
         ControlBag $controls,
         SubentryVisibility $subentries,
         ?SearchLimits $effectiveLimits = null,
+        ?PageSlice $slice = null,
     ): StorageListOptions {
         $limits = $effectiveLimits ?? $this->limits;
         $sortingControl = $controls->get(Control::OID_SORTING);
@@ -67,6 +69,8 @@ final readonly class StorageListOptionsFactory
             lookthroughLimit: $limits->maxSearchLookthrough,
             attributes: $this->materializedAttributes($request),
             subentries: $subentries,
+            after: $slice?->after,
+            maxCandidates: $slice?->limit,
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/WritableStorageBackend.php
@@ -117,6 +117,7 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
         SubentryVisibility $subentries,
         ControlBag $controls = new ControlBag(),
         ?SearchLimits $effectiveLimits = null,
+        ?PageSlice $slice = null,
     ): EntryStream {
         $baseDn = $request->getBaseDn() ?? new Dn('');
         $normBase = $baseDn->normalize();
@@ -141,6 +142,7 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             $controls,
             $subentries,
             $effectiveLimits,
+            $slice,
         );
 
         try {
@@ -149,6 +151,8 @@ final class WritableStorageBackend implements WritableLdapBackendInterface, Rese
             # RFC 4511 §4.5.1.7: unrecognized attribute descriptions evaluate to Undefined; yield zero entries.
             return new EntryStream((static function (): Generator {
                 yield from [];
+
+                return null;
             })());
         }
 

--- a/src/FreeDSx/Ldap/Server/RequestHistory.php
+++ b/src/FreeDSx/Ldap/Server/RequestHistory.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server;
 
+use FreeDSx\Ldap\Server\Backend\Storage\PageCursor;
 use FreeDSx\Ldap\Server\Paging\PagingRequests;
-use Generator;
 
 /**
  * Used to retain history regarding certain client request details.
@@ -26,12 +26,13 @@ final class RequestHistory
     private PagingRequests $pagingRequests;
 
     /**
-     * Per-connection generator store for active paging sessions.
-     * Keyed by the cookie that the client will send on the next request.
+     * Where each active paging session left off, keyed by the cookie the client returns on its next request.
      *
-     * @var array<string, Generator>
+     * A position rather than an open result, so nothing is held between requests but the place to resume from.
+     *
+     * @var array<string, PageCursor>
      */
-    private array $pagingGenerators = [];
+    private array $pagingCursors = [];
 
     public function __construct(?PagingRequests $pagingRequests = null)
     {
@@ -46,31 +47,20 @@ final class RequestHistory
         return $this->pagingRequests;
     }
 
-    /**
-     * Store a generator for the given paging cookie (the cookie that will be
-     * sent to the client and returned on the next page request).
-     */
-    public function storePagingGenerator(
+    public function storePagingCursor(
         string $cookie,
-        Generator $generator,
+        PageCursor $cursor,
     ): void {
-        $this->pagingGenerators[$cookie] = $generator;
+        $this->pagingCursors[$cookie] = $cursor;
     }
 
-    /**
-     * Retrieve the generator associated with the given cookie, or null if
-     * the cookie is not found.
-     */
-    public function getPagingGenerator(string $cookie): ?Generator
+    public function getPagingCursor(string $cookie): ?PageCursor
     {
-        return $this->pagingGenerators[$cookie] ?? null;
+        return $this->pagingCursors[$cookie] ?? null;
     }
 
-    /**
-     * Remove and discard the generator associated with the given cookie.
-     */
-    public function removePagingGenerator(string $cookie): void
+    public function removePagingCursor(string $cookie): void
     {
-        unset($this->pagingGenerators[$cookie]);
+        unset($this->pagingCursors[$cookie]);
     }
 }

--- a/tests/integration/LdapServerTest.php
+++ b/tests/integration/LdapServerTest.php
@@ -29,16 +29,9 @@ use Throwable;
 final class LdapServerTest extends ServerTestCase
 {
     /**
-     * Lookthrough limits count candidates examined before filter evaluation, and the filter these assert on is
-     * answered from an index on the database this harness now runs, so nothing is examined and the limit cannot
-     * trip. Revisit with the keyset paging work.
-     *
-     * @var list<string>
+     * The supertype arm is one the index cannot answer, so every candidate reaches the evaluator the limit counts.
      */
-    private const INDEX_ANSWERED_LOOKTHROUGH_TESTS = [
-        'testPagedSearchFallsBackToRegularLookthroughWhenPagedUnset',
-        'testPerIdentityRuleAppliesAuthenticatedLookthrough',
-    ];
+    private const PHP_EVALUATED_FILTER = '(&(employeeNumber=*)(name=*))';
 
     public static function setUpBeforeClass(): void
     {
@@ -59,10 +52,6 @@ final class LdapServerTest extends ServerTestCase
 
     public function setUp(): void
     {
-        if (in_array($this->name(), self::INDEX_ANSWERED_LOOKTHROUGH_TESTS, true)) {
-            self::markTestSkipped('The filter is index-answered here, so the lookthrough limit cannot trip.');
-        }
-
         $this->setServerMode('ldap-server');
 
         parent::setUp();
@@ -444,7 +433,7 @@ final class LdapServerTest extends ServerTestCase
         ]);
         $this->authenticateUser();
 
-        $search = Operations::search(Filters::raw('(employeeNumber=*)'))->base('dc=foo,dc=bar');
+        $search = Operations::search(Filters::raw(self::PHP_EVALUATED_FILTER))->base('dc=foo,dc=bar');
         $paging = $this->ldapClient()->paging($search);
 
         $count = 0;
@@ -471,7 +460,7 @@ final class LdapServerTest extends ServerTestCase
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::ADMIN_LIMIT_EXCEEDED);
 
-        $search = Operations::search(Filters::raw('(employeeNumber=*)'))->base('dc=foo,dc=bar');
+        $search = Operations::search(Filters::raw(self::PHP_EVALUATED_FILTER))->base('dc=foo,dc=bar');
         $paging = $this->ldapClient()->paging($search);
         while ($paging->hasEntries()) {
             $paging->getEntries(500);
@@ -492,7 +481,7 @@ final class LdapServerTest extends ServerTestCase
         $this->expectExceptionCode(ResultCode::ADMIN_LIMIT_EXCEEDED);
 
         $this->ldapClient()->search(
-            Operations::search(Filters::raw('(employeeNumber=*)'))->base('dc=foo,dc=bar')->useSubtreeScope(),
+            Operations::search(Filters::raw(self::PHP_EVALUATED_FILTER))->base('dc=foo,dc=bar')->useSubtreeScope(),
         );
     }
 

--- a/tests/integration/Storage/Concern/ControlTestsTrait.php
+++ b/tests/integration/Storage/Concern/ControlTestsTrait.php
@@ -84,6 +84,51 @@ trait ControlTestsTrait
         );
     }
 
+    /**
+     * RFC 2696 §3 promises no snapshot, so the walk need only stay coherent: end, and repeat nothing.
+     */
+    public function testPagingSurvivesWritesLandingBetweenPages(): void
+    {
+        $this->authenticateAdmin();
+
+        $search = Operations::search(Filters::present('objectClass'))
+            ->base('dc=foo,dc=bar')
+            ->useSubtreeScope();
+
+        $paging = $this->ldapClient()->paging($search, 2);
+        $dns = [];
+        $wrote = false;
+
+        while ($paging->hasEntries()) {
+            foreach ($paging->getEntries() as $entry) {
+                $dns[] = $entry->getDn()->toString();
+            }
+
+            if (!$wrote) {
+                $wrote = true;
+                $this->ldapClient()->create(Entry::fromArray('cn=mid-walk,dc=foo,dc=bar', [
+                    'objectClass' => ['top', 'inetOrgPerson'],
+                    'cn' => 'mid-walk',
+                    'sn' => 'Added',
+                ]));
+            }
+        }
+
+        // Dropped before asserting, so a sibling counting the fixture does not inherit it.
+        $this->ldapClient()->delete('cn=mid-walk,dc=foo,dc=bar');
+
+        self::assertSame(
+            array_values(array_unique($dns)),
+            $dns,
+            'A walk must not hand over an entry it already delivered.',
+        );
+        self::assertGreaterThanOrEqual(
+            8,
+            count($dns),
+            'Entries present before the write must still be delivered.',
+        );
+    }
+
     public function testPagingCanBeAbandoned(): void
     {
         $this->authenticateUser();

--- a/tests/integration/Storage/Concern/ControlTestsTrait.php
+++ b/tests/integration/Storage/Concern/ControlTestsTrait.php
@@ -52,6 +52,38 @@ trait ControlTestsTrait
         );
     }
 
+    public function testSortedPagingReturnsEveryEntryOnceInOrder(): void
+    {
+        $this->authenticateUser();
+
+        $search = Operations::search(Filters::present('objectClass'))
+            ->base('dc=foo,dc=bar')
+            ->useSubtreeScope();
+
+        $paging = $this->ldapClient()
+            ->paging($search, 3)
+            ->useControls(new SortingControl(SortKey::ascending('cn')));
+
+        $dns = [];
+
+        while ($paging->hasEntries()) {
+            foreach ($paging->getEntries() as $entry) {
+                $dns[] = $entry->getDn()->toString();
+            }
+        }
+
+        self::assertSame(
+            array_values(array_unique($dns)),
+            $dns,
+            'A sorted walk must not repeat an entry it already delivered.',
+        );
+        self::assertCount(
+            8,
+            $dns,
+            'A sorted walk must hand over every entry.',
+        );
+    }
+
     public function testPagingCanBeAbandoned(): void
     {
         $this->authenticateUser();

--- a/tests/integration/Storage/Concern/QueryTestsTrait.php
+++ b/tests/integration/Storage/Concern/QueryTestsTrait.php
@@ -1445,15 +1445,11 @@ trait QueryTestsTrait
         self::assertCount(0, $entries);
     }
 
-    public function testInexactSearchTripsLookthroughLimit(): void
+    /**
+     * A supertype the index cannot answer, so every candidate reaches the evaluator the limit counts.
+     */
+    public function testAFilterEvaluatedInPhpTripsTheLookthroughLimit(): void
     {
-        if (static::usesPdoStorage()) {
-            self::markTestSkipped(
-                'The filter is answered from an index, so no candidates are examined and the limit cannot trip. '
-                    . 'Revisit with the keyset paging work, which is what bounds transfer on that path.',
-            );
-        }
-
         $this->stopServer();
         $this->createServerProcess(
             'tcp',
@@ -1469,7 +1465,7 @@ trait QueryTestsTrait
         $this->expectExceptionCode(ResultCode::ADMIN_LIMIT_EXCEEDED);
 
         $this->ldapClient()->search(
-            Operations::search(Filters::endsWith('cn', 'zzz'))
+            Operations::search(Filters::equal('name', 'no-entry-has-this'))
                 ->base('dc=foo,dc=bar')
                 ->useSubtreeScope(),
         );

--- a/tests/integration/Storage/LdapBackendSqliteSwooleStorageTest.php
+++ b/tests/integration/Storage/LdapBackendSqliteSwooleStorageTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Storage;
+
+/**
+ * Runs the storage suite against SQLite on the Swoole runner.
+ */
+final class LdapBackendSqliteSwooleStorageTest extends LdapBackendStorageTestCase
+{
+    /**
+     * Tests that mutate the database and would pollute subsequent tests.
+     */
+    private const MUTATING_TESTS = [
+        'testAddStoresEntry',
+        'testDeleteRemovesEntry',
+        'testModifyReplacesAttributeValue',
+        'testRenameChangesRdn',
+    ];
+
+    public static function setUpBeforeClass(): void
+    {
+        // Intentionally skips the parent, which would start the in-memory PCNTL server.
+        if (!extension_loaded('swoole')) {
+            return;
+        }
+
+        static::initSharedServer(
+            'ldap-backend-storage',
+            'tcp',
+            static::storageExtraArgs(),
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        static::tearDownSharedServer();
+    }
+
+    public function setUp(): void
+    {
+        if (!extension_loaded('swoole')) {
+            $this->markTestSkipped('The swoole extension is required to run SwooleServerRunner tests.');
+        }
+
+        parent::setUp();
+
+        if (in_array($this->name(), self::MUTATING_TESTS, true)) {
+            $this->stopServer();
+            $this->createServerProcess(
+                'tcp',
+                static::storageExtraArgs(),
+            );
+        }
+    }
+
+    protected static function storageExtraArgs(): array
+    {
+        return ['--storage=sqlite', '--runner=swoole'];
+    }
+}

--- a/tests/integration/Storage/LdapBackendStorageTestCase.php
+++ b/tests/integration/Storage/LdapBackendStorageTestCase.php
@@ -75,16 +75,4 @@ abstract class LdapBackendStorageTestCase extends ServerTestCase
     {
         return [];
     }
-
-    /**
-     * Whether this variant runs on a database, which answers filters itself rather than handing over candidates.
-     */
-    protected static function usesPdoStorage(): bool
-    {
-        return !in_array(
-            '--storage=memory',
-            static::storageExtraArgs(),
-            true,
-        );
-    }
 }

--- a/tests/support/Backend/Storage/RecordingWriterQueue.php
+++ b/tests/support/Backend/Storage/RecordingWriterQueue.php
@@ -28,4 +28,9 @@ final class RecordingWriterQueue implements WriterQueueInterface
         $this->runs++;
         $job();
     }
+
+    /**
+     * Nothing is kept between jobs here, so there is nothing to release.
+     */
+    public function drain(): void {}
 }

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -23,8 +23,6 @@ use FreeDSx\Ldap\Server\Backend\Auth\ManagerIdentity;
 use FreeDSx\Ldap\Server\Config\Storage\InMemoryStorageConfig;
 use FreeDSx\Ldap\Server\Config\Storage\PdoConfig;
 use FreeDSx\Ldap\Server\Config\Storage\StorageConfigInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
 use FreeDSx\Ldap\Server\Backend\Storage\SeedOptions;
 use FreeDSx\Ldap\Ldif\Loader\FileLdifLoader;
 use FreeDSx\Ldap\Schema\LdifSchemaSource;
@@ -427,16 +425,19 @@ final class LdapBackendStorageCommand extends Command
         $seedLdif = $this->getStringOption($input, 'seed-ldif');
         $validateSeed = !$input->getOption('no-seed-validation');
 
-        $seed = function () use ($server, $entries, $container, $seedLdif, $validateSeed): void {
+        $seed = function () use ($server, $entries, $seedLdif, $validateSeed): void {
             $server->seed(
                 new FileLdifLoader($seedLdif),
                 new SeedOptions(ignoreValidation: !$validateSeed),
             );
 
-            // The generated entries stay a raw import, since they exist to widen the return path rather than to
-            // be valid directory content.
+            // The generated entries skip validation, since they exist to widen the return path rather than to be
+            // valid directory content.
             if ($entries !== []) {
-                (new LdapImporter($container->get(EntryStorageInterface::class)))->importEntries($entries);
+                $server->seedEntries(
+                    $entries,
+                    new SeedOptions(ignoreValidation: true),
+                );
             }
         };
 

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
@@ -117,6 +117,47 @@ class ServerPagingHandlerTest extends TestCase
         );
     }
 
+    public function test_a_page_is_filled_past_entries_access_control_hides(): void
+    {
+        $hidden = Entry::create('cn=1,dc=foo,dc=bar', ['cn' => '1']);
+        $visible = Entry::create('cn=2,dc=foo,dc=bar', ['cn' => '2']);
+
+        $mockAccessControl = $this->createMock(AccessControlInterface::class);
+        $mockAccessControl
+            ->method('filterEntry')
+            ->willReturnCallback(
+                static fn(TokenInterface $token, Entry $entry): ?Entry => $entry === $hidden
+                    ? null
+                    : $entry,
+            );
+
+        $this->mockBackend
+            ->method('search')
+            ->willReturnCallback($this->sliceAware(
+                $hidden,
+                $visible,
+            ));
+
+        $subject = new ServerPagingHandler(
+            backend: $this->mockBackend,
+            filterEvaluator: $this->mockFilterEvaluator,
+            accessControl: $mockAccessControl,
+            requestHistory: $this->requestHistory,
+            schema: $this->schema,
+        );
+
+        // A page of one, whose first candidate is hidden, so filling it means reading on rather than answering short.
+        $this->drive(
+            $subject,
+            $this->makeSearchMessage(size: 1),
+        );
+
+        self::assertEquals(
+            [new LdapMessageResponse(2, new SearchResultEntry($visible))],
+            $this->entryMessages(),
+        );
+    }
+
     public function test_it_should_call_the_backend_search_on_paging_start_and_return_entries(): void
     {
         $message = $this->makeSearchMessage(size: 10);

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
@@ -37,6 +37,9 @@ use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
+use FreeDSx\Ldap\Server\Backend\Storage\FetchedBatch;
+use FreeDSx\Ldap\Server\Backend\Storage\PageCursor;
+use FreeDSx\Ldap\Server\Backend\Storage\PageSlice;
 use FreeDSx\Ldap\Server\Paging\PagingRequest;
 use FreeDSx\Ldap\Server\RequestHistory;
 use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
@@ -125,7 +128,7 @@ class ServerPagingHandlerTest extends TestCase
             ->expects(self::once())
             ->method('search')
             ->with(self::isInstanceOf(SearchRequest::class))
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
+            ->willReturnCallback($this->sliceAware($entry1, $entry2));
 
         $result = $this->drive(
             $this->subject,
@@ -159,7 +162,7 @@ class ServerPagingHandlerTest extends TestCase
         $this->mockBackend
             ->expects(self::once())
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
+            ->willReturnCallback($this->sliceAware($entry1, $entry2));
 
         $this->drive(
             $this->subject,
@@ -174,7 +177,7 @@ class ServerPagingHandlerTest extends TestCase
         self::assertNotSame('', $this->donePagingControl()->getCookie());
     }
 
-    public function test_it_should_continue_from_the_stored_generator_on_subsequent_pages(): void
+    public function test_it_should_continue_from_the_stored_cursor_on_subsequent_pages(): void
     {
         // First page: size=1 with 2 entries in the backend.
         $firstMessage = $this->makeSearchMessage(size: 1);
@@ -182,10 +185,11 @@ class ServerPagingHandlerTest extends TestCase
         $entry1 = Entry::create('dc=foo,dc=bar', ['cn' => 'foo']);
         $entry2 = Entry::create('dc=bar,dc=foo', ['cn' => 'bar']);
 
+        // One search per page, since a page resumes from a position rather than from a result left open.
         $this->mockBackend
-            ->expects(self::once())
+            ->expects(self::exactly(2))
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
+            ->willReturnCallback($this->sliceAware($entry1, $entry2));
 
         $this->drive($this->subject, $firstMessage);
 
@@ -346,7 +350,7 @@ class ServerPagingHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2, $entry3)));
+            ->willReturnCallback($this->sliceAware($entry1, $entry2, $entry3));
 
         $subject = new ServerPagingHandler(
             backend: $this->mockBackend,
@@ -402,7 +406,7 @@ class ServerPagingHandlerTest extends TestCase
         $this->mockBackend
             ->expects(self::once())
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
+            ->willReturnCallback($this->sliceAware($entry1, $entry2));
 
         $this->drive($this->subject, $message);
 
@@ -429,11 +433,11 @@ class ServerPagingHandlerTest extends TestCase
         $entry4 = Entry::create('cn=4,dc=foo,dc=bar', ['cn' => '4']);
 
         $this->mockBackend
-            ->expects(self::once())
+            ->expects(self::exactly(2))
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2, $entry3, $entry4)));
+            ->willReturnCallback($this->sliceAware($entry1, $entry2, $entry3, $entry4));
 
-        // First page: pageSize=1, sizeLimit=2 — gets entry1, stores generator
+        // First page: pageSize=1, sizeLimit=2 — gets entry1, stores the cursor
         $this->drive(
             $this->subject,
             $this->makeSearchMessage(size: 1, searchRequest: $searchRequest),
@@ -442,7 +446,7 @@ class ServerPagingHandlerTest extends TestCase
         $capturedCookie = $this->donePagingControl()->getCookie();
         self::assertNotSame('', $capturedCookie, 'Expected a non-empty cookie after the first page.');
 
-        // Second page: pageSize=10, sizeLimit=2 — gets entry2+entry3 (hits limit), entry4 still in generator → SIZE_LIMIT_EXCEEDED
+        // Second page: pageSize=10, sizeLimit=2 — gets entry2+entry3 (hits limit), entry4 unread → SIZE_LIMIT_EXCEEDED
         $pagingReq = $this->requestHistory->pagingRequest()->findByNextCookie($capturedCookie);
         $this->drive(
             $this->subject,
@@ -474,7 +478,7 @@ class ServerPagingHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
+            ->willReturnCallback($this->sliceAware($entry1, $entry2));
 
         $subject = new ServerPagingHandler(
             backend: $this->mockBackend,
@@ -500,10 +504,10 @@ class ServerPagingHandlerTest extends TestCase
     {
         $this->mockBackend
             ->method('search')
-            ->willReturnCallback(fn(): EntryStream => new EntryStream($this->makeGenerator(
+            ->willReturnCallback($this->sliceAware(
                 Entry::create('cn=1,dc=foo,dc=bar', ['cn' => '1']),
                 Entry::create('cn=2,dc=foo,dc=bar', ['cn' => '2']),
-            )));
+            ));
 
         $subject = new ServerPagingHandler(
             backend: $this->mockBackend,
@@ -525,8 +529,8 @@ class ServerPagingHandlerTest extends TestCase
             $this->requestHistory->pagingRequest()->count(),
         );
         self::assertNull(
-            $this->requestHistory->getPagingGenerator($firstCookie),
-            'The evicted session must not keep its generator alive.',
+            $this->requestHistory->getPagingCursor($firstCookie),
+            'The evicted session must not keep a resume point.',
         );
         self::assertFalse(
             $this->requestHistory->pagingRequest()->has($firstCookie),
@@ -538,9 +542,9 @@ class ServerPagingHandlerTest extends TestCase
     {
         $this->mockBackend
             ->method('search')
-            ->willReturnCallback(fn(): EntryStream => new EntryStream($this->makeGenerator(
+            ->willReturnCallback($this->sliceAware(
                 Entry::create('cn=1,dc=foo,dc=bar', ['cn' => '1']),
-            )));
+            ));
 
         $subject = new ServerPagingHandler(
             backend: $this->mockBackend,
@@ -567,10 +571,10 @@ class ServerPagingHandlerTest extends TestCase
     {
         $this->mockBackend
             ->method('search')
-            ->willReturnCallback(fn(): EntryStream => new EntryStream($this->makeGenerator(
+            ->willReturnCallback($this->sliceAware(
                 Entry::create('cn=1,dc=foo,dc=bar', ['cn' => '1']),
                 Entry::create('cn=2,dc=foo,dc=bar', ['cn' => '2']),
-            )));
+            ));
 
         $subject = new ServerPagingHandler(
             backend: $this->mockBackend,
@@ -591,17 +595,17 @@ class ServerPagingHandlerTest extends TestCase
             0,
             $this->requestHistory->pagingRequest()->count(),
         );
-        self::assertNull($this->requestHistory->getPagingGenerator($cookie));
+        self::assertNull($this->requestHistory->getPagingCursor($cookie));
     }
 
     public function test_sessions_are_not_evicted_when_no_limit_is_set(): void
     {
         $this->mockBackend
             ->method('search')
-            ->willReturnCallback(fn(): EntryStream => new EntryStream($this->makeGenerator(
+            ->willReturnCallback($this->sliceAware(
                 Entry::create('cn=1,dc=foo,dc=bar', ['cn' => '1']),
                 Entry::create('cn=2,dc=foo,dc=bar', ['cn' => '2']),
-            )));
+            ));
 
         $subject = new ServerPagingHandler(
             backend: $this->mockBackend,
@@ -631,7 +635,7 @@ class ServerPagingHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
+            ->willReturnCallback($this->sliceAware($entry1, $entry2));
 
         $subject = new ServerPagingHandler(
             backend: $this->mockBackend,
@@ -663,7 +667,7 @@ class ServerPagingHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2, $entry3)));
+            ->willReturnCallback($this->sliceAware($entry1, $entry2, $entry3));
 
         $subject = new ServerPagingHandler(
             backend: $this->mockBackend,
@@ -690,7 +694,7 @@ class ServerPagingHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
+            ->willReturnCallback($this->sliceAware($entry1, $entry2));
 
         $subject = new ServerPagingHandler(
             backend: $this->mockBackend,
@@ -731,10 +735,10 @@ class ServerPagingHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator(
+            ->willReturnCallback($this->sliceAware(
                 $entry1,
                 $entry2,
-            )));
+            ));
 
         $subject = new ServerPagingHandler(
             backend: $this->mockBackend,
@@ -775,7 +779,7 @@ class ServerPagingHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry)));
+            ->willReturnCallback($this->sliceAware($entry));
 
         $subject = new ServerPagingHandler(
             backend: $this->mockBackend,
@@ -800,7 +804,7 @@ class ServerPagingHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator()));
+            ->willReturnCallback($this->sliceAware());
 
         $this->drive(
             $this->subject,
@@ -829,7 +833,7 @@ class ServerPagingHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator()));
+            ->willReturnCallback($this->sliceAware());
 
         $this->drive(
             $this->subject,
@@ -931,9 +935,9 @@ class ServerPagingHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator(
+            ->willReturnCallback($this->sliceAware(
                 Entry::create('dc=foo,dc=bar', ['cn' => 'foo']),
-            )));
+            ));
 
         $this->drive(
             $this->subject,
@@ -961,7 +965,7 @@ class ServerPagingHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator()));
+            ->willReturnCallback($this->sliceAware());
 
         $this->drive(
             $this->subject,
@@ -1073,9 +1077,59 @@ class ServerPagingHandlerTest extends TestCase
         );
     }
 
-    private function makeGenerator(Entry ...$entries): Generator
+    /**
+     * A search that honours the slice the way real storage does, keying entries by their position.
+     *
+     * @return callable(mixed...): EntryStream
+     */
+    private function sliceAware(Entry ...$entries): callable
     {
-        yield from $entries;
+        return fn(mixed ...$args): EntryStream => new EntryStream($this->sliceOf(
+            array_values($entries),
+            array_values(array_filter(
+                $args,
+                static fn(mixed $arg): bool => $arg instanceof PageSlice,
+            ))[0] ?? null,
+        ));
+    }
+
+    /**
+     * @param list<Entry> $entries
+     * @return Generator<int, Entry, mixed, FetchedBatch>
+     */
+    private function sliceOf(
+        array $entries,
+        ?PageSlice $slice,
+    ): Generator {
+        $after = $slice?->after->position ?? 0;
+        $cursor = $slice?->after;
+        $taken = 0;
+        $hasMore = false;
+
+        foreach ($entries as $index => $entry) {
+            $key = $index + 1;
+
+            if ($key <= $after) {
+                continue;
+            }
+
+            if ($slice !== null && $taken >= $slice->limit) {
+                $hasMore = true;
+
+                break;
+            }
+
+            $taken++;
+            $cursor = PageCursor::afterEntry($key);
+
+            yield $entry;
+        }
+
+        return new FetchedBatch(
+            $taken,
+            $cursor,
+            $hasMore,
+        );
     }
 
     /**
@@ -1125,7 +1179,7 @@ class ServerPagingHandlerTest extends TestCase
 
         $pagingReq->markProcessed();
         $this->requestHistory->pagingRequest()->add($pagingReq);
-        $this->requestHistory->storePagingGenerator($nextCookie, $this->makeGenerator());
+        $this->requestHistory->storePagingCursor($nextCookie, PageCursor::afterEntry(0));
 
         return $pagingReq;
     }

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSyncHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSyncHandlerTest.php
@@ -37,6 +37,7 @@ use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
+use FreeDSx\Ldap\Server\Backend\Storage\FetchedBatch;
 use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
@@ -606,11 +607,15 @@ final class ServerSyncHandlerTest extends TestCase
     }
 
     /**
-     * @return Generator<Entry>
+     * @return Generator<int, Entry, mixed, ?FetchedBatch>
      */
     private function stream(Entry ...$entries): Generator
     {
-        yield from $entries;
+        foreach ($entries as $entry) {
+            yield $entry;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/unit/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilderTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Pdo/PdoListQueryBuilderTest.php
@@ -17,20 +17,22 @@ use FreeDSx\Ldap\Control\Sorting\SortKey;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\MysqlDialect;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SortKeySpec;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SqliteDialect;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query\ListQuerySpec;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Query\PdoListQueryBuilder;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterResult;
 use PHPUnit\Framework\TestCase;
 
 final class PdoListQueryBuilderTest extends TestCase
 {
-    public function test_no_sort_keys_appends_no_order_by(): void
+    public function test_no_sort_keys_orders_by_the_entry_key(): void
     {
         [$sql, $params] = $this->rootQuery(
             new PdoListQueryBuilder(new SqliteDialect()),
             null,
         );
 
-        self::assertStringNotContainsString('ORDER BY', $sql);
+        // A walk resumes by seeking on this key, so the order it seeks in has to be the order it reads in.
+        self::assertStringEndsWith('ORDER BY entry_id', $sql);
         self::assertSame([], $params);
     }
 
@@ -49,13 +51,9 @@ final class PdoListQueryBuilderTest extends TestCase
 
     public function test_sqlite_orders_a_numeric_key_as_a_number(): void
     {
-        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(
-            '',
-            true,
-            null,
-            null,
-            [self::spec(SortKey::ascending('uidNumber'), numeric: true)],
-        );
+        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(self::querySpec(
+            sortKeys: [self::spec(SortKey::ascending('uidNumber'), numeric: true)],
+        ));
 
         self::assertStringContainsString(
             'MIN(CAST(eav.value_lower AS INTEGER))',
@@ -65,13 +63,9 @@ final class PdoListQueryBuilderTest extends TestCase
 
     public function test_mysql_orders_a_numeric_key_as_a_number(): void
     {
-        $query = (new PdoListQueryBuilder(new MysqlDialect()))->build(
-            '',
-            true,
-            null,
-            null,
-            [self::spec(SortKey::ascending('uidNumber'), numeric: true)],
-        );
+        $query = (new PdoListQueryBuilder(new MysqlDialect()))->build(self::querySpec(
+            sortKeys: [self::spec(SortKey::ascending('uidNumber'), numeric: true)],
+        ));
 
         self::assertStringContainsString(
             'MIN(CAST(eav.value_lower AS SIGNED))',
@@ -167,13 +161,11 @@ final class PdoListQueryBuilderTest extends TestCase
 
     public function test_streaming_subtree_pushes_limit_and_scope_into_the_sidecar_subquery(): void
     {
-        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(
-            'ou=people,dc=foo,dc=bar',
-            true,
-            $this->sidecarLeaf(),
-            500,
-            [],
-        );
+        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(self::querySpec(
+            base: 'ou=people,dc=foo,dc=bar',
+            filter: $this->sidecarLeaf(),
+            limit: 500,
+        ));
 
         self::assertStringContainsString(
             'SELECT DISTINCT s.owner_entry_id AS d',
@@ -191,8 +183,9 @@ final class PdoListQueryBuilderTest extends TestCase
             'LIMIT ?',
             $query->sql,
         );
-        self::assertStringNotContainsString(
-            'ORDER BY',
+        // Ordered inside the candidate select too, so the limit there is spent in the same order the walk resumes in.
+        self::assertStringContainsString(
+            'ORDER BY s.owner_entry_id',
             $query->sql,
         );
         self::assertSame(
@@ -203,13 +196,10 @@ final class PdoListQueryBuilderTest extends TestCase
 
     public function test_streaming_root_query_omits_the_subtree_scope(): void
     {
-        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(
-            '',
-            true,
-            $this->sidecarLeaf(),
-            500,
-            [],
-        );
+        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(self::querySpec(
+            filter: $this->sidecarLeaf(),
+            limit: 500,
+        ));
 
         self::assertStringContainsString(
             'IN (SELECT t.d FROM (',
@@ -227,13 +217,11 @@ final class PdoListQueryBuilderTest extends TestCase
 
     public function test_mysql_produces_the_same_streaming_shape(): void
     {
-        $query = (new PdoListQueryBuilder(new MysqlDialect()))->build(
-            'ou=people,dc=foo,dc=bar',
-            true,
-            $this->sidecarLeaf(),
-            500,
-            [],
-        );
+        $query = (new PdoListQueryBuilder(new MysqlDialect()))->build(self::querySpec(
+            base: 'ou=people,dc=foo,dc=bar',
+            filter: $this->sidecarLeaf(),
+            limit: 500,
+        ));
 
         self::assertStringContainsString(
             'SELECT DISTINCT s.owner_entry_id AS d',
@@ -247,13 +235,12 @@ final class PdoListQueryBuilderTest extends TestCase
 
     public function test_sort_keys_disable_the_streaming_fast_path(): void
     {
-        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(
-            'ou=people,dc=foo,dc=bar',
-            true,
-            $this->sidecarLeaf(),
-            500,
-            [self::spec(SortKey::ascending('cn'))],
-        );
+        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(self::querySpec(
+            base: 'ou=people,dc=foo,dc=bar',
+            filter: $this->sidecarLeaf(),
+            limit: 500,
+            sortKeys: [self::spec(SortKey::ascending('cn'))],
+        ));
 
         self::assertStringNotContainsString(
             'SELECT t.d FROM (',
@@ -267,13 +254,10 @@ final class PdoListQueryBuilderTest extends TestCase
 
     public function test_null_limit_disables_the_streaming_fast_path(): void
     {
-        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(
-            'ou=people,dc=foo,dc=bar',
-            true,
-            $this->sidecarLeaf(),
-            null,
-            [],
-        );
+        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(self::querySpec(
+            base: 'ou=people,dc=foo,dc=bar',
+            filter: $this->sidecarLeaf(),
+        ));
 
         self::assertStringNotContainsString(
             'SELECT t.d FROM (',
@@ -283,13 +267,11 @@ final class PdoListQueryBuilderTest extends TestCase
 
     public function test_absent_sidecar_condition_disables_the_streaming_fast_path(): void
     {
-        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(
-            'ou=people,dc=foo,dc=bar',
-            true,
-            new SqlFilterResult('(a) AND (b)', ['x', 'y']),
-            500,
-            [],
-        );
+        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(self::querySpec(
+            base: 'ou=people,dc=foo,dc=bar',
+            filter: new SqlFilterResult('(a) AND (b)', ['x', 'y']),
+            limit: 500,
+        ));
 
         self::assertStringNotContainsString(
             'SELECT t.d FROM (',
@@ -307,13 +289,12 @@ final class PdoListQueryBuilderTest extends TestCase
 
     public function test_child_scope_disables_the_streaming_fast_path(): void
     {
-        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(
-            'ou=people,dc=foo,dc=bar',
-            false,
-            $this->sidecarLeaf(),
-            500,
-            [],
-        );
+        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(self::querySpec(
+            base: 'ou=people,dc=foo,dc=bar',
+            subtree: false,
+            filter: $this->sidecarLeaf(),
+            limit: 500,
+        ));
 
         self::assertStringNotContainsString(
             'SELECT t.d FROM (',
@@ -323,13 +304,12 @@ final class PdoListQueryBuilderTest extends TestCase
 
     public function test_child_scope_uses_the_correlated_exists_form(): void
     {
-        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(
-            'ou=people,dc=foo,dc=bar',
-            false,
-            $this->sidecarLeaf(),
-            5001,
-            [],
-        );
+        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(self::querySpec(
+            base: 'ou=people,dc=foo,dc=bar',
+            subtree: false,
+            filter: $this->sidecarLeaf(),
+            limit: 5001,
+        ));
 
         self::assertStringContainsString(
             'lc_parent_dn = ?',
@@ -352,16 +332,15 @@ final class PdoListQueryBuilderTest extends TestCase
 
     public function test_child_scope_falls_back_to_the_in_form_without_a_correlated_form(): void
     {
-        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(
-            'ou=people,dc=foo,dc=bar',
-            false,
-            new SqlFilterResult(
+        $query = (new PdoListQueryBuilder(new SqliteDialect()))->build(self::querySpec(
+            base: 'ou=people,dc=foo,dc=bar',
+            subtree: false,
+            filter: new SqlFilterResult(
                 "entry_id IN (SELECT s.owner_entry_id FROM entry_attribute_values s WHERE s.attr_name_lower = 'cn')",
                 [],
             ),
-            5001,
-            [],
-        );
+            limit: 5001,
+        ));
 
         self::assertStringContainsString(
             'entry_id IN (',
@@ -390,18 +369,34 @@ final class PdoListQueryBuilderTest extends TestCase
         ?SqlFilterResult $filter,
         SortKey ...$sortKeys,
     ): array {
-        $query = $builder->build(
-            '',
-            true,
-            $filter,
-            null,
-            array_values(array_map(
+        $query = $builder->build(self::querySpec(
+            filter: $filter,
+            sortKeys: array_values(array_map(
                 self::spec(...),
                 $sortKeys,
             )),
-        );
+        ));
 
         return [$query->sql, $query->params];
+    }
+
+    /**
+     * @param list<SortKeySpec> $sortKeys
+     */
+    private static function querySpec(
+        string $base = '',
+        bool $subtree = true,
+        ?SqlFilterResult $filter = null,
+        ?int $limit = null,
+        array $sortKeys = [],
+    ): ListQuerySpec {
+        return new ListQuerySpec(
+            base: $base,
+            subtree: $subtree,
+            filter: $filter,
+            limit: $limit,
+            sortKeys: $sortKeys,
+        );
     }
 
     private static function spec(

--- a/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
@@ -986,7 +986,7 @@ final class PdoStorageTest extends TestCase
         );
     }
 
-    public function test_search_exact_filter_bounds_transfer_at_lookthrough(): void
+    public function test_search_exact_filter_returns_every_match_past_the_transfer_bound(): void
     {
         $storage = $this->pdoStorage(TestServerOptions::sqlite());
         $backend = $this->backendFor(
@@ -1013,8 +1013,9 @@ final class PdoStorageTest extends TestCase
             ->base('dc=example,dc=com')
             ->useSubtreeScope();
 
+        // The bound is on how much one statement transfers, not on the answer, so the walk continues past it.
         self::assertCount(
-            3,
+            5,
             iterator_to_array($backend->search(
                 $request,
                 SubentryVisibility::All,

--- a/tests/unit/Server/Backend/Storage/Adapter/Support/TestSynchronousWriterQueue.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/Support/TestSynchronousWriterQueue.php
@@ -28,4 +28,9 @@ final class TestSynchronousWriterQueue implements WriterQueueInterface
         $this->ranCount++;
         $job();
     }
+
+    /**
+     * Nothing is kept between jobs here, so there is nothing to release.
+     */
+    public function drain(): void {}
 }

--- a/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WritableStorageBackendTest.php
@@ -27,6 +27,7 @@ use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
+use FreeDSx\Ldap\Server\Backend\Storage\FetchedBatch;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalConfig;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeRecord;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
@@ -2135,11 +2136,12 @@ final class WritableStorageBackendTest extends TestCase
     }
 
     /**
-     * @return Generator<Entry>
+     * @return Generator<int, Entry, mixed, ?FetchedBatch>
      */
     private function makeTimeLimitStream(): Generator
     {
         yield new Entry(new Dn('dc=example,dc=com'));
+
         throw new TimeLimitExceededException();
     }
 
@@ -2154,11 +2156,15 @@ final class WritableStorageBackendTest extends TestCase
     }
 
     /**
-     * @return Generator<Entry>
+     * @return Generator<int, Entry, mixed, ?FetchedBatch>
      */
     private function makeGenerator(Entry ...$entries): Generator
     {
-        yield from $entries;
+        foreach ($entries as $entry) {
+            yield $entry;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/unit/Server/Backend/Storage/Adapter/WriteSerializingStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WriteSerializingStorageTest.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Writer\WriteSerializingStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
+use Generator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -107,8 +108,10 @@ final class WriteSerializingStorageTest extends TestCase
             subtree: true,
         );
         $stream = new EntryStream(
-            (function () {
+            (function (): Generator {
                 yield from [];
+
+                return null;
             })(),
         );
 

--- a/tests/unit/Server/Backend/Storage/Export/DirectoryDumperTest.php
+++ b/tests/unit/Server/Backend/Storage/Export/DirectoryDumperTest.php
@@ -27,6 +27,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Export\DirectoryDumper;
 use FreeDSx\Ldap\Server\Backend\Storage\Export\DumpOptions;
 use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
+use Generator;
 use PHPUnit\Framework\TestCase;
 use Tests\Support\FreeDSx\Ldap\ServerContainerTrait;
 
@@ -127,9 +128,11 @@ final class DirectoryDumperTest extends TestCase
         );
         $storage = $this->createMock(EntryStorageInterface::class);
         $storage->method('list')->willReturn(new EntryStream(
-            entries: (function () use ($alice, $bob): iterable {
+            entries: (function () use ($alice, $bob): Generator {
                 yield $alice;
                 yield $bob;
+
+                return null;
             })(),
             isPreFiltered: false,
         ));
@@ -165,8 +168,10 @@ final class DirectoryDumperTest extends TestCase
         $alice = Entry::create('cn=alice,dc=foo,dc=bar', ['cn' => 'alice']);
         $storage = $this->createMock(EntryStorageInterface::class);
         $storage->method('list')->willReturn(new EntryStream(
-            entries: (function () use ($alice): iterable {
+            entries: (function () use ($alice): Generator {
                 yield $alice;
+
+                return null;
             })(),
             isPreFiltered: true,
         ));
@@ -195,8 +200,10 @@ final class DirectoryDumperTest extends TestCase
                     => $opts->subtree === true && $opts->baseDn->toString() === 'dc=foo,dc=bar',
             ))
             ->willReturn(new EntryStream(
-                entries: (function (): iterable {
+                entries: (function (): Generator {
                     yield from [];
+
+                    return null;
                 })(),
             ));
 

--- a/tests/unit/Server/Config/Storage/PdoConfigTest.php
+++ b/tests/unit/Server/Config/Storage/PdoConfigTest.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Server\Config\Storage\PdoDriver;
 use FreeDSx\Ldap\Server\Config\Storage\StorageType;
 use FreeDSx\Ldap\Server\Config\Storage\SubstringIndexMode;
 use PDO;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class PdoConfigTest extends TestCase
@@ -143,5 +144,38 @@ final class PdoConfigTest extends TestCase
             SubstringIndexMode::None,
             $config->getSubstringIndexMode(),
         );
+    }
+
+    public function test_a_file_backed_sqlite_database_is_multi_process_safe(): void
+    {
+        self::assertTrue(PdoConfig::forSqlite('/var/lib/ldap.sqlite')->isMultiProcessSafe());
+    }
+
+    public function test_mysql_is_multi_process_safe(): void
+    {
+        self::assertTrue(
+            PdoConfig::forMysql(
+                'mysql:host=localhost;dbname=ldap',
+                'user',
+                'secret',
+            )->isMultiProcessSafe(),
+        );
+    }
+
+    #[DataProvider('inMemorySqliteDsnProvider')]
+    public function test_an_in_memory_sqlite_database_is_not_multi_process_safe(string $path): void
+    {
+        self::assertFalse(PdoConfig::forSqlite($path)->isMultiProcessSafe());
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function inMemorySqliteDsnProvider(): iterable
+    {
+        yield 'the bare in-memory path' => [':memory:'];
+        yield 'mixed case, since a DSN is not case sensitive here' => [':MEMORY:'];
+        yield 'a shared cache URI' => ['file:ldap?mode=memory&cache=shared'];
+        yield 'mixed case on the URI parameter' => ['file:ldap?mode=MEMORY'];
     }
 }

--- a/tests/unit/Server/PasswordPolicy/PasswordPolicyResolverTest.php
+++ b/tests/unit/Server/PasswordPolicy/PasswordPolicyResolverTest.php
@@ -295,6 +295,8 @@ final class PasswordPolicyResolverTest extends TestCase
         $backend->method('search')
             ->willReturn(new EntryStream((static function () use ($subentry): Generator {
                 yield $subentry;
+
+                return null;
             })()));
 
         return new GoverningSubentryResolver(


### PR DESCRIPTION
This reworks paging / sorted paging and searches to anchor to the entry_id. This makes fixing the current look through issues possible while also always maintaining a PDO limit on results. It also lets us to remove the stored generator situation for paged searches, which was actually problematic under swoole. It's not quite a stateless design, so it's still connection specific. But it's better than it was. Tested performance before / after the change and nothing was impacted by this. This also seems to have given sorted searches a small performance boost.

Additionally, added coverage for pdo + swoole as a backend, so it has the same coverage as the other runners + storage combos now. That hopefully prevents future regressions with it. 