### PR TITLE
[1.0.0] Storage fixes: attribute type lengths, locking, indexes

### DIFF
--- a/resources/pdo-schema/mysql/baseline.sql
+++ b/resources/pdo-schema/mysql/baseline.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS entries (
 -- Named apart from entries.entry_id so the correlated filter and sort SQL cannot bind to the inner scope.
 CREATE TABLE IF NOT EXISTS entry_attribute_values (
     owner_entry_id   BIGINT NOT NULL,
-    attr_name_lower  VARCHAR(255) NOT NULL,
+    attr_name_lower  VARCHAR(512) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
     value_lower      VARCHAR(255) NOT NULL,
     value_original   TEXT NOT NULL,
     INDEX idx_eav_attr_value (attr_name_lower, value_lower),

--- a/resources/pdo-schema/mysql/trigram.sql
+++ b/resources/pdo-schema/mysql/trigram.sql
@@ -1,7 +1,7 @@
 -- Named apart from entries.entry_id so the correlated filter SQL cannot bind to the inner scope.
 CREATE TABLE IF NOT EXISTS entry_attribute_trigrams (
     owner_entry_id   BIGINT NOT NULL,
-    attr_name_lower  VARCHAR(255) NOT NULL,
+    attr_name_lower  VARCHAR(512) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
     trigram          VARCHAR(3) NOT NULL,
     INDEX idx_trgm_attr (attr_name_lower, trigram),
     INDEX idx_trgm_entry (owner_entry_id),

--- a/src/FreeDSx/Ldap/Entry/Attribute.php
+++ b/src/FreeDSx/Ldap/Entry/Attribute.php
@@ -43,6 +43,13 @@ class Attribute implements IteratorAggregate, Countable, Stringable
 {
     use EscapeTrait;
 
+    /**
+     * Longest attribute type allowed.
+     *
+     * The backend keys on these, and they should have a sane limit.
+     */
+    public const MAX_TYPE_LENGTH = 512;
+
     private const ESCAPE_MAP = [
         '\\' => '\5c',
         '*' => '\2a',
@@ -213,6 +220,15 @@ class Attribute implements IteratorAggregate, Countable, Stringable
             '/^([a-z][a-z0-9-]*|\d+(\.\d+)+)(;[a-z0-9-]+)*$/D',
             strtolower($description),
         ) === 1;
+    }
+
+    /**
+     * Is it within the length bound and ASCII (as RFC 4512 2.5 requires)?
+     */
+    public static function isStorableType(string $type): bool
+    {
+        return strlen($type) <= self::MAX_TYPE_LENGTH
+            && preg_match('/^[\x20-\x7E]*$/D', $type) === 1;
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -35,7 +35,7 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
 /**
  * Handles generic requests that are dispatched to the backend.
  *
- * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+     * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
 {

--- a/src/FreeDSx/Ldap/Schema/Parser/SchemaDefinitionParser.php
+++ b/src/FreeDSx/Ldap/Schema/Parser/SchemaDefinitionParser.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Schema\Parser;
 
+use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Exception\SchemaParseException;
 use FreeDSx\Ldap\Schema\Definition\AttributeType;
 use FreeDSx\Ldap\Schema\Definition\AttributeUsage;
@@ -26,6 +27,7 @@ use FreeDSx\Ldap\Schema\Matching\MatchingRuleComparatorRegistry;
 use function count;
 use function sprintf;
 use function strcasecmp;
+use function strlen;
 
 /**
  * Parses RFC 4512 description strings into schema definitions; the inverse of toDescriptionString().
@@ -108,10 +110,12 @@ final class SchemaDefinitionParser
             self::ATTRIBUTE_TYPE_KEYWORDS,
         );
         $this->assertComplete($reader);
+        $names = $body->values(DefinitionKeyword::NAME);
+        $this->assertNamesStorable($names, $oid);
 
         return new AttributeType(
             oid: $oid,
-            names: $body->values(DefinitionKeyword::NAME),
+            names: $names,
             equalityOid: $body->string(DefinitionKeyword::EQUALITY),
             orderingOid: $body->string(DefinitionKeyword::ORDERING),
             substringOid: $body->string(DefinitionKeyword::SUBSTR),
@@ -215,6 +219,30 @@ final class SchemaDefinitionParser
             desc: $body->string(DefinitionKeyword::DESC),
             extensions: $body->extensions(),
         );
+    }
+
+    /**
+     * Refused here rather than at the write, so the subschema never advertises a type no entry could carry.
+     *
+     * @param list<string> $names
+     * @throws SchemaParseException
+     */
+    private function assertNamesStorable(
+        array $names,
+        string $oid,
+    ): void {
+        foreach ($names as $name) {
+            if (Attribute::isStorableType($name)) {
+                continue;
+            }
+
+            throw new SchemaParseException(sprintf(
+                'The attribute type "%s" names a type of %d bytes, beyond the %d the directory stores, or one that is not ASCII.',
+                $oid,
+                strlen($name),
+                Attribute::MAX_TYPE_LENGTH,
+            ));
+        }
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/EntryIndexWriter.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Pdo/EntryIndexWriter.php
@@ -214,12 +214,24 @@ final readonly class EntryIndexWriter
                     $entryId,
                     $attrNameLower,
                     $this->valueLower($attrNameLower, $value),
-                    $value,
+                    $this->valueOriginal($attrNameLower, $value),
                 ];
             }
         }
 
         return $rows;
+    }
+
+    /**
+     * Kept only for an index that reads it back.
+     */
+    private function valueOriginal(
+        string $attribute,
+        string $value,
+    ): string {
+        return $this->substringIndex?->readsOriginalValue($attribute) === true
+            ? $value
+            : '';
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SubstringIndex/Fts5SubstringIndex.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SubstringIndex/Fts5SubstringIndex.php
@@ -145,6 +145,14 @@ final class Fts5SubstringIndex implements SubstringIndexInterface
         return isset($this->attributes[$attributeLower]);
     }
 
+    /**
+     * The triggers copy the sidecar row's value into the FTS table, and only for the attributes in scope.
+     */
+    public function readsOriginalValue(string $attributeLower): bool
+    {
+        return $this->indexes($attributeLower);
+    }
+
     public function maintain(
         int $entryId,
         Entry $entry,

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SubstringIndex/SubstringIndexInterface.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SubstringIndex/SubstringIndexInterface.php
@@ -20,6 +20,8 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqlFilterResult;
 /**
  * A pluggable substring-search index for the PDO backend.
  *
+ * @internal
+ *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 interface SubstringIndexInterface
@@ -35,6 +37,11 @@ interface SubstringIndexInterface
      * Whether this strategy indexes the attribute, so a write can skip re-indexing when none of its own changed.
      */
     public function indexes(string $attributeLower): bool;
+
+    /**
+     * Whether this strategy reads the sidecar's value_original for the attribute.
+     */
+    public function readsOriginalValue(string $attributeLower): bool;
 
     /**
      * Re-index one entry, running each write through the executor inside the caller's transaction.

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SubstringIndex/TrigramSubstringIndex.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/SubstringIndex/TrigramSubstringIndex.php
@@ -90,6 +90,14 @@ final class TrigramSubstringIndex implements SubstringIndexInterface
         return isset($this->attributes[$attributeLower]);
     }
 
+    /**
+     * Trigrams live in a table of their own, so the sidecar's copy of the value is never read.
+     */
+    public function readsOriginalValue(string $attributeLower): bool
+    {
+        return false;
+    }
+
     public function maintain(
         int $entryId,
         Entry $entry,

--- a/src/FreeDSx/Ldap/Server/Backend/Write/Operation/ComputeUpdateHandler.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/Operation/ComputeUpdateHandler.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Write\Operation;
 
 use FreeDSx\Ldap\Exception\OperationException;
-use FreeDSx\Ldap\Server\Backend\Storage\Capability\RowLockableInterface;
 use FreeDSx\Ldap\Server\Backend\Write\AtomicWriter;
 use FreeDSx\Ldap\Server\Backend\Storage\Directory\EntryLocator;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
@@ -31,6 +30,7 @@ use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 readonly class ComputeUpdateHandler
 {
     use AppliesEntryUpdate;
+    use WritesLockedEntry;
 
     public function __construct(
         private EntryStorageInterface $storage,
@@ -48,32 +48,30 @@ readonly class ComputeUpdateHandler
         ComputeUpdateCommand $command,
         WriteContext $context,
     ): void {
-        $this->writer->write(function () use ($command, $context): void {
-            $dn = $command->dn->normalize();
+        $dn = $command->dn->normalize();
 
-            // Taken before the read, so what the changes are derived from cannot move under them.
-            if ($this->storage instanceof RowLockableInterface) {
-                $this->storage->lockForWrite($dn);
-            }
+        $this->writeLocked(
+            $dn,
+            function () use ($command, $context, $dn): void {
+                $entry = $this->storage->find($dn);
+                if ($entry === null) {
+                    return;
+                }
 
-            $entry = $this->storage->find($dn);
-            if ($entry === null) {
-                return;
-            }
+                $changes = ($command->compute)($entry);
+                if ($changes === []) {
+                    return;
+                }
 
-            $changes = ($command->compute)($entry);
-            if ($changes === []) {
-                return;
-            }
-
-            // Applied inline, since going back through the dispatcher would open a second transaction around this one.
-            $this->applyUpdate(
-                new UpdateCommand(
-                    $command->dn,
-                    $changes,
-                ),
-                $context,
-            );
-        });
+                // Applied inline, since going back through the dispatcher would open a second transaction around this one.
+                $this->applyUpdate(
+                    new UpdateCommand(
+                        $command->dn,
+                        $changes,
+                    ),
+                    $context,
+                );
+            },
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Write/Operation/DeleteEntryHandler.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/Operation/DeleteEntryHandler.php
@@ -28,6 +28,8 @@ use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
  */
 readonly class DeleteEntryHandler
 {
+    use WritesLockedEntry;
+
     public function __construct(
         private EntryStorageInterface $storage,
         private AtomicWriter $writer,
@@ -43,16 +45,20 @@ readonly class DeleteEntryHandler
         DeleteCommand $command,
         WriteContext $context,
     ): void {
-        $this->writer->write(function () use ($command, $context): void {
-            $dn = $command->dn->normalize();
-            $entry = $this->locator->findOrFail($dn);
-            $this->placement->assertDeletePlacement($command->dn);
+        $dn = $command->dn->normalize();
 
-            $this->storage->remove($dn);
-            $this->changeRecorder?->recordDelete(
-                $entry,
-                $context,
-            );
-        });
+        $this->writeLocked(
+            $dn,
+            function () use ($command, $context, $dn): void {
+                $entry = $this->locator->findOrFail($dn);
+                $this->placement->assertDeletePlacement($command->dn);
+
+                $this->storage->remove($dn);
+                $this->changeRecorder?->recordDelete(
+                    $entry,
+                    $context,
+                );
+            },
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Write/Operation/MoveEntryHandler.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/Operation/MoveEntryHandler.php
@@ -30,6 +30,8 @@ use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
  */
 readonly class MoveEntryHandler
 {
+    use WritesLockedEntry;
+
     public function __construct(
         private EntryStorageInterface $storage,
         private AtomicWriter $writer,
@@ -46,37 +48,42 @@ readonly class MoveEntryHandler
         MoveCommand $command,
         WriteContext $context,
     ): void {
-        $this->writer->write(function () use ($command, $context): void {
-            $normOld = $command->dn->normalize();
-            $newEntry = $this->mutation->forMove(
-                $this->locator->findOrFail($normOld),
-                $command,
-                $context,
-            );
-            $this->placement->assertMovePlacement(
-                $command,
-                $newEntry,
-                $normOld,
-                $context->isSystem(),
-            );
+        $normOld = $command->dn->normalize();
 
-            $normNew = $newEntry->getDn()->normalize();
-            // Re-keyed before the base is stored, so the upsert lands on the moved row rather than inserting a second.
-            if ($normNew->toString() !== $normOld->toString()) {
-                $this->storage->renameSubtree(
-                    $normOld,
-                    $newEntry->getDn(),
+        // Only the moved entry is locked; the destination is held by the unique key the rename and store land on.
+        $this->writeLocked(
+            $normOld,
+            function () use ($command, $context, $normOld): void {
+                $newEntry = $this->mutation->forMove(
+                    $this->locator->findOrFail($normOld),
+                    $command,
+                    $context,
                 );
-            }
+                $this->placement->assertMovePlacement(
+                    $command,
+                    $newEntry,
+                    $normOld,
+                    $context->isSystem(),
+                );
 
-            $this->storage->store($newEntry);
-            $this->moveRecorder?->record(
-                $context,
-                $newEntry,
-                $command->dn,
-                $normOld,
-                $normNew,
-            );
-        });
+                $normNew = $newEntry->getDn()->normalize();
+                // Re-keyed before the base is stored, so the upsert lands on the moved row rather than inserting a second.
+                if ($normNew->toString() !== $normOld->toString()) {
+                    $this->storage->renameSubtree(
+                        $normOld,
+                        $newEntry->getDn(),
+                    );
+                }
+
+                $this->storage->store($newEntry);
+                $this->moveRecorder?->record(
+                    $context,
+                    $newEntry,
+                    $command->dn,
+                    $normOld,
+                    $normNew,
+                );
+            },
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Write/Operation/UpdateEntryHandler.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/Operation/UpdateEntryHandler.php
@@ -29,6 +29,7 @@ use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 readonly class UpdateEntryHandler
 {
     use AppliesEntryUpdate;
+    use WritesLockedEntry;
 
     public function __construct(
         private EntryStorageInterface $storage,
@@ -46,11 +47,14 @@ readonly class UpdateEntryHandler
         UpdateCommand $command,
         WriteContext $context,
     ): void {
-        $this->writer->write(function () use ($command, $context): void {
-            $this->applyUpdate(
-                $command,
-                $context,
-            );
-        });
+        $this->writeLocked(
+            $command->dn->normalize(),
+            function () use ($command, $context): void {
+                $this->applyUpdate(
+                    $command,
+                    $context,
+                );
+            },
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Write/Operation/WritesLockedEntry.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/Operation/WritesLockedEntry.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Write\Operation;
+
+use Closure;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Server\Backend\Storage\Capability\RowLockableInterface;
+
+/**
+ * Opens the atomic write and takes the entry's row lock ahead of the body.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+trait WritesLockedEntry
+{
+    /**
+     * @param Closure(): void $body
+     * @throws OperationException
+     */
+    private function writeLocked(
+        Dn $dn,
+        Closure $body,
+    ): void {
+        $this->writer->write(function () use ($dn, $body): void {
+            $this->lockForWrite($dn);
+            $body();
+        });
+    }
+
+    private function lockForWrite(Dn $dn): void
+    {
+        if (!$this->storage instanceof RowLockableInterface) {
+            return;
+        }
+
+        $this->storage->lockForWrite($dn);
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Write/Schema/SchemaViolationGate.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Write/Schema/SchemaViolationGate.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Backend\Write\Schema;
 
 use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\SchemaRuleException;
@@ -25,7 +26,7 @@ use FreeDSx\Ldap\Server\Backend\Write\Command\UpdateCommand;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
 
 /**
- * Decides whether a schema violation stops the write, recording every one it sees either way.
+ * Decides whether a write proceeds: schema violations under the relax policy, and backend limits that nothing waives.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
@@ -40,6 +41,8 @@ final readonly class SchemaViolationGate
         Entry $entry,
         WriteContext $context,
     ): void {
+        $this->assertTypesStorable($entry);
+
         try {
             $this->validator->validateAdd(
                 $entry,
@@ -61,6 +64,8 @@ final readonly class SchemaViolationGate
         Entry $updated,
         WriteContext $context,
     ): void {
+        $this->assertTypesStorable($updated);
+
         try {
             $this->validator->validateModify(
                 $command,
@@ -83,6 +88,8 @@ final readonly class SchemaViolationGate
         Entry $moved,
         WriteContext $context,
     ): void {
+        $this->assertTypesStorable($moved);
+
         try {
             $this->validator->validateModifyDn(
                 $moved,
@@ -93,6 +100,28 @@ final readonly class SchemaViolationGate
             $this->recordOrReject(
                 $e,
                 $context,
+            );
+        }
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function assertTypesStorable(Entry $entry): void
+    {
+        foreach ($entry->getAttributes() as $attribute) {
+            $type = $attribute->getName();
+            if (Attribute::isStorableType($type)) {
+                continue;
+            }
+
+            throw new OperationException(
+                sprintf(
+                    'The attribute type is %d bytes, beyond the %d the directory stores, or is not ASCII.',
+                    strlen($type),
+                    Attribute::MAX_TYPE_LENGTH,
+                ),
+                ResultCode::ADMIN_LIMIT_EXCEEDED,
             );
         }
     }

--- a/tests/integration/Storage/Concern/WriteTestsTrait.php
+++ b/tests/integration/Storage/Concern/WriteTestsTrait.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\Entry\Attribute;
 use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\BindException;
+use FreeDSx\Ldap\Controls;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operations;
@@ -1131,5 +1132,107 @@ trait WriteTestsTrait
                 ->useSubtreeScope(),
         );
         self::assertCount(0, $notFound);
+    }
+
+    public function testAddStoresAValueThatIsNotUtf8(): void
+    {
+        $this->authenticateAdmin();
+        $photo = "\xFF\xD8\xFF\xE0\x00\x10JFIF\x00\x01\x02\x03\xFE";
+
+        $this->ldapClient()->create(new Entry(
+            'cn=binary,dc=foo,dc=bar',
+            new Attribute('objectClass', 'top', 'inetOrgPerson'),
+            new Attribute('cn', 'binary'),
+            new Attribute('sn', 'Binary'),
+            new Attribute('jpegPhoto', $photo),
+        ));
+
+        self::assertSame(
+            $photo,
+            $this->ldapClient()->read('cn=binary,dc=foo,dc=bar')?->get('jpegPhoto')?->firstValue(),
+        );
+        self::assertCount(
+            1,
+            $this->ldapClient()->search(
+                Operations::search(Filters::present('jpegPhoto'))
+                    ->base('dc=foo,dc=bar')
+                    ->useSubtreeScope(),
+            ),
+        );
+
+        $this->ldapClient()->delete('cn=binary,dc=foo,dc=bar');
+    }
+
+    public function testAddStoresAValueLargerThanSixtyFourKilobytes(): void
+    {
+        $this->authenticateAdmin();
+        $value = str_repeat('a', 70000);
+
+        $this->ldapClient()->create(new Entry(
+            'cn=oversized,dc=foo,dc=bar',
+            new Attribute('objectClass', 'top', 'inetOrgPerson'),
+            new Attribute('cn', 'oversized'),
+            new Attribute('sn', 'Oversized'),
+            new Attribute('description', $value),
+        ));
+
+        self::assertSame(
+            $value,
+            $this->ldapClient()->read('cn=oversized,dc=foo,dc=bar')?->get('description')?->firstValue(),
+        );
+
+        $this->ldapClient()->delete('cn=oversized,dc=foo,dc=bar');
+    }
+
+    public function testAnAttributeTypeWithinTheStorageBoundIsStored(): void
+    {
+        $this->authenticateAdmin();
+        $type = 'a' . str_repeat('b', Attribute::MAX_TYPE_LENGTH - 1);
+
+        $this->ldapClient()->send(
+            Operations::add(new Entry(
+                'cn=longattr,dc=foo,dc=bar',
+                new Attribute('objectClass', 'top', 'inetOrgPerson'),
+                new Attribute('cn', 'longattr'),
+                new Attribute('sn', 'Long'),
+                new Attribute($type, 'value'),
+            )),
+            Controls::relaxRules(),
+        );
+
+        self::assertSame(
+            'value',
+            $this->ldapClient()->read('cn=longattr,dc=foo,dc=bar')?->get($type)?->firstValue(),
+        );
+
+        $this->ldapClient()->delete('cn=longattr,dc=foo,dc=bar');
+    }
+
+    public function testAnOverLongAttributeTypeIsRefusedAndTheSessionSurvives(): void
+    {
+        $this->authenticateAdmin();
+        $type = 'a' . str_repeat('b', Attribute::MAX_TYPE_LENGTH);
+
+        try {
+            $this->ldapClient()->send(
+                Operations::add(new Entry(
+                    'cn=toolongattr,dc=foo,dc=bar',
+                    new Attribute('objectClass', 'top', 'inetOrgPerson'),
+                    new Attribute('cn', 'toolongattr'),
+                    new Attribute('sn', 'Too Long'),
+                    new Attribute($type, 'value'),
+                )),
+                Controls::relaxRules(),
+            );
+            self::fail('An attribute type beyond the storage bound should have been refused.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::ADMIN_LIMIT_EXCEEDED,
+                $e->getCode(),
+            );
+        }
+
+        // The refusal answers the operation rather than dropping the connection, so the session still serves.
+        self::assertNotNull($this->ldapClient()->read('cn=admin,dc=foo,dc=bar'));
     }
 }

--- a/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
@@ -29,6 +29,8 @@ use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\MysqlDialect;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Dialect\SqliteDialect;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\PdoStorage;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SqlFilter\SqliteFilterTranslator;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SubstringIndex\Fts5SubstringIndex;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SubstringIndex\SubstringIndexInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\SubstringIndex\TrigramSubstringIndex;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\Connection\SharedPdoConnectionProvider;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\EntryIndexWriter;
@@ -474,6 +476,38 @@ final class PdoStorageTest extends TestCase
         self::assertSame(
             1,
             (int) $count->fetchColumn(),
+        );
+    }
+
+    public function test_store_keeps_the_original_value_only_where_the_index_reads_it(): void
+    {
+        if (!Fts5SubstringIndex::isSupported()) {
+            self::markTestSkipped('This SQLite build lacks the FTS5 trigram tokenizer.');
+        }
+
+        self::assertSame(
+            [
+                'cn' => 'Smith',
+                'description' => '',
+            ],
+            $this->originalValuesFor(
+                new Fts5SubstringIndex(),
+                SubstringIndexMode::Auto,
+            ),
+        );
+    }
+
+    public function test_store_omits_every_original_value_when_no_index_reads_them(): void
+    {
+        self::assertSame(
+            [
+                'cn' => '',
+                'description' => '',
+            ],
+            $this->originalValuesFor(
+                new TrigramSubstringIndex(),
+                SubstringIndexMode::Trigram,
+            ),
         );
     }
 
@@ -1451,6 +1485,56 @@ final class PdoStorageTest extends TestCase
         }
 
         return $storage;
+    }
+
+    /**
+     * The sidecar's value_original per attribute, for an entry holding one indexed and one unindexed attribute.
+     *
+     * @return array<string, string>
+     */
+    private function originalValuesFor(
+        SubstringIndexInterface $index,
+        SubstringIndexMode $mode,
+    ): array {
+        $pdo = new PDO('sqlite::memory:');
+        PdoStorage::initialize(
+            $pdo,
+            new SqliteDialect(),
+            $index,
+        );
+
+        $storage = $this->fromContainer(
+            PdoStorageFactory::class,
+            options: TestServerOptions::forStorage(
+                PdoConfig::forSqlite(':memory:')
+                    ->setSubstringIndexMode($mode),
+            ),
+        )->storageOn(new SharedPdoConnectionProvider(
+            $pdo,
+            fn(): PDO => $pdo,
+        ));
+        $storage->store(new Entry(
+            new Dn('cn=Smith,dc=example,dc=com'),
+            new Attribute('cn', 'Smith'),
+            new Attribute('description', 'Not an indexed attribute'),
+        ));
+
+        $rows = $pdo->query(
+            "SELECT attr_name_lower, value_original FROM entry_attribute_values
+             WHERE attr_name_lower IN ('cn', 'description')",
+        );
+        self::assertNotFalse($rows);
+
+        $found = [];
+        foreach ($rows->fetchAll(PDO::FETCH_NUM) as $row) {
+            self::assertIsArray($row);
+            self::assertIsString($row[0]);
+            self::assertIsString($row[1]);
+            $found[$row[0]] = $row[1];
+        }
+        ksort($found);
+
+        return $found;
     }
 
     /**


### PR DESCRIPTION
A couple of storage related adjustments:

* Unify every write handler to use the same locking mechanism so writes under concurrency don't clash.
* Add an attribute type length limit that's sane. Prevents issues with index / writes for certain dialects that would otherwise cause issues. Supporting an arbitrarily long attribute type just doesn't seem worth it.
* Fix the index writes so it only writes attributes that will actually use it.