### PR TITLE
[1.0.0] Password modify request handling / superclass queries

### DIFF
--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -132,7 +132,11 @@ Whether authentication (bind) should be required before an operation is allowed.
 ------------------
 #### setAllowAnonymous
 
-Whether anonymous binds should be allowed.
+Whether anonymous binds should be allowed. Governs both RFC 4513 mechanisms: an anonymous bind (empty DN and
+password) and an unauthenticated bind (a DN with an empty password). Either way the connection ends up
+anonymous, so the DN carries no authorization.
+
+Reading the RootDSE needs no bind at all, so leaving this off does not prevent discovery.
 
 **Default**: `false`
 

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordModifyHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordModifyHandler.php
@@ -93,11 +93,32 @@ readonly class ServerPasswordModifyHandler implements ServerProtocolHandlerInter
 
         /** @var ExtendedRequest $raw */
         $raw = $message->getRequest();
+        $request = PasswordModifyRequest::fromAsn1($raw->toAsn1());
+        $this->assertNamesAField($request);
 
         return $this->service->change(
-            PasswordModifyRequest::fromAsn1($raw->toAsn1()),
+            $request,
             $token,
             $message->controls(),
         );
+    }
+
+    /**
+     * RFC 3062 2.1: a request value carries one or more fields.
+     *
+     * @throws OperationException
+     */
+    private function assertNamesAField(PasswordModifyRequest $request): void
+    {
+        $namesNothing = $request->getUsername() === null
+            && $request->getOldPassword() === null
+            && $request->getNewPassword() === null;
+
+        if ($namesNothing) {
+            throw new OperationException(
+                'The password modify request names no field.',
+                ResultCode::PROTOCOL_ERROR,
+            );
+        }
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Write/OperationalAttributeGenerator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/OperationalAttributeGenerator.php
@@ -61,6 +61,7 @@ final readonly class OperationalAttributeGenerator
             AttributeTypeOid::NAME_ENTRY_UUID,
             Uuid::v4(),
         );
+        $this->applySuperclasses($entry);
 
         $structuralOc = $this->resolveStructuralObjectClass($entry);
 
@@ -107,11 +108,12 @@ final readonly class OperationalAttributeGenerator
             AttributeTypeOid::NAME_MODIFIERS_NAME,
             $actorDn,
         );
+        $this->applySuperclasses($entry);
         $this->applyStructuralObjectClass($entry);
     }
 
     /**
-     * Updates modifyTimestamp and modifiersName only.
+     * Updates modifyTimestamp and modifiersName, and supplies any superclass a changed objectClass now implies.
      */
     public function applyForModify(
         Entry $entry,
@@ -125,6 +127,67 @@ final readonly class OperationalAttributeGenerator
             AttributeTypeOid::NAME_MODIFIERS_NAME,
             $context->getBoundDn() ?? '',
         );
+        $this->applySuperclasses($entry);
+    }
+
+    /**
+     * RFC 4512 3.3: the superclasses of every named class are added implicitly.
+     */
+    private function applySuperclasses(Entry $entry): void
+    {
+        $attribute = $entry->get(AttributeTypeOid::NAME_OBJECT_CLASS);
+        if ($attribute === null) {
+            return;
+        }
+
+        $missing = $this->missingSuperclassesOf(array_values($attribute->getValues()));
+        if ($missing !== []) {
+            $attribute->add(...$missing);
+        }
+    }
+
+    /**
+     * @param list<string> $names
+     * @return list<string>
+     */
+    private function missingSuperclassesOf(array $names): array
+    {
+        $seen = array_fill_keys(array_map(strtolower(...), $names), true);
+        $queue = $names;
+        $missing = [];
+
+        while ($queue !== []) {
+            $supers = array_values(array_filter(
+                $this->superclassNamesOf((string) array_shift($queue)),
+                static fn(string $name): bool => !isset($seen[strtolower($name)]),
+            ));
+
+            $seen += array_fill_keys(array_map(strtolower(...), $supers), true);
+            $missing = [...$missing, ...$supers];
+            $queue = [...$queue, ...$supers];
+        }
+
+        return $missing;
+    }
+
+    /**
+     * A class the schema does not define has no superclasses to supply, so validation reports it rather than this.
+     *
+     * @return list<string>
+     */
+    private function superclassNamesOf(string $name): array
+    {
+        $schema = $this->schema;
+        $class = $schema?->getObjectClass($name);
+
+        if ($schema === null || $class === null) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn(string $oid): ?string => $schema->getObjectClass($oid)?->names[0],
+            $class->superClassOids,
+        )));
     }
 
     private function generateTimestamp(): string

--- a/tests/integration/LdapPasswordModifyServerTest.php
+++ b/tests/integration/LdapPasswordModifyServerTest.php
@@ -112,6 +112,35 @@ final class LdapPasswordModifyServerTest extends ServerTestCase
         $this->assertStoredPasswordIsHashed();
     }
 
+    /**
+     * RFC 3062 2.1: a request value carries one or more fields, so one naming nothing cannot rotate a password.
+     */
+    public function testARequestNamingNoFieldIsRejected(): void
+    {
+        $this->ldapClient()->bind(
+            self::USER_DN,
+            self::USER_PASSWORD,
+        );
+
+        try {
+            $this->ldapClient()->sendAndReceive(new PasswordModifyRequest());
+            $this->fail('A password modify naming no field should have been refused.');
+        } catch (OperationException $e) {
+            $this->assertSame(
+                ResultCode::PROTOCOL_ERROR,
+                $e->getCode(),
+            );
+        }
+
+        // The bound identity's password is untouched, which is the point of the refusal.
+        $verifyClient = $this->buildClient('tcp');
+        $verifyClient->bind(
+            self::USER_DN,
+            self::USER_PASSWORD,
+        );
+        $verifyClient->unbind();
+    }
+
     public function testExplicitIdentityPasswordChange(): void
     {
         $this->ldapClient()->bind(

--- a/tests/integration/Schema/LdapSchemaConstraintTest.php
+++ b/tests/integration/Schema/LdapSchemaConstraintTest.php
@@ -262,6 +262,73 @@ final class LdapSchemaConstraintTest extends ServerTestCase
         );
     }
 
+    public function test_add_supplies_the_superclasses_of_the_named_object_classes(): void
+    {
+        $this->authenticateAdmin();
+
+        $this->ldapClient()->create(Entry::fromArray(
+            'cn=superclasses,dc=foo,dc=bar',
+            [
+                'cn' => 'superclasses',
+                'sn' => 'Smith',
+                'objectClass' => 'inetOrgPerson',
+            ],
+        ));
+
+        self::assertSame(
+            [
+                'inetOrgPerson',
+                'organizationalPerson',
+                'person',
+                'top',
+            ],
+            $this->ldapClient()
+                ->read('cn=superclasses,dc=foo,dc=bar', ['objectClass'])
+                ?->get('objectClass')
+                ?->getValues(),
+        );
+    }
+
+    /**
+     * The point of supplying them: a filter naming a superclass finds an entry that named only the subclass.
+     */
+    #[DataProvider('superclassFilterProvider')]
+    public function test_a_filter_naming_a_superclass_finds_the_entry(string $objectClass): void
+    {
+        $this->authenticateAdmin();
+
+        $cn = 'bysuperclass-' . strtolower($objectClass);
+        $dn = "cn=$cn,dc=foo,dc=bar";
+
+        $this->ldapClient()->create(Entry::fromArray(
+            $dn,
+            [
+                'cn' => $cn,
+                'sn' => 'Smith',
+                'objectClass' => 'inetOrgPerson',
+            ],
+        ));
+
+        $entries = $this->ldapClient()->search(
+            Operations::search(Filters::equal('objectClass', $objectClass))
+                ->base($dn)
+                ->useBaseScope(),
+        );
+
+        self::assertCount(1, $entries);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function superclassFilterProvider(): iterable
+    {
+        yield 'the named class' => ['inetOrgPerson'];
+        yield 'its immediate superclass' => ['organizationalPerson'];
+        yield 'a class further up the chain' => ['person'];
+        yield 'the abstract root' => ['top'];
+    }
+
     public function test_add_omitting_the_naming_attribute_still_stores_it(): void
     {
         $this->authenticateAdmin();

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordModifyHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordModifyHandlerTest.php
@@ -34,6 +34,7 @@ use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyService;
 use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyTargetResolver;
 use FreeDSx\Ldap\Server\Token\AnonToken;
 use FreeDSx\Ldap\Server\Token\BindToken;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -136,6 +137,54 @@ final class ServerPasswordModifyHandlerTest extends TestCase
             ResultCode::UNWILLING_TO_PERFORM,
             $this->singleResponse($stream->messages)->getResultCode(),
         );
+    }
+
+    public function test_a_request_naming_no_field_is_rejected_with_protocol_error(): void
+    {
+        $stream = $this->subject->handleRequest(
+            new LdapMessageRequest(1, new PasswordModifyRequest()),
+            $this->userToken,
+        );
+
+        self::assertSame(
+            ResultCode::PROTOCOL_ERROR,
+            $this->singleResponse($stream->messages)->getResultCode(),
+        );
+    }
+
+    #[DataProvider('singleFieldProvider')]
+    public function test_a_request_naming_one_field_is_accepted(PasswordModifyRequest $request): void
+    {
+        $this->mockBackend
+            ->method('get')
+            ->willReturn($this->userEntry);
+
+        $stream = $this->subject->handleRequest(
+            new LdapMessageRequest(1, $request),
+            $this->userToken,
+        );
+
+        self::assertNotSame(
+            ResultCode::PROTOCOL_ERROR,
+            $this->singleResponse($stream->messages)->getResultCode(),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{PasswordModifyRequest}>
+     */
+    public static function singleFieldProvider(): iterable
+    {
+        // Naming only the user is how an administrator asks the server to pick the new password.
+        yield 'userIdentity only' => [
+            new PasswordModifyRequest('cn=user,dc=foo,dc=bar'),
+        ];
+        yield 'newPasswd only' => [
+            new PasswordModifyRequest(null, null, 'newpass'),
+        ];
+        yield 'oldPasswd only' => [
+            new PasswordModifyRequest(null, '12345'),
+        ];
     }
 
     public function test_an_operation_error_is_sent_as_a_standard_response(): void

--- a/tests/unit/Server/Backend/Write/OperationalAttributeGeneratorTest.php
+++ b/tests/unit/Server/Backend/Write/OperationalAttributeGeneratorTest.php
@@ -182,6 +182,66 @@ final class OperationalAttributeGeneratorTest extends TestCase
         );
     }
 
+    public function test_apply_for_add_supplies_the_superclasses_of_the_named_classes(): void
+    {
+        $entry = $this->personEntry('inetOrgPerson');
+
+        $this->classAwareGenerator()->applyForAdd(
+            $entry,
+            $this->anonymousContext(),
+        );
+
+        self::assertSame(
+            ['inetOrgPerson', 'person', 'top'],
+            $entry->get('objectClass')?->getValues(),
+        );
+    }
+
+    public function test_apply_for_add_keeps_a_superclass_the_entry_already_named(): void
+    {
+        $entry = $this->personEntry('top', 'inetOrgPerson');
+
+        $this->classAwareGenerator()->applyForAdd(
+            $entry,
+            $this->anonymousContext(),
+        );
+
+        self::assertSame(
+            ['top', 'inetOrgPerson', 'person'],
+            $entry->get('objectClass')?->getValues(),
+        );
+    }
+
+    public function test_apply_for_add_leaves_a_class_the_schema_does_not_define(): void
+    {
+        $entry = $this->personEntry('x-undefined');
+
+        $this->classAwareGenerator()->applyForAdd(
+            $entry,
+            $this->anonymousContext(),
+        );
+
+        self::assertSame(
+            ['x-undefined'],
+            $entry->get('objectClass')?->getValues(),
+        );
+    }
+
+    public function test_apply_for_modify_supplies_a_superclass_a_changed_class_implies(): void
+    {
+        $entry = $this->personEntry('inetOrgPerson');
+
+        $this->classAwareGenerator()->applyForModify(
+            $entry,
+            $this->anonymousContext(),
+        );
+
+        self::assertSame(
+            ['inetOrgPerson', 'person', 'top'],
+            $entry->get('objectClass')?->getValues(),
+        );
+    }
+
     public function test_apply_for_add_with_schema_but_no_object_class_skips_structural_object_class(): void
     {
         $schema = new Schema();
@@ -424,6 +484,37 @@ final class OperationalAttributeGeneratorTest extends TestCase
         self::assertSame(
             'person',
             $entry->get('structuralObjectClass')?->getValues()[0],
+        );
+    }
+
+    private function classAwareGenerator(): OperationalAttributeGenerator
+    {
+        return new OperationalAttributeGenerator(
+            (new Schema())
+                ->addObjectClass(new ObjectClass(
+                    oid: '2.5.6.0',
+                    names: ['top'],
+                    type: ObjectClassType::AbstractClass,
+                ))
+                ->addObjectClass(new ObjectClass(
+                    oid: '2.5.6.6',
+                    names: ['person'],
+                    superClassOids: ['2.5.6.0'],
+                ))
+                ->addObjectClass(new ObjectClass(
+                    oid: '2.16.840.1.113730.3.2.2',
+                    names: ['inetOrgPerson'],
+                    superClassOids: ['2.5.6.6'],
+                )),
+        );
+    }
+
+    private function personEntry(string ...$objectClasses): Entry
+    {
+        return new Entry(
+            new Dn('cn=Alice,dc=example,dc=com'),
+            new Attribute('cn', 'Alice'),
+            new Attribute('objectClass', ...$objectClasses),
         );
     }
 


### PR DESCRIPTION
two very different fixes:

1. when handling a password modification request, verify that at least one field was actually provided. if they don't provide anything then we should reject it. the rfc is actually kind of ambiguous on this.
2. store the complete objectlcass superclasses chain when we store operational attributes for an entry. we need this to actually resolve queries against one it wasn't explicitly stored as. this was kind of a large initial oversight. though the fix was easy and in one spot.