### PR TITLE
Backport some fixes to the maintenance branch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+0.9.0 (2026-08-28)
+------------------
+* Fix the LDAP server shut down when connections arrive while others are still queued.
+* Fix each forked child process holding open the connections of every client that came before it.
+* Fix the server signal handlers only being installed once the first client connected.
+* Require the POSIX extension in the LdapServer.
+* Log errors that stop the server from accepting clients / notifying of shutdown.
+* Add a "max_clients" option to limit how many clients the LDAP server will handle. Defaults to 1024.
+
 0.8.1 (2026-04-25)
 ------------------
 * Lock FreeDSx dependencies to prepare for a 1.0 release. This will be the final 0.x release.

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
   },
   "suggest": {
     "ext-openssl": "For SSL/TLS support and some SASL mechanisms.",
-    "ext-pcntl": "For LDAP server functionality."
+    "ext-pcntl": "For LDAP server functionality.",
+    "ext-posix": "For LDAP server functionality."
   },
   "autoload": {
     "psr-4": {"FreeDSx\\Ldap\\": "src/FreeDSx/Ldap"}

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -8,6 +8,7 @@ LDAP Server Configuration
     * [transport](#transport)
     * [logger](#logger)
     * [idle_timeout](#idle_timeout)
+    * [max_clients](#max_clients)
     * [require_authentication](#require_authentication)
     * [allow_anonymous](#allow_anonymous)
 * [LDAP Protocol Handlers](#ldap-protocol-handlers)
@@ -102,6 +103,13 @@ Consider an idle client to timeout after this period of time (in seconds) and di
 -1, the client can idle indefinitely and not timeout the connection to the server.
 
 **Default**: `600`
+
+------------------
+#### max_clients
+
+The maximum number of clients served at once. Connections past the limit are closed. Set to `0` for no limit.
+
+**Default**: `1024`
 
 ------------------
 #### require_authentication

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -41,6 +41,7 @@ class LdapServer
         'unix_socket' => '/var/run/ldap.socket',
         'transport' => 'tcp',
         'idle_timeout' => 600,
+        'max_clients' => 1024,
         'require_authentication' => true,
         'allow_anonymous' => false,
         'request_handler' => null,

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -21,6 +21,7 @@ use FreeDSx\Ldap\Server\RequestHandler\HandlerFactory;
 use FreeDSx\Ldap\Server\RequestHandler\RequestHandlerInterface;
 use FreeDSx\Socket\Socket;
 use FreeDSx\Socket\SocketServer;
+use Throwable;
 
 /**
  * Uses PNCTL to fork incoming requests and send them to the server protocol handler.
@@ -69,16 +70,6 @@ class PcntlServerRunner implements ServerRunnerInterface
     /**
      * @var bool
      */
-    protected $isPosixExtLoaded;
-
-    /**
-     * @var bool
-     */
-    protected $isServerSignalsInstalled = false;
-
-    /**
-     * @var bool
-     */
     protected $isShuttingDown = false;
 
     /**
@@ -93,13 +84,13 @@ class PcntlServerRunner implements ServerRunnerInterface
      */
     public function __construct(array $options = [])
     {
-        if (!extension_loaded('pcntl')) {
-            throw new RuntimeException('The PCNTL extension is needed to fork incoming requests, which is only available on Linux.');
+        if (!extension_loaded('pcntl') || !extension_loaded('posix')) {
+            throw new RuntimeException(
+                'The PCNTL and POSIX extensions are needed to fork and manage child processes, which is only available on Linux.'
+            );
         }
         $this->options = $options;
 
-        // posix_kill needs this...we cannot clean up child processes without it on shutdown...
-        $this->isPosixExtLoaded = extension_loaded('posix');
         // We need to be able to handle signals as they come in, regardless of what is going on...
         pcntl_async_signals(true);
 
@@ -123,6 +114,19 @@ class PcntlServerRunner implements ServerRunnerInterface
 
         try {
             $this->acceptClients();
+        } catch (Throwable $e) {
+            $this->logError(
+                'The server stopped accepting clients due to an error.',
+                array_merge(
+                    $this->defaultContext,
+                    [
+                        'error' => $e->getMessage(),
+                        'error_class' => get_class($e),
+                    ]
+                )
+            );
+
+            throw $e;
         } finally {
             if ($this->isMainProcess) {
                 $this->handleServerShutdown();
@@ -167,6 +171,7 @@ class PcntlServerRunner implements ServerRunnerInterface
      */
     private function acceptClients(): void
     {
+        $this->installServerSignalHandlers();
         $this->logInfo(
             'The server process has started and is now accepting clients.',
             $this->defaultContext
@@ -194,6 +199,15 @@ class PcntlServerRunner implements ServerRunnerInterface
                 continue;
             }
 
+            if ($this->isClientLimitReached()) {
+                $this->cleanUpChildProcesses();
+            }
+            if ($this->isClientLimitReached()) {
+                $this->rejectClient($socket);
+
+                continue;
+            }
+
             $pid = pcntl_fork();
             if ($pid == -1) {
                 // In parent process, but could not fork...
@@ -214,7 +228,40 @@ class PcntlServerRunner implements ServerRunnerInterface
                     $socket
                 );
             }
-        } while ($this->server->isConnected());
+        } while (!$this->isShuttingDown);
+    }
+
+    private function releaseInheritedConnections(Socket $keep): void
+    {
+        // Dropping the reference to free the descriptors
+        foreach ($this->server->getClients() as $client) {
+            if ($client !== $keep) {
+                $this->server->removeClient($client);
+            }
+        }
+        $this->childProcesses = [];
+    }
+
+    private function isClientLimitReached(): bool
+    {
+        $maxClients = isset($this->options['max_clients'])
+            ? (int) $this->options['max_clients']
+            : 0;
+
+        return $maxClients > 0 && count($this->childProcesses) >= $maxClients;
+    }
+
+    private function rejectClient(Socket $socket): void
+    {
+        $this->logInfo(
+            'The maximum number of clients has been reached. Closing the connection.',
+            array_merge(
+                $this->defaultContext,
+                ['max_clients' => (int) $this->options['max_clients']]
+            )
+        );
+        $this->server->removeClient($socket);
+        $socket->close();
     }
 
     /**
@@ -241,7 +288,20 @@ class PcntlServerRunner implements ServerRunnerInterface
                         'The child process has received a signal to stop.',
                         $context
                     );
-                    $protocolHandler->shutdown($context);
+                    try {
+                        $protocolHandler->shutdown($context);
+                    } catch (Throwable $e) {
+                        $this->logError(
+                            'Unable to notify the client of the shutdown.',
+                            array_merge(
+                                $context,
+                                [
+                                    'error' => $e->getMessage(),
+                                    'error_class' => get_class($e),
+                                ]
+                            )
+                        );
+                    }
                 }
             );
         }
@@ -253,7 +313,7 @@ class PcntlServerRunner implements ServerRunnerInterface
     private function installServerSignalHandlers(): void
     {
         foreach ($this->handledSignals as $signal) {
-            $this->isServerSignalsInstalled = pcntl_signal(
+            pcntl_signal(
                 $signal,
                 function () {
                     $this->handleServerShutdown();
@@ -284,12 +344,6 @@ class PcntlServerRunner implements ServerRunnerInterface
             $this->defaultContext
         );
 
-        // We can't do anything else without the posix ext ... :(
-        if (!$this->isPosixExtLoaded) {
-            $this->cleanUpChildProcesses();
-
-            return;
-        }
         // Ask nicely first...
         $this->endChildProcesses(SIGTERM);
 
@@ -360,6 +414,7 @@ class PcntlServerRunner implements ServerRunnerInterface
     ): void {
         $context = ['pid' => $pid];
         $this->isMainProcess = false;
+        $this->releaseInheritedConnections($socket);
         $serverProtocolHandler = new ServerProtocolHandler(
             new ServerQueue($socket),
             new HandlerFactory($this->options),
@@ -387,17 +442,13 @@ class PcntlServerRunner implements ServerRunnerInterface
     /**
      * When a new Socket is received, we do the following:
      *
-     *     1. If the server has not installed its signal handlers, do that first.
-     *     2. Add the ChildProcess to the list of running child processes.
-     *     3. Clean-up any currently running child processes.
+     *     1. Add the ChildProcess to the list of running child processes.
+     *     2. Clean-up any currently running child processes.
      */
     private function runAfterChildStarted(
         int $pid,
         Socket $socket
     ): void {
-        if (!$this->isServerSignalsInstalled) {
-            $this->installServerSignalHandlers();
-        }
         $this->childProcesses[] = new ChildProcess(
             $pid,
             $socket

--- a/tests/spec/FreeDSx/Ldap/LdapServerSpec.php
+++ b/tests/spec/FreeDSx/Ldap/LdapServerSpec.php
@@ -76,6 +76,7 @@ class LdapServerSpec extends ObjectBehavior
             'unix_socket' => "/var/run/ldap.socket",
             'transport' => "tcp",
             'idle_timeout' => 600,
+            'max_clients' => 1024,
             'require_authentication' => true,
             'allow_anonymous' => false,
             'request_handler' => null,


### PR DESCRIPTION
This backports several fixes to the maintenance branch. One being a security advisory that was submitted (no max connections options for the LdapServer). However, that's arguably the least problematic thing with the server on the maintenance branch. This takes a bunch of fixes in the main branch and puts them into the maintenance branch.

On current main the server is no longer a shell and actually has a real storage component. It is very close to being release ready, but not quite there yet. I wasn't actually expecting people to use the current LdapServer class for anything substantial since it's just a shell that doesn't handle any LDAP semantics outside the base protocol.

However, these are the fixes I'll apply for the maintenance branch of the server:

* Fix the LDAP server shut down logic when connections arrive while others are still queued.
* Fix each forked child process holding open the connections of every client that came before it.
* Fix the server signal handlers only being installed once the first client connected.
* Require the POSIX extension in the LdapServer.
* Log errors that stop the server from accepting clients / notifying of shutdown.
* Add a "max_clients" option to limit how many clients the LDAP server will handle. Defaults to 1024.