### PR TITLE
[1.0.0] Support SyncIdSet and batching in the replica.

### DIFF
--- a/src/FreeDSx/Ldap/Control/Sync/SyncStateControl.php
+++ b/src/FreeDSx/Ldap/Control/Sync/SyncStateControl.php
@@ -20,11 +20,9 @@ use FreeDSx\Asn1\Type\OctetStringType;
 use FreeDSx\Asn1\Type\SequenceType;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Exception\ProtocolException;
+use FreeDSx\Ldap\Server\Utility\Uuid;
 
-use function bin2hex;
 use function count;
-use function implode;
-use function substr;
 
 /**
  * Represents a syncStateValue control. RFC 4533.
@@ -86,19 +84,7 @@ class SyncStateControl extends Control
      */
     public function decodedUuid(): string
     {
-        if ($this->decodedUuid === null) {
-            $hex = bin2hex($this->entryUuid);
-
-            $this->decodedUuid = implode('-', [
-                substr($hex, 0, 8),
-                substr($hex, 8, 4),
-                substr($hex, 12, 4),
-                substr($hex, 16, 4),
-                substr($hex, 20),
-            ]);
-        }
-
-        return $this->decodedUuid;
+        return $this->decodedUuid ??= Uuid::fromBinary($this->entryUuid);
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSyncHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSyncHandler.php
@@ -21,6 +21,7 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
+use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\Response\SyncInfo\SyncRefreshDelete;
 use FreeDSx\Ldap\Operation\Response\SyncInfo\SyncRefreshPresent;
 use FreeDSx\Ldap\Operation\Response\SyncInfoMessage;
@@ -40,6 +41,7 @@ use FreeDSx\Ldap\Sync\Provider\Exception\MalformedSyncCookieException;
 use FreeDSx\Ldap\Sync\Provider\SyncCookie;
 use FreeDSx\Ldap\Sync\Provider\SyncPersistStreamer;
 use FreeDSx\Ldap\Sync\Provider\SyncResult;
+use FreeDSx\Ldap\Sync\Provider\SyncResultBatcher;
 use FreeDSx\Ldap\Sync\Provider\SyncResultProjector;
 use Generator;
 
@@ -67,6 +69,7 @@ final class ServerSyncHandler implements ServerProtocolHandlerInterface
         private readonly ?ChangeStream $changeStream = null,
         private readonly ?SyncPersistStreamer $persistStreamer = null,
         private readonly bool $persistSupported = false,
+        private readonly SyncResultBatcher $batcher = new SyncResultBatcher(),
     ) {}
 
     /**
@@ -293,9 +296,20 @@ final class ServerSyncHandler implements ServerProtocolHandlerInterface
         int $sinceSeq,
         SearchResultState $state,
     ): Generator {
-        foreach ($streamer->projectSince($sinceSeq, $request, $token) as $result) {
+        $results = $streamer->projectSince(
+            $sinceSeq,
+            $request,
+            $token,
+        );
+
+        $responses = $this->batcher->batch(
+            $results,
+            $message->getMessageId(),
+        );
+
+        foreach ($responses as $response) {
             yield from $this->emit(
-                $this->toResponse($message->getMessageId(), $result),
+                $response,
                 $state,
             );
         }
@@ -327,7 +341,10 @@ final class ServerSyncHandler implements ServerProtocolHandlerInterface
             return;
         }
 
-        $state->entriesReturned++;
+        // A coalesced delete set is an intermediate response, so it is not one of the entries the result reports.
+        if ($response->getResponse() instanceof SearchResultEntry) {
+            $state->entriesReturned++;
+        }
 
         yield $response;
     }

--- a/src/FreeDSx/Ldap/Server/Utility/Uuid.php
+++ b/src/FreeDSx/Ldap/Server/Utility/Uuid.php
@@ -19,11 +19,13 @@ use function bin2hex;
 use function chr;
 use function ctype_xdigit;
 use function hex2bin;
+use function implode;
 use function ord;
 use function random_bytes;
 use function str_replace;
 use function str_split;
 use function strlen;
+use function substr;
 use function vsprintf;
 
 /**
@@ -53,6 +55,22 @@ final class Uuid
                 4,
             ),
         );
+    }
+
+    /**
+     * The dashed string form of a binary UUID, as RFC 4533 sync messages carry it on the wire.
+     */
+    public static function fromBinary(string $bytes): string
+    {
+        $hex = bin2hex($bytes);
+
+        return implode('-', [
+            substr($hex, 0, 8),
+            substr($hex, 8, 4),
+            substr($hex, 12, 4),
+            substr($hex, 16, 4),
+            substr($hex, 20),
+        ]);
     }
 
     /**

--- a/src/FreeDSx/Ldap/Sync/Consumer/ChangeApplierInterface.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/ChangeApplierInterface.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Sync\Consumer;
 
+use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Result\SyncIdSetResult;
 use FreeDSx\Ldap\Sync\Session;
 
 /**
@@ -38,6 +40,16 @@ interface ChangeApplierInterface
         SyncEntryResult $result,
         Session $session,
     ): void;
+
+    /**
+     * Apply one bulk UUID set: a delete set removes each entry, a present set marks them seen for reconciliation.
+     *
+     * @return list<Dn> the DNs the set removed, which only a UUID lookup against storage can resolve
+     */
+    public function applyIdSet(
+        SyncIdSetResult $result,
+        Session $session,
+    ): array;
 
     /**
      * Delete local entries not seen during a present-phase refresh (reconcile by absence).

--- a/src/FreeDSx/Ldap/Sync/Consumer/LdapReplica.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/LdapReplica.php
@@ -26,6 +26,7 @@ use FreeDSx\Ldap\Server\Process\Signals\ShutdownSignalsInterface;
 use FreeDSx\Ldap\Server\Process\Signals\SwooleShutdownSignals;
 use FreeDSx\Ldap\Sync\Consumer\Checkpoint\ReplicationCheckpointInterface;
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Result\SyncIdSetResult;
 use FreeDSx\Ldap\Sync\Session;
 use FreeDSx\Ldap\Sync\SyncRepl;
 use Psr\Log\LoggerInterface;
@@ -172,6 +173,7 @@ final class LdapReplica
         $syncRepl
             ->useCookie($this->checkpoint->read())
             ->useCookieHandler($this->persistCookie(...))
+            ->useIdSetHandler($this->applyIdSet(...))
             ->useRefreshDoneHandler($this->reconcileRefresh(...));
 
         $this->activeSync = $syncRepl;
@@ -193,6 +195,20 @@ final class LdapReplica
         }
 
         $this->applier->apply(
+            $result,
+            $session,
+        );
+    }
+
+    private function applyIdSet(
+        SyncIdSetResult $result,
+        Session $session,
+    ): void {
+        if ($this->stopping) {
+            throw new CancelRequestException();
+        }
+
+        $this->applier->applyIdSet(
             $result,
             $session,
         );

--- a/src/FreeDSx/Ldap/Sync/Consumer/ReconcilingChangeApplier.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/ReconcilingChangeApplier.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Sync\Consumer;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Result\SyncIdSetResult;
 use FreeDSx\Ldap\Sync\Session;
 
 /**
@@ -67,6 +68,22 @@ readonly class ReconcilingChangeApplier implements ChangeApplierInterface
             $dn,
             UserPasswordState::fromEntry($result->getEntry()),
         );
+    }
+
+    public function applyIdSet(
+        SyncIdSetResult $result,
+        Session $session,
+    ): array {
+        $removed = $this->baseApplier->applyIdSet(
+            $result,
+            $session,
+        );
+
+        foreach ($removed as $dn) {
+            $this->passwordStateStore->discard($dn);
+        }
+
+        return $removed;
     }
 
     public function reconcile(): void

--- a/src/FreeDSx/Ldap/Sync/Consumer/VerbatimStorageApplier.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/VerbatimStorageApplier.php
@@ -20,7 +20,10 @@ use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Result\SyncIdSetResult;
 use FreeDSx\Ldap\Sync\Session;
+
+use function strtolower;
 
 /**
  * Applies sync results verbatim to a local replica's raw storage, reconciling deletes by absence.
@@ -37,11 +40,17 @@ final class VerbatimStorageApplier implements ChangeApplierInterface
      */
     private array $presentDns = [];
 
+    /**
+     * @var array<string, true> Lower-cased UUIDs announced present in bulk during the current refresh phase.
+     */
+    private array $presentUuids = [];
+
     public function __construct(private readonly EntryStorageInterface $storage) {}
 
     public function beginRefresh(): void
     {
         $this->presentDns = [];
+        $this->presentUuids = [];
     }
 
     public function apply(
@@ -78,6 +87,28 @@ final class VerbatimStorageApplier implements ChangeApplierInterface
         $this->storage->store($this->identified($entry, $uuid));
     }
 
+    public function applyIdSet(
+        SyncIdSetResult $result,
+        Session $session,
+    ): array {
+        $uuids = $result->getDecodedEntryUuids();
+
+        if ($result->isDeleted()) {
+            return $this->removeByUuids($uuids);
+        }
+
+        // A present set only feeds the sweep, so it is worthless once the refresh that would run it is over.
+        if ($session->isRefreshComplete()) {
+            return [];
+        }
+
+        foreach ($uuids as $uuid) {
+            $this->presentUuids[strtolower($uuid)] = true;
+        }
+
+        return [];
+    }
+
     public function reconcile(): void
     {
         $options = StorageListOptions::matchAll(
@@ -90,7 +121,7 @@ final class VerbatimStorageApplier implements ChangeApplierInterface
             $dn = $entry->getDn()
                 ->normalize();
 
-            if (!isset($this->presentDns[$dn->toString()])) {
+            if (!$this->wasAnnouncedPresent($entry, $dn)) {
                 $stale[] = $dn;
             }
         }
@@ -100,6 +131,49 @@ final class VerbatimStorageApplier implements ChangeApplierInterface
         }
 
         $this->presentDns = [];
+        $this->presentUuids = [];
+    }
+
+    /**
+     * @param string[] $uuids
+     * @return list<Dn>
+     */
+    private function removeByUuids(array $uuids): array
+    {
+        $removed = [];
+
+        // Every DN is resolved before any is deleted, so the whole set goes out as one bulk delete.
+        foreach ($uuids as $uuid) {
+            $dn = $this->dnHolding($uuid);
+
+            // The replica never held it, so there is nothing to delete.
+            if ($dn === null) {
+                continue;
+            }
+
+            $removed[] = $dn;
+        }
+
+        $this->storage->removeAll($removed);
+
+        return $removed;
+    }
+
+    /**
+     * Whether the upstream announced this entry as still present, individually by DN or in bulk by UUID.
+     */
+    private function wasAnnouncedPresent(
+        Entry $entry,
+        Dn $dn,
+    ): bool {
+        if (isset($this->presentDns[$dn->toString()])) {
+            return true;
+        }
+
+        $uuid = $entry->get(AttributeTypeOid::NAME_ENTRY_UUID)
+            ?->firstValue();
+
+        return $uuid !== null && isset($this->presentUuids[strtolower($uuid)]);
     }
 
     /**
@@ -116,9 +190,14 @@ final class VerbatimStorageApplier implements ChangeApplierInterface
             ),
         );
 
+        $wanted = strtolower($uuid);
+
         // Storage answers the filter only where it can, so each candidate is checked rather than trusted.
         foreach ($this->storage->list($options)->entries as $entry) {
-            if ($entry->get(AttributeTypeOid::NAME_ENTRY_UUID)?->firstValue() !== $uuid) {
+            $candidate = $entry->get(AttributeTypeOid::NAME_ENTRY_UUID)
+                ?->firstValue();
+
+            if ($candidate === null || strtolower($candidate) !== $wanted) {
                 continue;
             }
 

--- a/src/FreeDSx/Ldap/Sync/Provider/SyncPersistStreamer.php
+++ b/src/FreeDSx/Ldap/Sync/Provider/SyncPersistStreamer.php
@@ -51,6 +51,7 @@ final readonly class SyncPersistStreamer
         private ChangeStream $stream,
         private SleeperInterface $sleeper,
         private float $pollInterval = self::DEFAULT_POLL_INTERVAL,
+        private SyncResultBatcher $batcher = new SyncResultBatcher(),
     ) {}
 
     /**
@@ -164,13 +165,14 @@ final readonly class SyncPersistStreamer
         TokenInterface $token,
         int $messageId,
     ): Generator {
-        foreach ($this->projectSince($sinceSeq, $request, $token) as $result) {
-            yield new LdapMessageResponse(
-                $messageId,
-                $result->entry,
-                $result->control,
-            );
-        }
+        yield from $this->batcher->batch(
+            $this->projectSince(
+                $sinceSeq,
+                $request,
+                $token,
+            ),
+            $messageId,
+        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Sync/Provider/SyncResultBatcher.php
+++ b/src/FreeDSx/Ldap/Sync/Provider/SyncResultBatcher.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Sync\Provider;
+
+use FreeDSx\Ldap\Operation\Response\SyncInfo\SyncIdSet;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use Generator;
+
+use function array_map;
+use function count;
+
+/**
+ * Wraps sync results in their message envelope, coalescing runs of deletes into a syncIdSet per RFC 4533 §3.3.2.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class SyncResultBatcher
+{
+    /**
+     * UUIDs per set before it is flushed, holding a set to roughly 9KB so the RFC's "one or more" bounds the message.
+     */
+    public const MAX_SET_SIZE = 500;
+
+    public function __construct(private int $maxSetSize = self::MAX_SET_SIZE) {}
+
+    /**
+     * @param iterable<SyncResult> $results
+     * @return Generator<LdapMessageResponse>
+     */
+    public function batch(
+        iterable $results,
+        int $messageId,
+    ): Generator {
+        $deletes = [];
+
+        foreach ($results as $result) {
+            if (!$result->control->isDelete()) {
+                yield $this->entry(
+                    $messageId,
+                    $result,
+                );
+
+                continue;
+            }
+            $deletes[] = $result;
+            if (count($deletes) < $this->maxSetSize) {
+                continue;
+            }
+
+            yield $this->idSet(
+                $messageId,
+                $deletes,
+            );
+            $deletes = [];
+        }
+
+        yield from $this->flush(
+            $messageId,
+            $deletes,
+        );
+    }
+
+    /**
+     * @param list<SyncResult> $deletes
+     * @return Generator<LdapMessageResponse>
+     */
+    private function flush(
+        int $messageId,
+        array $deletes,
+    ): Generator {
+        // Only multiple deletes are coalesced
+        if (count($deletes) === 1) {
+            yield $this->entry(
+                $messageId,
+                $deletes[0],
+            );
+
+            return;
+        }
+
+        if ($deletes !== []) {
+            yield $this->idSet(
+                $messageId,
+                $deletes,
+            );
+        }
+    }
+
+    /**
+     * @param list<SyncResult> $deletes
+     */
+    private function idSet(
+        int $messageId,
+        array $deletes,
+    ): LdapMessageResponse {
+        return new LdapMessageResponse(
+            $messageId,
+            new SyncIdSet(
+                array_map(
+                    static fn(SyncResult $result): string => $result->control->getEntryUuid(),
+                    $deletes,
+                ),
+                refreshDeletes: true,
+            ),
+        );
+    }
+
+    private function entry(
+        int $messageId,
+        SyncResult $result,
+    ): LdapMessageResponse {
+        return new LdapMessageResponse(
+            $messageId,
+            $result->entry,
+            $result->control,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Sync/Result/SyncIdSetResult.php
+++ b/src/FreeDSx/Ldap/Sync/Result/SyncIdSetResult.php
@@ -18,9 +18,11 @@ use Countable;
 use FreeDSx\Ldap\Exception\UnexpectedValueException;
 use FreeDSx\Ldap\Operation\Response\SyncInfo\SyncIdSet;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Server\Utility\Uuid;
 use IteratorAggregate;
 use Traversable;
 
+use function array_map;
 use function count;
 
 /**
@@ -66,6 +68,19 @@ class SyncIdSetResult implements Countable, IteratorAggregate
     {
         return $this->getSyncIdSet()
             ->getEntryUuids();
+    }
+
+    /**
+     * The same UUIDs in the dashed form entries carry them in, rather than the 16 bytes the wire does.
+     *
+     * @return string[]
+     */
+    public function getDecodedEntryUuids(): array
+    {
+        return array_map(
+            Uuid::fromBinary(...),
+            $this->getEntryUuids(),
+        );
     }
 
     /**

--- a/tests/integration/Sync/SyncReplPersistTestCase.php
+++ b/tests/integration/Sync/SyncReplPersistTestCase.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\CancelRequestException;
 use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Result\SyncIdSetResult;
 use FreeDSx\Ldap\Sync\Session;
 use FreeDSx\Ldap\Sync\SyncRepl;
 use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
@@ -153,6 +154,57 @@ abstract class SyncReplPersistTestCase extends ServerTestCase
         );
     }
 
+    /**
+     * RFC 4533 §3.4.2 asks for multiple delete entries to be coalesced into a syncIdSet.
+     */
+    public function testPersistCoalescesMultipleDeletionsIntoAnIdSet(): void
+    {
+        $dns = [
+            'cn=idset-one,dc=foo,dc=bar',
+            'cn=idset-two,dc=foo,dc=bar',
+            'cn=idset-three,dc=foo,dc=bar',
+        ];
+        $idSet = null;
+
+        $syncRepl = $this->boundSync();
+        $syncRepl->useIdSetHandler(function (SyncIdSetResult $result) use (&$idSet): void {
+            $idSet = $result;
+
+            throw new CancelRequestException();
+        });
+
+        $this->listenAfterWriting(
+            $syncRepl,
+            static function (LdapClient $w) use ($dns): void {
+                foreach ($dns as $dn) {
+                    $w->create(Entry::fromArray(
+                        $dn,
+                        [
+                            'cn' => explode(',', $dn)[0],
+                            'sn' => 'Doomed',
+                            'objectClass' => 'inetOrgPerson',
+                        ],
+                    ));
+                }
+
+                foreach ($dns as $dn) {
+                    $w->delete($dn);
+                }
+            },
+        );
+
+        self::assertInstanceOf(
+            SyncIdSetResult::class,
+            $idSet,
+            'Several deletions in one journal window are delivered as a single syncIdSet.',
+        );
+        self::assertTrue($idSet->isDeleted());
+        self::assertCount(
+            3,
+            $idSet,
+        );
+    }
+
     public function testListenResumesFromACookieWithAnIncrementalRefresh(): void
     {
         $dn = 'cn=persist-resume,dc=foo,dc=bar';
@@ -215,6 +267,35 @@ abstract class SyncReplPersistTestCase extends ServerTestCase
         );
 
         return $cookie;
+    }
+
+    /**
+     * Applies $write on another connection once the refresh phase begins, then persists until the result cap.
+     */
+    private function listenAfterWriting(
+        SyncRepl $syncRepl,
+        Closure $write,
+    ): void {
+        $wrote = false;
+        $seen = 0;
+
+        $syncRepl->listen(function (SyncEntryResult $entry, Session $session) use (&$wrote, &$seen, $write): void {
+            $refreshing = !$session->isRefreshComplete();
+            if ($refreshing && !$wrote) {
+                $wrote = true;
+                $this->onAnotherConnection($write);
+
+                return;
+            }
+            if ($refreshing) {
+                return;
+            }
+            $seen++;
+
+            if ($seen >= self::MAX_PERSIST_RESULTS) {
+                throw new CancelRequestException();
+            }
+        });
     }
 
     private function onAnotherConnection(Closure $do): void

--- a/tests/integration/Sync/SyncReplReplicaTestCase.php
+++ b/tests/integration/Sync/SyncReplReplicaTestCase.php
@@ -85,6 +85,48 @@ abstract class SyncReplReplicaTestCase extends ServerTestCase
     }
 
     /**
+     * Coalesced deletes name only UUIDs, so the replica has to resolve each one rather than read a DN off the message.
+     */
+    public function test_multiple_deletes_on_the_provider_propagate_as_a_uuid_set(): void
+    {
+        $dns = [
+            'cn=ivan,ou=people,dc=foo,dc=bar',
+            'cn=judy,ou=people,dc=foo,dc=bar',
+            'cn=karl,ou=people,dc=foo,dc=bar',
+        ];
+
+        $this->writeToProvider(static function (LdapClient $provider) use ($dns): void {
+            foreach ($dns as $dn) {
+                $provider->create(Entry::fromArray(
+                    $dn,
+                    [
+                        'objectClass' => 'inetOrgPerson',
+                        'cn' => explode('=', explode(',', $dn)[0])[1],
+                        'sn' => 'Doomed',
+                    ],
+                ));
+            }
+        });
+
+        foreach ($dns as $dn) {
+            self::assertNotNull($this->waitForReplica($dn));
+        }
+
+        $this->writeToProvider(static function (LdapClient $provider) use ($dns): void {
+            foreach ($dns as $dn) {
+                $provider->delete($dn);
+            }
+        });
+
+        foreach ($dns as $dn) {
+            self::assertNull(
+                $this->waitForReplicaGone($dn),
+                'Every entry named by the delete set must be removed from the replica.',
+            );
+        }
+    }
+
+    /**
      * RFC 4533 §3.6 keys entries by entryUUID, so a move must relocate the replica's copy rather than add a second.
      */
     public function test_a_rename_on_the_provider_relocates_rather_than_duplicating(): void

--- a/tests/unit/Server/Utility/UuidTest.php
+++ b/tests/unit/Server/Utility/UuidTest.php
@@ -33,4 +33,22 @@ final class UuidTest extends TestCase
             Uuid::v4(),
         );
     }
+
+    public function test_it_should_decode_the_binary_form_to_the_dashed_form(): void
+    {
+        self::assertSame(
+            '0f8fad5b-d9cb-469f-a165-70867728950e',
+            Uuid::fromBinary(pack('H*', '0f8fad5bd9cb469fa16570867728950e')),
+        );
+    }
+
+    public function test_it_should_round_trip_a_generated_uuid_through_both_forms(): void
+    {
+        $uuid = Uuid::v4();
+
+        self::assertSame(
+            $uuid,
+            Uuid::fromBinary(Uuid::toBinary($uuid)),
+        );
+    }
 }

--- a/tests/unit/Sync/Consumer/LdapReplicaTest.php
+++ b/tests/unit/Sync/Consumer/LdapReplicaTest.php
@@ -24,6 +24,7 @@ use FreeDSx\Ldap\Sync\Consumer\Checkpoint\InMemoryReplicationCheckpoint;
 use FreeDSx\Ldap\Sync\Consumer\LdapReplica;
 use FreeDSx\Ldap\Sync\Consumer\PrimaryConnectionFactory;
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Result\SyncIdSetResult;
 use FreeDSx\Ldap\Sync\Session;
 use FreeDSx\Ldap\Sync\SyncRepl;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -50,6 +51,8 @@ final class LdapReplicaTest extends TestCase
 
     private Closure $cookieHandler;
 
+    private Closure $idSetHandler;
+
     private ?string $usedCookie = null;
 
     protected function setUp(): void
@@ -58,6 +61,7 @@ final class LdapReplicaTest extends TestCase
         $this->shutdown = $noop;
         $this->refreshDoneHandler = $noop;
         $this->cookieHandler = $noop;
+        $this->idSetHandler = $noop;
 
         $this->applier = $this->createMock(ChangeApplierInterface::class);
         $this->checkpoint = new InMemoryReplicationCheckpoint();
@@ -78,6 +82,12 @@ final class LdapReplicaTest extends TestCase
         $this->syncRepl->method('useCookieHandler')
             ->willReturnCallback(function (Closure $handler): SyncRepl {
                 $this->cookieHandler = $handler;
+
+                return $this->syncRepl;
+            });
+        $this->syncRepl->method('useIdSetHandler')
+            ->willReturnCallback(function (Closure $handler): SyncRepl {
+                $this->idSetHandler = $handler;
 
                 return $this->syncRepl;
             });
@@ -134,6 +144,31 @@ final class LdapReplicaTest extends TestCase
             'cookie-after',
             $this->checkpoint->read(),
         );
+    }
+
+    public function test_a_received_id_set_is_routed_to_the_applier(): void
+    {
+        $idSet = $this->createMock(SyncIdSetResult::class);
+        $session = new Session(
+            Session::MODE_LISTEN,
+            'from-primary',
+        );
+
+        $this->syncRepl->method('listen')
+            ->willReturnCallback(function () use ($idSet, $session): void {
+                ($this->idSetHandler)($idSet, $session);
+                ($this->shutdown)();
+            });
+
+        $this->applier->expects(self::once())
+            ->method('applyIdSet')
+            ->with(
+                $idSet,
+                $session,
+            )
+            ->willReturn([]);
+
+        $this->subject->run();
     }
 
     public function test_an_incremental_refresh_applies_without_reconciling(): void

--- a/tests/unit/Sync/Consumer/ReconcilingChangeApplierTest.php
+++ b/tests/unit/Sync/Consumer/ReconcilingChangeApplierTest.php
@@ -26,6 +26,7 @@ use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
 use FreeDSx\Ldap\Sync\Consumer\ChangeApplierInterface;
 use FreeDSx\Ldap\Sync\Consumer\ReconcilingChangeApplier;
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Result\SyncIdSetResult;
 use FreeDSx\Ldap\Sync\Session;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -157,6 +158,51 @@ final class ReconcilingChangeApplierTest extends TestCase
                 SyncStateControl::STATE_DELETE,
                 $this->entry(),
             ),
+            $this->session(),
+        );
+    }
+
+    public function test_an_id_set_discards_the_local_state_of_every_dn_it_removed(): void
+    {
+        $removed = [
+            new Dn(self::DN),
+            new Dn('cn=bob,dc=example,dc=com'),
+        ];
+        $idSet = $this->createMock(SyncIdSetResult::class);
+        $session = $this->session();
+
+        $this->baseApplier
+            ->expects(self::once())
+            ->method('applyIdSet')
+            ->with(
+                $idSet,
+                $session,
+            )
+            ->willReturn($removed);
+        $this->passwordStateStore
+            ->expects(self::exactly(2))
+            ->method('discard');
+
+        self::assertSame(
+            $removed,
+            $this->subject->applyIdSet(
+                $idSet,
+                $session,
+            ),
+        );
+    }
+
+    public function test_an_id_set_that_removed_nothing_discards_no_local_state(): void
+    {
+        $this->baseApplier
+            ->method('applyIdSet')
+            ->willReturn([]);
+        $this->passwordStateStore
+            ->expects(self::never())
+            ->method('discard');
+
+        $this->subject->applyIdSet(
+            $this->createMock(SyncIdSetResult::class),
             $this->session(),
         );
     }

--- a/tests/unit/Sync/Consumer/VerbatimStorageApplierTest.php
+++ b/tests/unit/Sync/Consumer/VerbatimStorageApplierTest.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
+use FreeDSx\Ldap\Operation\Response\SyncInfo\SyncIdSet;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Search\Result\EntryResult;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
@@ -25,6 +26,7 @@ use FreeDSx\Ldap\Server\Utility\Uuid;
 use FreeDSx\Ldap\Sync\Consumer\ChangeApplierInterface;
 use FreeDSx\Ldap\Sync\Consumer\VerbatimStorageApplier;
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
+use FreeDSx\Ldap\Sync\Result\SyncIdSetResult;
 use FreeDSx\Ldap\Sync\Session;
 use PHPUnit\Framework\TestCase;
 
@@ -233,6 +235,103 @@ final class VerbatimStorageApplierTest extends TestCase
         self::assertTrue($this->exists('cn=new,dc=example,dc=com'));
     }
 
+    public function test_a_delete_set_removes_every_entry_it_names_by_uuid(): void
+    {
+        $this->storage->store($this->entry('cn=a,dc=example,dc=com', self::UUID_A));
+        $this->storage->store($this->entry('cn=b,dc=example,dc=com', self::UUID_B));
+        $this->storage->store($this->entry('cn=c,dc=example,dc=com', self::UUID_C));
+
+        $removed = $this->subject->applyIdSet(
+            $this->idSet(
+                [self::UUID_A, self::UUID_C],
+                deleted: true,
+            ),
+            $this->persistSession(),
+        );
+
+        self::assertFalse($this->exists('cn=a,dc=example,dc=com'));
+        self::assertTrue($this->exists('cn=b,dc=example,dc=com'));
+        self::assertFalse($this->exists('cn=c,dc=example,dc=com'));
+        self::assertSame(
+            [
+                'cn=a,dc=example,dc=com',
+                'cn=c,dc=example,dc=com',
+            ],
+            array_map(
+                static fn(Dn $dn): string => $dn->toString(),
+                $removed,
+            ),
+        );
+    }
+
+    public function test_a_delete_set_naming_an_unheld_uuid_is_a_no_op(): void
+    {
+        $this->storage->store($this->entry('cn=a,dc=example,dc=com', self::UUID_A));
+
+        $removed = $this->subject->applyIdSet(
+            $this->idSet(
+                [self::UUID_B],
+                deleted: true,
+            ),
+            $this->persistSession(),
+        );
+
+        self::assertTrue($this->exists('cn=a,dc=example,dc=com'));
+        self::assertSame(
+            [],
+            $removed,
+        );
+    }
+
+    /**
+     * The dangerous branch: a present set the consumer ignores leaves live entries for the sweep to delete.
+     */
+    public function test_entries_named_by_a_present_set_survive_reconciliation(): void
+    {
+        $this->storage->store($this->entry('cn=a,dc=example,dc=com', self::UUID_A));
+        $this->storage->store($this->entry('cn=b,dc=example,dc=com', self::UUID_B));
+
+        $this->subject->beginRefresh();
+        $this->subject->applyIdSet(
+            $this->idSet([self::UUID_A]),
+            $this->refreshSession(),
+        );
+        $this->subject->reconcile();
+
+        self::assertTrue($this->exists('cn=a,dc=example,dc=com'));
+        self::assertFalse($this->exists('cn=b,dc=example,dc=com'));
+    }
+
+    public function test_a_present_set_is_matched_regardless_of_uuid_case(): void
+    {
+        $this->storage->store($this->entry('cn=a,dc=example,dc=com', self::UUID_A));
+
+        $this->subject->beginRefresh();
+        $this->subject->applyIdSet(
+            $this->idSet([strtoupper(self::UUID_A)]),
+            $this->refreshSession(),
+        );
+        $this->subject->reconcile();
+
+        self::assertTrue($this->exists('cn=a,dc=example,dc=com'));
+    }
+
+    public function test_begin_refresh_clears_a_previous_present_set_of_uuids(): void
+    {
+        $this->storage->store($this->entry('cn=a,dc=example,dc=com', self::UUID_A));
+
+        $this->subject->beginRefresh();
+        $this->subject->applyIdSet(
+            $this->idSet([self::UUID_A]),
+            $this->refreshSession(),
+        );
+
+        $this->subject->beginRefresh();
+        $this->subject->reconcile();
+
+        self::assertFalse($this->exists('cn=a,dc=example,dc=com'));
+    }
+
     public function test_begin_refresh_clears_the_previous_present_set(): void
     {
         $session = $this->refreshSession();
@@ -281,6 +380,25 @@ final class VerbatimStorageApplierTest extends TestCase
         );
 
         return new SyncEntryResult(new EntryResult($message));
+    }
+
+    /**
+     * @param list<string> $uuids
+     */
+    private function idSet(
+        array $uuids,
+        bool $deleted = false,
+    ): SyncIdSetResult {
+        return new SyncIdSetResult(new LdapMessageResponse(
+            1,
+            new SyncIdSet(
+                array_map(
+                    Uuid::toBinary(...),
+                    $uuids,
+                ),
+                $deleted,
+            ),
+        ));
     }
 
     private function refreshSession(): Session

--- a/tests/unit/Sync/Provider/SyncResultBatcherTest.php
+++ b/tests/unit/Sync/Provider/SyncResultBatcherTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Sync\Provider;
+
+use FreeDSx\Ldap\Control\Sync\SyncStateControl;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
+use FreeDSx\Ldap\Operation\Response\SyncInfo\SyncIdSet;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Server\Utility\Uuid;
+use FreeDSx\Ldap\Sync\Provider\SyncResult;
+use FreeDSx\Ldap\Sync\Provider\SyncResultBatcher;
+use PHPUnit\Framework\TestCase;
+
+final class SyncResultBatcherTest extends TestCase
+{
+    private const MESSAGE_ID = 7;
+
+    private SyncResultBatcher $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new SyncResultBatcher();
+    }
+
+    public function test_a_single_delete_stays_an_entry(): void
+    {
+        $responses = $this->batch([$this->delete('cn=alice,dc=example,dc=com')]);
+
+        self::assertCount(
+            1,
+            $responses,
+        );
+        self::assertInstanceOf(
+            SearchResultEntry::class,
+            $responses[0]->getResponse(),
+        );
+    }
+
+    public function test_multiple_deletes_coalesce_into_one_id_set(): void
+    {
+        $responses = $this->batch([
+            $this->delete('cn=alice,dc=example,dc=com'),
+            $this->delete('cn=bob,dc=example,dc=com'),
+            $this->delete('cn=carol,dc=example,dc=com'),
+        ]);
+
+        self::assertCount(
+            1,
+            $responses,
+        );
+
+        $idSet = $responses[0]->getResponse();
+        self::assertInstanceOf(
+            SyncIdSet::class,
+            $idSet,
+        );
+        self::assertTrue($idSet->getRefreshDeletes());
+        self::assertCount(
+            3,
+            $idSet->getEntryUuids(),
+        );
+    }
+
+    public function test_the_coalesced_set_carries_the_binary_uuid_of_each_delete(): void
+    {
+        $uuid = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        $responses = $this->batch([
+            $this->delete('cn=alice,dc=example,dc=com', $uuid),
+            $this->delete('cn=bob,dc=example,dc=com'),
+        ]);
+
+        $idSet = $responses[0]->getResponse();
+        self::assertInstanceOf(
+            SyncIdSet::class,
+            $idSet,
+        );
+        self::assertSame(
+            Uuid::toBinary($uuid),
+            $idSet->getEntryUuids()[0],
+        );
+    }
+
+    public function test_adds_pass_through_in_order_around_a_delete_set(): void
+    {
+        $responses = $this->batch([
+            $this->add('cn=alice,dc=example,dc=com'),
+            $this->delete('cn=bob,dc=example,dc=com'),
+            $this->delete('cn=carol,dc=example,dc=com'),
+        ]);
+
+        self::assertCount(
+            2,
+            $responses,
+        );
+        self::assertInstanceOf(
+            SearchResultEntry::class,
+            $responses[0]->getResponse(),
+        );
+        self::assertInstanceOf(
+            SyncIdSet::class,
+            $responses[1]->getResponse(),
+        );
+    }
+
+    public function test_an_add_between_deletes_does_not_flush_the_pending_set(): void
+    {
+        $responses = $this->batch([
+            $this->delete('cn=alice,dc=example,dc=com'),
+            $this->add('cn=bob,dc=example,dc=com'),
+            $this->delete('cn=carol,dc=example,dc=com'),
+        ]);
+
+        self::assertCount(
+            2,
+            $responses,
+        );
+        self::assertInstanceOf(
+            SearchResultEntry::class,
+            $responses[0]->getResponse(),
+        );
+
+        $idSet = $responses[1]->getResponse();
+        self::assertInstanceOf(
+            SyncIdSet::class,
+            $idSet,
+        );
+        self::assertCount(
+            2,
+            $idSet->getEntryUuids(),
+        );
+    }
+
+    public function test_deletes_beyond_the_cap_split_across_sets(): void
+    {
+        $this->subject = new SyncResultBatcher(maxSetSize: 2);
+
+        $responses = $this->batch([
+            $this->delete('cn=alice,dc=example,dc=com'),
+            $this->delete('cn=bob,dc=example,dc=com'),
+            $this->delete('cn=carol,dc=example,dc=com'),
+            $this->delete('cn=dave,dc=example,dc=com'),
+        ]);
+
+        self::assertCount(
+            2,
+            $responses,
+        );
+
+        foreach ($responses as $response) {
+            $idSet = $response->getResponse();
+            self::assertInstanceOf(
+                SyncIdSet::class,
+                $idSet,
+            );
+            self::assertCount(
+                2,
+                $idSet->getEntryUuids(),
+            );
+        }
+    }
+
+    public function test_a_lone_delete_trailing_a_full_set_stays_an_entry(): void
+    {
+        $this->subject = new SyncResultBatcher(maxSetSize: 2);
+
+        $responses = $this->batch([
+            $this->delete('cn=alice,dc=example,dc=com'),
+            $this->delete('cn=bob,dc=example,dc=com'),
+            $this->delete('cn=carol,dc=example,dc=com'),
+        ]);
+
+        self::assertCount(
+            2,
+            $responses,
+        );
+        self::assertInstanceOf(
+            SyncIdSet::class,
+            $responses[0]->getResponse(),
+        );
+        self::assertInstanceOf(
+            SearchResultEntry::class,
+            $responses[1]->getResponse(),
+        );
+    }
+
+    public function test_nothing_is_emitted_for_an_empty_stream(): void
+    {
+        self::assertSame(
+            [],
+            $this->batch([]),
+        );
+    }
+
+    /**
+     * @param list<SyncResult> $results
+     * @return list<LdapMessageResponse>
+     */
+    private function batch(array $results): array
+    {
+        return iterator_to_array(
+            $this->subject->batch(
+                $results,
+                self::MESSAGE_ID,
+            ),
+            false,
+        );
+    }
+
+    private function delete(
+        string $dn,
+        string $uuid = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+    ): SyncResult {
+        return new SyncResult(
+            new SearchResultEntry(new Entry($dn)),
+            new SyncStateControl(
+                SyncStateControl::STATE_DELETE,
+                Uuid::toBinary($uuid),
+            ),
+        );
+    }
+
+    private function add(
+        string $dn,
+        string $uuid = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+    ): SyncResult {
+        return new SyncResult(
+            new SearchResultEntry(new Entry($dn)),
+            new SyncStateControl(
+                SyncStateControl::STATE_ADD,
+                Uuid::toBinary($uuid),
+            ),
+        );
+    }
+}

--- a/tests/unit/Sync/Result/SyncIdSetResultTest.php
+++ b/tests/unit/Sync/Result/SyncIdSetResultTest.php
@@ -41,6 +41,27 @@ final class SyncIdSetResultTest extends TestCase
         );
     }
 
+    public function test_it_should_decode_the_entry_uuids_from_their_wire_form(): void
+    {
+        $subject = new SyncIdSetResult(
+            new LdapMessageResponse(
+                1,
+                new SyncIdSet([
+                    pack('H*', '0f8fad5bd9cb469fa16570867728950e'),
+                    pack('H*', '7d4448409dc011d1b2455ffdce74fad2'),
+                ]),
+            ),
+        );
+
+        self::assertSame(
+            [
+                '0f8fad5b-d9cb-469f-a165-70867728950e',
+                '7d444840-9dc0-11d1-b245-5ffdce74fad2',
+            ],
+            $subject->getDecodedEntryUuids(),
+        );
+    }
+
     public function test_it_should_get_the_count_of_the_set(): void
     {
         self::assertCount(


### PR DESCRIPTION
This adds support for the SyncIdSet of RFC 4533. We never emitted these previously, so had to adjust our logic that batches these as we send them out. This also leverages the existing removeAll method that subtree deletion already provides. This also makes the sync more compliant with other RFC implementing servers. As ignoring it would actually be problematic.