### PR TITLE
[1.0.0] Update critical control handling / version validation.

### DIFF
--- a/src/FreeDSx/Ldap/Control/Control.php
+++ b/src/FreeDSx/Ldap/Control/Control.php
@@ -151,8 +151,11 @@ class Control implements ProtocolElementInterface, Stringable
     {
         $asn1 = Asn1::sequence(
             Asn1::octetString($this->controlType),
-            Asn1::boolean($this->criticality),
         );
+        // RFC 4511 5.1: a field holding its default value is absent from the encoding.
+        if ($this->criticality) {
+            $asn1->addChild(Asn1::boolean(true));
+        }
 
         if ($this->controlValue !== null) {
             $encoder = new LdapEncoder();

--- a/src/FreeDSx/Ldap/Control/Sync/SyncDoneControl.php
+++ b/src/FreeDSx/Ldap/Control/Sync/SyncDoneControl.php
@@ -66,9 +66,10 @@ class SyncDoneControl extends Control
                 $this->cookie,
             ));
         }
-        $this->controlValue->addChild(Asn1::boolean(
-            $this->refreshDeletes,
-        ));
+        // RFC 4511 5.1: a field holding its default value is absent from the encoding.
+        if ($this->refreshDeletes) {
+            $this->controlValue->addChild(Asn1::boolean(true));
+        }
 
         return parent::toAsn1();
     }

--- a/src/FreeDSx/Ldap/Control/Sync/SyncRequestControl.php
+++ b/src/FreeDSx/Ldap/Control/Sync/SyncRequestControl.php
@@ -102,7 +102,11 @@ class SyncRequestControl extends Control
         if ($this->cookie !== null) {
             $this->controlValue->addChild(Asn1::octetString($this->cookie));
         }
-        $this->controlValue->addChild(Asn1::boolean($this->reloadHint));
+
+        // RFC 4511 5.1: a field holding its default value is absent from the encoding.
+        if ($this->reloadHint) {
+            $this->controlValue->addChild(Asn1::boolean(true));
+        }
 
         return parent::toAsn1();
     }

--- a/src/FreeDSx/Ldap/Operation/Response/SyncInfo/SyncIdSet.php
+++ b/src/FreeDSx/Ldap/Operation/Response/SyncInfo/SyncIdSet.php
@@ -92,10 +92,12 @@ class SyncIdSet extends SyncInfoMessage
         foreach ($this->entryUuids as $uuid) {
             $uuids[] = Asn1::octetString($uuid);
         }
-        $asn1->addChild(
-            Asn1::boolean($this->refreshDeletes),
-            Asn1::setOf(...$uuids),
-        );
+        // RFC 4511 5.1: a field holding its default value is absent from the encoding.
+        if ($this->refreshDeletes) {
+            $asn1->addChild(Asn1::boolean(true));
+        }
+
+        $asn1->addChild(Asn1::setOf(...$uuids));
 
         $this->setResponseValueToEncode($asn1);
 

--- a/src/FreeDSx/Ldap/Operation/Response/SyncInfo/SyncRefreshDoneTrait.php
+++ b/src/FreeDSx/Ldap/Operation/Response/SyncInfo/SyncRefreshDoneTrait.php
@@ -57,9 +57,10 @@ trait SyncRefreshDoneTrait
             ));
         }
 
-        $asn1->addChild(Asn1::boolean(
-            $this->refreshDone,
-        ));
+        // RFC 4511 5.1: a field holding its default value is absent, and this one defaults to TRUE.
+        if (!$this->refreshDone) {
+            $asn1->addChild(Asn1::boolean(false));
+        }
 
         $this->setResponseValueToEncode($asn1);
 

--- a/src/FreeDSx/Ldap/Protocol/Bind/VersionValidatorTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/Bind/VersionValidatorTrait.php
@@ -15,17 +15,24 @@ namespace FreeDSx\Ldap\Protocol\Bind;
 
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\BindRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\ResultCode;
 
 trait VersionValidatorTrait
 {
+    private const SUPPORTED_VERSION = 3;
+
     /**
      * @throws OperationException
      */
-    private static function validateVersion(BindRequest $request): void
+    private static function validateVersion(RequestInterface $request): void
     {
+        if (!$request instanceof BindRequest) {
+            return;
+        }
+
         # Per RFC 4.2, a result code of protocol error must be sent back for unsupported versions.
-        if ($request->getVersion() !== 3) {
+        if ($request->getVersion() !== self::SUPPORTED_VERSION) {
             throw new OperationException(
                 'Only LDAP version 3 is supported.',
                 ResultCode::PROTOCOL_ERROR,

--- a/src/FreeDSx/Ldap/Search/Filter/MatchingRuleFilter.php
+++ b/src/FreeDSx/Ldap/Search/Filter/MatchingRuleFilter.php
@@ -151,10 +151,13 @@ class MatchingRuleFilter implements FilterInterface, FilterAttributeInterface, S
             tagNumber: 3,
             type: Asn1::octetString($this->value),
         ));
-        $matchingRule->addChild(Asn1::context(
-            tagNumber: 4,
-            type: Asn1::boolean($this->useDnAttributes),
-        ));
+        // RFC 4511 5.1: a field holding its default value is absent from the encoding.
+        if ($this->useDnAttributes) {
+            $matchingRule->addChild(Asn1::context(
+                tagNumber: 4,
+                type: Asn1::boolean(true),
+            ));
+        }
 
         return $matchingRule;
     }

--- a/src/FreeDSx/Ldap/Server/Middleware/BindMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/BindMiddleware.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Server\Middleware;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Authenticator;
+use FreeDSx\Ldap\Protocol\Bind\VersionValidatorTrait;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
@@ -32,6 +33,8 @@ use FreeDSx\Ldap\Server\Token\AnonToken;
  */
 final readonly class BindMiddleware implements MiddlewareInterface
 {
+    use VersionValidatorTrait;
+
     public function __construct(
         private ServerAuthorization $authorization,
         private Authenticator $authenticator,
@@ -53,7 +56,8 @@ final readonly class BindMiddleware implements MiddlewareInterface
 
         // RFC 4511 §4.2.1: a bind discards any prior authentication; a failed bind leaves the session anonymous.
         $this->authorization->setToken(new AnonToken());
-
+        // RFC 4511 §4.2: the version belongs to the message layer, so it is settled before anything the bind asks for.
+        self::validateVersion($request);
         // Checked here because the authenticator writes the response itself.
         // RFC 4511 §4.1.11 refuses the operation before it is performed.
         $this->criticalControls->assertSupportedForBind($context->message->controls());

--- a/src/FreeDSx/Ldap/Server/Middleware/CriticalControlMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/CriticalControlMiddleware.php
@@ -43,10 +43,12 @@ final readonly class CriticalControlMiddleware implements MiddlewareInterface
         MiddlewareHandlerInterface $next,
     ): ResponseStream {
         $controls = $context->message->controls();
+        $request = $context->message->getRequest();
 
-        $this->validator->assertSupportedForRoute(
+        $this->validator->assertSupportedForRequest(
+            $request,
             $this->routeResolver->routeIdFor(
-                $context->message->getRequest(),
+                $request,
                 $controls,
             ),
             $controls,

--- a/src/FreeDSx/Ldap/Server/Middleware/CriticalControlValidator.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/CriticalControlValidator.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Server\Middleware;
 
 use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Factory\HandlerId;
 
@@ -34,7 +35,8 @@ final readonly class CriticalControlValidator
     /**
      * @throws OperationException
      */
-    public function assertSupportedForRoute(
+    public function assertSupportedForRequest(
+        RequestInterface $request,
         HandlerId $routeId,
         ControlBag $controls,
     ): void {
@@ -44,7 +46,10 @@ final readonly class CriticalControlValidator
 
         $this->assertNoCriticalUnsupportedControls(
             $controls,
-            $this->controlRegistry->supportedControlsFor($routeId),
+            $this->controlRegistry->supportedControlsFor(
+                $routeId,
+                $request,
+            ),
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/Middleware/ServerControlRegistry.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/ServerControlRegistry.php
@@ -14,6 +14,12 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Middleware;
 
 use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Operation\Request\AddRequest;
+use FreeDSx\Ldap\Operation\Request\CompareRequest;
+use FreeDSx\Ldap\Operation\Request\DeleteRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Protocol\Factory\HandlerId;
 
 use function in_array;
@@ -41,6 +47,75 @@ final class ServerControlRegistry
     ];
 
     /**
+     * A bind is answered in middleware rather than routed to a handler, so it has no HandlerId to look up.
+     *
+     * Proxied authorization is absent deliberately: RFC 4370 §3 does not list Bind among the operations it may
+     * accompany, and its criticality must be TRUE, so it can only ever be refused here.
+     */
+    private const BIND_CONTROLS = [
+        Control::OID_MANAGE_DSA_IT,
+        Control::OID_PWD_POLICY,
+    ];
+
+    private const SEARCH_CONTROLS = [
+        Control::OID_SORTING,
+        Control::OID_ASSERTION,
+        Control::OID_SUBENTRIES,
+    ];
+
+    private const PAGING_CONTROLS = [
+        Control::OID_PAGING,
+        Control::OID_SORTING,
+        Control::OID_ASSERTION,
+        Control::OID_SUBENTRIES,
+    ];
+
+    private const SYNC_CONTROLS = [
+        Control::OID_SYNC_REQUEST,
+    ];
+
+    /**
+     * RFC 4527 §3.2 makes post-read appropriate for an add, and §3.1 leaves pre-read to the operations with a
+     * before image.
+     */
+    private const ADD_CONTROLS = [
+        Control::OID_RELAX_RULES,
+        Control::OID_ASSERTION,
+        Control::OID_POST_READ,
+    ];
+
+    private const MODIFY_CONTROLS = [
+        Control::OID_RELAX_RULES,
+        Control::OID_ASSERTION,
+        Control::OID_PRE_READ,
+        Control::OID_POST_READ,
+    ];
+
+    private const MODIFY_DN_CONTROLS = [
+        Control::OID_RELAX_RULES,
+        Control::OID_ASSERTION,
+        Control::OID_PRE_READ,
+        Control::OID_POST_READ,
+    ];
+
+    /**
+     * Post-read is absent because a deleted entry has no after image, and subtree delete applies here alone.
+     */
+    private const DELETE_CONTROLS = [
+        Control::OID_RELAX_RULES,
+        Control::OID_ASSERTION,
+        Control::OID_PRE_READ,
+        Control::OID_SUBTREE_DELETE,
+    ];
+
+    /**
+     * A compare reads rather than updates, so it takes neither the read-entry pair nor relax.
+     */
+    private const COMPARE_CONTROLS = [
+        Control::OID_ASSERTION,
+    ];
+
+    /**
      * Handlers whose requests carry no response, so the critical-control check does not apply.
      */
     private const EXEMPT_HANDLERS = [
@@ -49,19 +124,11 @@ final class ServerControlRegistry
     ];
 
     /**
-     * A bind is answered in middleware rather than routed to a handler, so it has no HandlerId to look up.
-     *
-     * Proxied authorization is absent deliberately: RFC 4370 §3 does not list Bind among the operations it may
-     * accompany, and its criticality must be TRUE, so it can only ever be refused here.
-     *
      * @return list<string>
      */
     public function supportedControlsForBind(): array
     {
-        return [
-            Control::OID_MANAGE_DSA_IT,
-            Control::OID_PWD_POLICY,
-        ];
+        return self::BIND_CONTROLS;
     }
 
     public function appliesTo(HandlerId $id): bool
@@ -76,41 +143,46 @@ final class ServerControlRegistry
     /**
      * @return list<string>
      */
-    public function supportedControlsFor(HandlerId $id): array
-    {
+    public function supportedControlsFor(
+        HandlerId $id,
+        RequestInterface $request,
+    ): array {
         return [
             ...self::GLOBAL_CONTROLS,
-            ...$this->handlerControlsFor($id),
+            ...$this->handlerControlsFor($id, $request),
         ];
     }
 
     /**
      * @return list<string>
      */
-    private function handlerControlsFor(HandlerId $id): array
-    {
+    private function handlerControlsFor(
+        HandlerId $id,
+        RequestInterface $request,
+    ): array {
         return match ($id) {
-            HandlerId::Search => [
-                Control::OID_SORTING,
-                Control::OID_ASSERTION,
-                Control::OID_SUBENTRIES,
-            ],
-            HandlerId::Paging => [
-                Control::OID_PAGING,
-                Control::OID_SORTING,
-                Control::OID_ASSERTION,
-                Control::OID_SUBENTRIES,
-            ],
-            HandlerId::Dispatch => [
-                Control::OID_RELAX_RULES,
-                Control::OID_ASSERTION,
-                Control::OID_PRE_READ,
-                Control::OID_POST_READ,
-                Control::OID_SUBTREE_DELETE,
-            ],
-            HandlerId::Sync => [
-                Control::OID_SYNC_REQUEST,
-            ],
+            HandlerId::Search => self::SEARCH_CONTROLS,
+            HandlerId::Paging => self::PAGING_CONTROLS,
+            HandlerId::Dispatch => $this->dispatchControlsFor($request),
+            HandlerId::Sync => self::SYNC_CONTROLS,
+            default => [],
+        };
+    }
+
+    /**
+     * One handler serves five operations whose control vocabularies differ, so the request decides rather than
+     * the route it took (RFC 4511 §4.1.11, RFC 4527 §3.1 and §3.2).
+     *
+     * @return list<string>
+     */
+    private function dispatchControlsFor(RequestInterface $request): array
+    {
+        return match (true) {
+            $request instanceof AddRequest => self::ADD_CONTROLS,
+            $request instanceof ModifyRequest => self::MODIFY_CONTROLS,
+            $request instanceof ModifyDnRequest => self::MODIFY_DN_CONTROLS,
+            $request instanceof DeleteRequest => self::DELETE_CONTROLS,
+            $request instanceof CompareRequest => self::COMPARE_CONTROLS,
             default => [],
         };
     }

--- a/tests/integration/Controls/ServerControlsTest.php
+++ b/tests/integration/Controls/ServerControlsTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Tests\Integration\FreeDSx\Ldap\Controls;
 
 use FreeDSx\Ldap\Control\Control;
-use FreeDSx\Ldap\Operation\Response\CompareResponse;
+use FreeDSx\Ldap\Operation\Response\ModifyResponse;
 use FreeDSx\Ldap\Control\ReadEntry\PostReadResponseControl;
 use FreeDSx\Ldap\Control\ReadEntry\PreReadResponseControl;
 use FreeDSx\Ldap\Controls;
@@ -349,16 +349,15 @@ final class ServerControlsTest extends ServerTestCase
         );
     }
 
-    public function test_a_privileged_control_on_a_compare_is_denied_to_a_non_administrator(): void
+    public function test_a_privileged_control_on_a_modify_is_denied_to_a_non_administrator(): void
     {
         $this->authenticateUser();
 
         try {
             $this->ldapClient()->send(
-                Operations::compare(
+                Operations::modify(
                     'cn=user,dc=foo,dc=bar',
-                    'cn',
-                    'user',
+                    Change::replace('description', 'relaxed'),
                 ),
                 Controls::relaxRules(),
             );
@@ -413,26 +412,26 @@ final class ServerControlsTest extends ServerTestCase
         }
     }
 
-    public function test_an_administrator_may_use_a_privileged_control_on_a_compare(): void
+    public function test_an_administrator_may_use_a_privileged_control_on_a_modify(): void
     {
         $this->authenticateAdmin();
 
         $response = $this->ldapClient()->send(
-            Operations::compare(
+            Operations::modify(
                 'cn=user,dc=foo,dc=bar',
-                'cn',
-                'user',
+                Change::replace('description', 'relaxed'),
             ),
             Controls::relaxRules(),
         );
 
+        $modify = $response?->getResponse();
         self::assertInstanceOf(
-            CompareResponse::class,
-            $response?->getResponse(),
+            ModifyResponse::class,
+            $modify,
         );
         self::assertSame(
-            ResultCode::COMPARE_TRUE,
-            $response->getResponse()->getResultCode(),
+            ResultCode::SUCCESS,
+            $modify->getResultCode(),
         );
     }
 

--- a/tests/integration/LdapServerTest.php
+++ b/tests/integration/LdapServerTest.php
@@ -774,6 +774,39 @@ final class LdapServerTest extends ServerTestCase
         }
     }
 
+    /**
+     * RFC 4511 4.2 requires protocolError for an unsupported version, whatever the bind method is.
+     */
+    public function testAnUnsupportedVersionIsRefusedAsProtocolErrorWhenTheBindMethodIsAlsoUnavailable(): void
+    {
+        // Anonymous binds are disabled on this server, which is the refusal the version must outrank.
+        try {
+            $this->ldapClient()->send(Operations::bindAnonymously()->setVersion(2));
+            $this->fail('An unsupported version should not have been accepted.');
+        } catch (BindException $e) {
+            $this->assertSame(
+                ResultCode::PROTOCOL_ERROR,
+                $e->getCode(),
+            );
+        }
+    }
+
+    public function testAnUnsupportedVersionIsRefusedAsProtocolErrorOnASimpleBind(): void
+    {
+        try {
+            $this->ldapClient()->send(Operations::bind(
+                'cn=admin,dc=foo,dc=bar',
+                '12345',
+            )->setVersion(2));
+            $this->fail('An unsupported version should not have been accepted.');
+        } catch (BindException $e) {
+            $this->assertSame(
+                ResultCode::PROTOCOL_ERROR,
+                $e->getCode(),
+            );
+        }
+    }
+
     public function testRenameWithoutDeleteKeepsOldRdn(): void
     {
         $this->authenticateAdmin();

--- a/tests/integration/Storage/Concern/ControlTestsTrait.php
+++ b/tests/integration/Storage/Concern/ControlTestsTrait.php
@@ -14,14 +14,19 @@ declare(strict_types=1);
 namespace Tests\Integration\FreeDSx\Ldap\Storage\Concern;
 
 use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\ReadEntry\PostReadControl;
+use FreeDSx\Ldap\Control\ReadEntry\PreReadControl;
 use FreeDSx\Ldap\Control\Sorting\SortingControl;
 use FreeDSx\Ldap\Control\Sorting\SortingResponseControl;
 use FreeDSx\Ldap\Control\Sorting\SortKey;
+use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Search\Filters;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Search controls the backend participates in: paged results and server side sorting.
@@ -191,6 +196,61 @@ trait ControlTestsTrait
                 (new SortingControl(SortKey::ascending('bogusAttr')))->setCriticality(true),
             );
             self::fail('The critical sort should have failed the search.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,
+                $e->getCode(),
+            );
+        }
+    }
+
+    /**
+     * @return iterable<string, array{RequestInterface, Control}>
+     */
+    public static function inappropriateCriticalControls(): iterable
+    {
+        // RFC 4527 §3.1 leaves pre-read to the operations with a before image, which an add has not.
+        yield 'pre-read on an add' => [
+            Operations::add(Entry::create(
+                'cn=ctl,dc=foo,dc=bar',
+                ['objectClass' => 'inetOrgPerson', 'cn' => 'ctl', 'sn' => 'Ctl'],
+            )),
+            new PreReadControl('cn'),
+        ];
+        // RFC 4527 §3.2: a deleted entry has no after image, so post-read does not suit a delete.
+        yield 'post-read on a delete' => [
+            Operations::delete('cn=ctl,dc=foo,dc=bar'),
+            new PostReadControl('cn'),
+        ];
+        yield 'pre-read on a compare' => [
+            Operations::compare('cn=alice,ou=people,dc=foo,dc=bar', 'sn', 'Smith'),
+            new PreReadControl('cn'),
+        ];
+        yield 'subtree delete on a modify' => [
+            Operations::modify(
+                'cn=alice,ou=people,dc=foo,dc=bar',
+                Change::replace('description', 'ctl'),
+            ),
+            new Control(Control::OID_SUBTREE_DELETE),
+        ];
+    }
+
+    /**
+     * RFC 4511 §4.1.11: a control the operation does not take must fail it rather than be dropped.
+     */
+    #[DataProvider('inappropriateCriticalControls')]
+    public function testACriticalControlTheOperationDoesNotTakeIsRefused(
+        RequestInterface $request,
+        Control $control,
+    ): void {
+        $this->authenticateAdmin();
+
+        try {
+            $this->ldapClient()->sendAndReceive(
+                $request,
+                $control->setCriticality(true),
+            );
+            self::fail('The critical control should have failed the operation.');
         } catch (OperationException $e) {
             self::assertSame(
                 ResultCode::UNAVAILABLE_CRITICAL_EXTENSION,

--- a/tests/unit/Control/Ad/DirSyncResponseControlTest.php
+++ b/tests/unit/Control/Ad/DirSyncResponseControlTest.php
@@ -71,7 +71,6 @@ class DirSyncResponseControlTest extends TestCase
         self::assertEquals(
             Asn1::sequence(
                 Asn1::octetString(Control::OID_DIR_SYNC),
-                Asn1::boolean(false),
                 Asn1::octetString($encoder->encode(Asn1::sequence(
                     Asn1::integer(0),
                     Asn1::integer(0),

--- a/tests/unit/Control/Ad/ExtendedDnControlTest.php
+++ b/tests/unit/Control/Ad/ExtendedDnControlTest.php
@@ -47,7 +47,6 @@ class ExtendedDnControlTest extends TestCase
         self::assertEquals(
             Asn1::sequence(
                 Asn1::octetString(Control::OID_EXTENDED_DN),
-                Asn1::boolean(false),
                 Asn1::octetString($encoder->encode(Asn1::sequence(
                     Asn1::integer(1),
                 ))),

--- a/tests/unit/Control/Ad/SdFlagsControlTest.php
+++ b/tests/unit/Control/Ad/SdFlagsControlTest.php
@@ -53,7 +53,6 @@ class SdFlagsControlTest extends \PHPUnit\Framework\TestCase
             $this->subject->toAsn1(),
             Asn1::sequence(
                 Asn1::octetString(Control::OID_SD_FLAGS),
-                Asn1::boolean(false),
                 Asn1::octetString($encoder->encode(Asn1::sequence(
                     Asn1::integer(4),
                 ))),

--- a/tests/unit/Control/ControlTest.php
+++ b/tests/unit/Control/ControlTest.php
@@ -68,7 +68,19 @@ class ControlTest extends TestCase
         self::assertEquals(
             Asn1::sequence(
                 Asn1::octetString('foo'),
-                Asn1::boolean(false),
+            ),
+            $this->subject->toAsn1(),
+        );
+    }
+
+    public function test_it_should_encode_the_criticality_only_when_it_is_true(): void
+    {
+        $this->subject->setCriticality(true);
+
+        self::assertEquals(
+            Asn1::sequence(
+                Asn1::octetString('foo'),
+                Asn1::boolean(true),
             ),
             $this->subject->toAsn1(),
         );

--- a/tests/unit/Control/PagingControlTest.php
+++ b/tests/unit/Control/PagingControlTest.php
@@ -68,7 +68,6 @@ class PagingControlTest extends TestCase
         self::assertEquals(
             Asn1::sequence(
                 Asn1::octetString(Control::OID_PAGING),
-                Asn1::boolean(false),
                 Asn1::octetString($encoder->encode(Asn1::sequence(
                     Asn1::integer(0),
                     Asn1::octetString('foo'),

--- a/tests/unit/Control/PwdPolicyResponseControlTest.php
+++ b/tests/unit/Control/PwdPolicyResponseControlTest.php
@@ -97,7 +97,6 @@ class PwdPolicyResponseControlTest extends TestCase
         self::assertEquals(
             Asn1::sequence(
                 Asn1::octetString(Control::OID_PWD_POLICY),
-                Asn1::boolean(false),
                 Asn1::octetString($encoder->encode(Asn1::sequence(
                     Asn1::context(0, Asn1::sequence(Asn1::context(0, Asn1::integer(100)))),
                     Asn1::context(1, Asn1::enumerated(2)),

--- a/tests/unit/Control/Sorting/SortingControlTest.php
+++ b/tests/unit/Control/Sorting/SortingControlTest.php
@@ -88,7 +88,6 @@ class SortingControlTest extends TestCase
         self::assertEquals(
             Asn1::sequence(
                 Asn1::octetString(Control::OID_SORTING),
-                Asn1::boolean(false),
                 Asn1::octetString($encoder->encode(Asn1::sequenceOf(
                     Asn1::sequence(Asn1::octetString('foo')),
                     Asn1::sequence(Asn1::octetString('bar')),

--- a/tests/unit/Control/Sorting/SortingResponseControlTest.php
+++ b/tests/unit/Control/Sorting/SortingResponseControlTest.php
@@ -71,7 +71,6 @@ class SortingResponseControlTest extends TestCase
         self::assertEquals(
             Asn1::sequence(
                 Asn1::octetString(Control::OID_SORTING_RESPONSE),
-                Asn1::boolean(false),
                 Asn1::octetString($encoder->encode(Asn1::sequence(
                     Asn1::enumerated(0),
                     Asn1::context(0, Asn1::octetString('cn')),

--- a/tests/unit/Control/Sync/SyncDoneControlTest.php
+++ b/tests/unit/Control/Sync/SyncDoneControlTest.php
@@ -55,7 +55,29 @@ class SyncDoneControlTest extends TestCase
                 Asn1::octetString(
                     $encoder->encode(Asn1::sequence(
                         Asn1::octetString('omnomnom'),
-                        Asn1::boolean(false),
+                    )),
+                ),
+            ),
+            $this->subject->toAsn1(),
+        );
+    }
+
+    public function test_it_should_encode_refresh_deletes_only_when_it_is_true(): void
+    {
+        $encoder = new LdapEncoder();
+        $this->subject = new SyncDoneControl(
+            cookie: 'omnomnom',
+            refreshDeletes: true,
+        );
+
+        self::assertEquals(
+            Asn1::sequence(
+                Asn1::octetString(Control::OID_SYNC_DONE),
+                Asn1::boolean(true),
+                Asn1::octetString(
+                    $encoder->encode(Asn1::sequence(
+                        Asn1::octetString('omnomnom'),
+                        Asn1::boolean(true),
                     )),
                 ),
             ),

--- a/tests/unit/Control/Sync/SyncRequestControlTest.php
+++ b/tests/unit/Control/Sync/SyncRequestControlTest.php
@@ -63,7 +63,29 @@ class SyncRequestControlTest extends TestCase
                 Asn1::octetString($encoder->encode(Asn1::sequence(
                     Asn1::enumerated(1),
                     Asn1::octetString('omnomnom'),
-                    Asn1::boolean(false),
+                ))),
+            ),
+            $this->subject->toAsn1(),
+        );
+    }
+
+    public function test_it_should_encode_the_reload_hint_only_when_it_is_true(): void
+    {
+        $encoder = new LdapEncoder();
+        $this->subject = new SyncRequestControl(
+            mode: 1,
+            cookie: 'omnomnom',
+            reloadHint: true,
+        );
+
+        self::assertEquals(
+            Asn1::sequence(
+                Asn1::octetString(Control::OID_SYNC_REQUEST),
+                Asn1::boolean(true),
+                Asn1::octetString($encoder->encode(Asn1::sequence(
+                    Asn1::enumerated(1),
+                    Asn1::octetString('omnomnom'),
+                    Asn1::boolean(true),
                 ))),
             ),
             $this->subject->toAsn1(),

--- a/tests/unit/Control/Sync/SyncStateControlTest.php
+++ b/tests/unit/Control/Sync/SyncStateControlTest.php
@@ -103,7 +103,6 @@ class SyncStateControlTest extends TestCase
         self::assertEquals(
             Asn1::sequence(
                 Asn1::octetString(Control::OID_SYNC_STATE),
-                Asn1::boolean(false),
                 Asn1::octetString($encoder->encode(Asn1::sequence(
                     Asn1::enumerated(0),
                     Asn1::octetString('foo'),

--- a/tests/unit/Control/Vlv/VlvControlTest.php
+++ b/tests/unit/Control/Vlv/VlvControlTest.php
@@ -78,7 +78,6 @@ class VlvControlTest extends TestCase
         self::assertEquals(
             Asn1::sequence(
                 Asn1::octetString(Control::OID_VLV),
-                Asn1::boolean(false),
                 Asn1::octetString($encoder->encode(Asn1::sequence(
                     Asn1::integer(10),
                     Asn1::integer(9),

--- a/tests/unit/Operation/Response/SyncInfo/SyncIdSetTest.php
+++ b/tests/unit/Operation/Response/SyncInfo/SyncIdSetTest.php
@@ -119,7 +119,28 @@ final class SyncIdSetTest extends TestCase
                 Asn1::context(0, Asn1::octetString(IntermediateResponse::OID_SYNC_INFO)),
                 Asn1::context(1, Asn1::octetString($encoder->encode(Asn1::context(3, Asn1::sequence(
                     Asn1::octetString('omnomnom'),
-                    Asn1::boolean(false),
+                    Asn1::setOf(Asn1::octetString('foo'), Asn1::octetString('bar')),
+                ))))),
+            )),
+            $this->subject->toAsn1(),
+        );
+    }
+
+    public function test_it_should_encode_refresh_deletes_only_when_it_is_true(): void
+    {
+        $encoder = new LdapEncoder();
+        $this->subject = new SyncIdSet(
+            ['foo', 'bar'],
+            true,
+            'omnomnom',
+        );
+
+        self::assertEquals(
+            Asn1::application(25, Asn1::sequence(
+                Asn1::context(0, Asn1::octetString(IntermediateResponse::OID_SYNC_INFO)),
+                Asn1::context(1, Asn1::octetString($encoder->encode(Asn1::context(3, Asn1::sequence(
+                    Asn1::octetString('omnomnom'),
+                    Asn1::boolean(true),
                     Asn1::setOf(Asn1::octetString('foo'), Asn1::octetString('bar')),
                 ))))),
             )),

--- a/tests/unit/Operation/Response/SyncInfo/SyncRefreshDeleteTest.php
+++ b/tests/unit/Operation/Response/SyncInfo/SyncRefreshDeleteTest.php
@@ -86,4 +86,26 @@ final class SyncRefreshDeleteTest extends TestCase
             $this->subject->toAsn1(),
         );
     }
+
+    public function test_it_should_omit_refresh_done_from_asn1_when_it_holds_its_default_of_true(): void
+    {
+        $encoder = new LdapEncoder();
+        $this->subject = new SyncRefreshDelete(
+            true,
+            'omnomnom',
+        );
+
+        self::assertEquals(
+            Asn1::application(25, Asn1::sequence(
+                Asn1::context(0, Asn1::octetString(IntermediateResponse::OID_SYNC_INFO)),
+                Asn1::context(
+                    1,
+                    Asn1::octetString($encoder->encode(Asn1::context(1, Asn1::sequence(
+                        Asn1::octetString('omnomnom'),
+                    )))),
+                ),
+            )),
+            $this->subject->toAsn1(),
+        );
+    }
 }

--- a/tests/unit/Operation/Response/SyncInfo/SyncRefreshPresentTest.php
+++ b/tests/unit/Operation/Response/SyncInfo/SyncRefreshPresentTest.php
@@ -83,4 +83,23 @@ final class SyncRefreshPresentTest extends TestCase
             $this->subject->toAsn1(),
         );
     }
+
+    public function test_it_should_omit_refresh_done_from_asn1_when_it_holds_its_default_of_true(): void
+    {
+        $encoder = new LdapEncoder();
+        $this->subject = new SyncRefreshPresent(
+            true,
+            'omnomnom',
+        );
+
+        self::assertEquals(
+            Asn1::application(25, Asn1::sequence(
+                Asn1::context(0, Asn1::octetString(IntermediateResponse::OID_SYNC_INFO)),
+                Asn1::context(1, Asn1::octetString($encoder->encode(Asn1::context(2, Asn1::sequence(
+                    Asn1::octetString('omnomnom'),
+                ))))),
+            )),
+            $this->subject->toAsn1(),
+        );
+    }
 }

--- a/tests/unit/Search/Filter/MatchingRuleFilterTest.php
+++ b/tests/unit/Search/Filter/MatchingRuleFilterTest.php
@@ -89,7 +89,6 @@ final class MatchingRuleFilterTest extends TestCase
                 Asn1::context(1, Asn1::octetString('foo')),
                 Asn1::context(2, Asn1::octetString('bar')),
                 Asn1::context(3, Asn1::octetString('foobar')),
-                Asn1::context(4, Asn1::boolean(false)),
             )),
             $this->subject->toAsn1(),
         );

--- a/tests/unit/Server/Middleware/BindMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/BindMiddlewareTest.php
@@ -195,6 +195,75 @@ final class BindMiddlewareTest extends TestCase
         }
     }
 
+    #[DataProvider('unsupportedVersionProvider')]
+    public function test_an_unsupported_version_is_refused_before_anything_else_the_bind_asks_for(
+        LdapMessageRequest $message,
+    ): void {
+        $this->authenticator
+            ->expects(self::never())
+            ->method('bind');
+
+        try {
+            $this->subject()->process(
+                new ServerRequestContext($message),
+                $this->next,
+            );
+            self::fail('Expected an OperationException.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::PROTOCOL_ERROR,
+                $e->getCode(),
+            );
+        }
+    }
+
+    /**
+     * @return iterable<string, array{LdapMessageRequest}>
+     */
+    public static function unsupportedVersionProvider(): iterable
+    {
+        yield 'a simple bind, whose method is supported' => [
+            new LdapMessageRequest(
+                1,
+                new SimpleBindRequest(
+                    username: 'cn=user,dc=foo,dc=bar',
+                    password: 'secret',
+                    version: 2,
+                ),
+            ),
+        ];
+        // Anonymous binds are disabled by default, so the method gate would otherwise answer first.
+        yield 'an anonymous bind, whose method is unsupported' => [
+            new LdapMessageRequest(
+                1,
+                new AnonBindRequest(
+                    username: '',
+                    version: 2,
+                ),
+            ),
+        ];
+        yield 'a name with an empty password, which RFC 4513 refuses on its own terms' => [
+            new LdapMessageRequest(
+                1,
+                new AnonBindRequest(
+                    username: 'cn=foo,dc=foo,dc=bar',
+                    version: 2,
+                ),
+            ),
+        ];
+        yield 'a bind carrying an unrecognized critical control' => [
+            new LdapMessageRequest(
+                1,
+                new SimpleBindRequest(
+                    username: 'cn=user,dc=foo,dc=bar',
+                    password: 'secret',
+                    version: 2,
+                ),
+                new Control('1.2.3.4.5', criticality: true),
+            ),
+        ];
+    }
+
     public function test_a_name_with_an_empty_password_is_refused_as_unwilling_to_perform(): void
     {
         $this->authenticator

--- a/tests/unit/Server/Middleware/ServerControlRegistryTest.php
+++ b/tests/unit/Server/Middleware/ServerControlRegistryTest.php
@@ -14,8 +14,14 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Server\Middleware;
 
 use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Protocol\Factory\HandlerId;
+use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\Middleware\ServerControlRegistry;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class ServerControlRegistryTest extends TestCase
@@ -38,7 +44,10 @@ final class ServerControlRegistryTest extends TestCase
                 Control::OID_ASSERTION,
                 Control::OID_SUBENTRIES,
             ],
-            $this->subject->supportedControlsFor(HandlerId::Search),
+            $this->subject->supportedControlsFor(
+                HandlerId::Search,
+                self::searchRequest(),
+            ),
         );
     }
 
@@ -54,24 +63,81 @@ final class ServerControlRegistryTest extends TestCase
                 Control::OID_ASSERTION,
                 Control::OID_SUBENTRIES,
             ],
-            $this->subject->supportedControlsFor(HandlerId::Paging),
+            $this->subject->supportedControlsFor(
+                HandlerId::Paging,
+                self::searchRequest(),
+            ),
         );
     }
 
-    public function test_dispatch_supports_expected_controls(): void
+    /**
+     * @return iterable<string, array{RequestInterface, list<string>}>
+     */
+    public static function dispatchRequests(): iterable
     {
+        // RFC 4527 3.2: post-read suits an add, and 3.1 leaves pre-read to the operations with a before image.
+        yield 'add' => [
+            Operations::add(Entry::create('cn=foo,dc=foo,dc=bar')),
+            [
+                Control::OID_RELAX_RULES,
+                Control::OID_ASSERTION,
+                Control::OID_POST_READ,
+            ],
+        ];
+        yield 'modify' => [
+            Operations::modify('cn=foo,dc=foo,dc=bar'),
+            [
+                Control::OID_RELAX_RULES,
+                Control::OID_ASSERTION,
+                Control::OID_PRE_READ,
+                Control::OID_POST_READ,
+            ],
+        ];
+        yield 'modify dn' => [
+            Operations::rename('cn=foo,dc=foo,dc=bar', 'cn=bar'),
+            [
+                Control::OID_RELAX_RULES,
+                Control::OID_ASSERTION,
+                Control::OID_PRE_READ,
+                Control::OID_POST_READ,
+            ],
+        ];
+        // A deleted entry has no after image, and subtree delete applies to this operation alone.
+        yield 'delete' => [
+            Operations::delete('cn=foo,dc=foo,dc=bar'),
+            [
+                Control::OID_RELAX_RULES,
+                Control::OID_ASSERTION,
+                Control::OID_PRE_READ,
+                Control::OID_SUBTREE_DELETE,
+            ],
+        ];
+        // A compare reads rather than updates, so it takes neither the read-entry pair nor relax.
+        yield 'compare' => [
+            Operations::compare('cn=foo,dc=foo,dc=bar', 'cn', 'foo'),
+            [Control::OID_ASSERTION],
+        ];
+    }
+
+    /**
+     * @param list<string> $expected
+     */
+    #[DataProvider('dispatchRequests')]
+    public function test_dispatch_supports_the_controls_its_operation_takes(
+        RequestInterface $request,
+        array $expected,
+    ): void {
         self::assertSame(
             [
                 Control::OID_PROXY_AUTHORIZATION,
                 Control::OID_MANAGE_DSA_IT,
                 Control::OID_PWD_POLICY,
-                Control::OID_RELAX_RULES,
-                Control::OID_ASSERTION,
-                Control::OID_PRE_READ,
-                Control::OID_POST_READ,
-                Control::OID_SUBTREE_DELETE,
+                ...$expected,
             ],
-            $this->subject->supportedControlsFor(HandlerId::Dispatch),
+            $this->subject->supportedControlsFor(
+                HandlerId::Dispatch,
+                $request,
+            ),
         );
     }
 
@@ -87,7 +153,10 @@ final class ServerControlRegistryTest extends TestCase
                 Control::OID_MANAGE_DSA_IT,
                 Control::OID_PWD_POLICY,
             ],
-            $this->subject->supportedControlsFor($id),
+            $this->subject->supportedControlsFor(
+                $id,
+                self::searchRequest(),
+            ),
         );
     }
 
@@ -99,7 +168,10 @@ final class ServerControlRegistryTest extends TestCase
     {
         self::assertContains(
             Control::OID_PWD_POLICY,
-            $this->subject->supportedControlsFor($id),
+            $this->subject->supportedControlsFor(
+                $id,
+                self::searchRequest(),
+            ),
         );
     }
 
@@ -144,5 +216,13 @@ final class ServerControlRegistryTest extends TestCase
         yield 'root dse' => [HandlerId::RootDse];
         yield 'cancel' => [HandlerId::Cancel];
         yield 'unsupported extended' => [HandlerId::UnsupportedExtended];
+    }
+
+    /**
+     * A stand-in for the cases that assert on the global set alone, which no request type varies.
+     */
+    private static function searchRequest(): SearchRequest
+    {
+        return Operations::search(Filters::present('objectClass'));
     }
 }


### PR DESCRIPTION
Adding additional checks around critical control rejection. We should be throwing errors when critical controls are provided for operations they make no sense to be used in. Also, missed one spot for version validation on authentication.