### PR TITLE
[1.0.0] Guard all server generated entries.

### DIFF
--- a/docs/Server/Access-Control.md
+++ b/docs/Server/Access-Control.md
@@ -287,16 +287,15 @@ AclRules::secureDefault(Subject::group('cn=admins,ou=groups,dc=example,dc=com'))
     ->withMonitorAccess(Subject::authenticated());
 ```
 
-The subschema entry takes the DN it applies to, since that DN is configurable:
+The subschema entry is opened the same way:
 
 ```php
 $options->setAclRules(
-    $options->getAclRules()->withSubschemaAccess(
-        Subject::anyone(),
-        $options->getSubschemaEntry(),
-    ),
+    $options->getAclRules()->withSubschemaAccess(Subject::anyone()),
 );
 ```
+
+These three names are reserved. No client write may target them.
 
 The Root DSE is never gated. RFC 4513 section 5.2.1.5 has servers let all clients, "even those with an
 anonymous authorization", read `supportedSASLMechanisms` before authenticating, and comparing that list

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -37,7 +37,6 @@ LDAP Server Configuration
     * [SchemaConfig:setSources](#schemaconfigsetsources)
     * [SchemaConfig:setValidationMode](#schemaconfigsetvalidationmode)
     * [SchemaConfig:setLoadMode](#schemaconfigsetloadmode)
-    * [SchemaConfig:setSubschemaEntry](#schemaconfigsetsubschemaentry)
 * [RootDSE Options](#rootdse-options)
     * [ServerOptions:setDseAltServer](#setdsealtserver)
     * [ServerOptions:setDseVendorName](#setdsevendorname)
@@ -631,13 +630,6 @@ Whether a definition referencing something no source provides fails the load. Se
 [SchemaLoadMode](Schema.md#schemaloadmode).
 
 **Default**: `SchemaLoadMode::Strict`
-
-------------------
-#### SchemaConfig:setSubschemaEntry
-
-The entry the schema is published on.
-
-**Default**: `cn=Subschema`
 
 ## RootDSE Options
 

--- a/src/FreeDSx/Ldap/Container/Provider/ConnectionGraphContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/ConnectionGraphContainerProvider.php
@@ -146,12 +146,9 @@ final class ConnectionGraphContainerProvider implements ContainerProviderInterfa
 
     private function makeOperationAuthorizationMiddleware(Container $container): OperationAuthorizationMiddleware
     {
-        $options = $container->get(ServerOptions::class);
-
         return new OperationAuthorizationMiddleware(
             $container->get(ServerProtocolHandlerFactory::class),
             $container->get(AccessControlInterface::class),
-            $options->getSubschemaEntry(),
         );
     }
 

--- a/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
@@ -258,10 +258,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
 
     private function makeDerivedResolver(Container $container): DerivedResolver
     {
-        return new DerivedResolver(
-            $container->get(EntryStorageInterface::class),
-            $container->get(ServerOptions::class)->getSubschemaEntry(),
-        );
+        return new DerivedResolver($container->get(EntryStorageInterface::class));
     }
 
     /**

--- a/src/FreeDSx/Ldap/Entry/Dn.php
+++ b/src/FreeDSx/Ldap/Entry/Dn.php
@@ -73,7 +73,8 @@ class Dn implements IteratorAggregate, Countable, Stringable
         Rdn $rdn,
         ?Dn $parent = null,
     ): self {
-        return $parent === null
+        // RFC 4511 4.9 lets a rename name the root DSE as the new superior.
+        return $parent === null || $parent->isRootDse()
             ? new self($rdn->toString())
             : new self($rdn->toString() . ',' . $parent->toString());
     }

--- a/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ServerProtocolHandlerFactory.php
@@ -15,13 +15,12 @@ namespace FreeDSx\Ldap\Protocol\Factory;
 
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Control\ControlBag;
-use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\Request\UnbindRequest;
-use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerMonitorHandler;
+use FreeDSx\Ldap\Server\GeneratedEntry;
 use FreeDSx\Ldap\ServerOptions;
 
 /**
@@ -37,6 +36,11 @@ readonly class ServerProtocolHandlerFactory implements HandlerRouteResolverInter
         RequestInterface $request,
         ControlBag $controls,
     ): HandlerId {
+        $generated = $this->generatedRouteIdFor($request);
+        if ($generated !== null) {
+            return $generated;
+        }
+
         return match (true) {
             $request instanceof AbandonRequest => HandlerId::Abandon,
             $request instanceof ExtendedRequest && $request->getName() === ExtendedRequest::OID_CANCEL => HandlerId::Cancel,
@@ -45,9 +49,6 @@ readonly class ServerProtocolHandlerFactory implements HandlerRouteResolverInter
             $request instanceof ExtendedRequest && $request->getName() === ExtendedRequest::OID_PPOLICY_STATE_FORWARD => HandlerId::PasswordPolicyForward,
             $request instanceof ExtendedRequest && $request->getName() === ExtendedRequest::OID_START_TLS => HandlerId::StartTls,
             $request instanceof ExtendedRequest => HandlerId::UnsupportedExtended,
-            $this->isRootDseSearch($request) => HandlerId::RootDse,
-            $this->isSubschemaSearch($request) => HandlerId::Subschema,
-            $this->isMonitorSearch($request) => HandlerId::Monitor,
             $this->isSyncSearch($request, $controls) => HandlerId::Sync,
             $this->isPagingSearch($request, $controls) => HandlerId::Paging,
             $request instanceof SearchRequest => HandlerId::Search,
@@ -56,52 +57,23 @@ readonly class ServerProtocolHandlerFactory implements HandlerRouteResolverInter
         };
     }
 
-    private function isSubschemaSearch(RequestInterface $request): bool
-    {
-        if (!$request instanceof SearchRequest) {
-            return false;
-        }
-
-        return $this->isBaseSearchFor(
-            $request,
-            $this->options->getSubschemaEntry(),
-        );
-    }
-
-    private function isMonitorSearch(RequestInterface $request): bool
-    {
-        if (!$this->options->isMonitorEnabled() || !$request instanceof SearchRequest) {
-            return false;
-        }
-
-        return $this->isBaseSearchFor(
-            $request,
-            new Dn(ServerMonitorHandler::DN),
-        );
-    }
-
     /**
-     * Compared as names rather than as text, so a client spelling the DN differently still reaches the handler.
+     * The names are reserved unconditionally, but a disabled monitor generates nothing to route to.
      */
-    private function isBaseSearchFor(
-        SearchRequest $request,
-        Dn $dn,
-    ): bool {
-        $baseDn = $request->getBaseDn();
-
-        return $request->getScope() === SearchRequest::SCOPE_BASE_OBJECT
-            && $baseDn !== null
-            && $baseDn->equals($dn);
-    }
-
-    private function isRootDseSearch(RequestInterface $request): bool
+    private function generatedRouteIdFor(RequestInterface $request): ?HandlerId
     {
-        if (!$request instanceof SearchRequest) {
-            return false;
+        if (!$request instanceof SearchRequest || $request->getScope() !== SearchRequest::SCOPE_BASE_OBJECT) {
+            return null;
         }
 
-        return $request->getScope() === SearchRequest::SCOPE_BASE_OBJECT
-            && $request->getBaseDn()?->isRootDse();
+        return match (GeneratedEntry::at($request->getBaseDn())) {
+            GeneratedEntry::RootDse => HandlerId::RootDse,
+            GeneratedEntry::Subschema => HandlerId::Subschema,
+            GeneratedEntry::Monitor => $this->options->isMonitorEnabled()
+                ? HandlerId::Monitor
+                : null,
+            null => null,
+        };
     }
 
     private function isPagingSearch(

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerMonitorHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerMonitorHandler.php
@@ -18,6 +18,7 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
+use FreeDSx\Ldap\Server\GeneratedEntry;
 use FreeDSx\Ldap\Server\Metrics\Snapshot\MetricsSnapshot;
 use FreeDSx\Ldap\Server\ServerRunner\CoroutineServerRunnerInterface;
 use FreeDSx\Ldap\Server\ServerRunner\PcntlServerRunner;
@@ -38,7 +39,7 @@ use function time;
  */
 class ServerMonitorHandler implements ServerProtocolHandlerInterface
 {
-    public const DN = 'cn=monitor';
+    public const DN = GeneratedEntry::Monitor->value;
 
     public function __construct(
         private readonly ServerOptions $options,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerRootDseHandler.php
@@ -21,6 +21,7 @@ use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Schema\Definition\ObjectClassOid;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\GeneratedEntry;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\ServerOptions;
 
@@ -59,7 +60,7 @@ class ServerRootDseHandler implements ServerProtocolHandlerInterface
                 fn(Dn $dn): string => $dn->toString(),
                 $this->storage->namingContexts(),
             ),
-            'subschemaSubentry' => [$this->options->getSubschemaEntry()->toString()],
+            'subschemaSubentry' => [GeneratedEntry::Subschema->value],
             'supportedControl' => [
                 Control::OID_PAGING,
                 Control::OID_SORTING,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSubschemaHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSubschemaHandler.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Schema\Definition\ObjectClassOid;
 use FreeDSx\Ldap\Schema\Schema;
+use FreeDSx\Ldap\Server\GeneratedEntry;
 use FreeDSx\Ldap\Server\Subentry\SubtreeSpecification;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\ServerOptions;
@@ -39,7 +40,7 @@ readonly class ServerSubschemaHandler implements ServerProtocolHandlerInterface
         LdapMessageRequest $message,
         TokenInterface $token,
     ): ResponseStream {
-        $schemaDn = $this->options->getSubschemaEntry();
+        $schemaDn = GeneratedEntry::Subschema->dn();
         $rdn = $schemaDn->getRdn();
         $schema = $this->options->getSchema();
 

--- a/src/FreeDSx/Ldap/Server/AccessControl/AclRules.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/AclRules.php
@@ -17,7 +17,7 @@ use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
-use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerMonitorHandler;
+use FreeDSx\Ldap\Server\GeneratedEntry;
 use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ConfidentialAccessRule;
@@ -421,12 +421,10 @@ final readonly class AclRules
     /**
      * Restrict searches of the subschema subentry to $subject, replacing any earlier rule for that entry.
      */
-    public function withSubschemaAccess(
-        SubjectMatcherInterface $subject,
-        Dn $subschemaEntry,
-    ): self {
+    public function withSubschemaAccess(?SubjectMatcherInterface $subject): self
+    {
         return $this->withGeneratedEntryAccess(
-            $subschemaEntry,
+            GeneratedEntry::Subschema->dn(),
             $subject,
         );
     }
@@ -437,7 +435,7 @@ final readonly class AclRules
     public function withMonitorAccess(?SubjectMatcherInterface $subject): self
     {
         return $this->withGeneratedEntryAccess(
-            new Dn(ServerMonitorHandler::DN),
+            GeneratedEntry::Monitor->dn(),
             $subject,
         );
     }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Derived/DerivedResolver.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Derived/DerivedResolver.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Derived;
 
-use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\GeneratedEntry;
 
 /**
  * Produces the operational attributes computed per read, so the read and filter paths share one definition.
@@ -26,10 +26,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
  */
 final readonly class DerivedResolver
 {
-    public function __construct(
-        private EntryStorageInterface $storage,
-        private Dn $subschemaEntry,
-    ) {}
+    public function __construct(private EntryStorageInterface $storage) {}
 
     /**
      * @param string $name A canonical type name, which callers get from {@see DerivedAttributeTrait}.
@@ -43,7 +40,7 @@ final readonly class DerivedResolver
             // RFC 5020: derived on read so a rename cannot leave it stale.
             AttributeTypeOid::NAME_ENTRY_DN => $entry->getDn()->toString(),
             // RFC 4512 §4.2: how a client locates the schema governing this entry.
-            AttributeTypeOid::NAME_SUBSCHEMA_SUBENTRY => $this->subschemaEntry->toString(),
+            AttributeTypeOid::NAME_SUBSCHEMA_SUBENTRY => GeneratedEntry::Subschema->value,
             // X.501: the one derived value needing a lookup rather than the entry alone.
             AttributeTypeOid::NAME_HAS_SUBORDINATES => $this->storage->hasChildren($entry->getDn())
                 ? 'TRUE'

--- a/src/FreeDSx/Ldap/Server/Backend/Write/Operation/EntryPlacementGuard.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/Operation/EntryPlacementGuard.php
@@ -150,11 +150,13 @@ readonly class EntryPlacementGuard
     /**
      * A single-RDN superior is held to this too, so a move cannot strand the entry under a DN that holds nothing.
      *
+     * Note: The RootDSE is never stored, and whether an entry may sit beneath it is settled before this runs.
+     *
      * @throws OperationException
      */
     private function assertNewSuperiorExists(?Dn $newParent): void
     {
-        if ($newParent === null) {
+        if ($newParent === null || $newParent->isRootDse()) {
             return;
         }
         if (!$this->storage->exists($newParent->normalize())) {

--- a/src/FreeDSx/Ldap/Server/Backend/Write/Routing/GeneratedEntryGuard.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/Routing/GeneratedEntryGuard.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Write\Routing;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\AddRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\AccessControl\OperationTargetDn;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
+use FreeDSx\Ldap\Server\GeneratedEntry;
+
+use function sprintf;
+
+/**
+ * Keeps a write off the entries the server generates that don't live in storage.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+readonly class GeneratedEntryGuard
+{
+    /**
+     * @throws OperationException
+     */
+    public function assertWritable(
+        RequestInterface $request,
+        WriteContext $context,
+    ): void {
+        $this->assertNotGenerated($request);
+        $this->assertParentIsNotGenerated(
+            $request,
+            $context,
+        );
+    }
+
+    /**
+     * Refused explicitly rather than reported missing incidentally.
+     *
+     * @throws OperationException
+     */
+    private function assertNotGenerated(RequestInterface $request): void
+    {
+        foreach ($this->targetDnsOf($request) as $dn) {
+            $generated = GeneratedEntry::at($dn);
+            if ($generated === null) {
+                continue;
+            }
+
+            throw new OperationException(
+                sprintf(
+                    'The %s cannot be written to.',
+                    $generated->label(),
+                ),
+                ResultCode::UNWILLING_TO_PERFORM,
+            );
+        }
+    }
+
+    /**
+     * A generated entry stores nothing. The RootDSE holds only naming contexts.
+     *
+     * @throws OperationException
+     */
+    private function assertParentIsNotGenerated(
+        RequestInterface $request,
+        WriteContext $context,
+    ): void {
+        $generated = GeneratedEntry::at($this->newParentOf($request));
+        if ($generated === null) {
+            return;
+        }
+        // A naming context is a child of the RootDSE, which only a server-initiated write may create.
+        if ($generated === GeneratedEntry::RootDse && $context->isSystem()) {
+            return;
+        }
+
+        throw new OperationException(
+            sprintf(
+                'An entry cannot be placed beneath the %s.',
+                $generated->label(),
+            ),
+            ResultCode::UNWILLING_TO_PERFORM,
+        );
+    }
+
+    /**
+     * A rename is held to both ends, since it can land an entry on a name the server generates.
+     *
+     * @return list<Dn>
+     */
+    private function targetDnsOf(RequestInterface $request): array
+    {
+        $target = OperationTargetDn::of($request);
+        if ($target === null) {
+            return [];
+        }
+
+        return $request instanceof ModifyDnRequest
+            ? [$target, OperationTargetDn::resultOf($request)]
+            : [$target];
+    }
+
+    /**
+     * The parent the write names for the entry, or null when it names none.
+     */
+    private function newParentOf(RequestInterface $request): ?Dn
+    {
+        return match (true) {
+            $request instanceof AddRequest => $request->getEntry()
+                ->getDn()
+                ->getParent(),
+            $request instanceof ModifyDnRequest => $request->getNewParentDn(),
+            default => null,
+        };
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Write/Routing/WriteCommandFactory.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/Routing/WriteCommandFactory.php
@@ -22,7 +22,6 @@ use FreeDSx\Ldap\Operation\Request\ModifyRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Schema\Text;
-use FreeDSx\Ldap\Server\AccessControl\OperationTargetDn;
 use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteSubtreeCommand;
@@ -36,8 +35,12 @@ use FreeDSx\Ldap\Server\Backend\Write\WriteRequestInterface;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final class WriteCommandFactory
+final readonly class WriteCommandFactory
 {
+    public function __construct(
+        private GeneratedEntryGuard $generatedEntries = new GeneratedEntryGuard(),
+    ) {}
+
     /**
      * @throws OperationException
      */
@@ -45,7 +48,7 @@ final class WriteCommandFactory
         RequestInterface $request,
         WriteContext $context,
     ): WriteRequestInterface {
-        $this->assertNotRootDse($request);
+        $this->generatedEntries->assertWritable($request, $context);
 
         return match (true) {
             $request instanceof AddRequest => new AddCommand($request->getEntry()),
@@ -60,23 +63,6 @@ final class WriteCommandFactory
                 ResultCode::NO_SUCH_OPERATION,
             ),
         };
-    }
-
-    /**
-     * Refused explicitly rather than reported missing incidentally.
-     *
-     * @throws OperationException
-     */
-    private function assertNotRootDse(RequestInterface $request): void
-    {
-        if (OperationTargetDn::of($request)?->isRootDse() !== true) {
-            return;
-        }
-
-        throw new OperationException(
-            'The RootDSE cannot be written to.',
-            ResultCode::UNWILLING_TO_PERFORM,
-        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Config/SchemaConfig.php
+++ b/src/FreeDSx/Ldap/Server/Config/SchemaConfig.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Config;
 
-use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\SchemaParseException;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Schema\SchemaLoadMode;
@@ -31,8 +30,6 @@ use FreeDSx\Ldap\Schema\Validation\SchemaReferenceValidator;
  */
 final class SchemaConfig
 {
-    private const DEFAULT_SUBSCHEMA_DN = 'cn=Subschema';
-
     /**
      * Sources merge in order, so a later one overrides an earlier one on OID or name collision. Vendor extensions
      * an overriding definition omits are carried forward, so protections such as X-CONFIDENTIAL survive.
@@ -49,14 +46,7 @@ final class SchemaConfig
 
     private SchemaLoadMode $loadMode = SchemaLoadMode::Strict;
 
-    private Dn $subschemaEntry;
-
     private ?Schema $resolved = null;
-
-    public function __construct()
-    {
-        $this->subschemaEntry = new Dn(self::DEFAULT_SUBSCHEMA_DN);
-    }
 
     /**
      * @return list<SchemaSourceInterface>
@@ -117,21 +107,6 @@ final class SchemaConfig
     {
         $this->loadMode = $mode;
         $this->resolved = null;
-
-        return $this;
-    }
-
-    /**
-     * The entry the schema is published on.
-     */
-    public function getSubschemaEntry(): Dn
-    {
-        return $this->subschemaEntry;
-    }
-
-    public function setSubschemaEntry(Dn $subschemaEntry): self
-    {
-        $this->subschemaEntry = $subschemaEntry;
 
         return $this;
     }

--- a/src/FreeDSx/Ldap/Server/GeneratedEntry.php
+++ b/src/FreeDSx/Ldap/Server/GeneratedEntry.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server;
+
+use FreeDSx\Ldap\Entry\Dn;
+
+/**
+ * The entries this server composes on demand rather than reading from storage.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+enum GeneratedEntry: string
+{
+    case RootDse = '';
+
+    case Subschema = 'cn=Subschema';
+
+    case Monitor = 'cn=monitor';
+
+    /**
+     * Compared as names rather than as text, so a client spelling the DN differently still resolves to it.
+     */
+    public static function at(?Dn $dn): ?self
+    {
+        if ($dn === null) {
+            return null;
+        }
+
+        foreach (self::cases() as $entry) {
+            if ($dn->equals($entry->dn())) {
+                return $entry;
+            }
+        }
+
+        return null;
+    }
+
+    public function dn(): Dn
+    {
+        return new Dn($this->value);
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::RootDse => 'RootDSE',
+            self::Subschema => 'subschema entry',
+            self::Monitor => self::Monitor->value . ' entry',
+        };
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
@@ -32,7 +32,7 @@ use FreeDSx\Ldap\Protocol\Factory\HandlerId;
 use FreeDSx\Ldap\Protocol\Factory\HandlerRouteResolverInterface;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
-use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerMonitorHandler;
+use FreeDSx\Ldap\Server\GeneratedEntry;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
 use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationAccess;
@@ -70,7 +70,6 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
     public function __construct(
         private HandlerRouteResolverInterface $routeResolver,
         private AccessControlInterface $accessControl,
-        private Dn $subschemaEntry,
     ) {}
 
     /**
@@ -101,13 +100,13 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
             $this->accessControl->authorizeOperation(
                 OperationType::Search,
                 $context->tokenOrFail(),
-                new Dn(ServerMonitorHandler::DN),
+                GeneratedEntry::Monitor->dn(),
             );
         } elseif ($routeId === HandlerId::Subschema) {
             $this->accessControl->authorizeOperation(
                 OperationType::Search,
                 $context->tokenOrFail(),
-                $this->subschemaEntry,
+                GeneratedEntry::Subschema->dn(),
             );
         } elseif ($routeId === HandlerId::RootDse) {
             // Left ungated on purpose. RFC 4513 section 5.2.1.5 has servers allow all clients, including anonymous

--- a/src/FreeDSx/Ldap/ServerOptions.php
+++ b/src/FreeDSx/Ldap/ServerOptions.php
@@ -183,11 +183,6 @@ final class ServerOptions implements ServerListenerOptionsInterface
         return $this;
     }
 
-    public function getSubschemaEntry(): Dn
-    {
-        return $this->schemaConfig->getSubschemaEntry();
-    }
-
     public function getDseVendorName(): string
     {
         return $this->dseVendorName;
@@ -348,12 +343,8 @@ final class ServerOptions implements ServerListenerOptionsInterface
 
     public function getAclRules(): AclRules
     {
-        // The subschema rule is applied here rather than in secureDefault(), since only this side knows the DN.
         return $this->aclRules ?? ($this->defaultAclRules ??= AclRules::secureDefault($this->administrators)
-            ->withSubschemaAccess(
-                Subject::authenticated(),
-                $this->getSubschemaEntry(),
-            ));
+            ->withSubschemaAccess(Subject::authenticated()));
     }
 
     public function getPasswordConfig(): PasswordConfig

--- a/tests/integration/LdapServerTest.php
+++ b/tests/integration/LdapServerTest.php
@@ -21,11 +21,13 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Entry\Rdn;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\Response\BindResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\GeneratedEntry;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Throwable;
 
@@ -777,8 +779,8 @@ final class LdapServerTest extends ServerTestCase
         }
     }
 
-    #[DataProvider('rootDseWriteProvider')]
-    public function testAWriteOnTheRootDseIsRefusedRatherThanReportedMissing(RequestInterface $request): void
+    #[DataProvider('generatedEntryWriteProvider')]
+    public function testAWriteOnAGeneratedEntryIsRefusedRatherThanReportedMissing(RequestInterface $request): void
     {
         $this->authenticateAdmin();
 
@@ -787,7 +789,7 @@ final class LdapServerTest extends ServerTestCase
 
         try {
             $this->ldapClient()->sendAndReceive($request);
-            $this->fail('A write on the root DSE should have been refused.');
+            $this->fail('A write on a generated entry should have been refused.');
         } catch (OperationException $e) {
             $this->assertSame(
                 ResultCode::UNWILLING_TO_PERFORM,
@@ -799,20 +801,100 @@ final class LdapServerTest extends ServerTestCase
     /**
      * @return iterable<string, array{RequestInterface}>
      */
-    public static function rootDseWriteProvider(): iterable
+    public static function generatedEntryWriteProvider(): iterable
     {
-        yield 'add' => [
-            Operations::add(Entry::fromArray('', ['objectClass' => 'device', 'cn' => 'rootprobe'])),
+        foreach (GeneratedEntry::cases() as $entry) {
+            yield "add the {$entry->name} entry" => [
+                Operations::add(Entry::fromArray($entry->value, ['objectClass' => 'device', 'cn' => 'shadow'])),
+            ];
+            yield "modify the {$entry->name} entry" => [
+                Operations::modify($entry->value, Change::add('description', 'probe')),
+            ];
+            yield "delete the {$entry->name} entry" => [
+                Operations::delete($entry->value),
+            ];
+            yield "rename the {$entry->name} entry" => [
+                Operations::rename($entry->value, 'cn=shadow'),
+            ];
+        }
+
+        // RFC 4511 4.9 lets a rename name the root DSE as the new superior, which is where the reserved names sit.
+        yield 'rename another entry onto a generated name' => [
+            new ModifyDnRequest(
+                'dc=foo,dc=bar',
+                'cn=monitor',
+                true,
+                '',
+            ),
         ];
-        yield 'modify' => [
-            Operations::modify('', Change::add('description', 'probe')),
-        ];
-        yield 'delete' => [
-            Operations::delete(''),
-        ];
-        yield 'modify dn' => [
-            Operations::rename('', 'cn=rootprobe'),
-        ];
+    }
+
+    #[DataProvider('generatedParentProvider')]
+    public function testPlacingAnEntryBeneathAGeneratedEntryIsRefused(RequestInterface $request): void
+    {
+        $this->authenticateAdmin();
+
+        try {
+            $this->ldapClient()->sendAndReceive($request);
+            $this->fail('An entry beneath a generated entry should have been refused.');
+        } catch (OperationException $e) {
+            $this->assertSame(
+                ResultCode::UNWILLING_TO_PERFORM,
+                $e->getCode(),
+            );
+        }
+    }
+
+    /**
+     * @return iterable<string, array{RequestInterface}>
+     */
+    public static function generatedParentProvider(): iterable
+    {
+        foreach (GeneratedEntry::cases() as $entry) {
+            yield "move beneath the {$entry->name} entry" => [
+                new ModifyDnRequest(
+                    'cn=user,dc=foo,dc=bar',
+                    'cn=user',
+                    true,
+                    $entry->value,
+                ),
+            ];
+
+            // A top level add names no parent at all, so the RootDSE can never be one.
+            if ($entry === GeneratedEntry::RootDse) {
+                continue;
+            }
+
+            yield "add beneath the {$entry->name} entry" => [
+                Operations::add(Entry::fromArray(
+                    "cn=child,{$entry->value}",
+                    ['objectClass' => 'device', 'cn' => 'child'],
+                )),
+            ];
+        }
+    }
+
+    public function testAGeneratedEntryLeavesNoShadowInASubtreeSearch(): void
+    {
+        $this->authenticateAdmin();
+
+        try {
+            $this->ldapClient()->create(Entry::fromArray(
+                'cn=Subschema',
+                ['objectClass' => 'device', 'cn' => 'Subschema', 'description' => 'SHADOW'],
+            ));
+            $this->fail('A shadow entry should not have been created.');
+        } catch (OperationException) {
+        }
+
+        $this->assertCount(
+            0,
+            $this->ldapClient()->search(
+                Operations::search(Filters::equal('description', 'SHADOW'))
+                    ->base('dc=foo,dc=bar')
+                    ->useSubtreeScope(),
+            ),
+        );
     }
 
     /**

--- a/tests/support/LdapBackendStorageCommand.php
+++ b/tests/support/LdapBackendStorageCommand.php
@@ -375,7 +375,6 @@ final class LdapBackendStorageCommand extends Command
             $serverOptions->setAclRules(
                 $serverOptions->getAclRules()->withSubschemaAccess(
                     Subject::group('cn=admins,dc=foo,dc=bar'),
-                    $serverOptions->getSubschemaEntry(),
                 ),
             );
         }

--- a/tests/unit/Entry/DnTest.php
+++ b/tests/unit/Entry/DnTest.php
@@ -71,6 +71,37 @@ class DnTest extends TestCase
         );
     }
 
+    #[DataProvider('rdnParentProvider')]
+    public function test_it_builds_a_dn_from_an_rdn_and_a_parent(
+        ?Dn $parent,
+        string $expected,
+    ): void {
+        self::assertSame(
+            $expected,
+            Dn::fromRdn(new Rdn('cn', 'foo'), $parent)->toString(),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{?Dn, string}>
+     */
+    public static function rdnParentProvider(): iterable
+    {
+        yield 'a parent to sit beneath' => [
+            new Dn('dc=foo,dc=bar'),
+            'cn=foo,dc=foo,dc=bar',
+        ];
+        yield 'no parent' => [
+            null,
+            'cn=foo',
+        ];
+        // RFC 4511 4.9 lets a rename name the root DSE as the new superior.
+        yield 'the root dse as the parent' => [
+            new Dn(''),
+            'cn=foo',
+        ];
+    }
+
     public function test_only_the_zero_length_dn_names_the_root_dse(): void
     {
         self::assertTrue((new Dn(''))->isRootDse());

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerRootDseHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerRootDseHandlerTest.php
@@ -239,24 +239,6 @@ final class ServerRootDseHandlerTest extends TestCase
         self::assertTrue($attr->has('cn=Subschema'));
     }
 
-    public function test_it_uses_configured_subschema_entry_dn(): void
-    {
-        $this->options->getSchemaConfig()
-            ->setSubschemaEntry(new Dn('cn=schema,dc=example,dc=com'));
-
-        $search = $this->rootDseSearch('*', '+');
-
-        $stream = $this->subject->handleRequest($search, $this->mockToken);
-        $messages = [...$stream->messages];
-
-        /** @var SearchResultEntry $result */
-        $result = $messages[0]->getResponse();
-        $attr = $result->getEntry()->get('subschemaSubentry');
-
-        self::assertNotNull($attr);
-        self::assertTrue($attr->has('cn=schema,dc=example,dc=com'));
-    }
-
     public function test_the_all_operational_selector_returns_every_root_dse_attribute_but_objectClass(): void
     {
         $this->options->setDseVendorName('Foo');

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSubschemaHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSubschemaHandlerTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
-use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
 use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
@@ -26,6 +25,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
+use FreeDSx\Ldap\Server\GeneratedEntry;
 use Tests\Support\FreeDSx\Ldap\ServerContainerTrait;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\ServerOptions;
@@ -113,7 +113,7 @@ final class ServerSubschemaHandlerTest extends TestCase
             new LdapMessageRequest(
                 1,
                 (new SearchRequest(Filters::equal('objectClass', 'subentry')))
-                    ->base($this->options->getSubschemaEntry()->toString())
+                    ->base(GeneratedEntry::Subschema->value)
                     ->useBaseScope(),
             ),
             $this->mockToken,
@@ -125,18 +125,15 @@ final class ServerSubschemaHandlerTest extends TestCase
         );
     }
 
-    public function test_it_uses_the_configured_subschema_entry_dn(): void
+    public function test_it_publishes_the_schema_on_the_reserved_subschema_dn(): void
     {
-        $this->options->getSchemaConfig()
-            ->setSubschemaEntry(new Dn('cn=schema,dc=example,dc=com'));
-
         $entry = $this->handleAndCaptureEntry();
 
         self::assertSame(
-            'cn=schema,dc=example,dc=com',
+            'cn=Subschema',
             $entry->getDn()->toString(),
         );
-        self::assertTrue($entry->get('cn')?->has('schema') ?? false);
+        self::assertTrue($entry->get('cn')?->has('Subschema') ?? false);
     }
 
     public function test_it_returns_non_empty_attribute_types_in_rfc4512_format(): void
@@ -249,7 +246,7 @@ final class ServerSubschemaHandlerTest extends TestCase
         return new LdapMessageRequest(
             1,
             (new SearchRequest(Filters::present('objectClass')))
-                ->base($this->options->getSubschemaEntry()->toString())
+                ->base(GeneratedEntry::Subschema->value)
                 ->useBaseScope()
                 ->setAttributes(...$selectors),
         );

--- a/tests/unit/Server/AccessControl/AclRulesTest.php
+++ b/tests/unit/Server/AccessControl/AclRulesTest.php
@@ -494,10 +494,7 @@ final class AclRulesTest extends TestCase
     {
         $acl = new RuleBasedAccessControl(
             AclRules::secureDefault(Subject::dn(self::ADMIN_DN))
-                ->withSubschemaAccess(
-                    Subject::dn(self::ADMIN_DN),
-                    new Dn('cn=Subschema'),
-                ),
+                ->withSubschemaAccess(Subject::dn(self::ADMIN_DN)),
         );
 
         $this->expectException(OperationException::class);
@@ -514,10 +511,7 @@ final class AclRulesTest extends TestCase
     {
         $acl = new RuleBasedAccessControl(
             AclRules::secureDefault(Subject::dn(self::ADMIN_DN))
-                ->withSubschemaAccess(
-                    Subject::anyone(),
-                    new Dn('cn=Subschema'),
-                ),
+                ->withSubschemaAccess(Subject::anyone()),
         );
 
         $acl->authorizeOperation(

--- a/tests/unit/Server/Backend/Write/Routing/GeneratedEntryGuardTest.php
+++ b/tests/unit/Server/Backend/Write/Routing/GeneratedEntryGuardTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Write\Routing;
+
+use FreeDSx\Ldap\Control\ControlBag;
+use FreeDSx\Ldap\Entry\Change;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\AddRequest;
+use FreeDSx\Ldap\Operation\Request\DeleteRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
+use FreeDSx\Ldap\Operation\Request\ModifyRequest;
+use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\Backend\Write\Routing\GeneratedEntryGuard;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
+use FreeDSx\Ldap\Server\GeneratedEntry;
+use FreeDSx\Ldap\Server\Token\AnonToken;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class GeneratedEntryGuardTest extends TestCase
+{
+    private GeneratedEntryGuard $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new GeneratedEntryGuard();
+    }
+
+    #[DataProvider('generatedEntryWriteProvider')]
+    public function test_a_write_naming_a_generated_entry_is_refused_rather_than_reported_missing(
+        RequestInterface $request,
+    ): void {
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
+
+        $this->subject->assertWritable(
+            $request,
+            $this->context(),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{RequestInterface}>
+     */
+    public static function generatedEntryWriteProvider(): iterable
+    {
+        foreach (GeneratedEntry::cases() as $entry) {
+            yield "add the {$entry->name} entry" => [
+                new AddRequest(Entry::create($entry->value)),
+            ];
+            yield "modify the {$entry->name} entry" => [
+                new ModifyRequest($entry->value, Change::add('description', 'probe')),
+            ];
+            yield "delete the {$entry->name} entry" => [
+                new DeleteRequest($entry->value),
+            ];
+        }
+
+        // A respelling of a reserved name is the same name, which is what the normalizing compare is for.
+        yield 'delete a respelled generated entry' => [
+            new DeleteRequest('cn = subschema'),
+        ];
+
+        yield 'modify dn away from a generated entry' => [
+            new ModifyDnRequest('cn=Subschema', 'cn=foo', true),
+        ];
+        // The name is taken wherever the rename would land it, not only where it starts.
+        yield 'modify dn onto a generated entry' => [
+            new ModifyDnRequest('cn=foo,dc=foo,dc=bar', 'cn=monitor', true, ''),
+        ];
+    }
+
+    #[DataProvider('generatedParentProvider')]
+    public function test_placing_an_entry_beneath_a_generated_entry_is_refused(RequestInterface $request): void
+    {
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
+
+        $this->subject->assertWritable(
+            $request,
+            $this->context(),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{RequestInterface}>
+     */
+    public static function generatedParentProvider(): iterable
+    {
+        foreach (GeneratedEntry::cases() as $entry) {
+            yield "move beneath the {$entry->name} entry" => [
+                new ModifyDnRequest('cn=foo,dc=foo,dc=bar', 'cn=foo', true, $entry->value),
+            ];
+
+            // A top level add names no parent at all, so the RootDSE can never be one.
+            if ($entry === GeneratedEntry::RootDse) {
+                continue;
+            }
+
+            yield "add beneath the {$entry->name} entry" => [
+                new AddRequest(Entry::create("cn=child,{$entry->value}")),
+            ];
+        }
+    }
+
+    public function test_a_system_write_may_create_a_naming_context_beneath_the_root_dse(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->subject->assertWritable(
+            new ModifyDnRequest('cn=foo,dc=foo,dc=bar', 'cn=foo', true, ''),
+            $this->systemContext(),
+        );
+    }
+
+    public function test_an_add_at_the_top_level_is_left_to_the_placement_guard(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->subject->assertWritable(
+            new AddRequest(Entry::create('dc=new')),
+            $this->context(),
+        );
+    }
+
+    public function test_a_write_below_a_naming_context_is_not_refused(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->subject->assertWritable(
+            new DeleteRequest('cn=monitor,dc=foo,dc=bar'),
+            $this->context(),
+        );
+    }
+
+    private function context(): WriteContext
+    {
+        return new WriteContext(
+            new AnonToken(),
+            new ControlBag(),
+        );
+    }
+
+    private function systemContext(): WriteContext
+    {
+        return WriteContext::system(
+            new AnonToken(),
+            new ControlBag(),
+        );
+    }
+}

--- a/tests/unit/Server/Backend/Write/Routing/WriteCommandFactoryTest.php
+++ b/tests/unit/Server/Backend/Write/Routing/WriteCommandFactoryTest.php
@@ -23,7 +23,6 @@ use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyRequest;
-use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\Backend\Write\Command\AddCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Command\DeleteCommand;
@@ -33,7 +32,6 @@ use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 use FreeDSx\Ldap\Server\Backend\Write\Routing\WriteCommandFactory;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 use FreeDSx\Ldap\Server\Token\AnonToken;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class WriteCommandFactoryTest extends TestCase
@@ -131,39 +129,7 @@ final class WriteCommandFactoryTest extends TestCase
         );
     }
 
-    #[DataProvider('rootDseWriteProvider')]
-    public function test_a_write_naming_the_root_dse_is_refused_rather_than_reported_missing(
-        RequestInterface $request,
-    ): void {
-        self::expectException(OperationException::class);
-        self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);
-
-        $this->subject->fromRequest(
-            $request,
-            $this->context(),
-        );
-    }
-
-    /**
-     * @return iterable<string, array{RequestInterface}>
-     */
-    public static function rootDseWriteProvider(): iterable
-    {
-        yield 'add' => [
-            new AddRequest(Entry::create('')),
-        ];
-        yield 'modify' => [
-            new ModifyRequest('', Change::add('description', 'probe')),
-        ];
-        yield 'delete' => [
-            new DeleteRequest(''),
-        ];
-        yield 'modify dn' => [
-            new ModifyDnRequest('', 'cn=foo', true),
-        ];
-    }
-
-    public function test_a_subtree_delete_of_the_root_dse_is_refused(): void
+    public function test_it_holds_a_write_to_the_generated_entry_guard(): void
     {
         self::expectException(OperationException::class);
         self::expectExceptionCode(ResultCode::UNWILLING_TO_PERFORM);

--- a/tests/unit/Server/GeneratedEntryTest.php
+++ b/tests/unit/Server/GeneratedEntryTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Server\GeneratedEntry;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class GeneratedEntryTest extends TestCase
+{
+    #[DataProvider('generatedDnProvider')]
+    public function test_it_resolves_the_entry_generated_at_a_dn(
+        string $dn,
+        GeneratedEntry $expected,
+    ): void {
+        self::assertSame(
+            $expected,
+            GeneratedEntry::at(new Dn($dn)),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, GeneratedEntry}>
+     */
+    public static function generatedDnProvider(): iterable
+    {
+        yield 'the zero length dn' => [
+            '',
+            GeneratedEntry::RootDse,
+        ];
+        yield 'the subschema dn' => [
+            'cn=Subschema',
+            GeneratedEntry::Subschema,
+        ];
+        // RFC 4514 permits whitespace around the separator and the type is case insensitive.
+        yield 'the subschema dn spelled with padding' => [
+            'cn = Subschema',
+            GeneratedEntry::Subschema,
+        ];
+        yield 'the subschema dn spelled in another case' => [
+            'CN=SUBSCHEMA',
+            GeneratedEntry::Subschema,
+        ];
+        yield 'the monitor dn' => [
+            'cn=monitor',
+            GeneratedEntry::Monitor,
+        ];
+        yield 'the monitor dn spelled in another case' => [
+            'CN=Monitor',
+            GeneratedEntry::Monitor,
+        ];
+    }
+
+    #[DataProvider('ordinaryDnProvider')]
+    public function test_an_ordinary_dn_generates_nothing(string $dn): void
+    {
+        self::assertNull(GeneratedEntry::at(new Dn($dn)));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function ordinaryDnProvider(): iterable
+    {
+        yield 'a naming context' => ['dc=foo,dc=bar'];
+        yield 'an entry beneath one' => ['cn=alice,dc=foo,dc=bar'];
+        // Only the reserved name itself is taken, not the same RDN somewhere else in the tree.
+        yield 'the subschema rdn beneath a naming context' => ['cn=Subschema,dc=foo,dc=bar'];
+        yield 'the monitor rdn beneath a naming context' => ['cn=monitor,dc=foo,dc=bar'];
+    }
+
+    public function test_a_null_dn_generates_nothing(): void
+    {
+        self::assertNull(GeneratedEntry::at(null));
+    }
+
+    #[DataProvider('everyEntryProvider')]
+    public function test_its_dn_resolves_back_to_it(GeneratedEntry $entry): void
+    {
+        self::assertSame(
+            $entry,
+            GeneratedEntry::at($entry->dn()),
+        );
+    }
+
+    #[DataProvider('everyEntryProvider')]
+    public function test_it_has_a_label_for_a_refusal_message(GeneratedEntry $entry): void
+    {
+        self::assertNotSame(
+            '',
+            $entry->label(),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{GeneratedEntry}>
+     */
+    public static function everyEntryProvider(): iterable
+    {
+        foreach (GeneratedEntry::cases() as $entry) {
+            yield $entry->name => [$entry];
+        }
+    }
+}

--- a/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
@@ -71,7 +71,6 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
         $this->subject = new OperationAuthorizationMiddleware(
             $this->resolver,
             $this->accessControl,
-            new Dn(self::SUBSCHEMA_DN),
         );
         $this->next = new RecordingMiddlewareHandler(new CallLog());
     }
@@ -505,7 +504,6 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
         $subject = new OperationAuthorizationMiddleware(
             $this->resolver,
             $this->accessControl,
-            new Dn(self::SUBSCHEMA_DN),
         );
         $this->routeResolvesTo(HandlerId::Sync);
         $this->accessControl
@@ -536,7 +534,6 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
         $subject = new OperationAuthorizationMiddleware(
             $this->resolver,
             $this->accessControl,
-            new Dn(self::SUBSCHEMA_DN),
         );
         $this->routeResolvesTo(HandlerId::Sync);
         $this->accessControl
@@ -841,7 +838,6 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
         $subject = new OperationAuthorizationMiddleware(
             $this->resolver,
             $this->accessControl,
-            new Dn(self::SUBSCHEMA_DN),
         );
         $this->routeResolvesTo(HandlerId::Sync);
         $this->accessControl

--- a/tests/unit/ServerOptionsTest.php
+++ b/tests/unit/ServerOptionsTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap;
 
 use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
-use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Schema\Definition\Nis\AttributeTypeOid as NisAttributeTypeOid;
@@ -268,25 +267,6 @@ final class ServerOptionsTest extends TestCase
         self::assertSame(
             'ldap://backup.example.com',
             $this->subject->getDseAltServer(),
-        );
-    }
-
-    public function test_subschema_entry_defaults_to_cn_subschema(): void
-    {
-        self::assertSame(
-            'cn=Subschema',
-            $this->subject->getSubschemaEntry()->toString(),
-        );
-    }
-
-    public function test_the_subschema_entry_comes_from_the_schema_config(): void
-    {
-        $this->subject->getSchemaConfig()
-            ->setSubschemaEntry(new Dn('cn=Subschema,dc=example,dc=com'));
-
-        self::assertSame(
-            'cn=Subschema,dc=example,dc=com',
-            $this->subject->getSubschemaEntry()->toString(),
         );
     }
 


### PR DESCRIPTION
This adds proper guarding for all generated entries, which don't actually live in storage, in a consolidated way. This way adding one in the future is more natural and it's properly guarded for writes / renames / etc.