### PR TITLE
[1.0.0] Improve performance for hasSubordinates.

### DIFF
--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoDialectTrait.php
@@ -80,25 +80,31 @@ trait PdoDialectTrait
         SQL;
     }
 
-    public function queryFetchAll(): string
+    public function queryFetchAll(bool $withChildFlag = false): string
     {
+        $columns = $this->listColumns() . $this->childFlagColumn($withChildFlag, 'entries');
+
         return <<<SQL
-            SELECT {$this->listColumns()}
+            SELECT {$columns}
             FROM entries
         SQL;
     }
 
-    public function queryFetchChildren(): string
+    public function queryFetchChildren(bool $withChildFlag = false): string
     {
+        $columns = $this->listColumns() . $this->childFlagColumn($withChildFlag, 'entries');
+
         return <<<SQL
-            SELECT {$this->listColumns()}
+            SELECT {$columns}
             FROM entries
             WHERE lc_parent_dn = ?
         SQL;
     }
 
-    public function querySubtree(): string
+    public function querySubtree(bool $withChildFlag = false): string
     {
+        $columns = $this->listColumns() . $this->childFlagColumn($withChildFlag, 'subtree');
+
         return <<<SQL
             WITH RECURSIVE subtree AS (
                 SELECT entry_id, lc_dn, dn, attributes
@@ -109,7 +115,7 @@ trait PdoDialectTrait
                 FROM entries e
                 INNER JOIN subtree s ON e.lc_parent_dn = s.lc_dn
             )
-            SELECT {$this->listColumns()} FROM subtree
+            SELECT {$columns} FROM subtree
         SQL;
     }
 
@@ -281,6 +287,25 @@ trait PdoDialectTrait
                 $baseParams,
             ),
         );
+    }
+
+    /**
+     * Correlated against the row being returned.
+     */
+    protected function childFlagColumn(
+        bool $withChildFlag,
+        string $outerTable,
+    ): string {
+        if (!$withChildFlag) {
+            return '';
+        }
+
+        return <<<SQL
+            , EXISTS (
+                SELECT 1
+                FROM entries child
+                WHERE child.lc_parent_dn = {$outerTable}.lc_dn) AS has_children
+            SQL;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoEntryDialectInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Dialect/PdoEntryDialectInterface.php
@@ -76,18 +76,24 @@ interface PdoEntryDialectInterface
 
     /**
      * SELECT dn, attributes with no WHERE clause (returns all entries).
+     *
+     * @param bool $withChildFlag Also project whether each row has children, answering hasSubordinates in one pass.
      */
-    public function queryFetchAll(): string;
+    public function queryFetchAll(bool $withChildFlag = false): string;
 
     /**
      * `SELECT dn, attributes FROM entries WHERE lc_parent_dn = ?`. Parameters: [lc_parent_dn]
+     *
+     * @param bool $withChildFlag Also project whether each row has children, answering hasSubordinates in one pass.
      */
-    public function queryFetchChildren(): string;
+    public function queryFetchChildren(bool $withChildFlag = false): string;
 
     /**
      * Recursive CTE returning (dn, attributes) for the base entry and its descendants; PdoStorage may append `WHERE (filter)`. Parameters: [lc_dn]
+     *
+     * @param bool $withChildFlag Also project whether each row has children, answering hasSubordinates in one pass.
      */
-    public function querySubtree(): string;
+    public function querySubtree(bool $withChildFlag = false): string;
 
     /**
      * Parameterless condition restricting $dnColumn to entries that lack, or carry, the subentry object class.

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/InMemoryStorage.php
@@ -52,6 +52,8 @@ final class InMemoryStorage implements EntryStorageInterface, ChangeJournalingIn
 
     private int $nextKey = 1;
 
+    private int $atomicDepth = 0;
+
     /**
      * @param Entry[] $entries pre-populated into the store
      */
@@ -147,12 +149,26 @@ final class InMemoryStorage implements EntryStorageInterface, ChangeJournalingIn
      */
     public function atomic(callable $operation): void
     {
+        // Only the outermost call snapshots...
+        if ($this->atomicDepth > 0) {
+            $this->atomicDepth++;
+
+            try {
+                $operation();
+            } finally {
+                $this->atomicDepth--;
+            }
+
+            return;
+        }
+
         $entries = array_map(
             static fn(Entry $entry): Entry => $entry->makeCopy(),
             $this->entries,
         );
         $keys = $this->keys;
         $nextKey = $this->nextKey;
+        $this->atomicDepth = 1;
 
         try {
             $operation();
@@ -162,6 +178,8 @@ final class InMemoryStorage implements EntryStorageInterface, ChangeJournalingIn
             $this->nextKey = $nextKey;
 
             throw $e;
+        } finally {
+            $this->atomicDepth = 0;
         }
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/Query/ListQuerySpec.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/Query/ListQuerySpec.php
@@ -38,6 +38,7 @@ final readonly class ListQuerySpec
         public array $sortKeys = [],
         public SubentryVisibility $subentries = SubentryVisibility::All,
         public ?PageCursor $after = null,
+        public bool $withChildFlag = false,
     ) {}
 
     /**
@@ -57,6 +58,7 @@ final readonly class ListQuerySpec
             sortKeys: $sortKeys,
             subentries: $options->subentries,
             after: $options->after,
+            withChildFlag: $options->withHasSubordinates,
         );
     }
 
@@ -73,6 +75,7 @@ final readonly class ListQuerySpec
             sortKeys: $this->sortKeys,
             subentries: $this->subentries,
             after: $after,
+            withChildFlag: $this->withChildFlag,
         );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/Query/PdoListQueryBuilder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/Query/PdoListQueryBuilder.php
@@ -61,17 +61,20 @@ final readonly class PdoListQueryBuilder
                 $spec->filter,
                 $subentryCondition,
                 $seek,
+                $spec->withChildFlag,
             ),
             $spec->base === '' => $this->buildRootQuery(
                 $spec->filter,
                 $subentryCondition,
                 $seek,
+                $spec->withChildFlag,
             ),
             default => $this->buildSubtreeQuery(
                 $spec->base,
                 $spec->filter,
                 $subentryCondition,
                 $seek,
+                $spec->withChildFlag,
             ),
         };
 
@@ -110,7 +113,7 @@ final readonly class PdoListQueryBuilder
         array $filterParams,
         ListQuerySpec $spec,
     ): SqlQuery {
-        $fetchAll = $this->dialect->queryFetchAll();
+        $fetchAll = $this->dialect->queryFetchAll($spec->withChildFlag);
         $params = $filterParams;
         $base = $spec->base;
         $after = $spec->after;
@@ -200,9 +203,10 @@ final readonly class PdoListQueryBuilder
         ?SqlFilterResult $filterResult,
         ?string $subentryCondition,
         ?SqlQuery $seek,
+        bool $withChildFlag = false,
     ): SqlQuery {
         $query = new SqlQuery(
-            $this->dialect->queryFetchChildren(),
+            $this->dialect->queryFetchChildren($withChildFlag),
             [$base],
         );
 
@@ -230,6 +234,7 @@ final readonly class PdoListQueryBuilder
         ?SqlFilterResult $filterResult,
         ?string $subentryCondition,
         ?SqlQuery $seek,
+        bool $withChildFlag = false,
     ): SqlQuery {
         $conditions = [];
         $params = [];
@@ -252,11 +257,11 @@ final readonly class PdoListQueryBuilder
         }
 
         if ($conditions === []) {
-            return new SqlQuery($this->dialect->queryFetchAll());
+            return new SqlQuery($this->dialect->queryFetchAll($withChildFlag));
         }
 
         return new SqlQuery(
-            $this->dialect->queryFetchAll() . ' WHERE ' . implode(' AND ', $conditions),
+            $this->dialect->queryFetchAll($withChildFlag) . ' WHERE ' . implode(' AND ', $conditions),
             $params,
         );
     }
@@ -266,10 +271,11 @@ final readonly class PdoListQueryBuilder
         ?SqlFilterResult $filterResult,
         ?string $subentryCondition,
         ?SqlQuery $seek,
+        bool $withChildFlag = false,
     ): SqlQuery {
         if ($filterResult === null) {
             $query = new SqlQuery(
-                $this->dialect->querySubtree(),
+                $this->dialect->querySubtree($withChildFlag),
                 [$base],
             );
             $hasWhere = $subentryCondition !== null;
@@ -290,6 +296,7 @@ final readonly class PdoListQueryBuilder
             $filterResult,
             $subentryCondition,
             $seek,
+            $withChildFlag,
         );
     }
 
@@ -301,8 +308,9 @@ final readonly class PdoListQueryBuilder
         SqlFilterResult $filterResult,
         ?string $subentryCondition,
         ?SqlQuery $seek,
+        bool $withChildFlag = false,
     ): SqlQuery {
-        $fetchAll = $this->dialect->queryFetchAll();
+        $fetchAll = $this->dialect->queryFetchAll($withChildFlag);
         $filterSql = $filterResult->sql;
         $subentryClause = $subentryCondition !== null
             ? "AND $subentryCondition"

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\RuntimeException;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Control\Sorting\SortKey;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\PdoDialectInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SortKeySpec;
@@ -788,6 +789,14 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
             $attributes[] = Attribute::fromArray(
                 $name,
                 $values,
+            );
+        }
+
+        // Present only when the query projected it, which is what spares the resolver a query per entry.
+        if (isset($row['has_children'])) {
+            $attributes[] = new Attribute(
+                AttributeTypeOid::NAME_HAS_SUBORDINATES,
+                $row['has_children'] ? 'TRUE' : 'FALSE',
             );
         }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/ArrayEntryStorageTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/ArrayEntryStorageTrait.php
@@ -15,6 +15,7 @@ namespace FreeDSx\Ldap\Server\Backend\Storage\Adapter\Support;
 
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
 use FreeDSx\Ldap\Server\Backend\Storage\FetchedBatch;
@@ -45,6 +46,13 @@ trait ArrayEntryStorageTrait
     ): EntryStream {
         $scoped = $this->yieldByScope($options, $entries);
 
+        if ($options->withHasSubordinates) {
+            $scoped = $this->withChildFlag(
+                $scoped,
+                $this->parentDnsIn($entries),
+            );
+        }
+
         if ($options->sortKeys === []) {
             return new EntryStream($this->pageByKey(
                 $scoped,
@@ -60,6 +68,50 @@ trait ArrayEntryStorageTrait
             $this->sortKeyComparator->sort($collected, $options->sortKeys),
             $options,
         ));
+    }
+
+    /**
+     * The normalised DN of every entry that is some other entry's parent.
+     *
+     * @param array<string, Entry> $entries
+     * @return array<string, true>
+     */
+    private function parentDnsIn(array $entries): array
+    {
+        $parents = [];
+
+        foreach ($entries as $entry) {
+            $parent = $entry->getDn()
+                ->getParent()
+                ?->normalize()
+                ->toString();
+
+            if ($parent !== null) {
+                $parents[$parent] = true;
+            }
+        }
+
+        return $parents;
+    }
+
+    /**
+     * @param iterable<Entry> $entries
+     * @param array<string, true> $parents
+     * @return Generator<int, Entry>
+     */
+    private function withChildFlag(
+        iterable $entries,
+        array $parents,
+    ): Generator {
+        foreach ($entries as $entry) {
+            $flagged = $entry->makeCopy();
+            $flagged->set(
+                AttributeTypeOid::NAME_HAS_SUBORDINATES,
+                isset($parents[$entry->getDn()->normalize()->toString()]) ? 'TRUE' : 'FALSE',
+            );
+
+            yield $flagged;
+        }
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Derived/DerivedAttributeTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Derived/DerivedAttributeTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Storage\Derived;
 
 use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 
 use function strcasecmp;
@@ -67,5 +68,53 @@ trait DerivedAttributeTrait
     private static function describesAnyDerivedAttribute(string $attributeDescription): bool
     {
         return self::derivedTypeName($attributeDescription) !== null;
+    }
+
+    /**
+     * Whether a description asks for the given derived type, either by naming it or through the operational wildcard.
+     */
+    private static function selectsDerivedType(
+        string $attributeDescription,
+        string $name,
+    ): bool {
+        return self::describesType($attributeDescription, $name)
+            || self::describesType($attributeDescription, SearchRequest::ATTRIBUTES_ALL_OPERATIONAL);
+    }
+
+    /**
+     * Whether a requested attribute list asks for the given derived type.
+     *
+     * @param array<Attribute> $requested
+     */
+    private static function requestsDerivedType(
+        array $requested,
+        string $name,
+    ): bool {
+        foreach ($requested as $attribute) {
+            if (self::selectsDerivedType($attribute->getName(), $name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The derived types a requested attribute list asks for, in a stable order.
+     *
+     * @param array<Attribute> $requested
+     * @return list<string>
+     */
+    private static function derivedTypesRequested(array $requested): array
+    {
+        $names = [];
+
+        foreach (array_keys(self::DERIVED_ATTRIBUTE_OIDS) as $name) {
+            if (self::requestsDerivedType($requested, $name)) {
+                $names[] = $name;
+            }
+        }
+
+        return $names;
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Derived/DerivedResolver.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Derived/DerivedResolver.php
@@ -42,10 +42,24 @@ final readonly class DerivedResolver
             // RFC 4512 §4.2: how a client locates the schema governing this entry.
             AttributeTypeOid::NAME_SUBSCHEMA_SUBENTRY => GeneratedEntry::Subschema->value,
             // X.501: the one derived value needing a lookup rather than the entry alone.
-            AttributeTypeOid::NAME_HAS_SUBORDINATES => $this->storage->hasChildren($entry->getDn())
-                ? 'TRUE'
-                : 'FALSE',
+            AttributeTypeOid::NAME_HAS_SUBORDINATES => $this->hasSubordinates($entry),
             default => throw new InvalidArgumentException("Unsupported derived attribute: $name"),
         };
+    }
+
+    /**
+     * A backend that answered this alongside the row already put it on the entry.
+     */
+    private function hasSubordinates(Entry $entry): string
+    {
+        $projected = $entry->get(AttributeTypeOid::NAME_HAS_SUBORDINATES)
+            ?->firstValue();
+        if ($projected !== null) {
+            return $projected;
+        }
+
+        return $this->storage->hasChildren($entry->getDn())
+            ? 'TRUE'
+            : 'FALSE';
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Search/SearchStreamBuilder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Search/SearchStreamBuilder.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\Backend\Storage\Search;
 
-use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
@@ -109,7 +108,7 @@ final readonly class SearchStreamBuilder
         Entry $entry,
         SearchRequest $request,
     ): Entry {
-        $requested = $this->requestedDerived($request);
+        $requested = self::derivedTypesRequested($request->getAttributes());
 
         if ($requested === []) {
             return $entry;
@@ -128,47 +127,6 @@ final readonly class SearchStreamBuilder
         }
 
         return $copy;
-    }
-
-    /**
-     * Derived attribute names the request asks for, by name, by OID, or through the operational wildcard.
-     *
-     * @return list<string>
-     */
-    private function requestedDerived(SearchRequest $request): array
-    {
-        $attributes = $request->getAttributes();
-        $wantsAllOperational = $this->namesAny(
-            $attributes,
-            SearchRequest::ATTRIBUTES_ALL_OPERATIONAL,
-        );
-        $requested = [];
-
-        foreach (array_keys(self::DERIVED_ATTRIBUTE_OIDS) as $name) {
-            if ($wantsAllOperational || $this->namesAny($attributes, $name)) {
-                $requested[] = $name;
-            }
-        }
-
-        return $requested;
-    }
-
-    /**
-     * Whether any requested description names the given type, allowing for its OID and its options.
-     *
-     * @param array<Attribute> $attributes
-     */
-    private function namesAny(
-        array $attributes,
-        string $name,
-    ): bool {
-        foreach ($attributes as $attr) {
-            if (self::describesType($attr->getName(), $name)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Search/StorageListOptionsFactory.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Search/StorageListOptionsFactory.php
@@ -19,8 +19,10 @@ use FreeDSx\Ldap\Control\Sorting\SortingControl;
 use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Schema\Schema;
 use FreeDSx\Ldap\Search\Filter\FilterAttributes;
+use FreeDSx\Ldap\Server\Backend\Storage\Derived\DerivedAttributeTrait;
 use FreeDSx\Ldap\Server\Backend\Storage\Paging\PageSlice;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 use FreeDSx\Ldap\Server\SearchLimits;
@@ -39,6 +41,8 @@ use function strtolower;
  */
 final readonly class StorageListOptionsFactory
 {
+    use DerivedAttributeTrait;
+
     public function __construct(
         private Schema $schema,
         private SearchLimits $limits = new SearchLimits(),
@@ -73,6 +77,18 @@ final readonly class StorageListOptionsFactory
             subentries: $subentries,
             after: $slice?->after,
             maxCandidates: $slice?->limit,
+            withHasSubordinates: $this->wantsHasSubordinates($request),
+        );
+    }
+
+    /**
+     * A backend that can answer this alongside the row saves the per-entry lookup the resolver would otherwise make.
+     */
+    private function wantsHasSubordinates(SearchRequest $request): bool
+    {
+        return self::requestsDerivedType(
+            $request->getAttributes(),
+            AttributeTypeOid::NAME_HAS_SUBORDINATES,
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/StorageListOptions.php
@@ -45,6 +45,7 @@ final readonly class StorageListOptions
         public SubentryVisibility $subentries = SubentryVisibility::All,
         public ?PageCursor $after = null,
         public ?int $maxCandidates = null,
+        public bool $withHasSubordinates = false,
     ) {}
 
     /**


### PR DESCRIPTION
The current performance for selecting hasSubordinates is kinda bad. Extremely so with InMemory. I was on the fence on whether this should just be materialized on the entry, but it's inexpensive enough to project on a query. This makes the case of selecting all operational attributes less expensive when it's for a search / list of entries.