### PR TITLE
[1.0.0] Some validation related updates.

### DIFF
--- a/src/FreeDSx/Ldap/Entry/Dn.php
+++ b/src/FreeDSx/Ldap/Entry/Dn.php
@@ -124,6 +124,14 @@ class Dn implements IteratorAggregate, Countable, Stringable
     }
 
     /**
+     * RFC 4512 5.1: the zero-length DN names the root DSE.
+     */
+    public function isRootDse(): bool
+    {
+        return $this->dn === '';
+    }
+
+    /**
      * @inheritDoc
      * @psalm-return 0|positive-int
      * @throws UnexpectedValueException

--- a/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
@@ -101,7 +101,7 @@ readonly class ServerProtocolHandlerFactory implements HandlerRouteResolverInter
         }
 
         return $request->getScope() === SearchRequest::SCOPE_BASE_OBJECT
-                && ((string) $request->getBaseDn() === '');
+            && $request->getBaseDn()?->isRootDse();
     }
 
     private function isPagingSearch(

--- a/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerAuthorization.php
@@ -135,6 +135,6 @@ class ServerAuthorization
         }
 
         return $request->getScope() === SearchRequest::SCOPE_BASE_OBJECT
-            && ((string) $request->getBaseDn() === '');
+            && $request->getBaseDn()?->isRootDse();
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSubschemaHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSubschemaHandler.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Schema\Definition\ObjectClassOid;
 use FreeDSx\Ldap\Schema\Schema;
+use FreeDSx\Ldap\Server\Subentry\SubtreeSpecification;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\ServerOptions;
 
@@ -27,11 +28,11 @@ use FreeDSx\Ldap\ServerOptions;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-class ServerSubschemaHandler implements ServerProtocolHandlerInterface
+readonly class ServerSubschemaHandler implements ServerProtocolHandlerInterface
 {
     public function __construct(
-        private readonly ServerOptions $options,
-        private readonly GeneratedEntryResponder $responder,
+        private ServerOptions $options,
+        private GeneratedEntryResponder $responder,
     ) {}
 
     public function handleRequest(
@@ -45,11 +46,16 @@ class ServerSubschemaHandler implements ServerProtocolHandlerInterface
         $entry = Entry::fromArray(
             $schemaDn->toString(),
             array_filter([
+                // RFC 4512 2.4.2: an entry has one structural class, and 4.2 declares subschema auxiliary.
                 AttributeTypeOid::NAME_OBJECT_CLASS => [
                     ObjectClassOid::NAME_TOP,
+                    ObjectClassOid::NAME_SUBENTRY,
                     ObjectClassOid::NAME_SUBSCHEMA,
                 ],
+                AttributeTypeOid::NAME_STRUCTURAL_OBJECT_CLASS => [ObjectClassOid::NAME_SUBENTRY],
                 $rdn->getName() => [$rdn->getValue()],
+                // Satisfies subentry's MUST, and RFC 3672 reads the empty specification as the whole subtree.
+                AttributeTypeOid::NAME_SUBTREE_SPECIFICATION => [(new SubtreeSpecification())->toString()],
                 // Self-referential, so a client discovering schema never has to special-case this entry.
                 AttributeTypeOid::NAME_SUBSCHEMA_SUBENTRY => [$schemaDn->toString()],
                 AttributeTypeOid::NAME_ATTRIBUTE_TYPES => array_map(

--- a/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/SchemaValidator.php
@@ -79,6 +79,9 @@ final class SchemaValidator
         }
         $this->checkDistinctAttributeDescriptions($entry);
         $this->checkNoEquivalentValues($entry);
+        if (!$entry->getDn()->isRootDse()) {
+            $this->checkNamingAttributesAreMatchable($entry->getDn()->getRdn());
+        }
         $this->validateStructure($entry);
     }
 
@@ -130,6 +133,7 @@ final class SchemaValidator
         }
 
         $this->checkNoEquivalentValues($result);
+        $this->checkNamingAttributesAreMatchable($newRdn);
         $this->validateStructure($result);
     }
 
@@ -150,6 +154,30 @@ final class SchemaValidator
             $this->fail(
                 sprintf('Attribute "%s" cannot be set by users.', $component->getName()),
                 ResultCode::CONSTRAINT_VIOLATION,
+            );
+        }
+    }
+
+    /**
+     * RFC 4512 §2.5.1: a type specifying no equality matching cannot be used for naming.
+     *
+     * @throws OperationException
+     */
+    private function checkNamingAttributesAreMatchable(Rdn $rdn): void
+    {
+        foreach ($rdn->getAll() as $component) {
+            $attrType = $this->schema->getAttributeType($component->getName());
+            // An undefined type is reported by its own check, which says something more useful about it.
+            if ($attrType === null || $this->schema->getEqualityRuleOid($attrType->oid) !== null) {
+                continue;
+            }
+
+            $this->fail(
+                sprintf(
+                    'Attribute "%s" has no equality matching rule and cannot name an entry.',
+                    $component->getName(),
+                ),
+                ResultCode::NAMING_VIOLATION,
             );
         }
     }

--- a/src/FreeDSx/Ldap/Schema/Validation/Syntax/SyntaxValidatorRegistry.php
+++ b/src/FreeDSx/Ldap/Schema/Validation/Syntax/SyntaxValidatorRegistry.php
@@ -39,6 +39,8 @@ final class SyntaxValidatorRegistry
             SyntaxOid::OID_OID => new OidSyntaxValidator(),
             SyntaxOid::OID_NUMERIC_STRING => new NumericStringSyntaxValidator(),
             SyntaxOid::OID_PRINTABLE_STRING => new PrintableStringSyntaxValidator(),
+            // RFC 4517 3.3.31 constrains the LDAP encoding to PrintableString. E.123 only describes the format.
+            SyntaxOid::OID_TELEPHONE_NUMBER => new PrintableStringSyntaxValidator(),
             SyntaxOid::OID_COUNTRY_STRING => new CountryStringSyntaxValidator(),
             SyntaxOid::OID_IA5_STRING => new Ia5StringSyntaxValidator(),
             SyntaxOid::OID_BIT_STRING => new BitStringSyntaxValidator(),

--- a/src/FreeDSx/Ldap/Server/Backend/Write/Routing/WriteCommandFactory.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/Routing/WriteCommandFactory.php
@@ -22,6 +22,7 @@ use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Schema\Text;
+use FreeDSx\Ldap\Server\AccessControl\OperationTargetDn;
 use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteSubtreeCommand;
@@ -31,7 +32,7 @@ use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Backend\Write\WriteRequestInterface;
 
 /**
- * Translates LDAP protocol request objects into write command DTOs.
+ * Translates LDAP protocol request objects into write command DTOs, refusing those no command could carry out.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -44,6 +45,8 @@ final class WriteCommandFactory
         RequestInterface $request,
         WriteContext $context,
     ): WriteRequestInterface {
+        $this->assertNotRootDse($request);
+
         return match (true) {
             $request instanceof AddRequest => new AddCommand($request->getEntry()),
             $request instanceof DeleteRequest => $this->deleteCommand($request, $context),
@@ -57,6 +60,23 @@ final class WriteCommandFactory
                 ResultCode::NO_SUCH_OPERATION,
             ),
         };
+    }
+
+    /**
+     * Refused explicitly rather than reported missing incidentally.
+     *
+     * @throws OperationException
+     */
+    private function assertNotRootDse(RequestInterface $request): void
+    {
+        if (OperationTargetDn::of($request)?->isRootDse() !== true) {
+            return;
+        }
+
+        throw new OperationException(
+            'The RootDSE cannot be written to.',
+            ResultCode::UNWILLING_TO_PERFORM,
+        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
@@ -427,7 +427,8 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
         $dn = OperationTargetDn::resultOf($request);
         $components = $request->getNewRdn()->getAll();
 
-        if ($request->getDeleteOldRdn()) {
+        // The root DSE has no RDN to remove, and the write router refuses it before any of this is acted on.
+        if ($request->getDeleteOldRdn() && !$request->getDn()->isRootDse()) {
             $components = [
                 ...$components,
                 ...$request->getDn()->getRdn()->getAll(),

--- a/tests/integration/LdapServerTest.php
+++ b/tests/integration/LdapServerTest.php
@@ -16,14 +16,17 @@ namespace Tests\Integration\FreeDSx\Ldap;
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\PagingControl;
+use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Entry\Rdn;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\Response\BindResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Search\Filters;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Throwable;
 
 final class LdapServerTest extends ServerTestCase
@@ -772,6 +775,44 @@ final class LdapServerTest extends ServerTestCase
                 $e->getCode(),
             );
         }
+    }
+
+    #[DataProvider('rootDseWriteProvider')]
+    public function testAWriteOnTheRootDseIsRefusedRatherThanReportedMissing(RequestInterface $request): void
+    {
+        $this->authenticateAdmin();
+
+        // Proves the entry the refusal talks about is the one the same connection can read.
+        $this->assertNotNull($this->ldapClient()->read(''));
+
+        try {
+            $this->ldapClient()->sendAndReceive($request);
+            $this->fail('A write on the root DSE should have been refused.');
+        } catch (OperationException $e) {
+            $this->assertSame(
+                ResultCode::UNWILLING_TO_PERFORM,
+                $e->getCode(),
+            );
+        }
+    }
+
+    /**
+     * @return iterable<string, array{RequestInterface}>
+     */
+    public static function rootDseWriteProvider(): iterable
+    {
+        yield 'add' => [
+            Operations::add(Entry::fromArray('', ['objectClass' => 'device', 'cn' => 'rootprobe'])),
+        ];
+        yield 'modify' => [
+            Operations::modify('', Change::add('description', 'probe')),
+        ];
+        yield 'delete' => [
+            Operations::delete(''),
+        ];
+        yield 'modify dn' => [
+            Operations::rename('', 'cn=rootprobe'),
+        ];
     }
 
     /**

--- a/tests/integration/Schema/LdapSchemaConstraintTest.php
+++ b/tests/integration/Schema/LdapSchemaConstraintTest.php
@@ -127,6 +127,141 @@ final class LdapSchemaConstraintTest extends ServerTestCase
         );
     }
 
+    public function test_the_subschema_entry_carries_a_structural_class_and_satisfies_its_must(): void
+    {
+        $this->authenticateAdmin();
+
+        $subschema = $this->ldapClient()->read(
+            'cn=Subschema',
+            [
+                'objectClass',
+                'structuralObjectClass',
+                'cn',
+                'subtreeSpecification',
+            ],
+        );
+
+        self::assertNotNull($subschema);
+        self::assertSame(
+            [
+                'top',
+                'subentry',
+                'subschema',
+            ],
+            $subschema->get('objectClass')?->getValues(),
+        );
+        self::assertSame(
+            ['subentry'],
+            $subschema->get('structuralObjectClass')?->getValues(),
+        );
+        self::assertSame(
+            ['{ }'],
+            $subschema->get('subtreeSpecification')?->getValues(),
+        );
+    }
+
+    public function test_the_subschema_entry_answers_a_filter_on_its_structural_class(): void
+    {
+        $this->authenticateAdmin();
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::equal('objectClass', 'subentry'))
+                ->base('cn=Subschema')
+                ->useBaseScope(),
+        );
+
+        self::assertCount(1, $entries);
+    }
+
+    #[DataProvider('telephoneNumberProvider')]
+    public function test_telephone_number_is_constrained_to_printable_characters(
+        string $value,
+        bool $isValid,
+    ): void {
+        $this->authenticateAdmin();
+
+        if (!$isValid) {
+            $this->expectException(OperationException::class);
+            $this->expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
+        }
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=tel-' . md5($value) . ',dc=foo,dc=bar',
+            [
+                'cn' => 'tel-' . md5($value),
+                'sn' => 'Smith',
+                'objectClass' => 'inetOrgPerson',
+                'telephoneNumber' => $value,
+            ],
+        ));
+
+        self::assertTrue($isValid);
+    }
+
+    /**
+     * @return iterable<string, array{string, bool}>
+     */
+    public static function telephoneNumberProvider(): iterable
+    {
+        yield 'an E.123 number' => [
+            '+1 512 315 0280',
+            true,
+        ];
+        // RFC 4517 3.3.31 constrains only the encoding, which E.123 formatting is a subset of.
+        yield 'printable but not a number' => [
+            'not-a-phone-number',
+            true,
+        ];
+        yield 'non-printable ascii' => [
+            'abc!@#$%',
+            false,
+        ];
+        yield 'non-ascii' => [
+            'h3llo-wörld',
+            false,
+        ];
+    }
+
+    public function test_add_named_by_an_attribute_with_no_equality_rule_is_rejected(): void
+    {
+        $this->authenticateAdmin();
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::NAMING_VIOLATION);
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'jpegPhoto=zz,dc=foo,dc=bar',
+            [
+                'sn' => 'Smith',
+                'objectClass' => 'inetOrgPerson',
+                'cn' => 'no-equality',
+            ],
+        ));
+    }
+
+    public function test_rename_onto_an_attribute_with_no_equality_rule_is_rejected(): void
+    {
+        $this->authenticateAdmin();
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=to-rename-naming,dc=foo,dc=bar',
+            [
+                'cn' => 'to-rename-naming',
+                'sn' => 'Smith',
+                'objectClass' => 'inetOrgPerson',
+            ],
+        ));
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::NAMING_VIOLATION);
+
+        $this->ldapClient()->rename(
+            'cn=to-rename-naming,dc=foo,dc=bar',
+            'jpegPhoto=zz',
+            false,
+        );
+    }
+
     public function test_add_omitting_the_naming_attribute_still_stores_it(): void
     {
         $this->authenticateAdmin();

--- a/tests/unit/Entry/DnTest.php
+++ b/tests/unit/Entry/DnTest.php
@@ -71,6 +71,13 @@ class DnTest extends TestCase
         );
     }
 
+    public function test_only_the_zero_length_dn_names_the_root_dse(): void
+    {
+        self::assertTrue((new Dn(''))->isRootDse());
+        self::assertFalse($this->subject->isRootDse());
+        self::assertFalse((new Dn('dc=foo'))->isRootDse());
+    }
+
     public function test_it_should_check_if_it_is_a_valid_dn(): void
     {
         self::assertTrue(Dn::isValid('cn=foo,dc=bar,dc=foo'));

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSubschemaHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSubschemaHandlerTest.php
@@ -75,6 +75,56 @@ final class ServerSubschemaHandlerTest extends TestCase
         );
     }
 
+    public function test_the_entry_carries_a_structural_object_class(): void
+    {
+        $entry = $this->handleAndCaptureEntry('+', '*');
+
+        self::assertSame(
+            [
+                'top',
+                'subentry',
+                'subschema',
+            ],
+            $entry->get('objectClass')?->getValues(),
+        );
+        self::assertSame(
+            ['subentry'],
+            $entry->get('structuralObjectClass')?->getValues(),
+        );
+    }
+
+    /**
+     * The structural class it carries declares subtreeSpecification as MUST.
+     */
+    public function test_the_entry_satisfies_the_must_of_the_class_it_declares(): void
+    {
+        $entry = $this->handleAndCaptureEntry('+', '*');
+
+        self::assertSame(
+            ['{ }'],
+            $entry->get('subtreeSpecification')?->getValues(),
+        );
+        self::assertTrue($entry->get('cn')?->has('Subschema') ?? false);
+    }
+
+    public function test_it_answers_a_filter_on_the_structural_class(): void
+    {
+        $stream = $this->subject->handleRequest(
+            new LdapMessageRequest(
+                1,
+                (new SearchRequest(Filters::equal('objectClass', 'subentry')))
+                    ->base($this->options->getSubschemaEntry()->toString())
+                    ->useBaseScope(),
+            ),
+            $this->mockToken,
+        );
+
+        self::assertInstanceOf(
+            SearchResultEntry::class,
+            ([...$stream->messages])[0]->getResponse(),
+        );
+    }
+
     public function test_it_uses_the_configured_subschema_entry_dn(): void
     {
         $this->options->getSchemaConfig()

--- a/tests/unit/Schema/Validation/SchemaValidatorTest.php
+++ b/tests/unit/Schema/Validation/SchemaValidatorTest.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Entry\Rdn;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Schema\Definition\AttributeType;
@@ -28,6 +29,7 @@ use FreeDSx\Ldap\Schema\SchemaValidationMode;
 use FreeDSx\Ldap\Schema\SchemaResource;
 use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class SchemaValidatorTest extends TestCase
@@ -61,6 +63,59 @@ final class SchemaValidatorTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
         $this->subject->validateAdd($this->personEntry());
+    }
+
+    #[DataProvider('unmatchableNamingAttributeProvider')]
+    public function test_add_named_by_a_type_with_no_equality_rule_throws_naming_violation(string $dn): void
+    {
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::NAMING_VIOLATION);
+
+        $this->subject->validateAdd($this->personEntry($dn));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function unmatchableNamingAttributeProvider(): iterable
+    {
+        yield 'single valued rdn' => [
+            'jpegPhoto=zz,dc=example,dc=com',
+        ];
+        // Every component of a multi-valued RDN names the entry, so one unmatchable component is enough.
+        yield 'multi valued rdn, unmatchable component second' => [
+            'cn=Alice+jpegPhoto=zz,dc=example,dc=com',
+        ];
+        yield 'multi valued rdn, unmatchable component first' => [
+            'jpegPhoto=zz+cn=Alice,dc=example,dc=com',
+        ];
+    }
+
+    public function test_add_named_by_a_type_inheriting_its_equality_rule_passes(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        // cn declares no EQUALITY of its own and inherits one from name through SUP.
+        $this->subject->validateAdd($this->personEntry('cn=Alice,dc=example,dc=com'));
+    }
+
+    public function test_add_below_an_ancestor_named_by_an_unmatchable_type_passes(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        // Only the leftmost RDN names this entry; the ancestor was its own add's problem.
+        $this->subject->validateAdd($this->personEntry('cn=Alice,jpegPhoto=zz,dc=example,dc=com'));
+    }
+
+    public function test_rename_onto_a_type_with_no_equality_rule_throws_naming_violation(): void
+    {
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::NAMING_VIOLATION);
+
+        $this->subject->validateModifyDn(
+            $this->personEntry('jpegPhoto=zz,dc=example,dc=com'),
+            new Rdn('jpegPhoto', 'zz'),
+        );
     }
 
     public function test_add_missing_structural_class_throws_object_class_violation(): void

--- a/tests/unit/Schema/Validation/Syntax/SyntaxValidatorRegistryTest.php
+++ b/tests/unit/Schema/Validation/Syntax/SyntaxValidatorRegistryTest.php
@@ -16,6 +16,7 @@ namespace Tests\Unit\FreeDSx\Ldap\Schema\Validation\Syntax;
 use FreeDSx\Ldap\Schema\Definition\SyntaxOid;
 use FreeDSx\Ldap\Schema\Validation\Syntax\BooleanSyntaxValidator;
 use FreeDSx\Ldap\Schema\Validation\Syntax\IntegerSyntaxValidator;
+use FreeDSx\Ldap\Schema\Validation\Syntax\PrintableStringSyntaxValidator;
 use FreeDSx\Ldap\Schema\Validation\Syntax\SyntaxValidatorInterface;
 use FreeDSx\Ldap\Schema\Validation\Syntax\SyntaxValidatorRegistry;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -62,6 +63,14 @@ final class SyntaxValidatorRegistryTest extends TestCase
         );
     }
 
+    public function test_telephone_number_is_enforced_as_a_printable_string(): void
+    {
+        self::assertInstanceOf(
+            PrintableStringSyntaxValidator::class,
+            SyntaxValidatorRegistry::default()->get(SyntaxOid::OID_TELEPHONE_NUMBER),
+        );
+    }
+
     /**
      * @return array<string, array{string}>
      */
@@ -76,6 +85,7 @@ final class SyntaxValidatorRegistryTest extends TestCase
             'oid' => [SyntaxOid::OID_OID],
             'numeric string' => [SyntaxOid::OID_NUMERIC_STRING],
             'printable string' => [SyntaxOid::OID_PRINTABLE_STRING],
+            'telephone number' => [SyntaxOid::OID_TELEPHONE_NUMBER],
             'ia5 string' => [SyntaxOid::OID_IA5_STRING],
             'bit string' => [SyntaxOid::OID_BIT_STRING],
             'uuid' => [SyntaxOid::OID_UUID],

--- a/tests/unit/Server/Backend/Write/Routing/WriteCommandFactoryTest.php
+++ b/tests/unit/Server/Backend/Write/Routing/WriteCommandFactoryTest.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
@@ -32,6 +33,7 @@ use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Routing\WriteCommandFactory;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Token\AnonToken;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class WriteCommandFactoryTest extends TestCase
@@ -126,6 +128,49 @@ final class WriteCommandFactoryTest extends TestCase
                 true,
             ),
             $this->context(),
+        );
+    }
+
+    #[DataProvider('rootDseWriteProvider')]
+    public function test_a_write_naming_the_root_dse_is_refused_rather_than_reported_missing(
+        RequestInterface $request,
+    ): void {
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
+
+        $this->subject->fromRequest(
+            $request,
+            $this->context(),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{RequestInterface}>
+     */
+    public static function rootDseWriteProvider(): iterable
+    {
+        yield 'add' => [
+            new AddRequest(Entry::create('')),
+        ];
+        yield 'modify' => [
+            new ModifyRequest('', Change::add('description', 'probe')),
+        ];
+        yield 'delete' => [
+            new DeleteRequest(''),
+        ];
+        yield 'modify dn' => [
+            new ModifyDnRequest('', 'cn=foo', true),
+        ];
+    }
+
+    public function test_a_subtree_delete_of_the_root_dse_is_refused(): void
+    {
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
+
+        $this->subject->fromRequest(
+            new DeleteRequest(''),
+            $this->context(new Control(Control::OID_SUBTREE_DELETE)),
         );
     }
 

--- a/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
@@ -916,6 +916,33 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
         );
     }
 
+    public function test_a_rename_of_the_root_dse_deleting_the_old_rdn_authorizes_only_the_new_one(): void
+    {
+        $this->routeResolvesTo(HandlerId::Dispatch);
+        $seen = [];
+        $this->accessControl
+            ->method('authorizeAttribute')
+            ->willReturnCallback(
+                function (TokenInterface $token, Dn $dn, string $attribute) use (&$seen): void {
+                    $seen[] = $attribute;
+                },
+            );
+
+        $this->subject->process(
+            $this->contextFor(new ModifyDnRequest(
+                '',
+                'cn=bar',
+                true,
+            )),
+            $this->next,
+        );
+
+        self::assertSame(
+            ['cn'],
+            $seen,
+        );
+    }
+
     public function test_a_rename_authorizes_every_component_of_a_multivalued_rdn(): void
     {
         $this->routeResolvesTo(HandlerId::Dispatch);


### PR DESCRIPTION
These are some validating tightening changes.

* Explicitly deny RootDSE writes rather than incidentally deny it.
* Add a structural class to the subschema entry.
* Telephone number must be printable string.
* Naming attributes must have equality matching.

I will have a follow up that touches the RootDSE logic again. We need something broader for generated entries overall. I'm going to make that a larger change, because a few other spots need to change.