### PR TITLE
[1.0.0] Rename WritableStorageBackend / the interface.

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -26,7 +26,6 @@ jobs:
         include:
           - { id: memory-swoole,      backend: memory, runner: swoole, profile: 'memory:swoole',      workers: 1 }
           - { id: sqlite-pcntl,       backend: sqlite, runner: pcntl,  profile: 'sqlite:pcntl',       workers: 1 }
-          - { id: sqlite-swoole,      backend: sqlite, runner: swoole, profile: 'sqlite:swoole',      workers: 1 }
           # Worker count left to auto-detect, so the pool is exercised on whatever cores the runner has.
           - { id: sqlite-swoole-pool, backend: sqlite, runner: swoole, profile: 'sqlite:swoole-pool', workers: 0 }
     steps:

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -28,8 +28,9 @@ LDAP Server Configuration
 * [Access Control](#access-control)
     * [ServerOptions:setAclRules](#setaclrules)
     * [ServerOptions:setAccessControl](#setaccesscontrol)
-* [Backend](#backend)
+* [Storage](#storage)
     * [ServerOptions:setStorageConfig](#setstorageconfig)
+* [Authentication](#authentication)
     * [ServerOptions:setPasswordAuthenticator](#setpasswordauthenticator)
     * [ServerOptions:setIdentityResolver](#setidentityresolver)
 * [Schema](#schema)
@@ -445,17 +446,13 @@ rule engine. Prefer `setAclRules()` unless the built-in rules are insufficient.
 
 **Default**: `RuleBasedAccessControl` over the rules from `setAclRules()`.
 
-## Backend
-
-The LDAP server handles directory data through `WritableStorageBackend`, which applies LDAP semantics over the
-storage built from the configured backend config.
+## Storage
 
 ------------------
 #### setStorageConfig
 
-Storage is configured on `ServerOptions` via `setStorageConfig()` or by passing a config to the `ServerOptions`
-constructor. Choose one of the built-in backend configs: `PdoConfig` (SQLite or MySQL) or `InMemoryStorageConfig`. All
-directory operations (search, authenticate, and optionally write) are dispatched to the resulting storage.
+Where directory data lives, set with `setStorageConfig()` or by passing the config to the `ServerOptions` constructor.
+All directory operations are dispatched to the resulting storage.
 
 ```php
 use FreeDSx\Ldap\LdapServer;
@@ -465,12 +462,13 @@ use FreeDSx\Ldap\ServerOptions;
 $server = new LdapServer(new ServerOptions(PdoConfig::forSqlite('/var/lib/myapp/ldap.sqlite')));
 ```
 
-A config is required, as no default suits every runner. `InMemoryStorageConfig` keeps entries in the process that holds
-them, so the forking runner refuses it at startup. Use it with the Swoole runner or for testing. Use
-`PdoConfig::forSqlite()` otherwise.
+A config is required, as no default suits every runner. For the available configs see
+[Built-In Storage Implementations](General-Usage.md#built-in-storage-implementations), and for the options each one
+carries see [Tuning a PDO config](General-Usage.md#tuning-a-pdo-config).
 
-The bundled SQLite and MySQL backends create their tables automatically on first connect. For managing that schema
-yourself, see [Database Schema](Database-Schema.md).
+**Default**: none, a config must be provided.
+
+## Authentication
 
 ------------------
 #### setPasswordAuthenticator

--- a/docs/Server/General-Usage.md
+++ b/docs/Server/General-Usage.md
@@ -13,6 +13,15 @@ General LDAP Server Usage
     * [InMemoryStorage](#inmemorystorage)
     * [SQLite](#sqlite)
     * [MySQL](#mysql)
+  * [Tuning a PDO config](#tuning-a-pdo-config)
+    * [PdoConfig:setDsn](#setdsn)
+    * [PdoConfig:setUsername](#setusername)
+    * [PdoConfig:setPassword](#setpassword)
+    * [PdoConfig:setPdoOptions](#setpdooptions)
+    * [PdoConfig:setSessionStatements](#setsessionstatements)
+    * [PdoConfig:setSerializeSwooleWrites](#setserializeswoolewrites)
+    * [PdoConfig:setInitializeSchema](#setinitializeschema)
+    * [PdoConfig:setSubstringIndexMode](#setsubstringindexmode)
 * [LDIF Data](#ldif-data)
   * [Seeding Initial Entries](#seeding-initial-entries)
   * [Replaying LDIF Changelogs](#replaying-ldif-changelogs)
@@ -40,9 +49,9 @@ using a forking method (PCNTL) for handling client connections, which is only av
 > than a FreeDSx issue. If you hit it, try running with `opcache.jit=off`. The single-process Swoole runner has not shown
 > this.
 
-The server has no built-in entry persistence. You provide a backend that implements the storage logic for your use
-case. Authentication is a separate, independently configurable concern. See [Providing a Backend](#providing-a-backend)
-and [Authentication](#authentication) for details.
+Entries are persisted by a storage config you pass to `ServerOptions`, chosen from the built-in SQLite, MySQL, and
+in-memory implementations. Authentication is a separate, independently configurable concern. See
+[Providing a Backend](#providing-a-backend) and [Authentication](#authentication) for details.
 
 ## Quick Start Scenarios
 
@@ -422,11 +431,11 @@ $server->run();
 The DSN follows the standard PDO MySQL format. The character set is automatically configured to `utf8mb4`
 and the time zone to UTC on each connection.
 
-##### Tuning a PDO config
+#### Tuning a PDO config
 
-`forSqlite()` and `forMysql()` pick the database engine, and everything that follows from it. The PDO options,
-per-connection session statements, and whether writes are serialized under Swoole all come from the driver.
-Override any of them with the setters:
+`forSqlite()` and `forMysql()` pick the database engine and everything that follows from it. The PDO options, the
+per-connection session statements, and whether writes are serialized under Swoole all come from the driver. Override
+any of them with the setters below. Each returns the config, so calls chain:
 
 ```php
 use FreeDSx\Ldap\Server\Config\Storage\PdoConfig;
@@ -445,16 +454,67 @@ $config = PdoConfig::forMysql(
 ```
 
 `PdoConfig` implements `StorageConfigInterface`, so pass `$config` to `setStorageConfig()` or the `ServerOptions`
-constructor like any other backend config.
+constructor like any other storage config.
 
-##### Substring index
+##### setDsn
 
-Substring filters such as `(cn=*smith*)` are narrowed by an index the storage maintains alongside the entries.
-Choose it with `setSubstringIndexMode()`:
+The PDO connection string. `forSqlite()` builds it as `sqlite:` followed by the path you give it, and `forMysql()`
+takes it verbatim. Set it to repoint an existing config at a different database.
+
+**Default**: derived from the factory method used.
+
+##### setUsername
+
+The connection user. SQLite has no authentication, so `forSqlite()` leaves it unset.
+
+**Default**: `null` for SQLite, the `forMysql()` argument for MySQL.
+
+##### setPassword
+
+The connection password, unset for SQLite for the same reason as the username.
+
+**Default**: `null` for SQLite, the `forMysql()` argument for MySQL.
+
+##### setPdoOptions
+
+The options array handed to the PDO constructor, keyed by the `PDO::ATTR_*` constants. It replaces the driver defaults
+outright rather than merging, so carry over any you still want.
+
+**Default**: `[PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]` for SQLite. MySQL adds
+`PDO::ATTR_EMULATE_PREPARES => false`.
+
+##### setSessionStatements
+
+Statements replayed on every new connection, used to put each one into the state the storage expects. This also
+replaces the defaults outright, so include the ones you want to keep.
+
+**Default**: for SQLite, `PRAGMA busy_timeout = 5000`, `PRAGMA synchronous = NORMAL`, `PRAGMA journal_mode = WAL`, and
+`PRAGMA foreign_keys = ON`. For MySQL, `SET NAMES utf8mb4` and `SET time_zone = '+00:00'`.
+
+##### setSerializeSwooleWrites
+
+Whether concurrent writes funnel through a single connection while reads stay on their own. Honoured only under the
+Swoole runner, as the forking runner already writes on one inherited connection.
+
+SQLite allows one writer at a time, so serializing turns lock contention between coroutines into an ordered queue.
+MySQL handles concurrent writers itself, so serializing it only costs throughput.
+
+**Default**: `true` for SQLite, `false` for MySQL.
+
+##### setInitializeSchema
+
+Whether the storage issues its DDL on first connect. Turn it off to manage the tables yourself, covered in
+[Database Schema](Database-Schema.md).
+
+**Default**: `true`.
+
+##### setSubstringIndexMode
+
+Which index narrows substring filters such as `(cn=*smith*)`, maintained by the storage alongside the entries.
 
 | Mode | Behavior |
 | --- | --- |
-| `SubstringIndexMode::Auto` | The default. FTS5 on SQLite where the build provides it, trigram everywhere else. |
+| `SubstringIndexMode::Auto` | FTS5 on SQLite where the build provides it, trigram everywhere else. |
 | `SubstringIndexMode::Trigram` | The portable trigram table, supported by every driver. |
 | `SubstringIndexMode::None` | No index. Substring filters scan instead. |
 
@@ -468,6 +528,8 @@ $config = PdoConfig::forSqlite('/var/lib/myapp/ldap.sqlite')
 
 The index adds write cost and disk, so turn it off for a directory that never runs substring filters. Changing
 the mode on a directory that already holds entries needs the index rebuilt before those filters match again.
+
+**Default**: `SubstringIndexMode::Auto`.
 
 ## LDIF Data
 

--- a/src/FreeDSx/Ldap/Container/Contributor/DirectoryListenerContributor.php
+++ b/src/FreeDSx/Ldap/Container/Contributor/DirectoryListenerContributor.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Container\Contributor;
 
 use FreeDSx\Ldap\Server\Backend\ResettableInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\StorageReadBackend;
 use FreeDSx\Ldap\Server\Config\Storage\StorageConfigInterface;
 
 /**
@@ -28,7 +28,7 @@ final readonly class DirectoryListenerContributor implements ListenerContributor
      * @param array<class-string, object> $reloadInstances
      */
     public function __construct(
-        private WritableStorageBackend $backend,
+        private StorageReadBackend $backend,
         private array $reloadInstances,
         private StorageConfigInterface $storageConfig,
     ) {}

--- a/src/FreeDSx/Ldap/Container/Provider/ConnectionGraphContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/ConnectionGraphContainerProvider.php
@@ -20,7 +20,7 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler\AssertionEvaluator;
 use FreeDSx\Ldap\Server\Backend\Storage\AliasResolver;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
 use FreeDSx\Ldap\Server\Metrics\Rollup\OperationRollupCoordinator;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
@@ -83,7 +83,7 @@ final class ConnectionGraphContainerProvider implements ContainerProviderInterfa
             return new ReplicaBindStrategy(
                 $engine,
                 $container->get(ReplicaPasswordStateStoreInterface::class),
-                $container->get(WritableStorageBackend::class),
+                $container->get(ReadBackendInterface::class),
             );
         }
 
@@ -100,7 +100,7 @@ final class ConnectionGraphContainerProvider implements ContainerProviderInterfa
             $options->getSearchLimitRules(),
             $options->makeSearchLimits(),
         );
-        $resolver->setBackend($container->get(WritableStorageBackend::class));
+        $resolver->setBackend($container->get(ReadBackendInterface::class));
 
         return $resolver;
     }
@@ -109,7 +109,7 @@ final class ConnectionGraphContainerProvider implements ContainerProviderInterfa
     {
         return new AssertionEvaluator(
             $container->get(FilterEvaluatorInterface::class),
-            $container->get(WritableStorageBackend::class),
+            $container->get(ReadBackendInterface::class),
             $container->get(AccessControlInterface::class),
         );
     }

--- a/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
@@ -63,7 +63,8 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Operation\WriteEntryOperationHan
 use FreeDSx\Ldap\Server\Backend\Storage\OperationalAttributeGenerator;
 use FreeDSx\Ldap\Server\Backend\Storage\SearchStreamBuilder;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptionsFactory;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
+use FreeDSx\Ldap\Server\Backend\StorageReadBackend;
 use FreeDSx\Ldap\Server\Clock\ClockInterface;
 use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
 use FreeDSx\Ldap\Server\Clock\Sleeper\CoroutineSleeper;
@@ -171,7 +172,8 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
                 ComputeUpdateCommand::class => $c->get(ComputeUpdateHandler::class)->handle(...),
                 MoveCommand::class => $c->get(MoveEntryHandler::class)->handle(...),
             ]),
-            WritableStorageBackend::class => $this->makeBackend(...),
+            StorageReadBackend::class => $this->makeBackend(...),
+            ReadBackendInterface::class => static fn(Container $c): ReadBackendInterface => $c->get(StorageReadBackend::class),
             WriteRequestReplayer::class => $this->makeWriteRequestReplayer(...),
             ServerProtocolFactory::class => $this->makeServerProtocolFactory(...),
             ServerProtocolFactoryInterface::class => static fn(Container $c): ServerProtocolFactoryInterface => $c->get(ServerProtocolFactory::class),
@@ -200,7 +202,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
         ));
 
         // Both wrappers pass this inward, so the configured policy is the one that actually receives it.
-        $acl->setBackend($container->get(WritableStorageBackend::class));
+        $acl->setBackend($container->get(ReadBackendInterface::class));
 
         return $acl;
     }
@@ -226,7 +228,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
         return $container->get(ServerOptions::class)->getPasswordAuthenticator()
             ?? new PasswordAuthenticator(
                 $container->get(BindNameResolverInterface::class),
-                $container->get(WritableStorageBackend::class),
+                $container->get(ReadBackendInterface::class),
             );
     }
 
@@ -313,9 +315,9 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
             : null;
     }
 
-    private function makeBackend(Container $container): WritableStorageBackend
+    private function makeBackend(Container $container): StorageReadBackend
     {
-        return new WritableStorageBackend(
+        return new StorageReadBackend(
             storage: $container->get(EntryStorageInterface::class),
             searchStream: $container->get(SearchStreamBuilder::class),
             listOptions: $container->get(StorageListOptionsFactory::class),
@@ -563,10 +565,11 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
 
     private function makeListenerContributor(Container $container): ListenerContributorInterface
     {
-        $backend = $container->get(WritableStorageBackend::class);
+        // The concrete key, since the reloaded generation resolves its interface alias through this instance.
+        $backend = $container->get(StorageReadBackend::class);
 
         $instances = [
-            WritableStorageBackend::class => $backend,
+            StorageReadBackend::class => $backend,
             EntryStorageInterface::class => $container->get(EntryStorageInterface::class),
         ];
 

--- a/src/FreeDSx/Ldap/Container/Provider/HandlerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/HandlerContainerProvider.php
@@ -41,7 +41,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeStream;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\Backend\Write\WriteRequestRouter;
 use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
@@ -141,7 +141,7 @@ final class HandlerContainerProvider implements ContainerProviderInterface
     private function makeForwardHandler(Container $container): ServerProtocolHandlerInterface
     {
         return new ServerPasswordPolicyForwardHandler(
-            backend: $container->get(WritableStorageBackend::class),
+            backend: $container->get(ReadBackendInterface::class),
             writes: $container->get(WriteOperationDispatcher::class),
             policyResolver: $container->get(PasswordPolicyResolver::class),
             engine: $container->get(PasswordPolicyEngine::class),
@@ -174,7 +174,7 @@ final class HandlerContainerProvider implements ContainerProviderInterface
         ?SearchLimits $searchLimits,
     ): ServerSyncHandler {
         $options = $container->get(ServerOptions::class);
-        $backend = $container->get(WritableStorageBackend::class);
+        $backend = $container->get(ReadBackendInterface::class);
         $journal = $this->syncJournalFor($container);
         $projector = new SyncResultProjector(
             accessControl: $container->get(AccessControlInterface::class),
@@ -218,7 +218,7 @@ final class HandlerContainerProvider implements ContainerProviderInterface
         Container $container,
         HandlerContext $context,
     ): ServerDispatchHandler {
-        $backend = $container->get(WritableStorageBackend::class);
+        $backend = $container->get(ReadBackendInterface::class);
 
         return new ServerDispatchHandler(
             backend: $backend,
@@ -240,7 +240,7 @@ final class HandlerContainerProvider implements ContainerProviderInterface
         $options = $container->get(ServerOptions::class);
 
         return new ServerSearchHandler(
-            backend: $container->get(WritableStorageBackend::class),
+            backend: $container->get(ReadBackendInterface::class),
             filterEvaluator: $container->get(FilterEvaluatorInterface::class),
             accessControl: $container->get(AccessControlInterface::class),
             schema: $options->getSchema(),
@@ -256,7 +256,7 @@ final class HandlerContainerProvider implements ContainerProviderInterface
         $options = $container->get(ServerOptions::class);
 
         return new ServerPagingHandler(
-            backend: $container->get(WritableStorageBackend::class),
+            backend: $container->get(ReadBackendInterface::class),
             filterEvaluator: $container->get(FilterEvaluatorInterface::class),
             accessControl: $container->get(AccessControlInterface::class),
             requestHistory: $context->requestHistory,

--- a/src/FreeDSx/Ldap/Container/Provider/PasswordPolicyContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/PasswordPolicyContainerProvider.php
@@ -17,7 +17,7 @@ use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoBackend;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Config\Storage\PdoConfig;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\Clock\ClockInterface;
@@ -101,7 +101,7 @@ final class PasswordPolicyContainerProvider implements ContainerProviderInterfac
     private function makePasswordModifyTargetResolver(Container $container): PasswordModifyTargetResolver
     {
         return new PasswordModifyTargetResolver(
-            $container->get(WritableStorageBackend::class),
+            $container->get(ReadBackendInterface::class),
             $container->get(BindNameResolverInterface::class),
         );
     }
@@ -119,7 +119,7 @@ final class PasswordPolicyContainerProvider implements ContainerProviderInterfac
     private function makePasswordPolicyResolver(Container $container): PasswordPolicyResolver
     {
         $options = $container->get(ServerOptions::class);
-        $backend = $container->get(WritableStorageBackend::class);
+        $backend = $container->get(ReadBackendInterface::class);
 
         return new PasswordPolicyResolver(
             $backend,
@@ -135,7 +135,7 @@ final class PasswordPolicyContainerProvider implements ContainerProviderInterfac
     private function makePasswordPolicyComponentFactory(Container $container): PasswordPolicyComponentFactory
     {
         return new PasswordPolicyComponentFactory(
-            backend: $container->get(WritableStorageBackend::class),
+            backend: $container->get(ReadBackendInterface::class),
             options: $container->get(ServerOptions::class),
             writeDispatcher: $container->get(WriteOperationDispatcher::class),
             passwordPolicyEngine: $container->get(PasswordPolicyEngine::class),

--- a/src/FreeDSx/Ldap/Protocol/Authorization/AuthzIdResolver.php
+++ b/src/FreeDSx/Ldap/Protocol/Authorization/AuthzIdResolver.php
@@ -22,7 +22,7 @@ use FreeDSx\Ldap\Exception\UnexpectedValueException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\ServerEvent;
@@ -40,7 +40,7 @@ final readonly class AuthzIdResolver
 {
     public function __construct(
         private AccessControlInterface $accessControl,
-        private LdapBackendInterface $backend,
+        private ReadBackendInterface $backend,
         private BindNameResolverInterface $identityResolver,
         private EventLogger $eventLogger,
     ) {}

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/AssertionEvaluator.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/AssertionEvaluator.php
@@ -20,7 +20,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
@@ -41,7 +41,7 @@ final readonly class AssertionEvaluator
 {
     public function __construct(
         private FilterEvaluatorInterface $filterEvaluator,
-        private LdapBackendInterface $backend,
+        private ReadBackendInterface $backend,
         private AccessControlInterface $accessControl,
     ) {}
 

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/MatchedDnAccessFilterTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/MatchedDnAccessFilterTrait.php
@@ -16,7 +16,7 @@ namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -30,7 +30,7 @@ trait MatchedDnAccessFilterTrait
     private function filterMatchedDn(
         ?Dn $matchedDn,
         TokenInterface $token,
-        LdapBackendInterface $backend,
+        ReadBackendInterface $backend,
         AccessControlInterface $accessControl,
     ): ?Dn {
         if ($matchedDn === null) {

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ReadEntryControlHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ReadEntryControlHandler.php
@@ -25,7 +25,7 @@ use FreeDSx\Ldap\Operation\Request;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\OperationTargetDn;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 /**
@@ -44,7 +44,7 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
 final readonly class ReadEntryControlHandler
 {
     public function __construct(
-        private LdapBackendInterface $backend,
+        private ReadBackendInterface $backend,
         private Schema $schema,
         private AccessControlInterface $accessControl,
     ) {}

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -25,7 +25,7 @@ use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Write\Schema\SchemaViolations;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Backend\Write\WriteRequestRouter;
 use FreeDSx\Ldap\Server\Operation\CompareOperationResult;
@@ -42,7 +42,7 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
     private ReadEntryControlHandler $readEntryControlHandler;
 
     public function __construct(
-        private LdapBackendInterface $backend,
+        private ReadBackendInterface $backend,
         private WriteRequestRouter $router,
         private AccessControlInterface $accessControl,
         Schema $schema,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -26,7 +26,7 @@ use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\PageCursor;
 use FreeDSx\Ldap\Server\Backend\Storage\PageSlice;
@@ -54,7 +54,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
     use MatchedDnAccessFilterTrait;
 
     public function __construct(
-        private readonly LdapBackendInterface $backend,
+        private readonly ReadBackendInterface $backend,
         private readonly FilterEvaluatorInterface $filterEvaluator,
         private readonly AccessControlInterface $accessControl,
         private readonly RequestHistory $requestHistory,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandler.php
@@ -26,7 +26,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\Command\ComputeUpdateCommand;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
@@ -46,7 +46,7 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
 readonly class ServerPasswordPolicyForwardHandler implements ServerProtocolHandlerInterface
 {
     public function __construct(
-        private LdapBackendInterface $backend,
+        private ReadBackendInterface $backend,
         private WriteHandlerInterface $writes,
         private PasswordPolicyResolver $policyResolver,
         private PasswordPolicyEngine $engine,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -21,7 +21,7 @@ use FreeDSx\Ldap\Protocol\Queue\Response\Cancellation;
 use FreeDSx\Ldap\Protocol\Queue\Response\QueueWriterConfig;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
@@ -42,7 +42,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
     private const CANCEL_CHECK_INTERVAL = 50;
 
     public function __construct(
-        private readonly LdapBackendInterface $backend,
+        private readonly ReadBackendInterface $backend,
         private readonly FilterEvaluatorInterface $filterEvaluator,
         private readonly AccessControlInterface $accessControl,
         private readonly Schema $schema,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSyncHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSyncHandler.php
@@ -31,7 +31,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\Response\Cancellation;
 use FreeDSx\Ldap\Protocol\Queue\Response\QueueWriterConfig;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeStream;
 use FreeDSx\Ldap\Server\Operation\SearchOperationResult;
 use FreeDSx\Ldap\Server\SearchLimits;
@@ -63,7 +63,7 @@ final class ServerSyncHandler implements ServerProtocolHandlerInterface
     ];
 
     public function __construct(
-        private readonly LdapBackendInterface $backend,
+        private readonly ReadBackendInterface $backend,
         private readonly SyncResultProjector $projector,
         private readonly SearchLimits $limits = new SearchLimits(),
         private readonly ?ChangeStream $changeStream = null,

--- a/src/FreeDSx/Ldap/Server/AccessControl/BackendAwareInterface.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/BackendAwareInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\AccessControl;
 
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 
 /**
  * Implemented by access control classes or matchers that need a backend injected at startup.
@@ -22,5 +22,5 @@ use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
  */
 interface BackendAwareInterface
 {
-    public function setBackend(LdapBackendInterface $backend): void;
+    public function setBackend(ReadBackendInterface $backend): void;
 }

--- a/src/FreeDSx/Ldap/Server/AccessControl/ConfidentialAttributeAccessControl.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/ConfidentialAttributeAccessControl.php
@@ -18,7 +18,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
 use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationAccess;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
 use function count;
@@ -35,7 +35,7 @@ final readonly class ConfidentialAttributeAccessControl implements AccessControl
         private ConfidentialAttributePolicy $policy,
     ) {}
 
-    public function setBackend(LdapBackendInterface $backend): void
+    public function setBackend(ReadBackendInterface $backend): void
     {
         if ($this->inner instanceof BackendAwareInterface) {
             $this->inner->setBackend($backend);

--- a/src/FreeDSx/Ldap/Server/AccessControl/PrivilegedBypassAccessControl.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/PrivilegedBypassAccessControl.php
@@ -18,7 +18,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
 use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationAccess;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Token\PrivilegedTokenInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
@@ -31,7 +31,7 @@ final readonly class PrivilegedBypassAccessControl implements AccessControlInter
 {
     public function __construct(private AccessControlInterface $inner) {}
 
-    public function setBackend(LdapBackendInterface $backend): void
+    public function setBackend(ReadBackendInterface $backend): void
     {
         if ($this->inner instanceof BackendAwareInterface) {
             $this->inner->setBackend($backend);

--- a/src/FreeDSx/Ldap/Server/AccessControl/RuleBasedAccessControl.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/RuleBasedAccessControl.php
@@ -29,7 +29,7 @@ use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationAccess;
 use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\SubjectMatcherInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
@@ -47,7 +47,7 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
         $this->rules = $rules ?? AclRules::secureDefault();
     }
 
-    public function setBackend(LdapBackendInterface $backend): void
+    public function setBackend(ReadBackendInterface $backend): void
     {
         $allRules = [
             ...$this->rules->operations,

--- a/src/FreeDSx/Ldap/Server/AccessControl/Subject/GroupSubjectMatcher.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Subject/GroupSubjectMatcher.php
@@ -18,7 +18,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\SubjectEvaluationException;
 use FreeDSx\Ldap\Server\AccessControl\BackendAwareInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Clock\ClockInterface;
 use FreeDSx\Ldap\Server\Clock\SystemClock;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
@@ -38,7 +38,7 @@ final class GroupSubjectMatcher implements SubjectMatcherInterface, BackendAware
 {
     private readonly Dn $groupDn;
 
-    private ?LdapBackendInterface $backend = null;
+    private ?ReadBackendInterface $backend = null;
 
     private ?Entry $cached = null;
 
@@ -56,7 +56,7 @@ final class GroupSubjectMatcher implements SubjectMatcherInterface, BackendAware
         $this->groupDn = new Dn($groupDn);
     }
 
-    public function setBackend(LdapBackendInterface $backend): void
+    public function setBackend(ReadBackendInterface $backend): void
     {
         $this->backend = $backend;
     }
@@ -122,7 +122,7 @@ final class GroupSubjectMatcher implements SubjectMatcherInterface, BackendAware
             || ($now->getTimestamp() - $this->cachedAt->getTimestamp()) >= $this->cacheTtl;
     }
 
-    private function backend(): LdapBackendInterface
+    private function backend(): ReadBackendInterface
     {
         if ($this->backend === null) {
             throw new LogicException('No backend set on GroupSubjectMatcher; call setBackend() before use.');

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/NameResolver/AttributeSearchBindNameResolver.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/NameResolver/AttributeSearchBindNameResolver.php
@@ -19,7 +19,7 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Search\Filters;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Subentry\SubentryVisibility;
 
 /**
@@ -44,7 +44,7 @@ final class AttributeSearchBindNameResolver implements BindNameResolverInterface
      */
     public function resolve(
         string $name,
-        LdapBackendInterface $backend,
+        ReadBackendInterface $backend,
     ): ?Entry {
         $request = (new SearchRequest(Filters::equal(
             $this->attribute,

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/NameResolver/BindNameResolverChain.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/NameResolver/BindNameResolverChain.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Auth\NameResolver;
 
 use FreeDSx\Ldap\Entry\Entry;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 
 /**
  * Tries each resolver in order, returning the first non-null result.
@@ -30,7 +30,7 @@ final readonly class BindNameResolverChain implements BindNameResolverInterface
 
     public function resolve(
         string $name,
-        LdapBackendInterface $backend,
+        ReadBackendInterface $backend,
     ): ?Entry {
         foreach ($this->resolvers as $resolver) {
             $entry = $resolver->resolve(

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/NameResolver/BindNameResolverInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/NameResolver/BindNameResolverInterface.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Auth\NameResolver;
 
 use FreeDSx\Ldap\Entry\Entry;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 
 /**
  * Translates a raw LDAP bind name into an Entry.
@@ -28,6 +28,6 @@ interface BindNameResolverInterface
      */
     public function resolve(
         string $name,
-        LdapBackendInterface $backend,
+        ReadBackendInterface $backend,
     ): ?Entry;
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/NameResolver/DnBindNameResolver.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/NameResolver/DnBindNameResolver.php
@@ -15,10 +15,10 @@ namespace FreeDSx\Ldap\Server\Backend\Auth\NameResolver;
 
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 
 /**
- * Default resolver: treats the bind name as a DN and delegates to LdapBackendInterface::get().
+ * Default resolver: treats the bind name as a DN and delegates to ReadBackendInterface::get().
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -26,7 +26,7 @@ final class DnBindNameResolver implements BindNameResolverInterface
 {
     public function resolve(
         string $name,
-        LdapBackendInterface $backend,
+        ReadBackendInterface $backend,
     ): ?Entry {
         return $backend->get(new Dn($name));
     }

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordAuthenticator.php
@@ -18,7 +18,7 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Sasl\Mechanism\MechanismName;
@@ -33,7 +33,7 @@ final class PasswordAuthenticator implements PasswordAuthenticatableInterface
 {
     public function __construct(
         private readonly BindNameResolverInterface $resolver,
-        private readonly LdapBackendInterface $backend,
+        private readonly ReadBackendInterface $backend,
         private readonly PasswordHashService $hashService = new PasswordHashService(),
     ) {}
 

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordPolicyAwareAuthenticator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/PasswordPolicyAwareAuthenticator.php
@@ -16,7 +16,7 @@ namespace FreeDSx\Ldap\Server\Backend\Auth;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\Attempt\PasswordBindAttempt;
 use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyBindGuard;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
@@ -33,7 +33,7 @@ final readonly class PasswordPolicyAwareAuthenticator implements PasswordAuthent
     public function __construct(
         private PasswordAuthenticatableInterface $decoratedAuthenticator,
         private BindNameResolverInterface $nameResolver,
-        private LdapBackendInterface $backend,
+        private ReadBackendInterface $backend,
         private PasswordPolicyResolver $policyResolver,
         private PasswordPolicyBindGuard $guard,
     ) {}

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/SaslBindPolicyEnforcer.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/SaslBindPolicyEnforcer.php
@@ -18,7 +18,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\Attempt\PasswordBindAttempt;
 use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyBindGuard;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyContext;
@@ -32,7 +32,7 @@ final readonly class SaslBindPolicyEnforcer
 {
     public function __construct(
         private BindNameResolverInterface $nameResolver,
-        private LdapBackendInterface $backend,
+        private ReadBackendInterface $backend,
         private PasswordPolicyResolver $resolver,
         private PasswordPolicyBindGuard $guard,
         private PasswordPolicyContext $context,

--- a/src/FreeDSx/Ldap/Server/Backend/ReadBackendInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/ReadBackendInterface.php
@@ -29,7 +29,7 @@ use FreeDSx\Ldap\Server\Subentry\SubentryVisibility;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-interface LdapBackendInterface
+interface ReadBackendInterface
 {
     /**
      * @param SubentryVisibility $subentries Which entry population is in scope; callers state it, as no default is safe for all.

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStorageInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStorageInterface.php
@@ -18,7 +18,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Support\DefaultHasChildrenTrait;
 
 /**
- * Raw persistence contract; LDAP semantics live in WritableStorageBackend. Dn parameters are always normalised (lowercased).
+ * Raw persistence contract; LDAP semantics live in the read backend and write handlers above it. Dn parameters are always normalised (lowercased).
  *
  * @internal
  *

--- a/src/FreeDSx/Ldap/Server/Backend/StorageReadBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/StorageReadBackend.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap\Server\Backend\Storage;
+namespace FreeDSx\Ldap\Server\Backend;
 
 use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Entry\Dn;
@@ -19,11 +19,14 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
-use FreeDSx\Ldap\Server\Backend\ResettableInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Directory\EntryLocator;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\InvalidAttributeException;
 use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\PageSlice;
+use FreeDSx\Ldap\Server\Backend\Storage\SearchStreamBuilder;
+use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptionsFactory;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Subentry\SubentryVisibility;
 use Generator;
@@ -33,14 +36,14 @@ use Generator;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final class WritableStorageBackend implements LdapBackendInterface, ResettableInterface
+final readonly class StorageReadBackend implements ReadBackendInterface, ResettableInterface
 {
     public function __construct(
-        private readonly EntryStorageInterface $storage,
-        private readonly SearchStreamBuilder $searchStream,
-        private readonly StorageListOptionsFactory $listOptions,
-        private readonly FilterEvaluatorInterface $filterEvaluator,
-        private readonly EntryLocator $locator,
+        private EntryStorageInterface $storage,
+        private SearchStreamBuilder $searchStream,
+        private StorageListOptionsFactory $listOptions,
+        private FilterEvaluatorInterface $filterEvaluator,
+        private EntryLocator $locator,
     ) {}
 
     public function reset(): void

--- a/src/FreeDSx/Ldap/Server/Backend/Write/PasswordPolicyWriteHandler.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/PasswordPolicyWriteHandler.php
@@ -19,7 +19,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 use FreeDSx\Ldap\Server\Backend\Write\SystemChange\SystemChangeWriterInterface;
@@ -41,7 +41,7 @@ final readonly class PasswordPolicyWriteHandler implements WriteHandlerInterface
     ];
 
     public function __construct(
-        private LdapBackendInterface $backend,
+        private ReadBackendInterface $backend,
         private WriteHandlerInterface $writes,
         private PasswordPolicyChangeGuard $changeGuard,
         private SystemChangeWriterInterface $systemChangeWriter,

--- a/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
+++ b/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
@@ -44,8 +44,7 @@ use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordPolicyAwareAuthenticator;
 use FreeDSx\Ldap\Server\Backend\Auth\SaslBindPolicyEnforcer;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
@@ -107,7 +106,7 @@ final class ConnectionHandlerBuilder implements ConnectionHandlerBuilderInterfac
         $metricsRecorder = $this->container->get(MetricsRecorderInterface::class);
 
         $eventLogger = $this->makeEventLogger($context);
-        $backend = $this->container->get(WritableStorageBackend::class);
+        $backend = $this->container->get(ReadBackendInterface::class);
         $passwordAuthenticator = $this->container->get(PasswordAuthenticatableInterface::class);
 
         // Always composed: policy may come from a DIT entry that appears after the server starts.
@@ -212,7 +211,7 @@ final class ConnectionHandlerBuilder implements ConnectionHandlerBuilderInterfac
 
     private function decoratePasswordAuthenticator(
         PasswordAuthenticatableInterface $inner,
-        LdapBackendInterface $backend,
+        ReadBackendInterface $backend,
         PasswordPolicyContext $policyContext,
         EventLogger $eventLogger,
     ): PasswordPolicyAwareAuthenticator {
@@ -236,7 +235,7 @@ final class ConnectionHandlerBuilder implements ConnectionHandlerBuilderInterfac
         EventLogger $eventLogger,
         PasswordAuthenticatableInterface $authenticator,
         AuthzIdResolver $authzIdResolver,
-        LdapBackendInterface $backend,
+        ReadBackendInterface $backend,
         ?PasswordPolicyContext $policyContext,
         array $saslMechanisms,
     ): SaslBind {
@@ -272,7 +271,7 @@ final class ConnectionHandlerBuilder implements ConnectionHandlerBuilderInterfac
     }
 
     private function makeSaslPolicyEnforcer(
-        LdapBackendInterface $backend,
+        ReadBackendInterface $backend,
         PasswordPolicyContext $policyContext,
         EventLogger $eventLogger,
     ): SaslBindPolicyEnforcer {
@@ -374,7 +373,7 @@ final class ConnectionHandlerBuilder implements ConnectionHandlerBuilderInterfac
         array $authenticators,
         DispatchAuthorizer $dispatchAuthorizer,
         ?PasswordPolicyContext $policyContext,
-        LdapBackendInterface $backend,
+        ReadBackendInterface $backend,
         ProtocolHandlerProviderInterface $handlerProvider,
     ): MiddlewareChain {
         $options = $this->serverOptions();

--- a/src/FreeDSx/Ldap/Server/Middleware/ResponseWriterMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/ResponseWriterMiddleware.php
@@ -21,7 +21,7 @@ use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseWriter;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\MatchedDnAccessFilterTrait;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
@@ -41,7 +41,7 @@ final readonly class ResponseWriterMiddleware implements MiddlewareInterface
 
     public function __construct(
         private ResponseWriter $writer,
-        private LdapBackendInterface $backend,
+        private ReadBackendInterface $backend,
         private AccessControlInterface $accessControl,
         private ResponseFactory $responseFactory = new ResponseFactory(),
     ) {}

--- a/src/FreeDSx/Ldap/Server/PasswordModify/PasswordModifyTargetResolver.php
+++ b/src/FreeDSx/Ldap/Server/PasswordModify/PasswordModifyTargetResolver.php
@@ -16,7 +16,7 @@ namespace FreeDSx\Ldap\Server\PasswordModify;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\Request\PasswordModifyRequest;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 
 /**
@@ -25,7 +25,7 @@ use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
 final readonly class PasswordModifyTargetResolver
 {
     public function __construct(
-        private LdapBackendInterface $backend,
+        private ReadBackendInterface $backend,
         private BindNameResolverInterface $identityResolver,
     ) {}
 

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Guard/BindStrategy/ReplicaBindStrategy.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Guard/BindStrategy/ReplicaBindStrategy.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\PasswordPolicy\Guard\BindStrategy;
 
 use FreeDSx\Ldap\Entry\Dn;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\Attempt\PasswordBindAttempt;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
 use FreeDSx\Ldap\Server\PasswordPolicy\Decision\PasswordPolicyOutcome;
@@ -35,7 +35,7 @@ final readonly class ReplicaBindStrategy implements PasswordPolicyBindStrategyIn
     public function __construct(
         private PasswordPolicyEngine $engine,
         private ReplicaPasswordStateStoreInterface $store,
-        private LdapBackendInterface $backend,
+        private ReadBackendInterface $backend,
     ) {}
 
     /**

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyComponentFactory.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyComponentFactory.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\PasswordPolicy;
 
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\PasswordPolicyWriteHandler;
 use FreeDSx\Ldap\Server\Backend\Write\SystemChange\NullSystemChangeWriter;
 use FreeDSx\Ldap\Server\Backend\Write\SystemChange\SystemChangeWriter;
 use FreeDSx\Ldap\Server\Backend\Write\SystemChange\SystemChangeWriterInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyChangeGuard;
@@ -32,7 +32,7 @@ use FreeDSx\Ldap\ServerOptions;
 final readonly class PasswordPolicyComponentFactory
 {
     public function __construct(
-        private LdapBackendInterface $backend,
+        private ReadBackendInterface $backend,
         private ServerOptions $options,
         private WriteHandlerInterface $writeDispatcher,
         private PasswordPolicyEngine $passwordPolicyEngine,

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyResolver.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/PasswordPolicyResolver.php
@@ -18,7 +18,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Subentry\GoverningSubentryResolver;
 
 /**
@@ -32,7 +32,7 @@ final readonly class PasswordPolicyResolver
      * @param ?GoverningSubentryResolver $subentries Null when subentry-based policy is not enabled.
      */
     public function __construct(
-        private LdapBackendInterface $backend,
+        private ReadBackendInterface $backend,
         private ?Dn $defaultPolicyDn,
         private ?PasswordPolicy $inMemoryFallback,
         private ?GoverningSubentryResolver $subentries = null,

--- a/src/FreeDSx/Ldap/Server/SearchLimit/SearchLimitResolver.php
+++ b/src/FreeDSx/Ldap/Server/SearchLimit/SearchLimitResolver.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\SearchLimit;
 
 use FreeDSx\Ldap\Server\AccessControl\BackendAwareInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\SearchLimits;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 
@@ -28,7 +28,7 @@ final class SearchLimitResolver implements SearchLimitResolverInterface, Backend
         private readonly SearchLimits $default,
     ) {}
 
-    public function setBackend(LdapBackendInterface $backend): void
+    public function setBackend(ReadBackendInterface $backend): void
     {
         foreach ($this->rules->rules as $rule) {
             if ($rule->subject instanceof BackendAwareInterface) {

--- a/src/FreeDSx/Ldap/Server/Subentry/GoverningSubentryResolver.php
+++ b/src/FreeDSx/Ldap/Server/Subentry/GoverningSubentryResolver.php
@@ -22,7 +22,7 @@ use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Search\Filters;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 
 use function iterator_to_array;
 use function sprintf;
@@ -35,7 +35,7 @@ use function sprintf;
 final readonly class GoverningSubentryResolver
 {
     public function __construct(
-        private LdapBackendInterface $backend,
+        private ReadBackendInterface $backend,
         private SubtreeSpecificationEvaluator $evaluator,
         private SubtreeSpecificationParser $parser = new SubtreeSpecificationParser(),
     ) {}

--- a/src/FreeDSx/Ldap/Sync/Provider/SyncPersistStreamer.php
+++ b/src/FreeDSx/Ldap/Sync/Provider/SyncPersistStreamer.php
@@ -23,7 +23,7 @@ use FreeDSx\Ldap\Operation\Response\SyncInfo\SyncNewCookie;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\Response\Cancellation;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ReplicaId;
@@ -46,7 +46,7 @@ final readonly class SyncPersistStreamer
     public const DEFAULT_POLL_INTERVAL = 1.0;
 
     public function __construct(
-        private LdapBackendInterface $backend,
+        private ReadBackendInterface $backend,
         private SyncResultProjector $projector,
         private ChangeStream $stream,
         private SleeperInterface $sleeper,

--- a/tests/integration/Security/PasswordPolicyBindEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyBindEnforcementTest.php
@@ -25,7 +25,7 @@ use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\DnBindNameResolver;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticator;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordPolicyAwareAuthenticator;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\StorageReadBackend;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
@@ -61,7 +61,7 @@ final class PasswordPolicyBindEnforcementTest extends TestCase
 
     private FrozenClock $clock;
 
-    private WritableStorageBackend $backend;
+    private StorageReadBackend $backend;
 
     private PasswordPolicyContext $context;
 
@@ -615,7 +615,7 @@ final class PasswordPolicyBindEnforcementTest extends TestCase
             ),
             $user,
         ]));
-        $this->backend = $container->get(WritableStorageBackend::class);
+        $this->backend = $container->get(StorageReadBackend::class);
 
         $nameResolver = new DnBindNameResolver();
         $engine = new PasswordPolicyEngine(

--- a/tests/integration/Security/PasswordPolicyChangeEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyChangeEnforcementTest.php
@@ -32,7 +32,7 @@ use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\DnBindNameResolver;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
 use FreeDSx\Ldap\Server\Clock\ClockInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\StorageReadBackend;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
@@ -70,7 +70,7 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
 
     private FrozenClock $clock;
 
-    private WritableStorageBackend $backend;
+    private StorageReadBackend $backend;
 
     private PasswordPolicyContext $context;
 
@@ -366,7 +366,7 @@ final class PasswordPolicyChangeEnforcementTest extends TestCase
                 ] + $extra,
             ),
         ]));
-        $this->backend = $container->get(WritableStorageBackend::class);
+        $this->backend = $container->get(StorageReadBackend::class);
 
         return new ServerPasswordModifyHandler(
             service: new PasswordModifyService(

--- a/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
+++ b/tests/integration/Security/PasswordPolicyPlainModifyEnforcementTest.php
@@ -32,7 +32,7 @@ use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
 use FreeDSx\Ldap\Server\Clock\ClockInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\StorageReadBackend;
 use FreeDSx\Ldap\Server\Backend\Write\PasswordPolicyWriteHandler;
 use FreeDSx\Ldap\Server\Backend\Write\SystemChange\SystemChangeWriter;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
@@ -68,7 +68,7 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
 
     private FrozenClock $clock;
 
-    private WritableStorageBackend $backend;
+    private StorageReadBackend $backend;
 
     private PasswordPolicyContext $context;
 
@@ -398,7 +398,7 @@ final class PasswordPolicyPlainModifyEnforcementTest extends TestCase
                 ] + $userAttrs,
             ),
         ]));
-        $this->backend = $container->get(WritableStorageBackend::class);
+        $this->backend = $container->get(StorageReadBackend::class);
 
         $guard = new PasswordPolicyChangeGuard(
             $this->fromContainer(

--- a/tests/support/ServerContainerTrait.php
+++ b/tests/support/ServerContainerTrait.php
@@ -15,7 +15,7 @@ namespace Tests\Support\FreeDSx\Ldap;
 
 use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\StorageReadBackend;
 use FreeDSx\Ldap\ServerOptions;
 use Tests\Support\FreeDSx\Ldap\Server\Configuration\TestServerOptions;
 
@@ -96,9 +96,9 @@ trait ServerContainerTrait
     private function backendFor(
         EntryStorageInterface $storage,
         ?ServerOptions $options = null,
-    ): WritableStorageBackend {
+    ): StorageReadBackend {
         return $this->fromContainer(
-            WritableStorageBackend::class,
+            StorageReadBackend::class,
             [EntryStorageInterface::class => $storage],
             $options,
         );

--- a/tests/unit/Protocol/Authorization/AuthzIdResolverTest.php
+++ b/tests/unit/Protocol/Authorization/AuthzIdResolverTest.php
@@ -21,7 +21,7 @@ use FreeDSx\Ldap\Protocol\Authorization\AuthzId;
 use FreeDSx\Ldap\Protocol\Authorization\AuthzIdResolver;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
 use FreeDSx\Ldap\Server\Token\AnonToken;
@@ -39,7 +39,7 @@ final class AuthzIdResolverTest extends TestCase
 
     private AccessControlInterface&MockObject $accessControl;
 
-    private LdapBackendInterface&MockObject $backend;
+    private ReadBackendInterface&MockObject $backend;
 
     private BindNameResolverInterface&MockObject $identityResolver;
 
@@ -50,7 +50,7 @@ final class AuthzIdResolverTest extends TestCase
     protected function setUp(): void
     {
         $this->accessControl = $this->createMock(AccessControlInterface::class);
-        $this->backend = $this->createMock(LdapBackendInterface::class);
+        $this->backend = $this->createMock(ReadBackendInterface::class);
         $this->identityResolver = $this->createMock(BindNameResolverInterface::class);
         $this->subject = new AuthzIdResolver(
             $this->accessControl,

--- a/tests/unit/Protocol/Authorization/DispatchAuthorizerTest.php
+++ b/tests/unit/Protocol/Authorization/DispatchAuthorizerTest.php
@@ -28,7 +28,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordResetGate;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
@@ -44,7 +44,7 @@ final class DispatchAuthorizerTest extends TestCase
 
     private ServerAuthorization&MockObject $authorizer;
 
-    private LdapBackendInterface&MockObject $backend;
+    private ReadBackendInterface&MockObject $backend;
 
     private AccessControlInterface&MockObject $accessControl;
 
@@ -53,7 +53,7 @@ final class DispatchAuthorizerTest extends TestCase
     protected function setUp(): void
     {
         $this->authorizer = $this->createMock(ServerAuthorization::class);
-        $this->backend = $this->createMock(LdapBackendInterface::class);
+        $this->backend = $this->createMock(ReadBackendInterface::class);
         $this->accessControl = $this->createMock(AccessControlInterface::class);
         $this->accessControl
             ->method('mayUseControl')

--- a/tests/unit/Protocol/Authorization/ProxiedAuthorizationResolverTest.php
+++ b/tests/unit/Protocol/Authorization/ProxiedAuthorizationResolverTest.php
@@ -29,7 +29,7 @@ use FreeDSx\Ldap\Protocol\Authorization\AuthzIdResolver;
 use FreeDSx\Ldap\Protocol\Authorization\ProxiedAuthorizationResolver;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
@@ -49,7 +49,7 @@ final class ProxiedAuthorizationResolverTest extends TestCase
 
     private AccessControlInterface&MockObject $accessControl;
 
-    private LdapBackendInterface&MockObject $backend;
+    private ReadBackendInterface&MockObject $backend;
 
     private BindNameResolverInterface&MockObject $identityResolver;
 
@@ -62,7 +62,7 @@ final class ProxiedAuthorizationResolverTest extends TestCase
     protected function setUp(): void
     {
         $this->accessControl = $this->createMock(AccessControlInterface::class);
-        $this->backend = $this->createMock(LdapBackendInterface::class);
+        $this->backend = $this->createMock(ReadBackendInterface::class);
         $this->identityResolver = $this->createMock(BindNameResolverInterface::class);
         $this->recordingLogger = new RecordingLogger();
         $this->subject = new ProxiedAuthorizationResolver(

--- a/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/ExternalMechanismOptionsBuilderTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/OptionsBuilder/ExternalMechanismOptionsBuilderTest.php
@@ -24,7 +24,7 @@ use FreeDSx\Ldap\Protocol\Bind\Sasl\OptionsBuilder\ExternalMechanismOptionsBuild
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
@@ -47,14 +47,14 @@ final class ExternalMechanismOptionsBuilderTest extends TestCase
 
     private AccessControlInterface&MockObject $accessControl;
 
-    private LdapBackendInterface&MockObject $backend;
+    private ReadBackendInterface&MockObject $backend;
 
     private AuthzIdResolver $authzIdResolver;
 
     protected function setUp(): void
     {
         $this->accessControl = $this->createMock(AccessControlInterface::class);
-        $this->backend = $this->createMock(LdapBackendInterface::class);
+        $this->backend = $this->createMock(ReadBackendInterface::class);
         $this->authzIdResolver = new AuthzIdResolver(
             $this->accessControl,
             $this->backend,

--- a/tests/unit/Protocol/Bind/Sasl/SaslExchangeTest.php
+++ b/tests/unit/Protocol/Bind/Sasl/SaslExchangeTest.php
@@ -31,7 +31,7 @@ use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\SaslIdentity;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Sasl\Challenge\ChallengeInterface;
 use FreeDSx\Sasl\Mechanism\CramMD5Mechanism;
@@ -68,7 +68,7 @@ final class SaslExchangeTest extends TestCase
             optionsBuilderFactory: new MechanismOptionsBuilderFactory($mockAuthenticator),
             authzIdResolver: new AuthzIdResolver(
                 $this->createMock(AccessControlInterface::class),
-                $this->createMock(LdapBackendInterface::class),
+                $this->createMock(ReadBackendInterface::class),
                 $this->createMock(BindNameResolverInterface::class),
                 new EventLogger(null),
             ),
@@ -365,7 +365,7 @@ final class SaslExchangeTest extends TestCase
             optionsBuilderFactory: new MechanismOptionsBuilderFactory($authenticator),
             authzIdResolver: new AuthzIdResolver(
                 $this->createMock(AccessControlInterface::class),
-                $this->createMock(LdapBackendInterface::class),
+                $this->createMock(ReadBackendInterface::class),
                 $this->createMock(BindNameResolverInterface::class),
                 new EventLogger(null),
             ),

--- a/tests/unit/Protocol/Bind/SaslBindTest.php
+++ b/tests/unit/Protocol/Bind/SaslBindTest.php
@@ -34,7 +34,7 @@ use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\SaslIdentity;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Ldap\ServerOptions;
@@ -162,7 +162,7 @@ final class SaslBindTest extends TestCase
 
         $accessControl = $this->createMock(AccessControlInterface::class);
         $accessControl->method('mayUseControl')->willReturn(true);
-        $backend = $this->createMock(LdapBackendInterface::class);
+        $backend = $this->createMock(ReadBackendInterface::class);
         $backend->method('get')->willReturn(new Entry(new Dn('cn=alice,dc=foo,dc=bar')));
 
         $this->mockQueue
@@ -213,7 +213,7 @@ final class SaslBindTest extends TestCase
 
         $this->subjectWith($this->resolverWith(
             $accessControl,
-            $this->createMock(LdapBackendInterface::class),
+            $this->createMock(ReadBackendInterface::class),
         ))->bind(new LdapMessageRequest(
             1,
             new SaslBindRequest('PLAIN', $credentials),
@@ -370,13 +370,13 @@ final class SaslBindTest extends TestCase
     {
         return $this->resolverWith(
             $this->createMock(AccessControlInterface::class),
-            $this->createMock(LdapBackendInterface::class),
+            $this->createMock(ReadBackendInterface::class),
         );
     }
 
     private function resolverWith(
         AccessControlInterface $accessControl,
-        LdapBackendInterface $backend,
+        ReadBackendInterface $backend,
     ): AuthzIdResolver {
         return new AuthzIdResolver(
             $accessControl,

--- a/tests/unit/Protocol/ServerProtocolHandler/AssertionEvaluatorTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/AssertionEvaluatorTest.php
@@ -17,7 +17,7 @@ use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\AccessControl\Target\Target;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
 use Tests\Support\FreeDSx\Ldap\ServerContainerTrait;
 use FreeDSx\Ldap\Server\Token\BindToken;
@@ -29,7 +29,7 @@ final class AssertionEvaluatorTest extends TestCase
 {
     use ServerContainerTrait;
 
-    private LdapBackendInterface&MockObject $backend;
+    private ReadBackendInterface&MockObject $backend;
 
     private AssertionEvaluator $subject;
 
@@ -39,7 +39,7 @@ final class AssertionEvaluatorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->backend = $this->createMock(LdapBackendInterface::class);
+        $this->backend = $this->createMock(ReadBackendInterface::class);
         $this->targetDn = new Dn('cn=foo,dc=ex,dc=com');
         $this->token = BindToken::fromDn('cn=foo,dc=ex,dc=com');
         $this->subject = new AssertionEvaluator(

--- a/tests/unit/Protocol/ServerProtocolHandler/ReadEntryControlHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ReadEntryControlHandlerTest.php
@@ -20,7 +20,7 @@ use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
 use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\AccessControl\Target\Target;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -28,7 +28,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ReadEntryControlHandlerTest extends TestCase
 {
-    private LdapBackendInterface&MockObject $backend;
+    private ReadBackendInterface&MockObject $backend;
 
     private ReadEntryControlHandler $subject;
 
@@ -38,7 +38,7 @@ final class ReadEntryControlHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->backend = $this->createMock(LdapBackendInterface::class);
+        $this->backend = $this->createMock(ReadBackendInterface::class);
         $this->dn = new Dn('cn=foo,dc=ex,dc=com');
         $this->token = BindToken::fromDn('cn=foo,dc=ex,dc=com');
         $this->subject = new ReadEntryControlHandler(

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerDispatchHandlerTest.php
@@ -28,7 +28,7 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerDispatchHandler;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Search\Filter\EqualityFilter;
 use FreeDSx\Ldap\Search\Filters;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteRequestRouter;
@@ -44,7 +44,7 @@ final class ServerDispatchHandlerTest extends TestCase
 {
     private ServerDispatchHandler $subject;
 
-    private LdapBackendInterface&MockObject $mockBackend;
+    private ReadBackendInterface&MockObject $mockBackend;
 
     private WriteHandlerInterface&MockObject $mockWriteHandler;
 
@@ -55,7 +55,7 @@ final class ServerDispatchHandlerTest extends TestCase
     protected function setUp(): void
     {
         $this->mockToken = $this->createMock(TokenInterface::class);
-        $this->mockBackend = $this->createMock(LdapBackendInterface::class);
+        $this->mockBackend = $this->createMock(ReadBackendInterface::class);
         $this->mockWriteHandler = $this->createMock(WriteHandlerInterface::class);
         $this->mockAccessControl = $this->createMock(AccessControlInterface::class);
 

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
@@ -35,7 +35,7 @@ use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Schema\SchemaResource;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\FetchedBatch;
 use FreeDSx\Ldap\Server\Backend\Storage\PageCursor;
@@ -58,7 +58,7 @@ class ServerPagingHandlerTest extends TestCase
 
     private ServerQueue&MockObject $mockQueue;
 
-    private LdapBackendInterface&MockObject $mockBackend;
+    private ReadBackendInterface&MockObject $mockBackend;
 
     private FilterEvaluatorInterface&MockObject $mockFilterEvaluator;
 
@@ -79,7 +79,7 @@ class ServerPagingHandlerTest extends TestCase
     {
         $this->mockToken = $this->createMock(TokenInterface::class);
         $this->mockQueue = $this->createMock(ServerQueue::class);
-        $this->mockBackend = $this->createMock(LdapBackendInterface::class);
+        $this->mockBackend = $this->createMock(ReadBackendInterface::class);
         $this->mockFilterEvaluator = $this->createMock(FilterEvaluatorInterface::class);
         $this->mockAccessControl = $this->createMock(AccessControlInterface::class);
         $this->requestHistory = new RequestHistory();

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordModifyHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordModifyHandlerTest.php
@@ -26,7 +26,7 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerPasswordModifyHandler;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\Operation\OperationOutcome;
 use FreeDSx\Ldap\Server\Operation\PasswordModifyOperationResult;
@@ -43,7 +43,7 @@ use PHPUnit\Framework\TestCase;
  */
 final class ServerPasswordModifyHandlerTest extends TestCase
 {
-    private LdapBackendInterface&MockObject $mockBackend;
+    private ReadBackendInterface&MockObject $mockBackend;
 
     private ServerPasswordModifyHandler $subject;
 
@@ -53,7 +53,7 @@ final class ServerPasswordModifyHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mockBackend = $this->createMock(LdapBackendInterface::class);
+        $this->mockBackend = $this->createMock(ReadBackendInterface::class);
         $mockWriteHandler = $this->createMock(WriteHandlerInterface::class);
 
         $this->userEntry = new Entry(

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandlerTest.php
@@ -25,7 +25,7 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerPasswordPolicyForwardHandler;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\Command\ComputeUpdateCommand;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
@@ -47,7 +47,7 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
 
     private const DN = 'cn=user,dc=foo,dc=bar';
 
-    private LdapBackendInterface&MockObject $backend;
+    private ReadBackendInterface&MockObject $backend;
 
     private WriteHandlerInterface&MockObject $writes;
 
@@ -59,7 +59,7 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->backend = $this->createMock(LdapBackendInterface::class);
+        $this->backend = $this->createMock(ReadBackendInterface::class);
         $this->writes = $this->createMock(WriteHandlerInterface::class);
         $this->accessControl = $this->createMock(AccessControlInterface::class);
         $this->subject = new ServerPasswordPolicyForwardHandler(

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
@@ -37,7 +37,7 @@ use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Schema\SchemaResource;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Operation\OperationOutcome;
@@ -56,7 +56,7 @@ final class ServerSearchHandlerTest extends TestCase
 
     private ServerQueue&MockObject $mockQueue;
 
-    private LdapBackendInterface&MockObject $mockBackend;
+    private ReadBackendInterface&MockObject $mockBackend;
 
     private FilterEvaluatorInterface&MockObject $mockFilterEvaluator;
 
@@ -75,7 +75,7 @@ final class ServerSearchHandlerTest extends TestCase
     {
         $this->mockToken = $this->createMock(TokenInterface::class);
         $this->mockQueue = $this->createMock(ServerQueue::class);
-        $this->mockBackend = $this->createMock(LdapBackendInterface::class);
+        $this->mockBackend = $this->createMock(ReadBackendInterface::class);
         $this->mockFilterEvaluator = $this->createMock(FilterEvaluatorInterface::class);
         $this->mockAccessControl = $this->createMock(AccessControlInterface::class);
         $this->schema = SchemaResource::Core->load();

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSyncHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSyncHandlerTest.php
@@ -35,7 +35,7 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerSyncHandler;
 use FreeDSx\Ldap\Schema\SchemaResource;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\FetchedBatch;
 use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
@@ -67,7 +67,7 @@ final class ServerSyncHandlerTest extends TestCase
 
     private ServerQueue&MockObject $queue;
 
-    private LdapBackendInterface&MockObject $backend;
+    private ReadBackendInterface&MockObject $backend;
 
     private FilterEvaluatorInterface&MockObject $filterEvaluator;
 
@@ -115,7 +115,7 @@ final class ServerSyncHandlerTest extends TestCase
     protected function setUp(): void
     {
         $this->queue = $this->createMock(ServerQueue::class);
-        $this->backend = $this->createMock(LdapBackendInterface::class);
+        $this->backend = $this->createMock(ReadBackendInterface::class);
         $this->filterEvaluator = $this->createMock(FilterEvaluatorInterface::class);
         $this->accessControl = $this->createMock(AccessControlInterface::class);
         $this->token = $this->createMock(TokenInterface::class);

--- a/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
+++ b/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
@@ -34,7 +34,7 @@ use FreeDSx\Ldap\Server\AccessControl\Subject\CallbackSubjectMatcher;
 use FreeDSx\Ldap\Server\AccessControl\Subject\SelfSubjectMatcher;
 use FreeDSx\Ldap\Server\AccessControl\Subject\SubjectMatcherInterface;
 use FreeDSx\Ldap\Server\AccessControl\Target\AnyTargetMatcher;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
@@ -724,7 +724,7 @@ final class RuleBasedAccessControlTest extends TestCase
 
     public function test_set_backend_propagates_to_backend_aware_subjects(): void
     {
-        $mockBackend = $this->createMock(LdapBackendInterface::class);
+        $mockBackend = $this->createMock(ReadBackendInterface::class);
 
         /** @var SubjectMatcherInterface&BackendAwareInterface&MockObject $mockBackendAwareSubject */
         $mockBackendAwareSubject = $this->createMockForIntersectionOfInterfaces([
@@ -749,7 +749,7 @@ final class RuleBasedAccessControlTest extends TestCase
      */
     public function test_set_backend_propagates_to_confidential_rule_subjects(): void
     {
-        $mockBackend = $this->createMock(LdapBackendInterface::class);
+        $mockBackend = $this->createMock(ReadBackendInterface::class);
 
         /** @var SubjectMatcherInterface&BackendAwareInterface&MockObject $mockBackendAwareSubject */
         $mockBackendAwareSubject = $this->createMockForIntersectionOfInterfaces([

--- a/tests/unit/Server/AccessControl/Subject/GroupSubjectMatcherTest.php
+++ b/tests/unit/Server/AccessControl/Subject/GroupSubjectMatcherTest.php
@@ -18,7 +18,7 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\SubjectEvaluationException;
 use FreeDSx\Ldap\Server\AccessControl\Subject\GroupSubjectMatcher;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -27,13 +27,13 @@ use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
 
 final class GroupSubjectMatcherTest extends TestCase
 {
-    private LdapBackendInterface&MockObject $mockBackend;
+    private ReadBackendInterface&MockObject $mockBackend;
 
     private Dn $targetDn;
 
     protected function setUp(): void
     {
-        $this->mockBackend = $this->createMock(LdapBackendInterface::class);
+        $this->mockBackend = $this->createMock(ReadBackendInterface::class);
         $this->targetDn = new Dn('dc=foo,dc=bar');
     }
 

--- a/tests/unit/Server/Backend/Auth/NameResolver/BindNameResolverChainTest.php
+++ b/tests/unit/Server/Backend/Auth/NameResolver/BindNameResolverChainTest.php
@@ -17,13 +17,13 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverChain;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class BindNameResolverChainTest extends TestCase
 {
-    private LdapBackendInterface&MockObject $mockBackend;
+    private ReadBackendInterface&MockObject $mockBackend;
 
     private BindNameResolverInterface&MockObject $mockResolverA;
 
@@ -31,7 +31,7 @@ final class BindNameResolverChainTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->mockBackend = $this->createMock(LdapBackendInterface::class);
+        $this->mockBackend = $this->createMock(ReadBackendInterface::class);
         $this->mockResolverA = $this->createMock(BindNameResolverInterface::class);
         $this->mockResolverB = $this->createMock(BindNameResolverInterface::class);
     }

--- a/tests/unit/Server/Backend/Auth/NameResolver/DnBindNameResolverTest.php
+++ b/tests/unit/Server/Backend/Auth/NameResolver/DnBindNameResolverTest.php
@@ -17,17 +17,17 @@ use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\DnBindNameResolver;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class DnBindNameResolverTest extends TestCase
 {
-    private LdapBackendInterface&MockObject $mockBackend;
+    private ReadBackendInterface&MockObject $mockBackend;
 
     protected function setUp(): void
     {
-        $this->mockBackend = $this->createMock(LdapBackendInterface::class);
+        $this->mockBackend = $this->createMock(ReadBackendInterface::class);
     }
 
     public function test_resolve_calls_backend_get_with_dn(): void

--- a/tests/unit/Server/Backend/Auth/NameResolver/PasswordAuthenticatorTest.php
+++ b/tests/unit/Server/Backend/Auth/NameResolver/PasswordAuthenticatorTest.php
@@ -23,7 +23,7 @@ use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticator;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashScheme;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
 use FreeDSx\Ldap\Server\Backend\Auth\SaslIdentity;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Sasl\Mechanism\MechanismName;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -49,12 +49,12 @@ final class PasswordAuthenticatorTest extends TestCase
 
     private BindNameResolverInterface&MockObject $mockResolver;
 
-    private LdapBackendInterface&MockObject $mockBackend;
+    private ReadBackendInterface&MockObject $mockBackend;
 
     protected function setUp(): void
     {
         $this->mockResolver = $this->createMock(BindNameResolverInterface::class);
-        $this->mockBackend = $this->createMock(LdapBackendInterface::class);
+        $this->mockBackend = $this->createMock(ReadBackendInterface::class);
     }
 
     public function test_throws_when_entry_not_found(): void

--- a/tests/unit/Server/Backend/Auth/PasswordPolicyAwareAuthenticatorTest.php
+++ b/tests/unit/Server/Backend/Auth/PasswordPolicyAwareAuthenticatorTest.php
@@ -21,7 +21,7 @@ use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordPolicyAwareAuthenticator;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteRequestInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
@@ -203,7 +203,7 @@ final class PasswordPolicyAwareAuthenticatorTest extends TestCase
 
     private function authenticator(?PasswordPolicy $policy): PasswordPolicyAwareAuthenticator
     {
-        $backend = $this->createMock(LdapBackendInterface::class);
+        $backend = $this->createMock(ReadBackendInterface::class);
         $updates = $this->createMock(WriteHandlerInterface::class);
         $updates->method('handle')->willReturnCallback(
             function (WriteRequestInterface $request, WriteContext $context): void {

--- a/tests/unit/Server/Backend/Auth/SaslBindPolicyEnforcerTest.php
+++ b/tests/unit/Server/Backend/Auth/SaslBindPolicyEnforcerTest.php
@@ -23,7 +23,7 @@ use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\DnBindNameResolver;
 use FreeDSx\Ldap\Server\Backend\Auth\SaslBindPolicyEnforcer;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\StorageReadBackend;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
@@ -51,7 +51,7 @@ final class SaslBindPolicyEnforcerTest extends TestCase
 
     private FrozenClock $clock;
 
-    private WritableStorageBackend $backend;
+    private StorageReadBackend $backend;
 
     private PasswordPolicyContext $context;
 
@@ -190,7 +190,7 @@ final class SaslBindPolicyEnforcerTest extends TestCase
                 ] + $userAttrs,
             ),
         ]));
-        $this->backend = $container->get(WritableStorageBackend::class);
+        $this->backend = $container->get(StorageReadBackend::class);
 
         $engine = new PasswordPolicyEngine(
             clock: $this->clock,

--- a/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
@@ -50,7 +50,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Exception\DnTooLongException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\StorageIoException;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 use FreeDSx\Ldap\Server\Backend\Storage\LdapImporter;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\StorageReadBackend;
 use FreeDSx\Ldap\Server\Backend\Write\Operation\AddEntryHandler;
 use FreeDSx\Ldap\Server\Subentry\SubentryVisibility;
 use FreeDSx\Ldap\Control\ControlBag;
@@ -76,7 +76,7 @@ final class PdoStorageTest extends TestCase
 
     use SubtreeRenameStorageContractTests;
 
-    private WritableStorageBackend $subject;
+    private StorageReadBackend $subject;
 
     private LdapImporter $importer;
 
@@ -94,7 +94,7 @@ final class PdoStorageTest extends TestCase
 
         $this->storage = $this->pdoStorage(TestServerOptions::sqlite());
         $container = $this->containerFor($this->storage);
-        $this->subject = $container->get(WritableStorageBackend::class);
+        $this->subject = $container->get(StorageReadBackend::class);
         $this->importer = $container->get(LdapImporter::class);
         $this->seed(
             new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example')),
@@ -676,7 +676,7 @@ final class PdoStorageTest extends TestCase
     public function test_list_from_root_returns_all_entries(): void
     {
         // Test the storage interface directly with an empty base DN (root listing).
-        // WritableStorageBackend requires the base DN to exist, so bypass it here.
+        // StorageReadBackend requires the base DN to exist, so bypass it here.
         $results = iterator_to_array($this->storage->list(StorageListOptions::matchAll(new Dn(''), true))->entries);
 
         self::assertCount(2, $results);
@@ -1559,14 +1559,14 @@ final class PdoStorageTest extends TestCase
     private function seededBackend(
         ServerOptions $options,
         Entry ...$entries,
-    ): WritableStorageBackend {
+    ): StorageReadBackend {
         $container = $this->containerFor(
             $this->pdoStorage(TestServerOptions::sqlite()),
             $options,
         );
         $container->get(LdapImporter::class)->importEntries($entries);
 
-        return $container->get(WritableStorageBackend::class);
+        return $container->get(StorageReadBackend::class);
     }
 
     /**

--- a/tests/unit/Server/Backend/StorageReadBackendTest.php
+++ b/tests/unit/Server/Backend/StorageReadBackendTest.php
@@ -28,7 +28,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Exception\InvalidAttributeException;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
 use FreeDSx\Ldap\Server\Backend\Storage\FetchedBatch;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\StorageReadBackend;
 use FreeDSx\Ldap\Server\Subentry\SubentryVisibility;
 use FreeDSx\Ldap\ServerOptions;
 use Generator;
@@ -38,11 +38,11 @@ use PHPUnit\Framework\TestCase;
 use Tests\Support\FreeDSx\Ldap\Server\Configuration\TestServerOptions;
 use Tests\Support\FreeDSx\Ldap\ServerContainerTrait;
 
-final class WritableStorageBackendTest extends TestCase
+final class StorageReadBackendTest extends TestCase
 {
     use ServerContainerTrait;
 
-    private WritableStorageBackend $subject;
+    private StorageReadBackend $subject;
 
     private Entry $alice;
 
@@ -593,7 +593,7 @@ final class WritableStorageBackendTest extends TestCase
         return TestServerOptions::unvalidatedCore();
     }
 
-    private function aliasBackend(): WritableStorageBackend
+    private function aliasBackend(): StorageReadBackend
     {
         return $this->backendFor(new InMemoryStorage([
             $this->base,

--- a/tests/unit/Server/Backend/Write/PasswordPolicyWriteHandlerTest.php
+++ b/tests/unit/Server/Backend/Write/PasswordPolicyWriteHandlerTest.php
@@ -23,7 +23,7 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
 use FreeDSx\Ldap\Server\Clock\ClockInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
-use FreeDSx\Ldap\Server\Backend\Storage\WritableStorageBackend;
+use FreeDSx\Ldap\Server\Backend\StorageReadBackend;
 use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
@@ -58,7 +58,7 @@ final class PasswordPolicyWriteHandlerTest extends TestCase
 
     private FrozenClock $clock;
 
-    private WritableStorageBackend $backend;
+    private StorageReadBackend $backend;
 
     private PasswordPolicyContext $context;
 
@@ -372,7 +372,7 @@ final class PasswordPolicyWriteHandlerTest extends TestCase
                 ] + $userAttrs,
             ),
         ]), $options);
-        $this->backend = $container->get(WritableStorageBackend::class);
+        $this->backend = $container->get(StorageReadBackend::class);
         $writes = $container->get(WriteOperationDispatcher::class);
 
         $guard = new PasswordPolicyChangeGuard(

--- a/tests/unit/Server/Middleware/AssertionMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/AssertionMiddlewareTest.php
@@ -27,7 +27,7 @@ use FreeDSx\Ldap\Protocol\ServerProtocolHandler\AssertionEvaluator;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\AccessControl\AclRules;
 use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
 use Tests\Support\FreeDSx\Ldap\ServerContainerTrait;
 use FreeDSx\Ldap\Server\Middleware\AssertionMiddleware;
@@ -42,7 +42,7 @@ final class AssertionMiddlewareTest extends TestCase
 {
     use ServerContainerTrait;
 
-    private LdapBackendInterface&MockObject $backend;
+    private ReadBackendInterface&MockObject $backend;
 
     private AssertionMiddleware $subject;
 
@@ -50,7 +50,7 @@ final class AssertionMiddlewareTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->backend = $this->createMock(LdapBackendInterface::class);
+        $this->backend = $this->createMock(ReadBackendInterface::class);
         $this->backend
             ->method('get')
             ->willReturn(Entry::fromArray(

--- a/tests/unit/Server/Middleware/ResponseWriterMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/ResponseWriterMiddlewareTest.php
@@ -30,7 +30,7 @@ use FreeDSx\Ldap\Protocol\Queue\Response\ResponseWriter;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
 use FreeDSx\Ldap\Server\Middleware\ResponseWriterMiddleware;
 use FreeDSx\Ldap\Server\Operation\OperationOutcome;
@@ -48,7 +48,7 @@ final class ResponseWriterMiddlewareTest extends TestCase
 {
     private ServerQueue&MockObject $mockQueue;
 
-    private LdapBackendInterface&MockObject $mockBackend;
+    private ReadBackendInterface&MockObject $mockBackend;
 
     private AccessControlInterface&MockObject $mockAccessControl;
 
@@ -64,7 +64,7 @@ final class ResponseWriterMiddlewareTest extends TestCase
     protected function setUp(): void
     {
         $this->mockQueue = $this->createMock(ServerQueue::class);
-        $this->mockBackend = $this->createMock(LdapBackendInterface::class);
+        $this->mockBackend = $this->createMock(ReadBackendInterface::class);
         $this->mockAccessControl = $this->createMock(AccessControlInterface::class);
         $this->mockToken = $this->createMock(TokenInterface::class);
 

--- a/tests/unit/Server/PasswordModify/PasswordModifyServiceTest.php
+++ b/tests/unit/Server/PasswordModify/PasswordModifyServiceTest.php
@@ -25,7 +25,7 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\NameResolver\BindNameResolverInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordHashService;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyService;
 use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyTargetResolver;
@@ -38,7 +38,7 @@ final class PasswordModifyServiceTest extends TestCase
 {
     private const USER_DN = 'cn=user,dc=foo,dc=bar';
 
-    private LdapBackendInterface&MockObject $backend;
+    private ReadBackendInterface&MockObject $backend;
 
     private BindNameResolverInterface&MockObject $resolver;
 
@@ -54,7 +54,7 @@ final class PasswordModifyServiceTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->backend = $this->createMock(LdapBackendInterface::class);
+        $this->backend = $this->createMock(ReadBackendInterface::class);
         $this->resolver = $this->createMock(BindNameResolverInterface::class);
         $this->accessControl = $this->createMock(AccessControlInterface::class);
         $writeHandler = $this->createMock(WriteHandlerInterface::class);

--- a/tests/unit/Server/PasswordPolicy/Guard/BindStrategy/ReplicaBindStrategyTest.php
+++ b/tests/unit/Server/PasswordPolicy/Guard/BindStrategy/ReplicaBindStrategyTest.php
@@ -35,7 +35,7 @@ use Tests\Support\FreeDSx\Ldap\ServerContainerTrait;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordLockoutRules;
 use FreeDSx\Ldap\Server\PasswordPolicy\UserPasswordState;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
@@ -52,7 +52,7 @@ final class ReplicaBindStrategyTest extends TestCase
 
     private ReplicaPasswordStateStoreInterface $store;
 
-    private LdapBackendInterface&MockObject $backend;
+    private ReadBackendInterface&MockObject $backend;
 
     private PasswordPolicyContext $context;
 
@@ -69,7 +69,7 @@ final class ReplicaBindStrategyTest extends TestCase
                 new Attribute('cn', 'foo'),
             ));
         $this->store = $this->fromContainer(ReplicaPasswordStateStoreInterface::class);
-        $this->backend = $this->createMock(LdapBackendInterface::class);
+        $this->backend = $this->createMock(ReadBackendInterface::class);
         $this->context = new PasswordPolicyContext();
         $this->sleeper = new RecordingSleeper();
 

--- a/tests/unit/Server/PasswordPolicy/Guard/PasswordPolicyChangeGuardTest.php
+++ b/tests/unit/Server/PasswordPolicy/Guard/PasswordPolicyChangeGuardTest.php
@@ -20,7 +20,7 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Clock\ClockInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\Attempt\PasswordModifyAttempt;
 use FreeDSx\Ldap\Server\PasswordPolicy\Guard\PasswordPolicyChangeGuard;
@@ -237,7 +237,7 @@ final class PasswordPolicyChangeGuardTest extends TestCase
                 [ClockInterface::class => $this->clock],
             ),
             new PasswordPolicyResolver(
-                $this->createMock(LdapBackendInterface::class),
+                $this->createMock(ReadBackendInterface::class),
                 null,
                 $policy,
             ),

--- a/tests/unit/Server/PasswordPolicy/PasswordPolicyResolverTest.php
+++ b/tests/unit/Server/PasswordPolicy/PasswordPolicyResolverTest.php
@@ -15,7 +15,7 @@ namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy;
 
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicy;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyResolver;
 use FreeDSx\Ldap\Server\PasswordPolicy\Rules\PasswordQualityRules;
@@ -284,7 +284,7 @@ final class PasswordPolicyResolverTest extends TestCase
             ] + $extra,
         );
 
-        $backend = $this->createMock(LdapBackendInterface::class);
+        $backend = $this->createMock(ReadBackendInterface::class);
         $backend->method('get')
             ->willReturnCallback(static fn(Dn $dn): ?Entry => $dn->toString() === 'dc=example,dc=com'
                 ? Entry::fromArray(
@@ -312,9 +312,9 @@ final class PasswordPolicyResolverTest extends TestCase
      *
      * @param array<string, Entry> $entries DN string → entry
      */
-    private function backend(array $entries = []): LdapBackendInterface&MockObject
+    private function backend(array $entries = []): ReadBackendInterface&MockObject
     {
-        $backend = $this->createMock(LdapBackendInterface::class);
+        $backend = $this->createMock(ReadBackendInterface::class);
         $backend->method('get')
             ->willReturnCallback(function (Dn $dn) use ($entries): ?Entry {
                 $key = $dn->toString();

--- a/tests/unit/Sync/Provider/SyncPersistStreamerTest.php
+++ b/tests/unit/Sync/Provider/SyncPersistStreamerTest.php
@@ -36,7 +36,7 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Schema\SchemaResource;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\Backend\LdapBackendInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\ChangeType;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Change\PendingChange;
@@ -62,7 +62,7 @@ final class SyncPersistStreamerTest extends TestCase
 
     private ServerQueue&MockObject $queue;
 
-    private LdapBackendInterface&MockObject $backend;
+    private ReadBackendInterface&MockObject $backend;
 
     private TokenInterface&MockObject $token;
 
@@ -111,7 +111,7 @@ final class SyncPersistStreamerTest extends TestCase
             ->method('peekForCancelSignal')
             ->willReturnCallback(fn(): ?LdapMessageRequest => array_shift($this->cancelSignals));
 
-        $this->backend = $this->createMock(LdapBackendInterface::class);
+        $this->backend = $this->createMock(ReadBackendInterface::class);
         $this->backend
             ->method('get')
             ->willReturnCallback(fn(Dn $dn): ?Entry => $this->liveEntries[$dn->toString()] ?? null);


### PR DESCRIPTION
With the writable storage backend decomposed, this renames the interface and class so it's more clear what it's for. This finishes breaking apart the early extension points of the server side. So hopefully there aren't any more large areas to churn.