### PR TITLE
[1.0.0] Add more logging / validation to LDIF seeding.

### DIFF
--- a/docs/Server/General-Usage.md
+++ b/docs/Server/General-Usage.md
@@ -58,7 +58,8 @@ in-memory implementations. Authentication is a separate, independently configura
 ### Seeded SQLite Server
 
 The simplest useful setup. A SQLite file holds the directory, so it survives restarts and works under the default
-forking runner. Seeding is an upsert, so running this again is safe.
+forking runner. Seeding refuses an entry that already exists, so running this again fails unless you set
+`setReplaceExisting(true)`.
 
 The built-in `PasswordAuthenticator` handles bind authentication automatically — it reads the `userPassword` attribute
 from entries and verifies credentials against it. Supported hash schemes: `{SHA}`, `{SSHA}`, `{MD5}`, `{SMD5}`, and
@@ -541,9 +542,9 @@ other source (database, remote URL, gzip stream, etc.). LDIF output uses the par
 ### Seeding Initial Entries
 
 `LdapServer::seed()` bulk-imports RFC 2849 LDIF content records into the storage configured via
-`ServerOptions::setStorageConfig()` in one atomic transaction, with schema validation and operational-attribute
-stamping (`createTimestamp`, `entryUUID`, etc.) applied. Use it to populate a persistent storage backend before
-`$server->run()`.
+`ServerOptions::setStorageConfig()` in one atomic transaction. Each entry runs through the same add operation a
+client write uses, minus the ACL, message controls and event auditing that need a connection. Use it to populate
+a persistent storage backend before `$server->run()`.
 
 ```php
 use FreeDSx\Ldap\Entry\Dn;
@@ -564,12 +565,20 @@ $server->seed(
 $server->run();
 ```
 
-The optional second argument is a `SeedOptions`. Its `creatorDn` is stamped as `creatorsName`/`modifiersName` on each
-imported entry, defaulting to the empty (anonymous) DN. It also carries `setIgnoreValidation()` for content the current
-schema does not cover, and `setUrlResolver()` to enable RFC 2849 URL values.
+The optional second argument is a `SeedOptions`:
+
+| Setter | Effect |
+|---|---|
+| `setCreatorDn()` | Stamped as `creatorsName`/`modifiersName` on entries carrying neither. Defaults to the empty DN. |
+| `setIgnoreValidation()` | Relaxes the structural, naming and duplicate-value rules. Still refuses a value its attribute syntax rejects. |
+| `setReplaceExisting()` | Overwrites a DN already present, which is otherwise refused with `entryAlreadyExists`. |
+| `setUrlResolver()` | Enables RFC 2849 URL values. |
+
+Supply `entryUUID` for every entry `setReplaceExisting()` replaces: an omitted one is generated fresh, which reads as a
+delete and an add to anything keyed on it. Each replacement is logged, with a record of the counts once the import commits.
 
 `seed()` accepts only content records (entries without `changetype:`) and requires depth-first input (parents first,
-then children entries). LDIF produced by `dump()` is already in this order. The operation itself is an upsert that overwrites.
+then children entries). LDIF produced by `dump()` is already in this order.
 
 When using the Swoole runner (`setRunnerConfig(RunnerConfig::forSwoole())`), call `seed()` inside
 `Swoole\Coroutine\run()` so the storage adapter's per-coroutine connection is available during import.
@@ -620,15 +629,15 @@ $server->seed(new FileLdifLoader('/etc/myapp/initial-data.ldif'))
     ->run();
 ```
 
-Unlike `seed()`, `applyChanges()` dispatches each request through the same write path the live server uses for client
-requests. Supported changetypes: `add`, `delete`, `modify` (`add:`/`delete:`/`replace:` mod-specs), and `modrdn`/`moddn`
-(rename or move; supports optional `newsuperior:` for moving across subtrees).
+Where `seed()` takes content records in one transaction, `applyChanges()` replays change records one at a time through
+the full request pipeline. Supported changetypes: `add`, `delete`, `modify` (`add:`/`delete:`/`replace:` mod-specs), and
+`modrdn`/`moddn` (rename or move; supports optional `newsuperior:` for moving across subtrees).
 
 ### Dumping the Directory
 
 `LdapServer::dump()` streams the configured storage backend's entries to an LDIF output as RFC 2849 content records.
 Operational attributes (`entryUUID`, `createTimestamp`, etc.) are preserved. So `dump()` then `seed()` restores the
-entries exactly as they were.
+entries exactly as they were, since seeding keeps the ones its source supplies rather than stamping new.
 
 ```php
 use FreeDSx\Ldap\LdapServer;

--- a/docs/Server/Logging.md
+++ b/docs/Server/Logging.md
@@ -46,6 +46,9 @@ $server = new LdapServer((new ServerOptions($storageConfig))->setLogger($logger)
 | `schema.violation`          | on      | notice | Add/Modify violates the schema (rejected, or allowed under Lenient mode / the Relax control) |
 | `session.disconnect_notice` | on      | notice | Server sends an unsolicited Notice of Disconnect          |
 | `paging.session_evicted`    | on      | notice | A connection hit `setMaxPagingSessions`, so its least recently started paged search was discarded |
+| `entry.replaced`            | on      | info   | While seeding, an entry already at that DN was overwritten |
+| `import.completed`          | on      | info   | Seeding committed, carrying the entries added and replaced |
+| `import.failed`             | on      | warning | Seeding was rolled back, carrying how far it got          |
 | `entry.added`               | off     | info   | Add succeeds (audit-trail)                                |
 | `entry.modified`            | off     | info   | Modify succeeds (audit-trail)                             |
 | `entry.deleted`             | off     | info   | Delete succeeds (audit-trail)                             |
@@ -72,6 +75,7 @@ Every event carries a structured `context` array with a stable shape:
 | `reason`                                                   | failure events                                                     | Human-readable diagnostic from the exception.                                                      |
 | `validation_mode`                                          | `schema.violation`                                                 | How it was handled: `strict` (rejected), `lenient` (allowed by policy), or `relaxed` (Relax control). |
 | `mechanism`, `version`                                     | bind events                                                        | SASL mechanism name (or `simple`) and LDAP protocol version.                                       |
+| `entries_added`, `entries_replaced`                        | `import.completed`, `import.failed`                                | Counts for the batch. On a failure they say how far it got before the rollback.                    |
 | `match`, `attribute`                                       | compare events                                                     | Match outcome + attribute compared.                                                                |
 | `entries_returned`                                         | search events                                                      | Count of entries delivered to the client.                                                          |
 | `base_dn`, `scope`                                         | search events                                                      | Inside `target`.                                                                                   |

--- a/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
@@ -417,16 +417,20 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
     }
 
     /**
-     * Bulk loading writes straight to storage, so it stamps and validates with the same components the write path uses.
+     * Bulk loading reuses the write path's add operation, so it cannot drift from the wire path.
      */
     private function makeLdapImporter(Container $container): LdapImporter
     {
-        $this->refuseBulkImportOnReplica($container->get(ServerOptions::class));
+        $options = $container->get(ServerOptions::class);
+        $this->refuseBulkImportOnReplica($options);
 
         return new LdapImporter(
             $container->get(EntryStorageInterface::class),
-            $container->get(OperationalAttributeGenerator::class),
-            $container->get(SchemaValidator::class),
+            new WriteRequestRouter($container->get(WriteOperationDispatcher::class)),
+            new EventLogger(
+                $options->getLogger(),
+                $options->getEventLogPolicy(),
+            ),
         );
     }
 

--- a/src/FreeDSx/Ldap/LdapServer.php
+++ b/src/FreeDSx/Ldap/LdapServer.php
@@ -111,6 +111,7 @@ class LdapServer
             $entries,
             $options->getCreatorDn(),
             $options->isIgnoreValidation(),
+            $options->isReplaceExisting(),
         );
 
         $this->drainWrites();

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Import/ImportResult.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Import/ImportResult.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Import;
+
+use FreeDSx\Ldap\Entry\Dn;
+
+use function count;
+
+/**
+ * What a bulk import did, accumulated as it runs.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class ImportResult
+{
+    private int $added = 0;
+
+    /**
+     * @var list<Dn>
+     */
+    private array $replaced = [];
+
+    public function recordAdded(): void
+    {
+        $this->added++;
+    }
+
+    public function recordReplaced(Dn $dn): void
+    {
+        $this->replaced[] = $dn;
+    }
+
+    public function added(): int
+    {
+        return $this->added;
+    }
+
+    /**
+     * @return list<Dn>
+     */
+    public function replaced(): array
+    {
+        return $this->replaced;
+    }
+
+    public function replacedCount(): int
+    {
+        return count($this->replaced);
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Import/LdapImporter.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Import/LdapImporter.php
@@ -13,17 +13,26 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Import;
 
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Control\ControlBag;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Exception\OperationException;
-use FreeDSx\Ldap\Schema\SchemaValidationMode;
-use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
+use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
-use FreeDSx\Ldap\Server\Backend\Write\OperationalAttributeGenerator;
+use FreeDSx\Ldap\Server\Backend\Write\BulkLoadOptions;
+use FreeDSx\Ldap\Server\Backend\Write\Routing\WriteRequestRouter;
+use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
+use FreeDSx\Ldap\Server\Logging\EventContext;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Logging\ServerEvent;
+use FreeDSx\Ldap\Server\Token\SystemToken;
+
+use function sprintf;
 
 /**
- * Bulk-imports entries into an EntryStorageInterface under a single atomic write.
+ * Bulk-loads entries through the server's add operation, under a single atomic write.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -31,49 +40,152 @@ final readonly class LdapImporter
 {
     public function __construct(
         private EntryStorageInterface $storage,
-        private OperationalAttributeGenerator $operationalAttrs = new OperationalAttributeGenerator(),
-        private ?SchemaValidator $validator = null,
+        private WriteRequestRouter $router,
+        private EventLogger $eventLogger = new EventLogger(null),
     ) {}
 
     /**
-     * Stream entries into storage under a single atomic write.
+     * Stream entries through the add operation under a single atomic write.
      *
      * Input must be in depth-first order (each entry's parent appears before its children). Unsorted input will fail
      * at the parent check.
      *
      * @param iterable<Entry> $entries
-     * @param Dn $creatorDn recorded as creatorsName/modifiersName on the imported entries.
-     * @param bool $ignoreValidation when true, skips parent and schema checks. only do this if you know what you're doing.
+     * @param Dn $creatorDn recorded as creatorsName/modifiersName on entries that do not carry their own.
+     * @param bool $ignoreValidation when true, relaxes the schema rules and skips the parent check.
+     * @param bool $replaceExisting when true, an entry already at the same DN is overwritten rather than refused.
      * @throws InvalidArgumentException when the creator DN is malformed, or a non-top-level entry's parent is not present in storage yet
-     * @throws OperationException when an entry violates the schema and validation mode is strict
+     * @throws OperationException when an entry is refused by the add operation
      */
     public function importEntries(
         iterable $entries,
         Dn $creatorDn = new Dn(''),
         bool $ignoreValidation = false,
+        bool $replaceExisting = false,
     ): void {
         $this->assertValidCreatorDn($creatorDn);
+        $result = new ImportResult();
 
-        $this->storage->atomic(function () use ($entries, $creatorDn, $ignoreValidation): void {
-            foreach ($entries as $entry) {
-                if (!$ignoreValidation) {
-                    $this->assertParentExists($entry->getDn());
-                }
+        try {
+            $this->storage->atomic(fn() => $this->load(
+                $entries,
+                $creatorDn,
+                $ignoreValidation,
+                $replaceExisting,
+                $result,
+            ));
+        } catch (OperationException $e) {
+            $this->recordFailure(
+                $result,
+                $e,
+            );
 
-                $this->validateForImport(
-                    $entry,
-                    $ignoreValidation,
-                );
-                $this->operationalAttrs->applyForBulkLoad(
-                    $entry,
-                    $creatorDn->toString(),
-                );
-                $this->storage->store(
-                    $entry,
-                    rebuildIndexes: true,
-                );
+            throw $e;
+        }
+
+        $this->recordOutcome($result);
+    }
+
+    /**
+     * @param iterable<Entry> $entries
+     * @throws InvalidArgumentException
+     * @throws OperationException
+     */
+    private function load(
+        iterable $entries,
+        Dn $creatorDn,
+        bool $ignoreValidation,
+        bool $replaceExisting,
+        ImportResult $result,
+    ): void {
+        foreach ($entries as $entry) {
+            if (!$ignoreValidation) {
+                $this->assertParentExists($entry->getDn());
             }
-        });
+
+            // Read before the write, since afterwards the entry is present either way.
+            $wasPresent = $replaceExisting
+                && $this->storage->exists($entry->getDn()->normalize());
+
+            $this->router->route(
+                new AddRequest($entry),
+                $this->contextFor(
+                    $creatorDn,
+                    $ignoreValidation,
+                    $replaceExisting,
+                ),
+            );
+
+            $wasPresent
+                ? $result->recordReplaced($entry->getDn())
+                : $result->recordAdded();
+        }
+    }
+
+    /**
+     * A fresh context per entry, so the schema violations of one are not carried into the next.
+     */
+    private function contextFor(
+        Dn $creatorDn,
+        bool $ignoreValidation,
+        bool $replaceExisting,
+    ): WriteContext {
+        // Relaxing through the control keeps the violations recorded rather than discarded.
+        $controls = $ignoreValidation
+            ? new ControlBag(new Control(Control::OID_RELAX_RULES))
+            : new ControlBag();
+
+        return WriteContext::bulkLoad(
+            new SystemToken(),
+            $controls,
+            new BulkLoadOptions(
+                $creatorDn,
+                $replaceExisting,
+            ),
+        );
+    }
+
+    /**
+     * Recorded once the batch commits, so a rollback leaves no trace of writes that did not happen.
+     */
+    private function recordOutcome(ImportResult $result): void
+    {
+        foreach ($result->replaced() as $dn) {
+            $this->eventLogger->record(
+                ServerEvent::EntryReplaced,
+                [EventContext::TARGET => [EventContext::DN => $dn->toString()]],
+            );
+        }
+
+        $this->eventLogger->record(
+            ServerEvent::BulkImportCompleted,
+            $this->counts($result),
+        );
+    }
+
+    /**
+     * The batch rolled back, so the counts say how far it got rather than what it left behind.
+     */
+    private function recordFailure(
+        ImportResult $result,
+        OperationException $exception,
+    ): void {
+        $this->eventLogger->recordFailure(
+            ServerEvent::BulkImportFailed,
+            $exception,
+            $this->counts($result),
+        );
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function counts(ImportResult $result): array
+    {
+        return [
+            EventContext::ENTRIES_ADDED => $result->added(),
+            EventContext::ENTRIES_REPLACED => $result->replacedCount(),
+        ];
     }
 
     /**
@@ -96,30 +208,6 @@ final readonly class LdapImporter
             $parent->toString(),
             $dn->toString(),
         ));
-    }
-
-    /**
-     * Validates a bulk-loaded entry as a system-initiated add; only strict mode rejects violations.
-     *
-     * @throws OperationException
-     */
-    private function validateForImport(
-        Entry $entry,
-        bool $ignoreValidation,
-    ): void {
-        $validator = $this->validator;
-
-        if ($ignoreValidation || $validator === null) {
-            return;
-        }
-        if ($validator->mode() !== SchemaValidationMode::Strict) {
-            return;
-        }
-
-        $validator->validateAdd(
-            $entry,
-            true,
-        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Import/SeedOptions.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Import/SeedOptions.php
@@ -30,6 +30,7 @@ final class SeedOptions
         private Dn $creatorDn = new Dn(''),
         private bool $ignoreValidation = false,
         private LdifUrlResolverInterface $urlResolver = new RefusingUrlResolver(),
+        private bool $replaceExisting = false,
     ) {}
 
     public function getCreatorDn(): Dn
@@ -58,6 +59,24 @@ final class SeedOptions
     public function setIgnoreValidation(bool $ignoreValidation): self
     {
         $this->ignoreValidation = $ignoreValidation;
+
+        return $this;
+    }
+
+    public function isReplaceExisting(): bool
+    {
+        return $this->replaceExisting;
+    }
+
+    /**
+     * Overwrites an entry already at the same DN, rather than refusing the seed with entryAlreadyExists.
+     *
+     * Supply entryUUID for every entry replaced. An omitted one is generated fresh, which reads as a delete
+     * and an add to anything keyed on it.
+     */
+    public function setReplaceExisting(bool $replaceExisting): self
+    {
+        $this->replaceExisting = $replaceExisting;
 
         return $this;
     }

--- a/src/FreeDSx/Ldap/Server/Backend/Write/BulkLoadOptions.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/BulkLoadOptions.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Write;
+
+use FreeDSx\Ldap\Entry\Dn;
+
+/**
+ * Marks a write as loading an entry as supplied, rather than composing one for a client.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class BulkLoadOptions
+{
+    public function __construct(
+        public Dn $actorDn = new Dn(''),
+        public bool $replaceExisting = false,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Write/Operation/AddEntryHandler.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/Operation/AddEntryHandler.php
@@ -53,6 +53,8 @@ readonly class AddEntryHandler
             // Merged before validation, so the values naming the entry count toward what its object classes require.
             $entry->mergeRdnAttributes();
 
+            $bulkLoad = $context->bulkLoadOptions();
+
             $this->schemaGate->assertAddAllowed(
                 $entry,
                 $context,
@@ -61,12 +63,22 @@ readonly class AddEntryHandler
                 $entry,
                 $entry->getDn()->normalize(),
                 $context->isSystem(),
+                $bulkLoad !== null && $bulkLoad->replaceExisting,
             );
 
-            $this->operationalAttrs->applyForAdd(
-                $entry,
-                $context,
-            );
+            // A bulk load keeps the operational attributes its source supplied.
+            if ($bulkLoad !== null) {
+                $this->operationalAttrs->applyForBulkLoad(
+                    $entry,
+                    $bulkLoad->actorDn->toString(),
+                );
+            } else {
+                $this->operationalAttrs->applyForAdd(
+                    $entry,
+                    $context,
+                );
+            }
+
             $this->applySystemChanges(
                 $entry,
                 $command->systemChanges,

--- a/src/FreeDSx/Ldap/Server/Backend/Write/Operation/EntryPlacementGuard.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/Operation/EntryPlacementGuard.php
@@ -44,6 +44,7 @@ readonly class EntryPlacementGuard
         Entry $entry,
         Dn $normDn,
         bool $isSystem,
+        bool $replaceExisting = false,
     ): void {
         $this->assertParentExists(
             $normDn,
@@ -54,6 +55,12 @@ readonly class EntryPlacementGuard
             $normDn,
             $isSystem,
         );
+
+        // A bulk load may deliberately overwrite.
+        if ($replaceExisting) {
+            return;
+        }
+
         $this->assertDoesNotExist(
             $normDn,
             $entry->getDn(),

--- a/src/FreeDSx/Ldap/Server/Backend/Write/WriteContext.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/WriteContext.php
@@ -32,6 +32,7 @@ final readonly class WriteContext
         private ControlBag $controls,
         private bool $isSystem = false,
         private SchemaViolations $schemaViolations = new SchemaViolations(),
+        private ?BulkLoadOptions $bulkLoad = null,
     ) {}
 
     /**
@@ -45,6 +46,22 @@ final readonly class WriteContext
             $token,
             $controls,
             isSystem: true,
+        );
+    }
+
+    /**
+     * Build a context for loading an entry as supplied, rather than composing one for a client.
+     */
+    public static function bulkLoad(
+        TokenInterface $token,
+        ControlBag $controls,
+        BulkLoadOptions $bulkLoad,
+    ): self {
+        return new self(
+            $token,
+            $controls,
+            isSystem: true,
+            bulkLoad: $bulkLoad,
         );
     }
 
@@ -82,5 +99,13 @@ final readonly class WriteContext
     public function schemaViolations(): SchemaViolations
     {
         return $this->schemaViolations;
+    }
+
+    /**
+     * Present when the entry is loaded as supplied, so attributes the source provided are kept rather than restamped.
+     */
+    public function bulkLoadOptions(): ?BulkLoadOptions
+    {
+        return $this->bulkLoad;
     }
 }

--- a/src/FreeDSx/Ldap/Server/Logging/EventContext.php
+++ b/src/FreeDSx/Ldap/Server/Logging/EventContext.php
@@ -80,6 +80,10 @@ final class EventContext
 
     public const DURATION_SECONDS = 'duration_seconds';
 
+    public const ENTRIES_ADDED = 'entries_added';
+
+    public const ENTRIES_REPLACED = 'entries_replaced';
+
     public const NEW_RDN = 'new_rdn';
 
     public const NEW_SUPERIOR_DN = 'new_superior_dn';

--- a/src/FreeDSx/Ldap/Server/Logging/EventLogPolicy.php
+++ b/src/FreeDSx/Ldap/Server/Logging/EventLogPolicy.php
@@ -72,6 +72,9 @@ final readonly class EventLogPolicy
             ServerEvent::PasswordPolicyMustChange,
             ServerEvent::PasswordPolicyGraceLogin,
             ServerEvent::PasswordPolicyChangeRejected,
+            ServerEvent::EntryReplaced,
+            ServerEvent::BulkImportCompleted,
+            ServerEvent::BulkImportFailed,
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/Logging/ServerEvent.php
+++ b/src/FreeDSx/Ldap/Server/Logging/ServerEvent.php
@@ -34,6 +34,9 @@ enum ServerEvent: string
     case EntryModified                  = 'entry.modified';
     case EntryDeleted                   = 'entry.deleted';
     case EntryRenamed                   = 'entry.renamed';
+    case EntryReplaced                  = 'entry.replaced';
+    case BulkImportCompleted            = 'import.completed';
+    case BulkImportFailed               = 'import.failed';
     case SearchAuthorized               = 'search.authorized';
     case CompareCompleted               = 'compare.completed';
     case PasswordModifySuccess          = 'password_modify.success';
@@ -64,6 +67,7 @@ enum ServerEvent: string
         return match ($this) {
             self::PasswordPolicyAccountLocked,
             self::SyncEntrySkipped,
+            self::BulkImportFailed,
             self::JournalPruneFailed => LogLevel::WARNING,
             self::BindFailure,
             self::StartTlsFailed,

--- a/tests/integration/Ldif/LdapSeedServerTest.php
+++ b/tests/integration/Ldif/LdapSeedServerTest.php
@@ -13,89 +13,132 @@ declare(strict_types=1);
 
 namespace Tests\Integration\FreeDSx\Ldap\Ldif;
 
-use FreeDSx\Ldap\Operations;
-use FreeDSx\Ldap\Search\Filters;
-use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+use FreeDSx\Ldap\Container;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\LdapServer;
+use FreeDSx\Ldap\Ldif\Loader\StringLdifLoader;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Import\SeedOptions;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Server\Configuration\TestServerOptions;
 
-final class LdapSeedServerTest extends ServerTestCase
+final class LdapSeedServerTest extends TestCase
 {
-    private const SEED_LDIF = __DIR__ . '/../../resources/seed/seed-test.ldif';
+    private const SEED_LDIF = <<<LDIF
+        dn: dc=example,dc=com
+        objectClass: top
+        objectClass: domain
+        dc: example
 
-    public static function setUpBeforeClass(): void
+        dn: cn=alice,dc=example,dc=com
+        objectClass: top
+        objectClass: person
+        cn: alice
+        sn: Anderson
+        LDIF;
+
+    private LdapServer $subject;
+
+    private EntryStorageInterface $storage;
+
+    protected function setUp(): void
     {
-        parent::setUpBeforeClass();
+        $options = TestServerOptions::sqlite();
+        $container = Container::forServer($options);
 
-        if (!extension_loaded('pcntl')) {
-            return;
-        }
-
-        static::initSharedServer(
-            'ldap-server',
-            'tcp',
-            ['--seed=' . self::SEED_LDIF],
+        $this->subject = new LdapServer(
+            $options,
+            $container,
         );
+        $this->storage = $container->get(EntryStorageInterface::class);
     }
 
-    public static function tearDownAfterClass(): void
+    public function test_it_seeds_the_content_records(): void
     {
-        parent::tearDownAfterClass();
-        static::tearDownSharedServer();
+        $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
+
+        self::assertNotNull($this->storage->find(new Dn('dc=example,dc=com')));
+        self::assertNotNull($this->storage->find(new Dn('cn=alice,dc=example,dc=com')));
     }
 
-    public function setUp(): void
+    public function test_it_refuses_an_entry_that_already_exists(): void
     {
-        $this->setServerMode('ldap-server');
+        $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
 
-        parent::setUp();
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::ENTRY_ALREADY_EXISTS);
 
-        $this->authenticateUser();
+        $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
     }
 
-    public function test_it_serves_a_seeded_entry_with_its_attributes(): void
+    public function test_it_replaces_an_existing_entry_when_asked(): void
     {
-        $alice = $this->ldapClient()->read('cn=alice,dc=foo,dc=bar');
+        $this->subject->seed(new StringLdifLoader(self::SEED_LDIF));
+        $uuid = $this->storage->find(new Dn('cn=alice,dc=example,dc=com'))
+            ?->get('entryUUID')
+            ?->firstValue();
 
-        $this->assertNotNull($alice);
-        $this->assertSame(
-            'Anderson',
+        $this->subject->seed(
+            new StringLdifLoader(str_replace('sn: Anderson', 'sn: Replaced', self::SEED_LDIF)),
+            (new SeedOptions())->setReplaceExisting(true),
+        );
+
+        $alice = $this->storage->find(new Dn('cn=alice,dc=example,dc=com'));
+        self::assertNotNull($alice);
+        self::assertSame(
+            'Replaced',
             $alice->get('sn')?->firstValue(),
         );
-    }
-
-    public function test_it_unfolds_a_folded_value_through_to_the_served_entry(): void
-    {
-        $alice = $this->ldapClient()->read('cn=alice,dc=foo,dc=bar');
-
-        $this->assertNotNull($alice);
-        $this->assertSame(
-            'A folded description value that is intentionally longer than seventy-six characters so the parser must unfold it.',
-            $alice->get('description')?->firstValue(),
+        self::assertNotSame(
+            $uuid,
+            $alice->get('entryUUID')?->firstValue(),
+            'An LDIF carrying no entryUUID gives the replacement a new one.',
         );
     }
 
-    public function test_it_serves_all_seeded_entries_in_a_subtree_search(): void
+    public function test_a_replacement_keeps_the_entry_uuid_the_source_supplies(): void
     {
-        $entries = $this->ldapClient()->search(
-            Operations::search(Filters::equal('objectClass', 'inetOrgPerson'))
-                ->base('dc=foo,dc=bar'),
+        $withUuid = self::SEED_LDIF . "\nentryUUID: 11111111-2222-4333-8444-555555555555\n";
+
+        $this->subject->seed(new StringLdifLoader($withUuid));
+        $this->subject->seed(
+            new StringLdifLoader($withUuid),
+            (new SeedOptions())->setReplaceExisting(true),
         );
 
-        $dns = [];
-        foreach ($entries as $entry) {
-            $dns[] = $entry->getDn()->toString();
+        self::assertSame(
+            '11111111-2222-4333-8444-555555555555',
+            $this->storage->find(new Dn('cn=alice,dc=example,dc=com'))
+                ?->get('entryUUID')
+                ?->firstValue(),
+        );
+    }
+
+    public function test_a_failure_rolls_the_whole_batch_back(): void
+    {
+        try {
+            $this->subject->seedEntries([
+                Entry::fromArray('dc=example,dc=com', ['objectClass' => ['top', 'domain'], 'dc' => 'example']),
+                Entry::fromArray('cn=alice,dc=example,dc=com', [
+                    'objectClass' => ['top', 'person'],
+                    'cn' => 'alice',
+                    'sn' => 'Anderson',
+                ]),
+                // Refused as a duplicate, which must take the two before it down with it.
+                Entry::fromArray('cn=alice,dc=example,dc=com', [
+                    'objectClass' => ['top', 'person'],
+                    'cn' => 'alice',
+                    'sn' => 'Anderson',
+                ]),
+            ]);
+            self::fail('The duplicate entry should have failed the batch.');
+        } catch (OperationException) {
         }
 
-        $this->assertContains(
-            'cn=alice,dc=foo,dc=bar',
-            $dns,
-        );
-        $this->assertContains(
-            'cn=bob,dc=foo,dc=bar',
-            $dns,
-        );
-        $this->assertContains(
-            'cn=user,dc=foo,dc=bar',
-            $dns,
-        );
+        self::assertNull($this->storage->find(new Dn('dc=example,dc=com')));
+        self::assertNull($this->storage->find(new Dn('cn=alice,dc=example,dc=com')));
     }
 }

--- a/tests/support/LdapAclCommand.php
+++ b/tests/support/LdapAclCommand.php
@@ -19,8 +19,6 @@ use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\AccessControl\Target\Target;
 use FreeDSx\Ldap\Container;
-use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\Import\LdapImporter;
 use FreeDSx\Ldap\Server\Config\Storage\PdoConfig;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\Server\Config\SchemaConfig;
@@ -273,7 +271,7 @@ class LdapAclCommand extends Command
             $container,
         );
 
-        (new LdapImporter($container->get(EntryStorageInterface::class)))->importEntries($entries);
+        $server->seedEntries($entries);
         $server->run();
 
         return Command::SUCCESS;

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -29,7 +29,7 @@ use FreeDSx\Ldap\Server\Config\Storage\InMemoryStorageConfig;
 use FreeDSx\Ldap\Server\Config\Storage\PdoConfig;
 use FreeDSx\Ldap\Server\Config\Storage\StorageConfigInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\Import\LdapImporter;
+use FreeDSx\Ldap\Server\Backend\Storage\Import\SeedOptions;
 use FreeDSx\Ldap\Server\Config\ConfidentialityRequirement;
 use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\Server\Config\Replication\ProviderConfig;
@@ -416,12 +416,15 @@ final class LdapServerCommand extends Command
             ? self::SASL_SEED_LDIF
             : self::SEED_LDIF;
 
-        $loadData = function () use ($server, $storage, $seedFile, $fixedSeed, $entries, $changesFile, $dumpFile): void {
+        $loadData = function () use ($server, $seedFile, $fixedSeed, $entries, $changesFile, $dumpFile): void {
             $server->seed(new FileLdifLoader($seedFile !== '' ? $seedFile : $fixedSeed));
 
-            // The generated and cert-mapped entries stay a raw import, since they carry synthetic attributes.
+            // Validation is skipped, since these carry synthetic attributes the configured schema does not cover.
             if ($entries !== []) {
-                (new LdapImporter($storage))->importEntries($entries);
+                $server->seedEntries(
+                    $entries,
+                    (new SeedOptions())->setIgnoreValidation(true),
+                );
             }
 
             if ($changesFile !== '') {

--- a/tests/unit/Server/Backend/Storage/Import/LdapImporterTest.php
+++ b/tests/unit/Server/Backend/Storage/Import/LdapImporterTest.php
@@ -18,141 +18,120 @@ use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\InvalidArgumentException;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Schema\SchemaValidationMode;
-use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Import\LdapImporter;
-use Tests\Support\FreeDSx\Ldap\Server\Configuration\TestServerOptions;
+use FreeDSx\Ldap\Server\Logging\EventContext;
+use FreeDSx\Ldap\Server\Logging\ServerEvent;
+use FreeDSx\Ldap\ServerOptions;
+use Tests\Support\FreeDSx\Ldap\Logging\RecordingLogger;
 use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Server\Configuration\TestServerOptions;
+use Tests\Support\FreeDSx\Ldap\ServerContainerTrait;
 
 final class LdapImporterTest extends TestCase
 {
+    use ServerContainerTrait;
+
+    private InMemoryStorage $storage;
+
+    protected function setUp(): void
+    {
+        $this->storage = new InMemoryStorage();
+    }
+
     public function test_importEntries_persists_all_entries(): void
     {
-        $storage = new InMemoryStorage();
-        $importer = new LdapImporter($storage);
-
-        $importer->importEntries([
-            new Entry(
-                new Dn('dc=example,dc=com'),
-                new Attribute('dc', 'example'),
-            ),
-            new Entry(
-                new Dn('cn=Alice,dc=example,dc=com'),
-                new Attribute('cn', 'Alice'),
-            ),
+        $this->importer()->importEntries([
+            $this->domain(),
+            $this->person('cn=Alice,dc=example,dc=com'),
         ]);
 
-        self::assertNotNull($storage->find(new Dn('dc=example,dc=com')));
-        self::assertNotNull($storage->find(new Dn('cn=alice,dc=example,dc=com')));
+        self::assertNotNull($this->storage->find(new Dn('dc=example,dc=com')));
+        self::assertNotNull($this->storage->find(new Dn('cn=alice,dc=example,dc=com')));
     }
 
     public function test_importEntries_handles_empty_input(): void
     {
-        $storage = new InMemoryStorage();
+        $this->importer()->importEntries([]);
 
-        (new LdapImporter($storage))->importEntries([]);
-
-        self::assertNull($storage->find(new Dn('dc=example,dc=com')));
-    }
-
-    public function test_importEntries_runs_in_single_atomic_call(): void
-    {
-        $storage = $this->createMock(EntryStorageInterface::class);
-        $storage
-            ->expects(self::once())
-            ->method('atomic');
-
-        (new LdapImporter($storage))->importEntries([
-            new Entry(new Dn('dc=example,dc=com')),
-            new Entry(new Dn('cn=Alice,dc=example,dc=com')),
-        ]);
+        self::assertNull($this->storage->find(new Dn('dc=example,dc=com')));
     }
 
     public function test_importEntries_requires_input_in_depth_first_order(): void
     {
-        $storage = new InMemoryStorage();
-
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('Parent entry "dc=example,dc=com" does not exist for "cn=Alice,dc=example,dc=com".');
 
-        (new LdapImporter($storage))->importEntries([
-            new Entry(new Dn('cn=Alice,dc=example,dc=com'), new Attribute('cn', 'Alice')),
-            new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example')),
+        $this->importer()->importEntries([
+            $this->person('cn=Alice,dc=example,dc=com'),
+            $this->domain(),
         ]);
     }
 
     public function test_importEntries_throws_when_parent_is_missing(): void
     {
-        $storage = new InMemoryStorage();
-
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('Parent entry "dc=example,dc=com" does not exist for "cn=Alice,dc=example,dc=com".');
 
-        (new LdapImporter($storage))->importEntries([
-            new Entry(new Dn('cn=Alice,dc=example,dc=com'), new Attribute('cn', 'Alice')),
+        $this->importer()->importEntries([
+            $this->person('cn=Alice,dc=example,dc=com'),
         ]);
     }
 
     public function test_importEntries_accepts_existing_parent_in_pre_seeded_storage(): void
     {
-        $storage = new InMemoryStorage([
-            new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example')),
-        ]);
+        $this->importer()->importEntries([$this->domain()]);
+        $this->importer()->importEntries([$this->person('cn=Alice,dc=example,dc=com')]);
 
-        (new LdapImporter($storage))->importEntries([
-            new Entry(new Dn('cn=Alice,dc=example,dc=com'), new Attribute('cn', 'Alice')),
-        ]);
-
-        self::assertNotNull($storage->find(new Dn('cn=alice,dc=example,dc=com')));
+        self::assertNotNull($this->storage->find(new Dn('cn=alice,dc=example,dc=com')));
     }
 
     public function test_importEntries_ignoreValidation_skips_parent_check(): void
     {
-        $storage = new InMemoryStorage();
-
-        (new LdapImporter($storage))->importEntries(
-            entries: [
-                new Entry(new Dn('cn=Alice,dc=example,dc=com'), new Attribute('cn', 'Alice')),
-            ],
+        $this->importer()->importEntries(
+            entries: [$this->person('cn=Alice,dc=example,dc=com')],
             ignoreValidation: true,
         );
 
-        self::assertNotNull($storage->find(new Dn('cn=alice,dc=example,dc=com')));
+        self::assertNotNull($this->storage->find(new Dn('cn=alice,dc=example,dc=com')));
     }
 
     public function test_importEntries_stamps_operational_attributes_by_default(): void
     {
-        $storage = new InMemoryStorage();
+        $this->importer()->importEntries([$this->domain()]);
 
-        (new LdapImporter($storage))->importEntries([
-            new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example')),
-        ]);
-
-        $entry = $storage->find(new Dn('dc=example,dc=com'));
-
-        self::assertNotNull($entry);
         self::assertMatchesRegularExpression(
             '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
-            $entry->get('entryUUID')?->getValues()[0] ?? '',
+            $this->storage->find(new Dn('dc=example,dc=com'))?->get('entryUUID')?->firstValue() ?? '',
+        );
+    }
+
+    public function test_importEntries_keeps_the_operational_attributes_the_source_supplied(): void
+    {
+        $entry = $this->domain();
+        $entry->add('entryUUID', '11111111-2222-4333-8444-555555555555');
+
+        $this->importer()->importEntries([$entry]);
+
+        self::assertSame(
+            '11111111-2222-4333-8444-555555555555',
+            $this->storage->find(new Dn('dc=example,dc=com'))?->get('entryUUID')?->firstValue(),
         );
     }
 
     public function test_importEntries_records_the_creator_dn_on_stamped_entries(): void
     {
-        $storage = new InMemoryStorage();
-
-        (new LdapImporter($storage))->importEntries(
-            entries: [
-                new Entry(new Dn('dc=example,dc=com'), new Attribute('dc', 'example')),
-            ],
+        $this->importer()->importEntries(
+            entries: [$this->domain()],
             creatorDn: new Dn('cn=Importer,dc=example,dc=com'),
         );
 
         self::assertSame(
             'cn=Importer,dc=example,dc=com',
-            $storage->find(new Dn('dc=example,dc=com'))?->get('creatorsName')?->getValues()[0],
+            $this->storage->find(new Dn('dc=example,dc=com'))?->get('creatorsName')?->firstValue(),
         );
     }
 
@@ -161,77 +140,204 @@ final class LdapImporterTest extends TestCase
         self::expectException(InvalidArgumentException::class);
         self::expectExceptionMessage('The import creator DN "not a dn" is not a valid DN.');
 
-        (new LdapImporter(new InMemoryStorage()))->importEntries(
+        $this->importer()->importEntries(
             entries: [],
             creatorDn: new Dn('not a dn'),
         );
     }
 
-    public function test_importEntries_rejects_a_schema_violation_in_strict_mode(): void
+    public function test_importEntries_refuses_an_entry_that_already_exists(): void
     {
-        $validator = new SchemaValidator(
-            (TestServerOptions::defaults())->getSchema(),
-            SchemaValidationMode::Strict,
-        );
+        $this->importer()->importEntries([$this->domain()]);
 
         self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::ENTRY_ALREADY_EXISTS);
 
-        (new LdapImporter(
-            new InMemoryStorage(),
-            validator: $validator,
-        ))->importEntries([
-            new Entry(
-                new Dn('dc=example,dc=com'),
-                new Attribute('cn', 'foo'),
-                new Attribute('objectClass', 'top', 'person'),
-            ),
+        $this->importer()->importEntries([$this->domain()]);
+    }
+
+    public function test_importEntries_records_the_counts_once_the_batch_commits(): void
+    {
+        $logger = new RecordingLogger();
+
+        $this->importerFor(
+            $this->storage,
+            $this->optionsLogging($logger),
+        )->importEntries([
+            $this->domain(),
+            $this->person('cn=Alice,dc=example,dc=com'),
         ]);
+
+        self::assertSame(
+            [ServerEvent::BulkImportCompleted->value],
+            $this->loggedEvents($logger),
+        );
+        self::assertSame(
+            2,
+            $logger->records[0]['context'][EventContext::ENTRIES_ADDED] ?? null,
+        );
+    }
+
+    public function test_importEntries_records_each_entry_it_replaced(): void
+    {
+        $logger = new RecordingLogger();
+        $options = $this->optionsLogging($logger);
+
+        $this->importerFor($this->storage, $options)->importEntries([$this->domain()]);
+        $logger->records = [];
+
+        $this->importerFor($this->storage, $options)->importEntries(
+            entries: [$this->domain()],
+            replaceExisting: true,
+        );
+
+        self::assertSame(
+            [
+                ServerEvent::EntryReplaced->value,
+                ServerEvent::BulkImportCompleted->value,
+            ],
+            $this->loggedEvents($logger),
+        );
+    }
+
+    public function test_importEntries_records_a_failure_rather_than_a_completion(): void
+    {
+        $logger = new RecordingLogger();
+        $options = $this->optionsLogging($logger);
+
+        $this->importerFor($this->storage, $options)->importEntries([$this->domain()]);
+        $logger->records = [];
+
+        try {
+            $this->importerFor($this->storage, $options)->importEntries([$this->domain()]);
+        } catch (OperationException) {
+        }
+
+        self::assertSame(
+            [ServerEvent::BulkImportFailed->value],
+            $this->loggedEvents($logger),
+        );
+    }
+
+    public function test_importEntries_does_not_mutate_the_entries_it_was_given(): void
+    {
+        $entry = $this->domain();
+
+        $this->importer()->importEntries([$entry]);
+
+        self::assertNull($entry->get('entryUUID'));
+    }
+
+    public function test_importEntries_rejects_a_schema_violation_in_strict_mode(): void
+    {
+        self::expectException(OperationException::class);
+
+        $this->importerFor(
+            $this->storage,
+            TestServerOptions::validatedCore(SchemaValidationMode::Strict),
+        )->importEntries([$this->schemaViolation()]);
     }
 
     public function test_importEntries_allows_a_schema_violation_in_lenient_mode(): void
     {
-        $storage = new InMemoryStorage();
-        $validator = new SchemaValidator(
-            (TestServerOptions::defaults())->getSchema(),
-            SchemaValidationMode::Lenient,
-        );
+        $this->importerFor(
+            $this->storage,
+            TestServerOptions::validatedCore(SchemaValidationMode::Lenient),
+        )->importEntries([$this->schemaViolation()]);
 
-        (new LdapImporter(
-            $storage,
-            validator: $validator,
-        ))->importEntries([
-            new Entry(
-                new Dn('dc=example,dc=com'),
-                new Attribute('cn', 'foo'),
-                new Attribute('objectClass', 'top', 'person'),
-            ),
-        ]);
-
-        self::assertNotNull($storage->find(new Dn('dc=example,dc=com')));
+        self::assertNotNull($this->storage->find(new Dn('dc=example,dc=com')));
     }
 
-    public function test_importEntries_ignoreValidation_skips_schema_validation_in_strict_mode(): void
+    public function test_importEntries_ignoreValidation_relaxes_schema_validation_in_strict_mode(): void
     {
-        $storage = new InMemoryStorage();
-        $validator = new SchemaValidator(
-            (TestServerOptions::defaults())->getSchema(),
-            SchemaValidationMode::Strict,
+        $this->importerFor(
+            $this->storage,
+            TestServerOptions::validatedCore(SchemaValidationMode::Strict),
+        )->importEntries(
+            entries: [$this->schemaViolation()],
+            ignoreValidation: true,
         );
 
-        (new LdapImporter(
-            $storage,
-            validator: $validator,
-        ))->importEntries(
+        self::assertNotNull($this->storage->find(new Dn('dc=example,dc=com')));
+    }
+
+    public function test_importEntries_ignoreValidation_still_rejects_an_invalid_attribute_syntax(): void
+    {
+        self::expectException(OperationException::class);
+        self::expectExceptionCode(ResultCode::INVALID_ATTRIBUTE_SYNTAX);
+
+        $this->importerFor(
+            $this->storage,
+            TestServerOptions::validatedCore(SchemaValidationMode::Strict),
+        )->importEntries(
             entries: [
                 new Entry(
                     new Dn('dc=example,dc=com'),
-                    new Attribute('cn', 'foo'),
-                    new Attribute('objectClass', 'top', 'person'),
+                    new Attribute('dc', 'example'),
+                    new Attribute('objectClass', 'top', 'domain'),
+                    new Attribute('seeAlso', 'not a dn'),
                 ),
             ],
             ignoreValidation: true,
         );
+    }
 
-        self::assertNotNull($storage->find(new Dn('dc=example,dc=com')));
+    private function optionsLogging(RecordingLogger $logger): ServerOptions
+    {
+        return TestServerOptions::unvalidatedCore()->setLogger($logger);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function loggedEvents(RecordingLogger $logger): array
+    {
+        return array_map(
+            static fn(array $record): string => $record['message'],
+            $logger->records,
+        );
+    }
+
+    private function importer(): LdapImporter
+    {
+        return $this->importerFor($this->storage);
+    }
+
+    private function importerFor(
+        EntryStorageInterface $storage,
+        ?ServerOptions $options = null,
+    ): LdapImporter {
+        return $this->containerFor(
+            $storage,
+            $options ?? TestServerOptions::unvalidatedCore(),
+        )->get(LdapImporter::class);
+    }
+
+    private function domain(): Entry
+    {
+        return new Entry(
+            new Dn('dc=example,dc=com'),
+            new Attribute('dc', 'example'),
+            new Attribute('objectClass', 'top', 'domain'),
+        );
+    }
+
+    private function person(string $dn): Entry
+    {
+        return new Entry(
+            new Dn($dn),
+            new Attribute('cn', 'Alice'),
+            new Attribute('sn', 'Anderson'),
+            new Attribute('objectClass', 'top', 'person'),
+        );
+    }
+
+    private function schemaViolation(): Entry
+    {
+        return new Entry(
+            new Dn('dc=example,dc=com'),
+            new Attribute('cn', 'foo'),
+            new Attribute('objectClass', 'top', 'person'),
+        );
     }
 }


### PR DESCRIPTION
The seed path was long a mostly straight write into storage. This is problematic because we need it to enforce LDAP semantics that the other paths already have to prevent people from doing things that would otherwise cause really weird issues.

So this funnels seeds through the write path to get all the normal checks. This still bypasses the normal middleware pipeline, but that is intentional in this case. This also adds logging so there's more context on what actually happened during the seed process in a log somewhere.