### PR TITLE
[1.0.0] Funnel LDIF applyChanges through middleware.

### DIFF
--- a/docs/Server/General-Usage.md
+++ b/docs/Server/General-Usage.md
@@ -517,6 +517,18 @@ When using the Swoole runner (`setRunnerConfig(RunnerConfig::forSwoole())`), cal
 `LdapServer::applyChanges()` replays an LDIF changelog through the live write path. Use it for applying diffs, migrations,
 or administrative changes after the initial directory is populated.
 
+Each record runs through the same request validation, auditing and control handling a client request gets, so a replayed
+record and the same operation sent by a client behave alike. A record may carry the controls RFC 2849 allows:
+
+```ldif
+dn: ou=staff,dc=example,dc=com
+control: 1.2.840.113556.1.4.805 true
+changetype: delete
+```
+
+Replay applies the subtree delete, relax rules, and assertion controls. Anything else is ignored when it is not critical
+and refused when it is, since there is no client connection to answer with a response control.
+
 ```ldif
 version: 1
 

--- a/docs/Server/Replication.md
+++ b/docs/Server/Replication.md
@@ -224,6 +224,10 @@ Any client write to a replica (add, modify, delete, rename, password modify) is 
 referral to the provider. Call `ConsumerConfig::setReferWrites(false)` to reject it with `unwillingToPerform` instead.
 Reads, binds, compares, and StartTLS are served normally.
 
+In-process writes are refused for the same reason. `seed()` and `applyChanges()` both fail on a replica, since the
+provider owns the content and the next refresh would sweep away anything written locally. Apply changes to the provider
+and let them replicate.
+
 ### Storage Requirement
 
 A replica requires PDO storage (SQLite or MySQL) on either runner. Any other storage fails at startup. The reasons:

--- a/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
@@ -57,7 +57,18 @@ use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\DnBindNameResolver;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticator;
+use FreeDSx\Ldap\Server\Backend\Write\ReplayWriteHandler;
+use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\Backend\Write\WriteRequestRouter;
+use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Logging\OperationAuditor;
+use FreeDSx\Ldap\Server\Middleware\AssertionMiddleware;
+use FreeDSx\Ldap\Server\Middleware\CriticalControlMiddleware;
+use FreeDSx\Ldap\Server\Middleware\OperationAuditMiddleware;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareChain;
+use FreeDSx\Ldap\Server\Middleware\ReadOnlyMiddleware;
+use FreeDSx\Ldap\Server\Middleware\RequestValidationMiddleware;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\LdapClientForwardStateSender;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\PasswordPolicyForwardWorker;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
@@ -189,9 +200,33 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
         );
     }
 
+    /**
+     * Replay runs the pipeline stages that need no connection, so it cannot drift from the wire path.
+     */
     private function makeWriteRequestReplayer(Container $container): WriteRequestReplayer
     {
-        return new WriteRequestReplayer($container->get(WritableStorageBackend::class));
+        $options = $container->get(ServerOptions::class);
+        $consumerConfig = $options->getConsumerConfig();
+
+        return new WriteRequestReplayer(new MiddlewareChain(
+            [
+                new RequestValidationMiddleware(),
+                new OperationAuditMiddleware(new OperationAuditor(new EventLogger(
+                    $options->getLogger(),
+                    $options->getEventLogPolicy(),
+                    (new ConnectionContext())->toLogContext(),
+                ))),
+                ...($consumerConfig !== null
+                    ? [new ReadOnlyMiddleware($consumerConfig)]
+                    : []),
+                $container->get(CriticalControlMiddleware::class),
+                $container->get(AssertionMiddleware::class),
+            ],
+            new ReplayWriteHandler(new WriteRequestRouter(
+                $container->get(WritableStorageBackend::class),
+                $container->get(WriteOperationDispatcher::class),
+            )),
+        ));
     }
 
     private function makeDirectoryDumper(Container $container): DirectoryDumper
@@ -255,6 +290,8 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
      */
     private function makeLdapImporter(Container $container): LdapImporter
     {
+        $this->refuseBulkImportOnReplica($container->get(ServerOptions::class));
+
         return new LdapImporter(
             $container->get(EntryStorageInterface::class),
             $container->get(OperationalAttributeGenerator::class),
@@ -375,6 +412,19 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
             'A read-only replica requires PDO storage, but "%s" is configured.',
             $storageConfig::class,
         ));
+    }
+
+    /**
+     * @throws RuntimeException when a replica would be seeded locally
+     */
+    private function refuseBulkImportOnReplica(ServerOptions $options): void
+    {
+        if (!$options->isReadOnly()) {
+            return;
+        }
+
+        // The provider owns a replica's content, so the next refresh would sweep away whatever was imported here.
+        throw new RuntimeException('A read-only replica cannot be seeded locally; seed the provider instead.');
     }
 
     private function makeListenerContributor(Container $container): ListenerContributorInterface

--- a/src/FreeDSx/Ldap/Container/Provider/HandlerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/HandlerContainerProvider.php
@@ -43,6 +43,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeStream;
 use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\Backend\Write\WriteRequestRouter;
 use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
 use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
 use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyService;
@@ -217,19 +218,16 @@ final class HandlerContainerProvider implements ContainerProviderInterface
         HandlerContext $context,
     ): ServerDispatchHandler {
         $backend = $container->get(WritableStorageBackend::class);
-        $policyWriteHandler = $container->get(PasswordPolicyComponentFactory::class)->makeWriteHandler(
-            $context->eventLogger,
-            $context->passwordPolicyContext,
-        );
 
         return new ServerDispatchHandler(
             backend: $backend,
-            writeDispatcher: $policyWriteHandler !== null
-                ? new WriteOperationDispatcher(
-                    $policyWriteHandler,
-                    $backend,
-                )
-                : $container->get(WriteOperationDispatcher::class),
+            router: new WriteRequestRouter(
+                $backend,
+                $container->get(PasswordPolicyComponentFactory::class)->makeWriteDispatcher(
+                    $context->eventLogger,
+                    $context->passwordPolicyContext,
+                ),
+            ),
             accessControl: $container->get(AccessControlInterface::class),
             schema: $container->get(ServerOptions::class)->getSchema(),
         );

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -25,7 +25,6 @@ use FreeDSx\Ldap\Ldif\Url\RefusingUrlResolver;
 use FreeDSx\Ldap\Ldif\Loader\LdifLoaderInterface;
 use FreeDSx\Ldap\Ldif\Output\LdifOutputInterface;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
-use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\EntryIndexReindexer;
 use FreeDSx\Ldap\Server\Backend\Storage\DrainableWritesInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
@@ -132,7 +131,7 @@ class LdapServer
         LdifUrlResolverInterface $urlResolver = new RefusingUrlResolver(),
     ): self {
         $this->container->get(WriteRequestReplayer::class)
-            ->apply($this->streamChangeRequests($loader, $urlResolver));
+            ->apply($this->parseLdif($loader, $urlResolver));
 
         return $this;
     }
@@ -197,19 +196,6 @@ class LdapServer
             }
 
             yield $record->request->getEntry();
-        }
-    }
-
-    /**
-     * @return Generator<RequestInterface>
-     * @throws LdifParseException
-     */
-    private function streamChangeRequests(
-        LdifLoaderInterface $loader,
-        LdifUrlResolverInterface $urlResolver,
-    ): Generator {
-        foreach ($this->parseLdif($loader, $urlResolver) as $record) {
-            yield $record->request;
         }
     }
 

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -26,12 +26,10 @@ use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Operation\OperationType;
-use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Schema\SchemaViolations;
 use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
-use FreeDSx\Ldap\Server\Backend\Write\WriteCommandFactory;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
-use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\Backend\Write\WriteRequestRouter;
 use FreeDSx\Ldap\Server\Operation\CompareOperationResult;
 use FreeDSx\Ldap\Server\Operation\WriteOperationResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -47,10 +45,9 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
 
     public function __construct(
         private WritableLdapBackendInterface $backend,
-        private WriteOperationDispatcher $writeDispatcher,
+        private WriteRequestRouter $router,
         private AccessControlInterface $accessControl,
         Schema $schema,
-        private WriteCommandFactory $commandFactory = new WriteCommandFactory(),
         private ResponseFactory $responseFactory = new ResponseFactory(),
     ) {
         $this->readEntryControlHandler = new ReadEntryControlHandler(
@@ -171,44 +168,15 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
         TokenInterface $token,
         SchemaViolations $schemaViolations,
     ): void {
-        if ($request instanceof Request\DeleteRequest && $controls->has(Control::OID_SUBTREE_DELETE)) {
-            $this->handleSubtreeDelete(
-                $request,
-                $controls,
-                $token,
-                $schemaViolations,
-            );
-
-            return;
-        }
-
-        $this->writeDispatcher->dispatch(
-            $this->commandFactory->fromRequest($request),
+        $this->router->route(
+            $request,
             new WriteContext(
                 $token,
                 $controls,
                 schemaViolations: $schemaViolations,
             ),
-        );
-    }
-
-    /**
-     * @throws OperationException
-     */
-    private function handleSubtreeDelete(
-        Request\DeleteRequest $request,
-        ControlBag $controls,
-        TokenInterface $token,
-        SchemaViolations $schemaViolations,
-    ): void {
-        // Permissive by default; lock down by denying the Delete operation on the subtree (per-entry authorization below).
-        $this->backend->deleteSubtree(
-            new DeleteCommand($request->getDn()),
-            new WriteContext(
-                $token,
-                $controls,
-                schemaViolations: $schemaViolations,
-            ),
+            // Permissive by default.
+            // lock down by denying the delete operation on the subtree.
             function (Dn $dn) use ($token): void {
                 $this->accessControl->authorizeOperation(
                     OperationType::Delete,

--- a/src/FreeDSx/Ldap/Server/Backend/Write/ReplayWriteHandler.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/ReplayWriteHandler.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Write;
+
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
+use FreeDSx\Ldap\Server\Backend\Write\Schema\SchemaViolations;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\WriteOperationResult;
+
+use function in_array;
+use function sprintf;
+
+/**
+ * Terminal step of the replay pipeline: applies the write the record describes, with no client to answer.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ReplayWriteHandler implements MiddlewareHandlerInterface
+{
+    /**
+     * Controls a replayed record can be given effect; a critical control outside this set has to be refused.
+     */
+    private const HONORED_CONTROLS = [
+        // Routed by the write router.
+        Control::OID_SUBTREE_DELETE,
+        // Read off the write context by the storage backend.
+        Control::OID_RELAX_RULES,
+        // Evaluated ahead of this handler by AssertionMiddleware.
+        Control::OID_ASSERTION,
+        // Recognized server-wide and inert, since there are no referral entries to reinterpret.
+        Control::OID_MANAGE_DSA_IT,
+    ];
+
+    public function __construct(private WriteRequestRouter $router) {}
+
+    /**
+     * @throws OperationException
+     */
+    public function handle(ServerRequestContext $context): ResponseStream
+    {
+        $controls = $context->message->controls();
+        $this->assertAnswerable($controls);
+
+        $this->router->route(
+            $context->message->getRequest(),
+            WriteContext::system(
+                $context->tokenOrFail(),
+                $controls,
+            ),
+            // Replay is privileged by construction, so a subtree delete authorizes no descendant separately.
+            static function (Dn $dn): void {},
+        );
+
+        return ResponseStream::of(
+            [],
+            WriteOperationResult::success(
+                $context->message,
+                new SchemaViolations(),
+            ),
+        );
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function assertAnswerable(ControlBag $controls): void
+    {
+        foreach ($controls->toArray() as $control) {
+            $oid = (string) $control->getTypeOid();
+
+            if (!$control->getCriticality() || in_array($oid, self::HONORED_CONTROLS, true)) {
+                continue;
+            }
+
+            throw new OperationException(
+                sprintf('The "%s" control cannot be honored when replaying a change record.', $oid),
+                ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
+            );
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Write/WriteRequestReplayer.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/WriteRequestReplayer.php
@@ -13,43 +13,62 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Write;
 
-use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Exception\OperationException;
-use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Ldif\LdifChangeRecord;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationOutcome;
 use FreeDSx\Ldap\Server\Token\SystemToken;
 
 /**
- * Replays a sequence of client write requests against a backend as system-initiated operations.
+ * Replays parsed change records through the server's request pipeline as system-initiated operations.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final class WriteRequestReplayer
+final readonly class WriteRequestReplayer
 {
-    private readonly WriteOperationDispatcher $dispatcher;
+    public function __construct(private MiddlewareHandlerInterface $pipeline) {}
 
-    public function __construct(
-        WriteHandlerInterface $backend,
-        private readonly WriteCommandFactory $commandFactory = new WriteCommandFactory(),
-    ) {
-        $this->dispatcher = new WriteOperationDispatcher($backend);
+    /**
+     * @param iterable<LdifChangeRecord> $records
+     * @throws OperationException
+     */
+    public function apply(iterable $records): void
+    {
+        $messageId = 0;
+
+        foreach ($records as $record) {
+            ++$messageId;
+
+            $this->assertApplied($this->pipeline->handle(new ServerRequestContext(
+                new LdapMessageRequest(
+                    $messageId,
+                    $record->request,
+                    ...$record->controls,
+                ),
+                new SystemToken(),
+            )));
+        }
     }
 
     /**
-     * @param iterable<RequestInterface> $requests
+     * A refusal answered as a response rather than thrown has no client to read it here, so it is raised instead.
+     *
      * @throws OperationException
      */
-    public function apply(iterable $requests): void
+    private function assertApplied(ResponseStream $stream): void
     {
-        $context = WriteContext::system(
-            new SystemToken(),
-            new ControlBag(),
-        );
+        $result = $stream->outcome();
 
-        foreach ($requests as $request) {
-            $this->dispatcher->dispatch(
-                $this->commandFactory->fromRequest($request),
-                $context,
-            );
+        if ($result->outcome() === OperationOutcome::Succeeded) {
+            return;
         }
+
+        throw new OperationException(
+            'The change record was refused by the server.',
+            $result->resultCode(),
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Write/WriteRequestRouter.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/WriteRequestRouter.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Write;
+
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\DeleteRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
+
+/**
+ * Decides which write a request means.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class WriteRequestRouter
+{
+    public function __construct(
+        private WritableLdapBackendInterface $backend,
+        private WriteOperationDispatcher $dispatcher,
+        private WriteCommandFactory $commandFactory = new WriteCommandFactory(),
+    ) {}
+
+    /**
+     * @param callable(Dn): void $authorize Throws OperationException to deny removal of a subtree entry.
+     * @throws OperationException
+     */
+    public function route(
+        RequestInterface $request,
+        WriteContext $context,
+        callable $authorize,
+    ): void {
+        if ($this->isSubtreeDelete($request, $context)) {
+            $this->backend->deleteSubtree(
+                new DeleteCommand($request->getDn()),
+                $context,
+                $authorize,
+            );
+
+            return;
+        }
+
+        $this->dispatcher->dispatch(
+            $this->commandFactory->fromRequest($request),
+            $context,
+        );
+    }
+
+    /**
+     * @phpstan-assert-if-true DeleteRequest $request
+     */
+    private function isSubtreeDelete(
+        RequestInterface $request,
+        WriteContext $context,
+    ): bool {
+        return $request instanceof DeleteRequest
+            && $context->getControls()->has(Control::OID_SUBTREE_DELETE);
+    }
+}

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyComponentFactory.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyComponentFactory.php
@@ -59,6 +59,27 @@ final readonly class PasswordPolicyComponentFactory
         );
     }
 
+    /**
+     * The write dispatcher for a connection, with policy enforcement ahead of the backend where policy is active.
+     */
+    public function makeWriteDispatcher(
+        EventLogger $eventLogger,
+        ?PasswordPolicyContext $passwordPolicyContext,
+    ): WriteOperationDispatcher {
+        $writeHandler = $this->makeWriteHandler(
+            $eventLogger,
+            $passwordPolicyContext,
+        );
+        if ($writeHandler === null) {
+            return $this->writeDispatcher;
+        }
+
+        return new WriteOperationDispatcher(
+            $writeHandler,
+            $this->backend,
+        );
+    }
+
     public function makeChangeGuard(
         EventLogger $eventLogger,
         ?PasswordPolicyContext $passwordPolicyContext,

--- a/tests/integration/Ldif/LdapApplyChangesServerTest.php
+++ b/tests/integration/Ldif/LdapApplyChangesServerTest.php
@@ -105,6 +105,17 @@ final class LdapApplyChangesServerTest extends ServerTestCase
         );
     }
 
+    /**
+     * The changelog adds ou=team with a child, then deletes it carrying "control: 1.2.840.113556.1.4.805 true".
+     *
+     * Replay runs at test startup, so this asserts the state it left.
+     */
+    public function test_a_delete_change_carrying_the_subtree_control_removes_the_whole_subtree(): void
+    {
+        $this->assertNull($this->ldapClient()->read('cn=erin,ou=team,dc=foo,dc=bar'));
+        $this->assertNull($this->ldapClient()->read('ou=team,dc=foo,dc=bar'));
+    }
+
     public function test_an_added_entry_groups_descriptions_that_differ_only_in_case(): void
     {
         $dave = $this->ldapClient()->read('cn=dave,dc=foo,dc=bar');

--- a/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
@@ -36,6 +36,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
 use FreeDSx\Ldap\Server\Backend\Write\PasswordPolicyWriteHandler;
 use FreeDSx\Ldap\Server\Backend\Write\SystemChange\SystemChangeWriter;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\Backend\Write\WriteRequestRouter;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerDispatchHandler;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyChangeGuard;
@@ -419,9 +420,12 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
 
         return new ServerDispatchHandler(
             backend: $this->backend,
-            writeDispatcher: new WriteOperationDispatcher(
-                $policyWriteHandler,
+            router: new WriteRequestRouter(
                 $this->backend,
+                new WriteOperationDispatcher(
+                    $policyWriteHandler,
+                    $this->backend,
+                ),
             ),
             accessControl: $this->createMock(AccessControlInterface::class),
             schema: new Schema(),

--- a/tests/resources/changes/apply-test.ldif
+++ b/tests/resources/changes/apply-test.ldif
@@ -33,3 +33,19 @@ cn: dave
 sn: Davis
 description: first
 DESCRIPTION: second
+
+# A subtree the record below removes whole, which only works if the control is honored on replay.
+dn: ou=team,dc=foo,dc=bar
+changetype: add
+objectClass: organizationalUnit
+ou: team
+
+dn: cn=erin,ou=team,dc=foo,dc=bar
+changetype: add
+objectClass: inetOrgPerson
+cn: erin
+sn: Engels
+
+dn: ou=team,dc=foo,dc=bar
+control: 1.2.840.113556.1.4.805 true
+changetype: delete

--- a/tests/unit/LdapServerTest.php
+++ b/tests/unit/LdapServerTest.php
@@ -15,7 +15,9 @@ namespace Tests\Unit\FreeDSx\Ldap;
 
 use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\LdapServer;
 use FreeDSx\Ldap\Exception\LdifParseException;
 use FreeDSx\Ldap\Ldif\Loader\StringLdifLoader;
@@ -57,6 +59,19 @@ class LdapServerTest extends TestCase
         objectClass: person
         cn: foo
         sn: Bar
+        LDIF;
+
+    private const SUBTREE_LDIF = <<<'LDIF'
+        dn: ou=people,dc=example,dc=com
+        objectClass: top
+        objectClass: organizationalUnit
+        ou: people
+
+        dn: cn=child,ou=people,dc=example,dc=com
+        objectClass: top
+        objectClass: person
+        cn: child
+        sn: Child
         LDIF;
 
     private LdapServer $subject;
@@ -303,6 +318,57 @@ class LdapServerTest extends TestCase
         ));
 
         self::assertNull($this->storage()->find(new Dn('cn=foo,dc=example,dc=com')));
+    }
+
+    /**
+     * RFC 2849 lets a change record carry controls, and the wire path routes this one to a subtree delete.
+     */
+    public function test_it_should_apply_a_delete_carrying_the_subtree_control_to_the_whole_subtree(): void
+    {
+        $this->subject->seed(new StringLdifLoader(self::SEED_LDIF . "\n\n" . self::SUBTREE_LDIF));
+
+        $this->subject->applyChanges(new StringLdifLoader(
+            "dn: ou=people,dc=example,dc=com\ncontrol: 1.2.840.113556.1.4.805 true\nchangetype: delete\n",
+        ));
+
+        self::assertNull($this->storage()->find(new Dn('cn=child,ou=people,dc=example,dc=com')));
+        self::assertNull($this->storage()->find(new Dn('ou=people,dc=example,dc=com')));
+    }
+
+    public function test_it_should_refuse_a_change_record_carrying_a_critical_control_it_cannot_honor(): void
+    {
+        $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::UNAVAILABLE_CRITICAL_EXTENSION);
+
+        $this->subject->applyChanges(new StringLdifLoader(
+            "dn: cn=foo,dc=example,dc=com\ncontrol: 1.3.6.1.1.13.1 true\nchangetype: delete\n",
+        ));
+    }
+
+    public function test_it_should_apply_a_change_record_carrying_a_non_critical_control_it_cannot_honor(): void
+    {
+        $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
+
+        $this->subject->applyChanges(new StringLdifLoader(
+            "dn: cn=foo,dc=example,dc=com\ncontrol: 1.3.6.1.1.13.1 false\nchangetype: delete\n",
+        ));
+
+        self::assertNull($this->storage()->find(new Dn('cn=foo,dc=example,dc=com')));
+    }
+
+    public function test_it_should_refuse_to_seed_a_read_only_replica(): void
+    {
+        $options = (new ServerOptions(
+            PdoConfig::forSqlite(':memory:'),
+            networkConfig: NetworkConfig::withPort(33389),
+        ))->setReplicationConfig(ReplicationConfig::forReplica(new ConsumerConfig(new ClientOptions())));
+
+        $this->expectException(RuntimeException::class);
+
+        (new LdapServer($options, Container::forServer($options)))
+            ->seed(new StringLdifLoader(self::SEED_LDIF));
     }
 
     public function test_it_should_dump_seeded_entries_to_the_given_output(): void

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
@@ -32,6 +32,7 @@ use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\Backend\Write\WriteRequestRouter;
 use FreeDSx\Ldap\Server\Backend\Write\WriteRequestInterface;
 use FreeDSx\Ldap\Server\Operation\CompareOperationResult;
 use FreeDSx\Ldap\Server\Operation\OperationOutcome;
@@ -65,7 +66,10 @@ final class ServerDispatchHandlerTest extends TestCase
 
         $this->subject = new ServerDispatchHandler(
             backend: $this->mockBackend,
-            writeDispatcher: new WriteOperationDispatcher($this->mockWriteHandler),
+            router: new WriteRequestRouter(
+                $this->mockBackend,
+                new WriteOperationDispatcher($this->mockWriteHandler),
+            ),
             accessControl: $this->mockAccessControl,
             schema: new Schema(),
         );
@@ -150,7 +154,10 @@ final class ServerDispatchHandlerTest extends TestCase
     {
         $subject = new ServerDispatchHandler(
             backend: $this->mockBackend,
-            writeDispatcher: new WriteOperationDispatcher(),
+            router: new WriteRequestRouter(
+                $this->mockBackend,
+                new WriteOperationDispatcher(),
+            ),
             accessControl: $this->mockAccessControl,
             schema: new Schema(),
         );

--- a/tests/unit/Server/Backend/Write/ReplayWriteHandlerTest.php
+++ b/tests/unit/Server/Backend/Write/ReplayWriteHandlerTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Write;
+
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\AddRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use FreeDSx\Ldap\Server\Backend\Write\ReplayWriteHandler;
+use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
+use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
+use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\Backend\Write\WriteRequestInterface;
+use FreeDSx\Ldap\Server\Backend\Write\WriteRequestRouter;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+use FreeDSx\Ldap\Server\Operation\OperationOutcome;
+use FreeDSx\Ldap\Server\Token\SystemToken;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class ReplayWriteHandlerTest extends TestCase
+{
+    private const DN = 'cn=foo,dc=example,dc=com';
+
+    private WriteHandlerInterface&MockObject $writeHandler;
+
+    private ReplayWriteHandler $subject;
+
+    protected function setUp(): void
+    {
+        $this->writeHandler = $this->createMock(WriteHandlerInterface::class);
+        $this->writeHandler
+            ->method('supports')
+            ->willReturn(true);
+
+        $this->subject = new ReplayWriteHandler(new WriteRequestRouter(
+            $this->createMock(WritableLdapBackendInterface::class),
+            new WriteOperationDispatcher($this->writeHandler),
+        ));
+    }
+
+    public function test_it_applies_the_write_and_reports_success(): void
+    {
+        $this->writeHandler
+            ->expects(self::once())
+            ->method('handle');
+
+        self::assertSame(
+            OperationOutcome::Succeeded,
+            $this->subject->handle($this->contextWith())
+                ->outcome()
+                ->outcome(),
+        );
+    }
+
+    public function test_the_controls_reach_the_write_context(): void
+    {
+        $seen = null;
+        $this->writeHandler
+            ->method('handle')
+            ->willReturnCallback(static function (
+                WriteRequestInterface $request,
+                WriteContext $context,
+            ) use (&$seen): void {
+                $seen = $context->getControls();
+            });
+
+        $this->subject->handle($this->contextWith(new Control(Control::OID_RELAX_RULES)));
+
+        self::assertTrue($seen?->has(Control::OID_RELAX_RULES));
+    }
+
+    public function test_a_critical_control_it_cannot_honor_is_refused(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::UNAVAILABLE_CRITICAL_EXTENSION);
+
+        $this->subject->handle($this->contextWith(new Control(
+            Control::OID_PRE_READ,
+            criticality: true,
+        )));
+    }
+
+    public function test_a_non_critical_control_it_cannot_honor_is_ignored(): void
+    {
+        $this->writeHandler
+            ->expects(self::once())
+            ->method('handle');
+
+        $this->subject->handle($this->contextWith(new Control(Control::OID_PRE_READ)));
+    }
+
+    public function test_a_critical_control_it_can_honor_is_applied(): void
+    {
+        $this->writeHandler
+            ->expects(self::once())
+            ->method('handle');
+
+        $this->subject->handle($this->contextWith(new Control(
+            Control::OID_RELAX_RULES,
+            criticality: true,
+        )));
+    }
+
+    public function test_a_critical_password_policy_control_is_refused(): void
+    {
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::UNAVAILABLE_CRITICAL_EXTENSION);
+
+        $this->subject->handle($this->contextWith(new Control(
+            Control::OID_PWD_POLICY,
+            criticality: true,
+        )));
+    }
+
+    private function contextWith(Control ...$controls): ServerRequestContext
+    {
+        return new ServerRequestContext(
+            new LdapMessageRequest(
+                1,
+                new AddRequest(Entry::create(self::DN)),
+                ...$controls,
+            ),
+            new SystemToken(),
+        );
+    }
+}

--- a/tests/unit/Server/Backend/Write/WriteRequestRouterTest.php
+++ b/tests/unit/Server/Backend/Write/WriteRequestRouterTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Write;
+
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Operation\Request\AddRequest;
+use FreeDSx\Ldap\Operation\Request\DeleteRequest;
+use FreeDSx\Ldap\Server\Backend\Write\WritableLdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
+use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
+use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
+use FreeDSx\Ldap\Server\Backend\Write\WriteRequestRouter;
+use FreeDSx\Ldap\Server\Token\SystemToken;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class WriteRequestRouterTest extends TestCase
+{
+    private const DN = 'cn=foo,dc=example,dc=com';
+
+    private WritableLdapBackendInterface&MockObject $backend;
+
+    private WriteHandlerInterface&MockObject $writeHandler;
+
+    private WriteRequestRouter $subject;
+
+    protected function setUp(): void
+    {
+        $this->backend = $this->createMock(WritableLdapBackendInterface::class);
+        $this->writeHandler = $this->createMock(WriteHandlerInterface::class);
+        $this->writeHandler
+            ->method('supports')
+            ->willReturn(true);
+
+        $this->subject = new WriteRequestRouter(
+            $this->backend,
+            new WriteOperationDispatcher($this->writeHandler),
+        );
+    }
+
+    public function test_a_delete_carrying_the_subtree_control_removes_the_whole_subtree(): void
+    {
+        $this->backend
+            ->expects(self::once())
+            ->method('deleteSubtree');
+        $this->writeHandler
+            ->expects(self::never())
+            ->method('handle');
+
+        $this->subject->route(
+            new DeleteRequest(self::DN),
+            $this->contextWith(new Control(Control::OID_SUBTREE_DELETE)),
+            static function (Dn $dn): void {},
+        );
+    }
+
+    public function test_a_delete_without_the_subtree_control_goes_to_the_write_handler(): void
+    {
+        $this->backend
+            ->expects(self::never())
+            ->method('deleteSubtree');
+        $this->writeHandler
+            ->expects(self::once())
+            ->method('handle');
+
+        $this->subject->route(
+            new DeleteRequest(self::DN),
+            $this->contextWith(),
+            static function (Dn $dn): void {},
+        );
+    }
+
+    public function test_the_subtree_control_on_another_operation_is_not_routed_as_a_subtree_delete(): void
+    {
+        $this->backend
+            ->expects(self::never())
+            ->method('deleteSubtree');
+        $this->writeHandler
+            ->expects(self::once())
+            ->method('handle');
+
+        $this->subject->route(
+            new AddRequest(Entry::create(self::DN)),
+            $this->contextWith(new Control(Control::OID_SUBTREE_DELETE)),
+            static function (Dn $dn): void {},
+        );
+    }
+
+    public function test_the_subtree_delete_is_given_the_callers_authorization_check(): void
+    {
+        $authorized = false;
+        $this->backend
+            ->method('deleteSubtree')
+            ->willReturnCallback(static function (
+                object $command,
+                WriteContext $context,
+                callable $authorize,
+            ): void {
+                $authorize(new Dn(self::DN));
+            });
+
+        $this->subject->route(
+            new DeleteRequest(self::DN),
+            $this->contextWith(new Control(Control::OID_SUBTREE_DELETE)),
+            static function (Dn $dn) use (&$authorized): void {
+                $authorized = true;
+            },
+        );
+
+        self::assertTrue($authorized);
+    }
+
+    private function contextWith(Control ...$controls): WriteContext
+    {
+        return new WriteContext(
+            new SystemToken(),
+            new ControlBag(...$controls),
+        );
+    }
+}


### PR DESCRIPTION
This funnels LDIF triggered via applyChanges through the same sort of middleware checks that standard request would go through. This makes sure controls / auditing is consistent in this case. The seed method on LdapServer is still a bulk add operation which does explicitly not flow through this same path.