### PR TITLE
[1.0.0] StartTLS on Swoole / Paging Cursor Reads Optimizations.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=8.2",
     "freedsx/asn1": "dev-main#d6cee05",
-    "freedsx/socket": "dev-main#091b092",
+    "freedsx/socket": "dev-main#02ed927",
     "freedsx/sasl": "dev-main#525d0e9",
     "psr/log": "^3"
   },

--- a/src/FreeDSx/Ldap/Container/Provider/HandlerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/HandlerContainerProvider.php
@@ -46,6 +46,7 @@ use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
 use FreeDSx\Ldap\Server\Backend\Write\Routing\WriteRequestRouter;
 use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
 use FreeDSx\Ldap\Server\Metrics\MetricsSnapshotProvider;
+use FreeDSx\Ldap\Server\Paging\PageFiller;
 use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyService;
 use FreeDSx\Ldap\Server\PasswordModify\PasswordModifyTargetResolver;
 use FreeDSx\Ldap\Server\PasswordPolicy\PasswordPolicyComponentFactory;
@@ -254,14 +255,23 @@ final class HandlerContainerProvider implements ContainerProviderInterface
         ?SearchLimits $searchLimits,
     ): ServerPagingHandler {
         $options = $container->get(ServerOptions::class);
+        $backend = $container->get(ReadBackendInterface::class);
+        $accessControl = $container->get(AccessControlInterface::class);
+        $limits = $searchLimits ?? $options->makeSearchLimits();
 
         return new ServerPagingHandler(
-            backend: $container->get(ReadBackendInterface::class),
-            filterEvaluator: $container->get(FilterEvaluatorInterface::class),
-            accessControl: $container->get(AccessControlInterface::class),
+            backend: $backend,
+            accessControl: $accessControl,
             requestHistory: $context->requestHistory,
             schema: $options->getSchema(),
-            limits: $searchLimits ?? $options->makeSearchLimits(),
+            pageFiller: new PageFiller(
+                $backend,
+                $container->get(FilterEvaluatorInterface::class),
+                $accessControl,
+                $options->getSchema(),
+                $limits,
+            ),
+            limits: $limits,
             eventLogger: $context->eventLogger,
         );
     }

--- a/src/FreeDSx/Ldap/Container/Provider/ServerListenerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/ServerListenerContainerProvider.php
@@ -17,6 +17,7 @@ use Closure;
 use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\Container\ContainerReloadFactory;
 use FreeDSx\Ldap\Container\Contributor\ListenerContributorInterface;
+use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\Protocol\ServerAuthorization;
 use FreeDSx\Ldap\Server\Metrics\File\FileSnapshotProvider;
 use FreeDSx\Ldap\Server\Metrics\File\FileSnapshotWriter;
@@ -39,6 +40,7 @@ use FreeDSx\Ldap\Server\ServerRunner\Swoole\WorkerFactory;
 use FreeDSx\Ldap\Server\SocketServerFactory;
 use FreeDSx\Ldap\Server\Utility\CpuCount;
 use FreeDSx\Ldap\ServerListenerOptionsInterface;
+use FreeDSx\Ldap\ServerOptions;
 
 /**
  * Registers the listener services shared by every server type: the socket, runner, reload, authorization, and metrics.
@@ -88,6 +90,7 @@ final class ServerListenerContainerProvider implements ContainerProviderInterfac
         $metricsRecorder = $container->get(MetricsRecorderInterface::class);
 
         if ($options->isRunnerMode(RunnerMode::Swoole)) {
+            $this->assertClientCertificatesAreNotExpected($options);
             $workers = $this->resolveWorkerCount($container);
             $workerFactory = new WorkerFactory(
                 serverProtocolFactory: $protocolFactoryProvider($options),
@@ -118,6 +121,29 @@ final class ServerListenerContainerProvider implements ContainerProviderInterfac
             resettable: $container->get(ListenerContributorInterface::class)->forkResettable(),
             backgroundTasks: $container->get(BackgroundTasksInterface::class),
         );
+    }
+
+    /**
+     * The following features are not supported with Swoole:
+     *
+     *   * mTLS
+     *   * External SASL
+     *
+     * Swoole does not support capturing client certificates.
+     */
+    private function assertClientCertificatesAreNotExpected(ServerListenerOptionsInterface $options): void
+    {
+        if ($options->getNetworkConfig()->isSslValidateCert()) {
+            throw new RuntimeException(
+                'The Swoole runner cannot verify client certificates. Unset sslValidateCert or use the PCNTL runner.',
+            );
+        }
+
+        if (in_array(ServerOptions::SASL_EXTERNAL, $options->getSaslMechanisms(), true)) {
+            throw new RuntimeException(
+                'The Swoole runner cannot support the EXTERNAL SASL mechanism. Remove it or use the PCNTL runner.',
+            );
+        }
     }
 
     /**

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPagingHandler.php
@@ -15,27 +15,21 @@ namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
 
 use FreeDSx\Ldap\Control\PagingControl;
 use FreeDSx\Ldap\Entry\Entries;
-use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\ProtocolException;
-use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\Response\Cancellation;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Schema\Schema;
-use FreeDSx\Ldap\Search\Filter\FilterInterface;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
-use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
-use FreeDSx\Ldap\Server\Backend\Storage\Paging\PageCursor;
-use FreeDSx\Ldap\Server\Backend\Storage\Paging\PageSlice;
-use FreeDSx\Ldap\Server\Paging\PageBudget;
+use FreeDSx\Ldap\Server\Paging\CollectedPage;
+use FreeDSx\Ldap\Server\Paging\PageFiller;
 use FreeDSx\Ldap\Server\Paging\PagingRequest;
 use FreeDSx\Ldap\Server\Paging\PagingRequestComparator;
 use FreeDSx\Ldap\Server\Paging\PagingResponse;
 use FreeDSx\Ldap\Server\RequestHistory;
-use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Operation\SearchOperationResult;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
@@ -56,10 +50,10 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
 
     public function __construct(
         private readonly ReadBackendInterface $backend,
-        private readonly FilterEvaluatorInterface $filterEvaluator,
         private readonly AccessControlInterface $accessControl,
         private readonly RequestHistory $requestHistory,
         private readonly Schema $schema,
+        private readonly PageFiller $pageFiller,
         private readonly PagingRequestComparator $requestComparator = new PagingRequestComparator(),
         private readonly SearchLimits $limits = new SearchLimits(),
         private readonly ?EventLogger $eventLogger = null,
@@ -202,7 +196,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
         PagingRequest $pagingRequest,
         TokenInterface $token,
     ): PagingResponse {
-        $collected = $this->collectPage(
+        $collected = $this->pageFiller->fill(
             $pagingRequest,
             $token,
             null,
@@ -249,7 +243,7 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
 
         $this->requestHistory->removePagingCursor($currentCookie);
 
-        $collected = $this->collectPage(
+        $collected = $this->pageFiller->fill(
             $pagingRequest,
             $token,
             $resumeFrom,
@@ -287,178 +281,6 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
 
         return PagingResponse::make(
             new Entries(...$collected->entries),
-        );
-    }
-
-    /**
-     * Fills one page from $resumeFrom, reading bounded slices to their end so each says where it stopped.
-     *
-     * @throws OperationException
-     */
-    private function collectPage(
-        PagingRequest $pagingRequest,
-        TokenInterface $token,
-        ?PageCursor $resumeFrom,
-    ): CollectedPage {
-        $request = $pagingRequest->getSearchRequest();
-        $projection = $this->projectionFor($request);
-        $filter = $request->getFilter();
-        $effectivePageSize = $this->effectiveLimit(
-            $pagingRequest->getSize(),
-            $this->limits->maxSearchPageSize(),
-        );
-        $sizeLimit = $this->effectiveLimit(
-            $request->getSizeLimit(),
-            $this->limits->maxSearchSize(),
-        );
-
-        // Deliberate: the size limit bounds each page rather than the whole paged operation.
-        $collectCap = $this->effectiveLimit(
-            $effectivePageSize,
-            $sizeLimit,
-        );
-        $pageLimit = $collectCap > 0
-            ? $collectCap
-            : null;
-
-        $budget = PageBudget::of(
-            $this->effectiveLimit(
-                $request->getTimeLimit(),
-                $this->limits->maxSearchTimeLimit(),
-            ),
-            $this->limits->effectivePagedLookthrough(),
-        );
-
-        $page = [];
-        $cursor = $resumeFrom;
-        $exhausted = false;
-        $hasFurtherMatch = false;
-
-        while (!$exhausted) {
-            $isFilling = $this->pageHasCapacity($page, $pageLimit);
-
-            // A full page only overflows the size limit if a further match exists
-            if (!$isFilling && !$this->mayExceedSizeLimit($page, $sizeLimit)) {
-                break;
-            }
-
-            $stream = $this->readSlice(
-                $pagingRequest,
-                new PageSlice(
-                    $this->sliceSizeFor(
-                        $isFilling ? $page : [],
-                        $pageLimit,
-                    ),
-                    $cursor,
-                    $budget->deadline(),
-                ),
-                $budget->remainingLookthrough(),
-            );
-
-            foreach ($stream->entries as $entry) {
-                $kept = $this->keepForPage(
-                    $entry,
-                    $token,
-                    $filter,
-                );
-
-                if ($kept === null) {
-                    continue;
-                }
-
-                if (!$isFilling) {
-                    $hasFurtherMatch = true;
-
-                    break;
-                }
-
-                $page[] = $projection->project($kept);
-            }
-
-            // The stream was abandoned mid-slice and can say nothing about where it stopped.
-            if ($hasFurtherMatch) {
-                break;
-            }
-
-            // A stream that reports nothing cannot be resumed, so the result has to be taken as finished.
-            $read = $stream->entries->getReturn();
-            $exhausted = $read === null || !$read->hasMore || $read->cursor === null;
-            $cursor = $read->cursor ?? $cursor;
-            $budget->spend($read->rows ?? 0);
-        }
-
-        return new CollectedPage(
-            $page,
-            $exhausted,
-            $hasFurtherMatch,
-            $cursor,
-        );
-    }
-
-    /**
-     * Whether a page this full would overflow the size limit.
-     *
-     * @param list<Entry> $page
-     */
-    private function mayExceedSizeLimit(
-        array $page,
-        int $sizeLimit,
-    ): bool {
-        return $sizeLimit > 0
-            && count($page) >= $sizeLimit;
-    }
-
-    /**
-     * @throws OperationException
-     */
-    private function readSlice(
-        PagingRequest $pagingRequest,
-        PageSlice $slice,
-        int $lookthrough,
-    ): EntryStream {
-        return $this->backend->search(
-            $pagingRequest->getSearchRequest(),
-            $this->subentryVisibility($pagingRequest->controls()),
-            $pagingRequest->controls(),
-            new SearchLimits(
-                maxSearchTimeLimit: $this->limits->maxSearchTimeLimit(),
-                maxSearchLookthrough: $lookthrough,
-            ),
-            $slice,
-        );
-    }
-
-    /**
-     * The entry as this identity may see it, or null when it may not see it at all.
-     *
-     * @throws OperationException
-     */
-    private function keepForPage(
-        Entry $entry,
-        TokenInterface $token,
-        FilterInterface $filter,
-    ): ?Entry {
-        $filtered = $this->accessControl->filterEntry(
-            $token,
-            $entry,
-        );
-
-        if ($filtered === null) {
-            return null;
-        }
-
-        // Stripping an attribute can cost the entry its match, so a changed entry is judged against the filter again.
-        return $filtered !== $entry && !$this->filterEvaluator->evaluate($filtered, $filter)
-            ? null
-            : $filtered;
-    }
-
-    private function projectionFor(SearchRequest $request): AttributeProjection
-    {
-        return AttributeProjection::forRequest(
-            $request->getAttributes(),
-            $request->getAttributesOnly(),
-            $this->schema,
         );
     }
 
@@ -539,33 +361,6 @@ class ServerPagingHandler implements ServerProtocolHandlerInterface
                 ResultCode::UNWILLING_TO_PERFORM,
             );
         }
-    }
-
-    /**
-     * @param list<Entry> $page
-     */
-    private function pageHasCapacity(
-        array $page,
-        ?int $pageLimit,
-    ): bool {
-        return $pageLimit === null
-            || count($page) < $pageLimit;
-    }
-
-    /**
-     * What the page can still take, since a slice appends everything it keeps and would otherwise overfill the page.
-     *
-     * @param list<Entry> $page
-     */
-    private function sliceSizeFor(
-        array $page,
-        ?int $pageLimit,
-    ): int {
-        $remaining = $pageLimit === null
-            ? $this->limits->maxSearchPageSize()
-            : $pageLimit - count($page);
-
-        return max($remaining, 1);
     }
 
     private function generateCookie(): string

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchHandler.php
@@ -140,7 +140,7 @@ class ServerSearchHandler implements ServerProtocolHandlerInterface
         $filter = $request->getFilter();
         $emitted = 0;
 
-        foreach ($backend->entries as $entry) {
+        foreach ($backend->entries() as $entry) {
             $filtered = $this->accessControl->filterEntry(
                 $token,
                 $entry,

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerStartTlsHandler.php
@@ -26,6 +26,7 @@ use FreeDSx\Ldap\Server\Logging\ServerEvent;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use FreeDSx\Ldap\ServerListenerOptionsInterface;
+use Throwable;
 
 use function extension_loaded;
 
@@ -81,7 +82,17 @@ class ServerStartTlsHandler implements ServerProtocolHandlerInterface
             // Plaintext waiting behind the request is the command-injection shape, so its loss is worth reporting.
             $discarded = $connection->hasBufferedInput();
 
-            $connection->encrypt();
+            try {
+                $connection->encrypt();
+            } catch (Throwable $e) {
+                $this->eventLogger->record(
+                    ServerEvent::StartTlsFailed,
+                    [EventContext::REASON => $e->getMessage()],
+                    message: $message,
+                );
+
+                throw $e;
+            }
 
             if ($discarded) {
                 $this->eventLogger->record(

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSyncHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSyncHandler.php
@@ -268,7 +268,7 @@ final class ServerSyncHandler implements ServerProtocolHandlerInterface
             $this->limits,
         );
 
-        foreach ($result->entries as $entry) {
+        foreach ($result->entries() as $entry) {
             yield from $this->emit(
                 $this->toResponse(
                     $message->getMessageId(),

--- a/src/FreeDSx/Ldap/Server/Backend/Auth/NameResolver/AttributeSearchBindNameResolver.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Auth/NameResolver/AttributeSearchBindNameResolver.php
@@ -61,7 +61,7 @@ final class AttributeSearchBindNameResolver implements BindNameResolverInterface
 
         /** @var Entry[] $entries */
         $entries = iterator_to_array(
-            $stream->entries,
+            $stream->entries(),
             false,
         );
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/EntryIndexReindexer.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/EntryIndexReindexer.php
@@ -66,7 +66,7 @@ final readonly class EntryIndexReindexer
                 subtree: true,
             ));
 
-            foreach ($stream->entries as $entry) {
+            foreach ($stream->entries() as $entry) {
                 $dns[] = $entry->getDn();
             }
         }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/PdoStorage.php
@@ -46,6 +46,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Capability\RowLockableInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
 use FreeDSx\Ldap\Server\Backend\Storage\FetchedBatch;
+use FreeDSx\Ldap\Server\Backend\Storage\FetchedEntry;
 use FreeDSx\Ldap\Server\Backend\Storage\Paging\PageCursor;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 use FreeDSx\Ldap\Server\Backend\ResettableInterface;
@@ -197,7 +198,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
         // A composed filter with a selective drivable leaf streams off that leaf; PHP re-evaluates the full filter.
         $composed = $this->tryComposedStreamingQuery($filterResult, $options);
         if ($composed !== null) {
-            return new EntryStream(
+            return EntryStream::positioned(
                 $this->generateBatches(
                     $composed,
                     $deadline,
@@ -220,7 +221,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
             $this->sortSpecs($options),
         );
 
-        return new EntryStream(
+        return EntryStream::positioned(
             $this->generateBatches(
                 $this->queryBuilder->build($spec),
                 $deadline,
@@ -602,7 +603,7 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
     /**
      * Walks the result in bounded batches, seeking past the last row read rather than holding one cursor open.
      *
-     * @return Generator<int, Entry, mixed, FetchedBatch>
+     * @return Generator<int, FetchedEntry, mixed, FetchedBatch>
      */
     private function generateBatches(
         SqlQuery $query,
@@ -634,6 +635,9 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
                 $deadline,
                 $allowed,
                 $remaining,
+                $isSorted
+                    ? $delivered
+                    : null,
             );
             $read += $batch->rows;
             $delivered += $batch->rows;
@@ -663,13 +667,15 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
      * One statement's worth of rows, released as this returns so only one is ever open.
      *
      * @param array<string, true>|null $allowed
-     * @return Generator<int, Entry, mixed, FetchedBatch>
+     * @param ?int $deliveredBefore Rows handed over prior to this batch.
+     * @return Generator<int, FetchedEntry, mixed, FetchedBatch>
      */
     private function generateBatch(
         SqlQuery $query,
         ?float $deadline,
         ?array $allowed,
         ?int $yieldCap = null,
+        ?int $deliveredBefore = null,
     ): Generator {
         $stmt = $this->statements->execute(
             $query->sql,
@@ -699,7 +705,12 @@ final class PdoStorage implements EntryStorageInterface, ResettableInterface, Ch
             );
 
             if ($entry !== null) {
-                yield $entry;
+                yield new FetchedEntry(
+                    $entry,
+                    $deliveredBefore === null
+                        ? $cursor
+                        : PageCursor::afterSorted($deliveredBefore + $rows),
+                );
             }
         }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/ArrayEntryStorageTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/ArrayEntryStorageTrait.php
@@ -19,6 +19,7 @@ use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
 use FreeDSx\Ldap\Server\Backend\Storage\FetchedBatch;
+use FreeDSx\Ldap\Server\Backend\Storage\FetchedEntry;
 use FreeDSx\Ldap\Server\Backend\Storage\Paging\PageCursor;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 use FreeDSx\Ldap\Server\Subentry\SubentryDetector;
@@ -54,7 +55,7 @@ trait ArrayEntryStorageTrait
         }
 
         if ($options->sortKeys === []) {
-            return new EntryStream($this->pageByKey(
+            return EntryStream::positioned($this->pageByKey(
                 $scoped,
                 $keys,
                 $options,
@@ -64,7 +65,7 @@ trait ArrayEntryStorageTrait
         /** @var list<Entry> $collected */
         $collected = iterator_to_array($scoped, false);
 
-        return new EntryStream($this->pageByCount(
+        return EntryStream::positioned($this->pageByCount(
             $this->sortKeyComparator->sort($collected, $options->sortKeys),
             $options,
         ));
@@ -119,7 +120,7 @@ trait ArrayEntryStorageTrait
      *
      * @param iterable<Entry> $entries
      * @param array<string, int> $keys Entry key per normalised DN string
-     * @return Generator<int, Entry, mixed, FetchedBatch>
+     * @return Generator<int, FetchedEntry, mixed, FetchedBatch>
      */
     private function pageByKey(
         iterable $entries,
@@ -152,7 +153,12 @@ trait ArrayEntryStorageTrait
                 $cursor = PageCursor::afterEntry($key);
             }
 
-            yield $entry;
+            yield new FetchedEntry(
+                $entry,
+                $key !== null
+                    ? $cursor
+                    : null,
+            );
         }
 
         return new FetchedBatch(
@@ -169,7 +175,7 @@ trait ArrayEntryStorageTrait
      * anything. The sort is recomputed identically for every page.
      *
      * @param iterable<Entry> $entries
-     * @return Generator<int, Entry, mixed, FetchedBatch>
+     * @return Generator<int, FetchedEntry, mixed, FetchedBatch>
      */
     private function pageByCount(
         iterable $entries,
@@ -196,7 +202,10 @@ trait ArrayEntryStorageTrait
 
             $taken++;
 
-            yield $entry;
+            yield new FetchedEntry(
+                $entry,
+                PageCursor::afterSorted($delivered + $taken),
+            );
         }
 
         return new FetchedBatch(

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/DefaultHasChildrenTrait.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Adapter/Support/DefaultHasChildrenTrait.php
@@ -28,7 +28,7 @@ trait DefaultHasChildrenTrait
 
     public function hasChildren(Dn $dn): bool
     {
-        foreach ($this->list(StorageListOptions::firstChild($dn))->entries as $ignored) {
+        foreach ($this->list(StorageListOptions::firstChild($dn))->entries() as $ignored) {
             return true;
         }
 

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Directory/SubtreeEnumerator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Directory/SubtreeEnumerator.php
@@ -43,7 +43,7 @@ final readonly class SubtreeEnumerator
         );
 
         $dnList = [];
-        foreach ($this->storage->list($options)->entries as $entry) {
+        foreach ($this->storage->list($options)->entries() as $entry) {
             $dnList[] = $entry->getDn()->normalize();
         }
         usort(
@@ -67,7 +67,7 @@ final readonly class SubtreeEnumerator
             subtree: true,
         );
 
-        foreach ($this->storage->list($options)->entries as $entry) {
+        foreach ($this->storage->list($options)->entries() as $entry) {
             if ($entry->getDn()->normalize()->toString() !== $base->toString()) {
                 $descendants[] = $entry;
             }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStream.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/EntryStream.php
@@ -17,17 +17,103 @@ use FreeDSx\Ldap\Entry\Entry;
 use Generator;
 
 /**
- * Lazy entry generator returned by storage list() / backend search(); $isPreFiltered marks an exact native filter match.
+ * Lazy entries from storage. Single use only.
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
 final readonly class EntryStream
 {
     /**
-     * @param Generator<int, Entry, mixed, ?FetchedBatch> $entries Returns what it read, once read to its end.
+     * @param Generator<int, Entry|FetchedEntry, mixed, ?FetchedBatch> $stream Returns what it read, once read to its end.
+     * @param bool $isPreFiltered marks an exact native filter match.
      */
-    public function __construct(
-        public Generator $entries,
+    private function __construct(
+        private Generator $stream,
+        private bool $isPositioned,
         public bool $isPreFiltered = false,
     ) {}
+
+    /**
+     * Entries alone, for a read with no position to resume from.
+     *
+     * @param Generator<int, Entry, mixed, ?FetchedBatch> $entries
+     */
+    public static function of(
+        Generator $entries,
+        bool $isPreFiltered = false,
+    ): self {
+        return new self(
+            $entries,
+            false,
+            $isPreFiltered,
+        );
+    }
+
+    /**
+     * Entries that each carry the point a later read resumes from.
+     *
+     * @param Generator<int, FetchedEntry, mixed, ?FetchedBatch> $entries
+     */
+    public static function positioned(
+        Generator $entries,
+        bool $isPreFiltered = false,
+    ): self {
+        return new self(
+            $entries,
+            true,
+            $isPreFiltered,
+        );
+    }
+
+    /**
+     * @return Generator<int, Entry, mixed, ?FetchedBatch>
+     */
+    public function entries(): Generator
+    {
+        if (!$this->isPositioned) {
+            /** @var Generator<int, Entry, mixed, ?FetchedBatch> */
+            return $this->stream;
+        }
+
+        return $this->unwrapped();
+    }
+
+    /**
+     * @return Generator<int, FetchedEntry, mixed, ?FetchedBatch>
+     */
+    public function fetched(): Generator
+    {
+        if ($this->isPositioned) {
+            /** @var Generator<int, FetchedEntry, mixed, ?FetchedBatch> */
+            return $this->stream;
+        }
+
+        return $this->positionless();
+    }
+
+    /**
+     * @return Generator<int, Entry, mixed, ?FetchedBatch>
+     */
+    private function unwrapped(): Generator
+    {
+        foreach ($this->stream as $fetched) {
+            /** @var FetchedEntry $fetched */
+            yield $fetched->entry;
+        }
+
+        return $this->stream->getReturn();
+    }
+
+    /**
+     * @return Generator<int, FetchedEntry, mixed, ?FetchedBatch>
+     */
+    private function positionless(): Generator
+    {
+        foreach ($this->stream as $entry) {
+            /** @var Entry $entry */
+            yield new FetchedEntry($entry);
+        }
+
+        return $this->stream->getReturn();
+    }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Export/DirectoryDumper.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Export/DirectoryDumper.php
@@ -95,7 +95,7 @@ final readonly class DirectoryDumper
         );
         $stream = $this->storage->list($listOptions);
 
-        foreach ($stream->entries as $entry) {
+        foreach ($stream->entries() as $entry) {
             if (!$stream->isPreFiltered && $filter !== null) {
                 if (!$this->filterEvaluator->evaluate($entry, $filter)) {
                     continue;

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/FetchedBatch.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/FetchedBatch.php
@@ -32,4 +32,13 @@ final readonly class FetchedBatch
         public ?PageCursor $cursor = null,
         public bool $hasMore = false,
     ) {}
+
+    /**
+     * Whether the result ended here, either because nothing follows or because there is no position to resume from.
+     */
+    public function isExhausted(): bool
+    {
+        return !$this->hasMore
+            || $this->cursor === null;
+    }
 }

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/FetchedEntry.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/FetchedEntry.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage;
+
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Server\Backend\Storage\Paging\PageCursor;
+
+/**
+ * One entry, paired with the point a later read resumes from once this one is taken.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class FetchedEntry
+{
+    /**
+     * @param ?PageCursor $cursor null when the read cannot say where it is.
+     */
+    public function __construct(
+        public Entry $entry,
+        public ?PageCursor $cursor = null,
+    ) {}
+}

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Search/SearchStreamBuilder.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Search/SearchStreamBuilder.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Derived\DerivedResolver;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\Exception\TimeLimitExceededException;
 use FreeDSx\Ldap\Server\Backend\Storage\FetchedBatch;
+use FreeDSx\Ldap\Server\Backend\Storage\FetchedEntry;
 use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\SearchLimits;
 use Generator;
@@ -58,7 +59,7 @@ final readonly class SearchStreamBuilder
             $request->getFilter(),
         );
 
-        return new EntryStream(
+        return EntryStream::positioned(
             $this->wrapWithDerived(
                 $generator,
                 $request,
@@ -77,7 +78,7 @@ final readonly class SearchStreamBuilder
     ): EntryStream {
         // In-search alias dereferencing is not implemented, so an alias is returned as the ordinary entry it is
         // rather than failing the search. This is a deliberate RFC difference.
-        $generator = $this->wrapWithTimeLimitHandling($stream->entries);
+        $generator = $this->wrapWithTimeLimitHandling($stream->fetched());
 
         // Every candidate examined is charged.
         $generator = $this->wrapWithLookthrough(
@@ -94,22 +95,25 @@ final readonly class SearchStreamBuilder
 
         $generator = $this->wrapWithDerived($generator, $request);
 
-        return new EntryStream(
+        return EntryStream::positioned(
             $generator,
             true,
         );
     }
 
     /**
-     * @param Generator<int, Entry, mixed, ?FetchedBatch> $generator
-     * @return Generator<int, Entry, mixed, ?FetchedBatch>
+     * @param Generator<int, FetchedEntry, mixed, ?FetchedBatch> $generator
+     * @return Generator<int, FetchedEntry, mixed, ?FetchedBatch>
      */
     private function wrapWithDerived(
         Generator $generator,
         SearchRequest $request,
     ): Generator {
-        foreach ($generator as $entry) {
-            yield $this->injectDerived($entry, $request);
+        foreach ($generator as $fetched) {
+            yield new FetchedEntry(
+                $this->injectDerived($fetched->entry, $request),
+                $fetched->cursor,
+            );
         }
 
         return $generator->getReturn();
@@ -144,17 +148,17 @@ final readonly class SearchStreamBuilder
     }
 
     /**
-     * @param Generator<int, Entry, mixed, ?FetchedBatch> $generator
-     * @return Generator<int, Entry, mixed, ?FetchedBatch>
+     * @param Generator<int, FetchedEntry, mixed, ?FetchedBatch> $generator
+     * @return Generator<int, FetchedEntry, mixed, ?FetchedBatch>
      * @throws OperationException
      */
     private function wrapWithFilterEvaluation(
         Generator $generator,
         FilterInterface $filter,
     ): Generator {
-        foreach ($generator as $entry) {
-            if ($this->filterEvaluator->evaluate($entry, $filter)) {
-                yield $entry;
+        foreach ($generator as $fetched) {
+            if ($this->filterEvaluator->evaluate($fetched->entry, $filter)) {
+                yield $fetched;
             }
         }
 
@@ -162,8 +166,8 @@ final readonly class SearchStreamBuilder
     }
 
     /**
-     * @param Generator<int, Entry, mixed, ?FetchedBatch> $generator
-     * @return Generator<int, Entry, mixed, ?FetchedBatch>
+     * @param Generator<int, FetchedEntry, mixed, ?FetchedBatch> $generator
+     * @return Generator<int, FetchedEntry, mixed, ?FetchedBatch>
      * @throws OperationException
      */
     private function wrapWithLookthrough(
@@ -173,7 +177,7 @@ final readonly class SearchStreamBuilder
         $lookthrough = ($effectiveLimits ?? $this->limits)->maxSearchLookthrough();
         $examined = 0;
 
-        foreach ($generator as $entry) {
+        foreach ($generator as $fetched) {
             if ($lookthrough > 0 && ++$examined > $lookthrough) {
                 throw new OperationException(
                     'Administrative limit exceeded.',
@@ -181,22 +185,22 @@ final readonly class SearchStreamBuilder
                 );
             }
 
-            yield $entry;
+            yield $fetched;
         }
 
         return $generator->getReturn();
     }
 
     /**
-     * @param Generator<int, Entry, mixed, ?FetchedBatch> $generator
-     * @return Generator<int, Entry, mixed, ?FetchedBatch>
+     * @param Generator<int, FetchedEntry, mixed, ?FetchedBatch> $generator
+     * @return Generator<int, FetchedEntry, mixed, ?FetchedBatch>
      * @throws OperationException
      */
     private function wrapWithTimeLimitHandling(Generator $generator): Generator
     {
         try {
-            foreach ($generator as $entry) {
-                yield $entry;
+            foreach ($generator as $fetched) {
+                yield $fetched;
             }
         } catch (TimeLimitExceededException) {
             throw new OperationException(
@@ -209,11 +213,11 @@ final readonly class SearchStreamBuilder
     }
 
     /**
-     * @return Generator<int, Entry, mixed, ?FetchedBatch>
+     * @return Generator<int, FetchedEntry, mixed, ?FetchedBatch>
      */
     private function yieldSingle(Entry $entry): Generator
     {
-        yield $entry;
+        yield new FetchedEntry($entry);
 
         // A base-object read is one entry, so there is never anywhere to resume from.
         return null;

--- a/src/FreeDSx/Ldap/Server/Backend/StorageReadBackend.php
+++ b/src/FreeDSx/Ldap/Server/Backend/StorageReadBackend.php
@@ -121,7 +121,7 @@ final readonly class StorageReadBackend implements ReadBackendInterface, Resetta
             $stream = $this->storage->list($options);
         } catch (InvalidAttributeException) {
             # RFC 4511 §4.5.1.7: unrecognized attribute descriptions evaluate to Undefined; yield zero entries.
-            return new EntryStream((static function (): Generator {
+            return EntryStream::of((static function (): Generator {
                 yield from [];
 
                 return null;

--- a/src/FreeDSx/Ldap/Server/Paging/CollectedPage.php
+++ b/src/FreeDSx/Ldap/Server/Paging/CollectedPage.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+namespace FreeDSx\Ldap\Server\Paging;
 
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Server\Backend\Storage\Paging\PageCursor;
@@ -27,8 +27,8 @@ final readonly class CollectedPage
 {
     /**
      * @param Entry[] $entries
-     * @param bool $isResultExhausted Whether the result ran out, so no further page can exist.
-     * @param ?PageCursor $cursor Where to resume, or null when nothing was read.
+     * @param bool $isResultExhausted Whether the result ran out.
+     * @param ?PageCursor $cursor Where to resume.
      */
     public function __construct(
         public array $entries,

--- a/src/FreeDSx/Ldap/Server/Paging/FillingPage.php
+++ b/src/FreeDSx/Ldap/Server/Paging/FillingPage.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Paging;
+
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Server\Backend\Storage\Paging\PageCursor;
+use FreeDSx\Ldap\Server\Backend\Storage\Paging\PageSlice;
+
+use function ceil;
+use function count;
+use function max;
+use function min;
+
+/**
+ * One page as it fills: what it holds, what it can still take, and where the next read resumes from.
+ *
+ * @internal
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class FillingPage
+{
+    /**
+     * @var list<Entry>
+     */
+    private array $entries = [];
+
+    private int $slices = 0;
+
+    private int $candidates = 0;
+
+    private bool $canOverfetch = true;
+
+    /**
+     * @param ?int $pageLimit Entries the page may hold, or null when nothing bounds it.
+     * @param int $widestSlice The most candidates one read may examine.
+     */
+    public function __construct(
+        private readonly ?int $pageLimit,
+        private readonly int $sizeLimit,
+        private readonly int $widestSlice,
+        private ?PageCursor $cursor = null,
+    ) {}
+
+    public function hasCapacity(): bool
+    {
+        return $this->pageLimit === null
+            || count($this->entries) < $this->pageLimit;
+    }
+
+    /**
+     * Whether a page this full would overflow the size limit.
+     */
+    public function mayExceedSizeLimit(): bool
+    {
+        return $this->sizeLimit > 0
+            && count($this->entries) >= $this->sizeLimit;
+    }
+
+    /**
+     * The next bounded read, sized to what the page still needs.
+     *
+     * @param bool $isFilling False when the page is full and the read only probes for a further match.
+     */
+    public function nextSlice(
+        bool $isFilling,
+        ?float $deadline,
+    ): PageSlice {
+        $this->slices++;
+
+        return new PageSlice(
+            $this->sliceSize($isFilling),
+            $this->cursor,
+            $deadline,
+        );
+    }
+
+    /**
+     * Records what a read cost, which is the candidates it examined rather than the entries it handed back.
+     */
+    public function readCandidates(int $rows): void
+    {
+        $this->candidates += $rows;
+    }
+
+    /**
+     * Whether an entry at this position may be taken, which it may not be if the read cannot place it.
+     */
+    public function canPlace(?PageCursor $cursor): bool
+    {
+        return $cursor !== null
+            || !$this->isOverfetching();
+    }
+
+    public function add(
+        Entry $entry,
+        ?PageCursor $cursor,
+    ): void {
+        $this->entries[] = $entry;
+        $this->cursor = $cursor ?? $this->cursor;
+    }
+
+    /**
+     * Gives up on reading further from a slice, having taken what it could.
+     */
+    public function abandonSlice(SliceEnd $reason): void
+    {
+        if ($reason === SliceEnd::Unplaceable) {
+            $this->canOverfetch = false;
+        }
+    }
+
+    public function advanceTo(?PageCursor $cursor): void
+    {
+        $this->cursor = $cursor ?? $this->cursor;
+    }
+
+    public function collected(
+        bool $isResultExhausted,
+        bool $hasFurtherMatch,
+    ): CollectedPage {
+        return new CollectedPage(
+            $this->entries,
+            $isResultExhausted,
+            $hasFurtherMatch,
+            $this->cursor,
+        );
+    }
+
+    /**
+     * Candidates to ask for next, scaled by what a match has cost so far once the shortfall proves too narrow.
+     */
+    private function sliceSize(bool $isFilling): int
+    {
+        $shortfall = $this->pageLimit === null
+            ? $this->widestSlice
+            : $this->pageLimit - ($isFilling ? count($this->entries) : 0);
+
+        if (!$isFilling || !$this->isOverfetching()) {
+            return max($shortfall, 1);
+        }
+
+        $placed = count($this->entries);
+        $estimate = $placed > 0
+            ? (int) ceil($shortfall * ($this->candidates / $placed))
+            : $this->widestSlice;
+
+        return max(
+            min($estimate, $this->widestSlice),
+            $shortfall,
+            1,
+        );
+    }
+
+    private function isOverfetching(): bool
+    {
+        return $this->canOverfetch
+            && $this->slices > 1;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Paging/PageFiller.php
+++ b/src/FreeDSx/Ldap/Server/Paging/PageFiller.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Paging;
+
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Protocol\ServerProtocolHandler\AttributeProjection;
+use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerSearchTrait;
+use FreeDSx\Ldap\Schema\Schema;
+use FreeDSx\Ldap\Search\Filter\FilterInterface;
+use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
+use FreeDSx\Ldap\Server\Backend\Storage\FetchedEntry;
+use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Paging\PageCursor;
+use FreeDSx\Ldap\Server\Backend\Storage\Paging\PageSlice;
+use FreeDSx\Ldap\Server\SearchLimits;
+use FreeDSx\Ldap\Server\Token\TokenInterface;
+use Generator;
+
+/**
+ * Fills one page of a paged search from as many bounded reads as it takes.
+ *
+ * @internal
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class PageFiller
+{
+    use ServerSearchTrait;
+
+    public function __construct(
+        private ReadBackendInterface $backend,
+        private FilterEvaluatorInterface $filterEvaluator,
+        private AccessControlInterface $accessControl,
+        private Schema $schema,
+        private SearchLimits $limits = new SearchLimits(),
+    ) {}
+
+    /**
+     * Fills one page from $resumeFrom, reading bounded slices to their end so each says where it stopped.
+     *
+     * @throws OperationException
+     */
+    public function fill(
+        PagingRequest $pagingRequest,
+        TokenInterface $token,
+        ?PageCursor $resumeFrom,
+    ): CollectedPage {
+        $request = $pagingRequest->getSearchRequest();
+        $page = $this->startPage($pagingRequest, $resumeFrom);
+        $budget = $this->budgetFor($request);
+        $projection = $this->projectionFor($request);
+        $exhausted = false;
+        $hasFurtherMatch = false;
+
+        while (!$exhausted) {
+            $isFilling = $page->hasCapacity();
+
+            // A full page only overflows the size limit if a further match exists
+            if (!$isFilling && !$page->mayExceedSizeLimit()) {
+                break;
+            }
+
+            $entries = $this->readSlice(
+                $pagingRequest,
+                $page->nextSlice($isFilling, $budget->deadline()),
+                $budget->remainingLookthrough(),
+            )->fetched();
+
+            $end = $this->collectSlice(
+                $entries,
+                $page,
+                $isFilling,
+                $token,
+                $request->getFilter(),
+                $projection,
+            );
+
+            // The stream was abandoned mid-slice and can say nothing about where it stopped.
+            if ($end === SliceEnd::FurtherMatch) {
+                $hasFurtherMatch = true;
+
+                break;
+            }
+
+            // The page took what it could and resumes from the last entry it placed.
+            if ($end !== SliceEnd::Complete) {
+                $page->abandonSlice($end);
+
+                continue;
+            }
+
+            // A stream that reports nothing cannot be resumed, so the result has to be taken as finished.
+            $read = $entries->getReturn();
+            $exhausted = $read?->isExhausted() ?? true;
+            $page->advanceTo($read?->cursor);
+            $page->readCandidates($read->rows ?? 0);
+            $budget->spend($read->rows ?? 0);
+        }
+
+        return $page->collected($exhausted, $hasFurtherMatch);
+    }
+
+    /**
+     * Adds what this identity may see, reporting why the read stopped.
+     *
+     * @param Generator<int, FetchedEntry, mixed, mixed> $entries
+     * @throws OperationException
+     */
+    private function collectSlice(
+        Generator $entries,
+        FillingPage $page,
+        bool $isFilling,
+        TokenInterface $token,
+        FilterInterface $filter,
+        AttributeProjection $projection,
+    ): SliceEnd {
+        foreach ($entries as $fetched) {
+            $kept = $this->keepForPage(
+                $fetched->entry,
+                $token,
+                $filter,
+            );
+
+            if ($kept === null) {
+                continue;
+            }
+
+            if (!$isFilling) {
+                return SliceEnd::FurtherMatch;
+            }
+
+            if (!$page->hasCapacity()) {
+                return SliceEnd::PageFull;
+            }
+
+            if (!$page->canPlace($fetched->cursor)) {
+                return SliceEnd::Unplaceable;
+            }
+
+            $page->add(
+                $projection->project($kept),
+                $fetched->cursor,
+            );
+        }
+
+        return SliceEnd::Complete;
+    }
+
+    private function startPage(
+        PagingRequest $pagingRequest,
+        ?PageCursor $resumeFrom,
+    ): FillingPage {
+        $sizeLimit = $this->effectiveLimit(
+            $pagingRequest->getSearchRequest()->getSizeLimit(),
+            $this->limits->maxSearchSize(),
+        );
+
+        // Deliberate: the size limit bounds each page rather than the whole paged operation.
+        $collectCap = $this->effectiveLimit(
+            $this->effectiveLimit(
+                $pagingRequest->getSize(),
+                $this->limits->maxSearchPageSize(),
+            ),
+            $sizeLimit,
+        );
+
+        return new FillingPage(
+            $collectCap > 0
+                ? $collectCap
+                : null,
+            $sizeLimit,
+            $this->limits->maxSearchPageSize(),
+            $resumeFrom,
+        );
+    }
+
+    private function budgetFor(SearchRequest $request): PageBudget
+    {
+        return PageBudget::of(
+            $this->effectiveLimit(
+                $request->getTimeLimit(),
+                $this->limits->maxSearchTimeLimit(),
+            ),
+            $this->limits->effectivePagedLookthrough(),
+        );
+    }
+
+    /**
+     * @throws OperationException
+     */
+    private function readSlice(
+        PagingRequest $pagingRequest,
+        PageSlice $slice,
+        int $lookthrough,
+    ): EntryStream {
+        return $this->backend->search(
+            $pagingRequest->getSearchRequest(),
+            $this->subentryVisibility($pagingRequest->controls()),
+            $pagingRequest->controls(),
+            new SearchLimits(
+                maxSearchTimeLimit: $this->limits->maxSearchTimeLimit(),
+                maxSearchLookthrough: $lookthrough,
+            ),
+            $slice,
+        );
+    }
+
+    /**
+     * The entry as this identity may see it, or null when it may not see it at all.
+     *
+     * @throws OperationException
+     */
+    private function keepForPage(
+        Entry $entry,
+        TokenInterface $token,
+        FilterInterface $filter,
+    ): ?Entry {
+        $filtered = $this->accessControl->filterEntry(
+            $token,
+            $entry,
+        );
+
+        if ($filtered === null) {
+            return null;
+        }
+
+        // Stripping an attribute can cost the entry its match, so a changed entry is judged against the filter again.
+        return $filtered !== $entry && !$this->filterEvaluator->evaluate($filtered, $filter)
+            ? null
+            : $filtered;
+    }
+
+    private function projectionFor(SearchRequest $request): AttributeProjection
+    {
+        return AttributeProjection::forRequest(
+            $request->getAttributes(),
+            $request->getAttributesOnly(),
+            $this->schema,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Paging/SliceEnd.php
+++ b/src/FreeDSx/Ldap/Server/Paging/SliceEnd.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Paging;
+
+/**
+ * Why a slice stopped being read. This decides where the next one resumes from.
+ *
+ * @internal
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+enum SliceEnd
+{
+    /**
+     * Read to its end. The read itself says where it stopped.
+     */
+    case Complete;
+
+    /**
+     * A match exists past what the page may hold.
+     */
+    case FurtherMatch;
+
+    /**
+     * The page filled part-way through. The rest of the slice belongs to the next page.
+     */
+    case PageFull;
+
+    /**
+     * A match arrived with no position to resume from. Nothing further may be taken from this read.
+     */
+    case Unplaceable;
+}

--- a/src/FreeDSx/Ldap/Server/SocketServerFactory.php
+++ b/src/FreeDSx/Ldap/Server/SocketServerFactory.php
@@ -74,6 +74,8 @@ class SocketServerFactory
             ->setSslCryptoMethod($this->network->getMinTlsVersion()->toServerCryptoMethod())
             ->setSslCiphers($this->network->getSslCiphers())
             ->setSslValidateCert($this->network->isSslValidateCert())
+            // Swoole does not support populating the peer certificate. Asking for one breaks StartTLS.
+            ->setSslCapturePeerCert($this->runner !== RunnerMode::Swoole)
             ->setSslAllowSelfSigned($this->network->getSslAllowSelfSigned())
             ->setSslCaCert($this->network->getSslCaCert())
             ->setReusePort($this->reusePort);

--- a/src/FreeDSx/Ldap/Server/Subentry/GoverningSubentryResolver.php
+++ b/src/FreeDSx/Ldap/Server/Subentry/GoverningSubentryResolver.php
@@ -132,7 +132,7 @@ final readonly class GoverningSubentryResolver
                 $request,
                 SubentryVisibility::Only,
                 new ControlBag(),
-            )->entries,
+            )->entries(),
             false,
         );
 

--- a/src/FreeDSx/Ldap/Server/Subentry/SubentryPlacementGuard.php
+++ b/src/FreeDSx/Ldap/Server/Subentry/SubentryPlacementGuard.php
@@ -101,7 +101,7 @@ final readonly class SubentryPlacementGuard
             SubentryVisibility::Only,
         ));
 
-        foreach ($stream->entries as $ignored) {
+        foreach ($stream->entries() as $ignored) {
             return true;
         }
 

--- a/src/FreeDSx/Ldap/Sync/Consumer/VerbatimStorageApplier.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/VerbatimStorageApplier.php
@@ -117,7 +117,7 @@ final class VerbatimStorageApplier implements ChangeApplierInterface
         );
 
         $stale = [];
-        foreach ($this->storage->list($options)->entries as $entry) {
+        foreach ($this->storage->list($options)->entries() as $entry) {
             $dn = $entry->getDn()
                 ->normalize();
 
@@ -193,7 +193,7 @@ final class VerbatimStorageApplier implements ChangeApplierInterface
         $wanted = strtolower($uuid);
 
         // Storage answers the filter only where it can, so each candidate is checked rather than trusted.
-        foreach ($this->storage->list($options)->entries as $entry) {
+        foreach ($this->storage->list($options)->entries() as $entry) {
             $candidate = $entry->get(AttributeTypeOid::NAME_ENTRY_UUID)
                 ?->firstValue();
 

--- a/tests/integration/LdapServerTest.php
+++ b/tests/integration/LdapServerTest.php
@@ -21,24 +21,18 @@ use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Entry\Rdn;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\OperationException;
-use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\Response\BindResponse;
-use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operations;
-use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\GeneratedEntry;
 use PHPUnit\Framework\Attributes\DataProvider;
-use Tests\Support\FreeDSx\Ldap\RawClientQueueTrait;
 use Throwable;
 
 final class LdapServerTest extends ServerTestCase
 {
-    use RawClientQueueTrait;
-
     /**
      * The supertype arm is one the index cannot answer, so every candidate reaches the evaluator the limit counts.
      */
@@ -508,64 +502,6 @@ final class LdapServerTest extends ServerTestCase
         $this->assertNotEmpty($result->toArray());
     }
 
-    public function testItCanStartTLSThenStillPerformOperations(): void
-    {
-        $this->ldapClient()->startTls();
-        $result = $this->ldapClient()->read();
-
-        $this->assertNotNull($result);
-    }
-
-    public function testItDiscardsPlaintextPipelinedBehindStartTls(): void
-    {
-        $queue = $this->rawQueue(
-            timeoutRead: 2,
-            validateSslCert: false,
-        );
-
-        // One variadic send buffers both PDUs into a single plaintext write, which is the command-injection shape.
-        $queue->sendMessage(
-            new LdapMessageRequest(1, Operations::extended(ExtendedRequest::OID_START_TLS)),
-            new LdapMessageRequest(2, Operations::whoami()),
-        );
-
-        $startTls = $queue->getMessage(1)->getResponse();
-
-        $this->assertInstanceOf(
-            ExtendedResponse::class,
-            $startTls,
-        );
-        $this->assertSame(
-            ResultCode::SUCCESS,
-            $startTls->getResultCode(),
-        );
-
-        $queue->encrypt();
-        $injected = null;
-
-        try {
-            $injected = $queue->getMessage();
-        } catch (Throwable) {
-            // Nothing to read is the expected outcome; the injected PDU was dropped with the plaintext buffer.
-        } finally {
-            $queue->close();
-        }
-
-        $this->assertNull(
-            $injected,
-            'A PDU pipelined ahead of the upgrade must not be answered over the encrypted channel.',
-        );
-    }
-
-    public function testItCanRunOverSSLOnly(): void
-    {
-        $this->stopServer();
-        $this->createServerProcess('ssl');
-
-        $result = $this->ldapClient()->read('');
-        $this->assertNotNull($result);
-    }
-
     public function testItKeepsAnSSLConnectionAliveWhenALaterConnectionEnds(): void
     {
         $this->stopServer();
@@ -599,58 +535,6 @@ final class LdapServerTest extends ServerTestCase
         $this->assertNotNull($result);
     }
 
-    public function testItRefusesASimpleBindInTheClearWhenConfidentialityIsRequired(): void
-    {
-        $this->stopServer();
-        $this->createServerProcess('tcp', ['--require-confidentiality=bind']);
-
-        try {
-            $this->ldapClient()->bind(
-                'cn=user,dc=foo,dc=bar',
-                '12345',
-            );
-            $this->fail('Expected the bind to be refused.');
-        } catch (BindException $e) {
-            $this->assertSame(
-                ResultCode::CONFIDENTIALITY_REQUIRED,
-                $e->getCode(),
-            );
-        }
-    }
-
-    public function testItAcceptsTheSameBindAfterStartTLS(): void
-    {
-        $this->stopServer();
-        $this->createServerProcess('tcp', ['--require-confidentiality=bind']);
-
-        $this->ldapClient()->startTls();
-        $this->ldapClient()->bind(
-            'cn=user,dc=foo,dc=bar',
-            '12345',
-        );
-
-        $this->assertSame(
-            'dn:cn=user,dc=foo,dc=bar',
-            $this->ldapClient()->whoami(),
-        );
-    }
-
-    public function testItAcceptsABindOverSSLWhenConfidentialityIsRequired(): void
-    {
-        $this->stopServer();
-        $this->createServerProcess('ssl', ['--require-confidentiality=bind']);
-
-        $this->ldapClient()->bind(
-            'cn=user,dc=foo,dc=bar',
-            '12345',
-        );
-
-        $this->assertSame(
-            'dn:cn=user,dc=foo,dc=bar',
-            $this->ldapClient()->whoami(),
-        );
-    }
-
     public function testAUnixSocketSatisfiesTheConfidentialityRequirement(): void
     {
         $this->stopServer();
@@ -681,20 +565,6 @@ final class LdapServerTest extends ServerTestCase
                 $e->getCode(),
             );
         }
-    }
-
-    public function testRequiringAllOperationsStillPermitsStartTLS(): void
-    {
-        $this->stopServer();
-        $this->createServerProcess('tcp', ['--require-confidentiality=all']);
-
-        $this->ldapClient()->startTls();
-        $this->ldapClient()->bind(
-            'cn=user,dc=foo,dc=bar',
-            '12345',
-        );
-
-        $this->assertNotNull($this->ldapClient()->read(''));
     }
 
     public function testAMalformedDnIsAnsweredRatherThanEndingTheSession(): void

--- a/tests/integration/Runner/Concern/TlsTestsTrait.php
+++ b/tests/integration/Runner/Concern/TlsTestsTrait.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Runner\Concern;
+
+use FreeDSx\Ldap\Exception\BindException;
+use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
+use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
+use Tests\Support\FreeDSx\Ldap\RawClientQueueTrait;
+use Throwable;
+
+trait TlsTestsTrait
+{
+    use RawClientQueueTrait;
+
+    public function testItCanStartTLSThenStillPerformOperations(): void
+    {
+        $this->ldapClient()->startTls();
+        $result = $this->ldapClient()->read();
+
+        $this->assertNotNull($result);
+    }
+
+    public function testItDiscardsPlaintextPipelinedBehindStartTls(): void
+    {
+        $queue = $this->rawQueue(
+            timeoutRead: 2,
+            validateSslCert: false,
+        );
+
+        $queue->sendMessage(
+            new LdapMessageRequest(1, Operations::extended(ExtendedRequest::OID_START_TLS)),
+            new LdapMessageRequest(2, Operations::whoami()),
+        );
+
+        $startTls = $queue->getMessage(1)->getResponse();
+
+        $this->assertInstanceOf(
+            ExtendedResponse::class,
+            $startTls,
+        );
+        $this->assertSame(
+            ResultCode::SUCCESS,
+            $startTls->getResultCode(),
+        );
+
+        $queue->encrypt();
+        $injected = null;
+
+        try {
+            $injected = $queue->getMessage();
+        } catch (Throwable) {
+            // Nothing to read is the expected outcome
+            // The injected PDU was dropped with the plaintext buffer.
+        } finally {
+            $queue->close();
+        }
+
+        $this->assertNull(
+            $injected,
+            'A PDU pipelined ahead of the upgrade must not be answered over the encrypted channel.',
+        );
+    }
+
+    public function testItCanRunOverSSLOnly(): void
+    {
+        $this->stopServer();
+        $this->createServerProcess('ssl');
+
+        $result = $this->ldapClient()->read('');
+        $this->assertNotNull($result);
+    }
+
+    public function testItRefusesASimpleBindInTheClearWhenConfidentialityIsRequired(): void
+    {
+        $this->stopServer();
+        $this->createServerProcess('tcp', ['--require-confidentiality=bind']);
+
+        try {
+            $this->ldapClient()->bind(
+                'cn=user,dc=foo,dc=bar',
+                '12345',
+            );
+            $this->fail('Expected the bind to be refused.');
+        } catch (BindException $e) {
+            $this->assertSame(
+                ResultCode::CONFIDENTIALITY_REQUIRED,
+                $e->getCode(),
+            );
+        }
+    }
+
+    public function testItAcceptsTheSameBindAfterStartTLS(): void
+    {
+        $this->stopServer();
+        $this->createServerProcess('tcp', ['--require-confidentiality=bind']);
+
+        $this->ldapClient()->startTls();
+        $this->ldapClient()->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+
+        $this->assertSame(
+            'dn:cn=user,dc=foo,dc=bar',
+            $this->ldapClient()->whoami(),
+        );
+    }
+
+    public function testItAcceptsABindOverSSLWhenConfidentialityIsRequired(): void
+    {
+        $this->stopServer();
+        $this->createServerProcess('ssl', ['--require-confidentiality=bind']);
+
+        $this->ldapClient()->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+
+        $this->assertSame(
+            'dn:cn=user,dc=foo,dc=bar',
+            $this->ldapClient()->whoami(),
+        );
+    }
+
+    public function testRequiringAllOperationsStillPermitsStartTLS(): void
+    {
+        $this->stopServer();
+        $this->createServerProcess('tcp', ['--require-confidentiality=all']);
+
+        $this->ldapClient()->startTls();
+        $this->ldapClient()->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+
+        $this->assertNotNull($this->ldapClient()->read(''));
+    }
+}

--- a/tests/integration/Runner/ServerRunnerPcntlTest.php
+++ b/tests/integration/Runner/ServerRunnerPcntlTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Runner;
+
+/**
+ * Runs the shared runner suite against the PcntlServerRunner.
+ */
+final class ServerRunnerPcntlTest extends ServerRunnerTestCase {}

--- a/tests/integration/Runner/ServerRunnerSwooleTest.php
+++ b/tests/integration/Runner/ServerRunnerSwooleTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Runner;
+
+use function extension_loaded;
+
+/**
+ * Runs the shared runner suite against the Swoole ServerRunner.
+ */
+final class ServerRunnerSwooleTest extends ServerRunnerTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!extension_loaded('swoole')) {
+            return;
+        }
+
+        parent::setUpBeforeClass();
+    }
+
+    public function setUp(): void
+    {
+        $this->requireSwoole();
+
+        parent::setUp();
+    }
+
+    protected static function runnerArgs(): array
+    {
+        return ['--runner=swoole'];
+    }
+}

--- a/tests/integration/Runner/ServerRunnerSwooleTest.php
+++ b/tests/integration/Runner/ServerRunnerSwooleTest.php
@@ -20,15 +20,6 @@ use function extension_loaded;
  */
 final class ServerRunnerSwooleTest extends ServerRunnerTestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        if (!extension_loaded('swoole')) {
-            return;
-        }
-
-        parent::setUpBeforeClass();
-    }
-
     public function setUp(): void
     {
         $this->requireSwoole();
@@ -39,5 +30,10 @@ final class ServerRunnerSwooleTest extends ServerRunnerTestCase
     protected static function runnerArgs(): array
     {
         return ['--runner=swoole'];
+    }
+
+    protected static function isRunnerAvailable(): bool
+    {
+        return extension_loaded('swoole');
     }
 }

--- a/tests/integration/Runner/ServerRunnerTestCase.php
+++ b/tests/integration/Runner/ServerRunnerTestCase.php
@@ -16,6 +16,8 @@ namespace Tests\Integration\FreeDSx\Ldap\Runner;
 use Tests\Integration\FreeDSx\Ldap\Runner\Concern\TlsTestsTrait;
 use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
 
+use function extension_loaded;
+
 /**
  * Behavior that runs against every server runner.
  */
@@ -25,6 +27,9 @@ abstract class ServerRunnerTestCase extends ServerTestCase
 
     public static function setUpBeforeClass(): void
     {
+        if (!static::isRunnerAvailable()) {
+            return;
+        }
         parent::setUpBeforeClass();
 
         static::initSharedServer(
@@ -70,5 +75,14 @@ abstract class ServerRunnerTestCase extends ServerTestCase
     protected static function runnerArgs(): array
     {
         return [];
+    }
+
+    /**
+     * Whether this runner can run here, which the pcntl one cannot without process control.
+     */
+    protected static function isRunnerAvailable(): bool
+    {
+        return extension_loaded('pcntl')
+            && extension_loaded('posix');
     }
 }

--- a/tests/integration/Runner/ServerRunnerTestCase.php
+++ b/tests/integration/Runner/ServerRunnerTestCase.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Integration\FreeDSx\Ldap\Runner;
+
+use Tests\Integration\FreeDSx\Ldap\Runner\Concern\TlsTestsTrait;
+use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+
+/**
+ * Behavior that runs against every server runner.
+ */
+abstract class ServerRunnerTestCase extends ServerTestCase
+{
+    use TlsTestsTrait;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        static::initSharedServer(
+            'ldap-server',
+            'tcp',
+            static::runnerArgs(),
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        static::tearDownSharedServer();
+    }
+
+    public function setUp(): void
+    {
+        $this->setServerMode('ldap-server');
+
+        parent::setUp();
+    }
+
+    /**
+     * Appends the runner selection to every server this suite starts, including the per-test ones.
+     *
+     * @param list<string> $extraArgs
+     */
+    protected function createServerProcess(
+        string $transport,
+        array $extraArgs = [],
+    ): void {
+        parent::createServerProcess(
+            $transport,
+            [...$extraArgs, ...static::runnerArgs()],
+        );
+    }
+
+    /**
+     * Hook for subclasses to name the runner the server runs under.
+     *
+     * @return list<string>
+     */
+    protected static function runnerArgs(): array
+    {
+        return [];
+    }
+}

--- a/tests/integration/Storage/LdapReindexTestCase.php
+++ b/tests/integration/Storage/LdapReindexTestCase.php
@@ -128,7 +128,7 @@ abstract class LdapReindexTestCase extends TestCase
             baseDn: new Dn('dc=foo,dc=bar'),
             subtree: true,
             filter: $filter,
-        ))->entries;
+        ))->entries();
 
         $dns = [];
         foreach ($entries as $entry) {

--- a/tests/support/Storage/SubtreeRenameStorageContractTests.php
+++ b/tests/support/Storage/SubtreeRenameStorageContractTests.php
@@ -195,7 +195,7 @@ trait SubtreeRenameStorageContractTests
         $dns = [];
 
         $stream = $storage->list(StorageListOptions::matchAll(new Dn($baseDn), false));
-        foreach ($stream->entries as $entry) {
+        foreach ($stream->entries() as $entry) {
             $dns[] = $entry->getDn()->toString();
         }
         sort($dns);

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap;
 
 use FreeDSx\Ldap\Server\Config\ReplicationConfig;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
 use FreeDSx\Ldap\Server\Config\RunnerConfig;
 use FreeDSx\Ldap\Server\Config\Storage\InMemoryStorageConfig;
 use FreeDSx\Ldap\Server\Config\Storage\PdoConfig;
@@ -63,6 +64,7 @@ use FreeDSx\Ldap\ProxyServerOptions;
 use FreeDSx\Ldap\Server\Proxy\ProxyProtocolFactory;
 use FreeDSx\Ldap\Server\ServerProtocolFactory;
 use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
+use FreeDSx\Ldap\Server\ServerRunner\PcntlServerRunner;
 use FreeDSx\Ldap\Server\ServerRunner\ServerRunnerInterface;
 use FreeDSx\Ldap\Server\ServerRunner\Swoole\PooledServerRunner;
 use FreeDSx\Ldap\Server\ServerRunner\Swoole\ServerRunner as SwooleServerRunner;
@@ -362,6 +364,52 @@ class ContainerTest extends TestCase
 
         self::assertInstanceOf(
             SwooleServerRunner::class,
+            $container->get(ServerRunnerInterface::class),
+        );
+    }
+
+    public function test_the_swoole_runner_is_refused_when_client_certificate_validation_is_on(): void
+    {
+        $this->requireSwoole();
+
+        $container = $this->containerFor(
+            (TestServerOptions::defaults())
+                ->setRunnerConfig(new RunnerConfig(RunnerMode::Swoole))
+                ->setNetworkConfig((new NetworkConfig())->setSslValidateCert(true)),
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The Swoole runner cannot verify client certificates.');
+
+        $container->get(ServerRunnerInterface::class);
+    }
+
+    public function test_the_swoole_runner_is_refused_when_external_sasl_is_offered(): void
+    {
+        $this->requireSwoole();
+
+        $container = $this->containerFor(
+            (TestServerOptions::defaults())
+                ->setRunnerConfig(new RunnerConfig(RunnerMode::Swoole))
+                ->setSaslMechanisms(ServerOptions::SASL_EXTERNAL),
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The Swoole runner cannot support the EXTERNAL SASL mechanism.');
+
+        $container->get(ServerRunnerInterface::class);
+    }
+
+    public function test_the_pcntl_runner_accepts_client_certificate_validation(): void
+    {
+        $container = $this->containerFor(
+            TestServerOptions::forStorage($this->sharedStorage())
+                ->setNetworkConfig((new NetworkConfig())->setSslValidateCert(true))
+                ->setSaslMechanisms(ServerOptions::SASL_EXTERNAL),
+        );
+
+        self::assertInstanceOf(
+            PcntlServerRunner::class,
             $container->get(ServerRunnerInterface::class),
         );
     }

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -252,9 +252,8 @@ class ContainerTest extends TestCase
 
     public function test_it_should_make_the_default_ServerRunner(): void
     {
-        if (str_starts_with(strtoupper(PHP_OS), 'WIN')) {
-            self::markTestSkipped('Cannot construct the default PCNTL runner on Windows.');
-        }
+        $this->requirePcntl();
+        $this->requirePosix();
 
         // Shared storage, since the forking runner refuses anything a fork would not carry.
         $container = $this->containerFor(TestServerOptions::forStorage($this->sharedStorage()));
@@ -325,9 +324,8 @@ class ContainerTest extends TestCase
 
     public function test_the_pcntl_runner_builds_with_journaling_and_retention_configured(): void
     {
-        if (str_starts_with(strtoupper(PHP_OS), 'WIN')) {
-            self::markTestSkipped('Cannot construct the default PCNTL runner on Windows.');
-        }
+        $this->requirePcntl();
+        $this->requirePosix();
 
         $container = $this->containerFor($this->journalingOptions());
 
@@ -402,6 +400,9 @@ class ContainerTest extends TestCase
 
     public function test_the_pcntl_runner_accepts_client_certificate_validation(): void
     {
+        $this->requirePcntl();
+        $this->requirePosix();
+
         $container = $this->containerFor(
             TestServerOptions::forStorage($this->sharedStorage())
                 ->setNetworkConfig((new NetworkConfig())->setSslValidateCert(true))

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPagingHandlerTest.php
@@ -38,8 +38,10 @@ use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStream;
 use FreeDSx\Ldap\Server\Backend\Storage\FetchedBatch;
+use FreeDSx\Ldap\Server\Backend\Storage\FetchedEntry;
 use FreeDSx\Ldap\Server\Backend\Storage\Paging\PageCursor;
 use FreeDSx\Ldap\Server\Backend\Storage\Paging\PageSlice;
+use FreeDSx\Ldap\Server\Paging\PageFiller;
 use FreeDSx\Ldap\Server\Paging\PagingRequest;
 use FreeDSx\Ldap\Server\RequestHistory;
 use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
@@ -108,13 +110,7 @@ class ServerPagingHandlerTest extends TestCase
                 return $this->mockQueue;
             });
 
-        $this->subject = new ServerPagingHandler(
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $this->mockAccessControl,
-            requestHistory: $this->requestHistory,
-            schema: $this->schema,
-        );
+        $this->subject = $this->makeHandler();
     }
 
     public function test_a_page_is_filled_past_entries_access_control_hides(): void
@@ -138,13 +134,7 @@ class ServerPagingHandlerTest extends TestCase
                 $visible,
             ));
 
-        $subject = new ServerPagingHandler(
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $mockAccessControl,
-            requestHistory: $this->requestHistory,
-            schema: $this->schema,
-        );
+        $subject = $this->makeHandler($mockAccessControl);
 
         // A page of one, whose first candidate is hidden, so filling it means reading on rather than answering short.
         $this->drive(
@@ -154,6 +144,68 @@ class ServerPagingHandlerTest extends TestCase
 
         self::assertEquals(
             [new LdapMessageResponse(2, new SearchResultEntry($visible))],
+            $this->entryMessages(),
+        );
+    }
+
+    public function test_a_page_filled_part_way_through_a_read_resumes_from_the_last_entry_it_took(): void
+    {
+        $entries = [];
+        for ($i = 1; $i <= 10; $i++) {
+            $entries[] = Entry::create("cn=$i,dc=foo,dc=bar", ['cn' => (string) $i]);
+        }
+
+        // Hiding the first two starves the opening read, so the next one is widened and overshoots the page.
+        $mockAccessControl = $this->createMock(AccessControlInterface::class);
+        $mockAccessControl
+            ->method('filterEntry')
+            ->willReturnCallback(
+                static fn(TokenInterface $token, Entry $entry): ?Entry => in_array(
+                    $entry,
+                    [$entries[0], $entries[1]],
+                    true,
+                )
+                    ? null
+                    : $entry,
+            );
+
+        $this->mockBackend
+            ->method('search')
+            ->willReturnCallback($this->sliceAware(...$entries));
+
+        $subject = $this->makeHandler(
+            $mockAccessControl,
+            new SearchLimits(maxSearchPageSize: 10),
+        );
+
+        $this->drive($subject, $this->makeSearchMessage(size: 2));
+
+        self::assertEquals(
+            [
+                new LdapMessageResponse(2, new SearchResultEntry($entries[2])),
+                new LdapMessageResponse(2, new SearchResultEntry($entries[3])),
+            ],
+            $this->entryMessages(),
+        );
+
+        $cookie = $this->donePagingControl()->getCookie();
+        $pagingRequest = $this->requestHistory->pagingRequest()->findByNextCookie($cookie);
+        $this->sentMessages = [];
+
+        $this->drive(
+            $subject,
+            $this->makeSearchMessage(
+                size: 2,
+                cookie: $cookie,
+                searchRequest: $pagingRequest->getSearchRequest(),
+            ),
+        );
+
+        self::assertEquals(
+            [
+                new LdapMessageResponse(2, new SearchResultEntry($entries[4])),
+                new LdapMessageResponse(2, new SearchResultEntry($entries[5])),
+            ],
             $this->entryMessages(),
         );
     }
@@ -393,14 +445,7 @@ class ServerPagingHandlerTest extends TestCase
             ->method('search')
             ->willReturnCallback($this->sliceAware($entry1, $entry2, $entry3));
 
-        $subject = new ServerPagingHandler(
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $this->mockAccessControl,
-            requestHistory: $this->requestHistory,
-            schema: $this->schema,
-            limits: new SearchLimits(maxSearchPageSize: 1),
-        );
+        $subject = $this->makeHandler(limits: new SearchLimits(maxSearchPageSize: 1));
         $this->drive($subject, $this->makeSearchMessage(size: 1));
 
         $cookie = $this->donePagingControl()->getCookie();
@@ -464,13 +509,9 @@ class ServerPagingHandlerTest extends TestCase
             ->method('filterEntry')
             ->willReturn(null);
 
-        $subject = new ServerPagingHandler(
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $mockAccessControl,
-            requestHistory: $this->requestHistory,
-            schema: $this->schema,
-            limits: new SearchLimits(maxSearchPageSize: 2),
+        $subject = $this->makeHandler(
+            $mockAccessControl,
+            new SearchLimits(maxSearchPageSize: 2),
         );
         $this->drive($subject, $this->makeSearchMessage(size: 2, searchRequest: $searchRequest));
 
@@ -573,14 +614,7 @@ class ServerPagingHandlerTest extends TestCase
             ->method('search')
             ->willReturnCallback($this->sliceAware($entry1, $entry2));
 
-        $subject = new ServerPagingHandler(
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $this->mockAccessControl,
-            requestHistory: $this->requestHistory,
-            schema: $this->schema,
-            limits: new SearchLimits(maxSearchSize: 1),
-        );
+        $subject = $this->makeHandler(limits: new SearchLimits(maxSearchSize: 1));
         $this->drive($subject, $message);
 
         self::assertEquals(
@@ -602,14 +636,7 @@ class ServerPagingHandlerTest extends TestCase
                 Entry::create('cn=2,dc=foo,dc=bar', ['cn' => '2']),
             ));
 
-        $subject = new ServerPagingHandler(
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $this->mockAccessControl,
-            requestHistory: $this->requestHistory,
-            schema: $this->schema,
-            limits: new SearchLimits(maxPagingSessions: 2),
-        );
+        $subject = $this->makeHandler(limits: new SearchLimits(maxPagingSessions: 2));
 
         // Each leaves a page outstanding, so none of them completes and releases its slot.
         $this->drive($subject, $this->makeSearchMessage(size: 1));
@@ -639,14 +666,7 @@ class ServerPagingHandlerTest extends TestCase
                 Entry::create('cn=1,dc=foo,dc=bar', ['cn' => '1']),
             ));
 
-        $subject = new ServerPagingHandler(
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $this->mockAccessControl,
-            requestHistory: $this->requestHistory,
-            schema: $this->schema,
-            limits: new SearchLimits(maxPagingSessions: 2),
-        );
+        $subject = $this->makeHandler(limits: new SearchLimits(maxPagingSessions: 2));
 
         // A page larger than the result set finishes the search outright.
         $this->drive($subject, $this->makeSearchMessage(size: 10));
@@ -669,14 +689,7 @@ class ServerPagingHandlerTest extends TestCase
                 Entry::create('cn=2,dc=foo,dc=bar', ['cn' => '2']),
             ));
 
-        $subject = new ServerPagingHandler(
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $this->mockAccessControl,
-            requestHistory: $this->requestHistory,
-            schema: $this->schema,
-            limits: new SearchLimits(maxPagingSessions: 2),
-        );
+        $subject = $this->makeHandler(limits: new SearchLimits(maxPagingSessions: 2));
 
         $this->drive($subject, $this->makeSearchMessage(size: 1));
         $cookie = $this->donePagingControl()->getCookie();
@@ -700,14 +713,7 @@ class ServerPagingHandlerTest extends TestCase
                 Entry::create('cn=2,dc=foo,dc=bar', ['cn' => '2']),
             ));
 
-        $subject = new ServerPagingHandler(
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $this->mockAccessControl,
-            requestHistory: $this->requestHistory,
-            schema: $this->schema,
-            limits: new SearchLimits(maxPagingSessions: 0),
-        );
+        $subject = $this->makeHandler(limits: new SearchLimits(maxPagingSessions: 0));
 
         $this->drive($subject, $this->makeSearchMessage(size: 1));
         $this->drive($subject, $this->makeSearchMessage(size: 1));
@@ -730,14 +736,7 @@ class ServerPagingHandlerTest extends TestCase
             ->method('search')
             ->willReturnCallback($this->sliceAware($entry1, $entry2));
 
-        $subject = new ServerPagingHandler(
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $this->mockAccessControl,
-            requestHistory: $this->requestHistory,
-            schema: $this->schema,
-            limits: new SearchLimits(maxSearchPageSize: 1),
-        );
+        $subject = $this->makeHandler(limits: new SearchLimits(maxSearchPageSize: 1));
         $this->drive($subject, $message);
 
         // Only 1 entry returned despite client requesting page size 10.
@@ -762,14 +761,7 @@ class ServerPagingHandlerTest extends TestCase
             ->method('search')
             ->willReturnCallback($this->sliceAware($entry1, $entry2, $entry3));
 
-        $subject = new ServerPagingHandler(
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $this->mockAccessControl,
-            requestHistory: $this->requestHistory,
-            schema: $this->schema,
-            limits: new SearchLimits(maxSearchPageSize: 2),
-        );
+        $subject = $this->makeHandler(limits: new SearchLimits(maxSearchPageSize: 2));
         $this->drive($subject, $message);
 
         // Server applies its max of 2 entries per page.
@@ -789,14 +781,7 @@ class ServerPagingHandlerTest extends TestCase
             ->method('search')
             ->willReturnCallback($this->sliceAware($entry1, $entry2));
 
-        $subject = new ServerPagingHandler(
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $this->mockAccessControl,
-            requestHistory: $this->requestHistory,
-            schema: $this->schema,
-            limits: new SearchLimits(maxSearchPageSize: 5),
-        );
+        $subject = $this->makeHandler(limits: new SearchLimits(maxSearchPageSize: 5));
         $this->drive($subject, $message);
 
         // Client requested 1 per page; server max is 5 — client's lower value wins.
@@ -833,13 +818,7 @@ class ServerPagingHandlerTest extends TestCase
                 $entry2,
             ));
 
-        $subject = new ServerPagingHandler(
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $mockAccessControl,
-            requestHistory: $this->requestHistory,
-            schema: $this->schema,
-        );
+        $subject = $this->makeHandler($mockAccessControl);
         $this->drive($subject, $message);
 
         self::assertEquals(
@@ -874,12 +853,9 @@ class ServerPagingHandlerTest extends TestCase
             ->method('search')
             ->willReturnCallback($this->sliceAware($entry));
 
-        $subject = new ServerPagingHandler(
-            backend: $this->mockBackend,
+        $subject = $this->makeHandler(
+            $mockAccessControl,
             filterEvaluator: $mockFilterEvaluator,
-            accessControl: $mockAccessControl,
-            requestHistory: $this->requestHistory,
-            schema: $this->schema,
         );
         $this->drive($subject, $message);
 
@@ -1130,13 +1106,7 @@ class ServerPagingHandlerTest extends TestCase
             ->method('filterEntry')
             ->willReturn(null);
 
-        $subject = new ServerPagingHandler(
-            backend: $this->mockBackend,
-            filterEvaluator: $this->mockFilterEvaluator,
-            accessControl: $mockAccessControl,
-            requestHistory: $this->requestHistory,
-            schema: $this->schema,
-        );
+        $subject = $this->makeHandler($mockAccessControl);
 
         $this->drive(
             $subject,
@@ -1170,6 +1140,30 @@ class ServerPagingHandlerTest extends TestCase
         );
     }
 
+    private function makeHandler(
+        ?AccessControlInterface $accessControl = null,
+        ?SearchLimits $limits = null,
+        ?FilterEvaluatorInterface $filterEvaluator = null,
+    ): ServerPagingHandler {
+        $accessControl ??= $this->mockAccessControl;
+        $limits ??= new SearchLimits();
+
+        return new ServerPagingHandler(
+            backend: $this->mockBackend,
+            accessControl: $accessControl,
+            requestHistory: $this->requestHistory,
+            schema: $this->schema,
+            pageFiller: new PageFiller(
+                $this->mockBackend,
+                $filterEvaluator ?? $this->mockFilterEvaluator,
+                $accessControl,
+                $this->schema,
+                $limits,
+            ),
+            limits: $limits,
+        );
+    }
+
     /**
      * A search that honours the slice the way real storage does, keying entries by their position.
      *
@@ -1177,7 +1171,7 @@ class ServerPagingHandlerTest extends TestCase
      */
     private function sliceAware(Entry ...$entries): callable
     {
-        return fn(mixed ...$args): EntryStream => new EntryStream($this->sliceOf(
+        return fn(mixed ...$args): EntryStream => EntryStream::positioned($this->sliceOf(
             array_values($entries),
             array_values(array_filter(
                 $args,
@@ -1188,7 +1182,7 @@ class ServerPagingHandlerTest extends TestCase
 
     /**
      * @param list<Entry> $entries
-     * @return Generator<int, Entry, mixed, FetchedBatch>
+     * @return Generator<int, FetchedEntry, mixed, FetchedBatch>
      */
     private function sliceOf(
         array $entries,
@@ -1215,7 +1209,7 @@ class ServerPagingHandlerTest extends TestCase
             $taken++;
             $cursor = PageCursor::afterEntry($key);
 
-            yield $entry;
+            yield new FetchedEntry($entry, $cursor);
         }
 
         return new FetchedBatch(

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
@@ -116,7 +116,7 @@ final class ServerSearchHandlerTest extends TestCase
             ->expects(self::once())
             ->method('search')
             ->with(self::isInstanceOf(SearchRequest::class))
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
+            ->willReturn(EntryStream::of($this->makeGenerator($entry1, $entry2)));
 
         $this->mockFilterEvaluator
             ->method('evaluate')
@@ -208,7 +208,7 @@ final class ServerSearchHandlerTest extends TestCase
     {
         $this->mockBackend
             ->method('search')
-            ->willReturnCallback(fn(): EntryStream => new EntryStream($this->makeGenerator()));
+            ->willReturnCallback(fn(): EntryStream => EntryStream::of($this->makeGenerator()));
 
         foreach (SearchRequest::SUPPORTED_SCOPES as $scope) {
             $result = $this->drive(
@@ -243,7 +243,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry)));
+            ->willReturn(EntryStream::of($this->makeGenerator($entry)));
 
         $this->mockFilterEvaluator
             ->method('evaluate')
@@ -305,7 +305,7 @@ final class ServerSearchHandlerTest extends TestCase
         $this->mockBackend
             ->expects(self::once())
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
+            ->willReturn(EntryStream::of($this->makeGenerator($entry1, $entry2)));
 
         $this->mockFilterEvaluator
             ->method('evaluate')
@@ -336,7 +336,7 @@ final class ServerSearchHandlerTest extends TestCase
         $this->mockBackend
             ->expects(self::once())
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry1)));
+            ->willReturn(EntryStream::of($this->makeGenerator($entry1)));
 
         $this->mockFilterEvaluator
             ->method('evaluate')
@@ -365,7 +365,7 @@ final class ServerSearchHandlerTest extends TestCase
         $this->mockBackend
             ->expects(self::once())
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
+            ->willReturn(EntryStream::of($this->makeGenerator($entry1, $entry2)));
 
         $this->mockFilterEvaluator
             ->method('evaluate')
@@ -394,7 +394,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
+            ->willReturn(EntryStream::of($this->makeGenerator($entry1, $entry2)));
 
         $this->mockFilterEvaluator
             ->method('evaluate')
@@ -426,7 +426,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
+            ->willReturn(EntryStream::of($this->makeGenerator($entry1, $entry2)));
 
         $this->mockFilterEvaluator
             ->method('evaluate')
@@ -458,7 +458,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry1, $entry2)));
+            ->willReturn(EntryStream::of($this->makeGenerator($entry1, $entry2)));
 
         $this->mockFilterEvaluator
             ->method('evaluate')
@@ -486,7 +486,7 @@ final class ServerSearchHandlerTest extends TestCase
         $this->mockBackend
             ->expects(self::once())
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator()));
+            ->willReturn(EntryStream::of($this->makeGenerator()));
 
         $this->drive(
             $this->subject,
@@ -526,7 +526,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator(
+            ->willReturn(EntryStream::of($this->makeGenerator(
                 $entry1,
                 $entry2,
             )));
@@ -570,7 +570,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry)));
+            ->willReturn(EntryStream::of($this->makeGenerator($entry)));
 
         $this->mockFilterEvaluator
             ->method('evaluate')
@@ -603,7 +603,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator(...$entries)));
+            ->willReturn(EntryStream::of($this->makeGenerator(...$entries)));
 
         $this->mockFilterEvaluator
             ->method('evaluate')
@@ -639,7 +639,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator(...$entries)));
+            ->willReturn(EntryStream::of($this->makeGenerator(...$entries)));
 
         $this->mockFilterEvaluator
             ->method('evaluate')
@@ -682,7 +682,7 @@ final class ServerSearchHandlerTest extends TestCase
         $this->mockBackend
             ->expects(self::once())
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator()));
+            ->willReturn(EntryStream::of($this->makeGenerator()));
 
         $this->drive(
             $this->subject,
@@ -707,7 +707,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator()));
+            ->willReturn(EntryStream::of($this->makeGenerator()));
 
         $this->drive(
             $this->subject,
@@ -737,7 +737,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator()));
+            ->willReturn(EntryStream::of($this->makeGenerator()));
 
         $this->drive(
             $this->subject,
@@ -774,7 +774,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator()));
+            ->willReturn(EntryStream::of($this->makeGenerator()));
 
         $this->drive(
             $this->subject,
@@ -800,7 +800,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator()));
+            ->willReturn(EntryStream::of($this->makeGenerator()));
 
         $this->drive(
             $this->subject,
@@ -823,7 +823,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator()));
+            ->willReturn(EntryStream::of($this->makeGenerator()));
 
         $this->drive(
             $this->subject,
@@ -849,7 +849,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator()));
+            ->willReturn(EntryStream::of($this->makeGenerator()));
 
         $this->drive(
             $this->subject,
@@ -875,7 +875,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator()));
+            ->willReturn(EntryStream::of($this->makeGenerator()));
 
         $this->drive(
             $this->subject,
@@ -947,7 +947,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator($entry)));
+            ->willReturn(EntryStream::of($this->makeGenerator($entry)));
         $this->mockFilterEvaluator
             ->method('evaluate')
             ->willReturn(true);
@@ -972,7 +972,7 @@ final class ServerSearchHandlerTest extends TestCase
 
         $this->mockBackend
             ->method('search')
-            ->willReturn(new EntryStream($this->makeGenerator()));
+            ->willReturn(EntryStream::of($this->makeGenerator()));
 
         $this->drive(
             $this->subject,

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSyncHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSyncHandlerTest.php
@@ -133,7 +133,7 @@ final class ServerSyncHandlerTest extends TestCase
             ->willReturnCallback(fn(): bool => $this->filterMatches);
         $this->backend
             ->method('search')
-            ->willReturnCallback(fn(): EntryStream => new EntryStream($this->stream(...$this->searchEntries)));
+            ->willReturnCallback(fn(): EntryStream => EntryStream::of($this->stream(...$this->searchEntries)));
         $this->backend
             ->method('get')
             ->willReturnCallback(fn(Dn $dn): ?Entry => $this->liveEntries[$dn->toString()] ?? null);

--- a/tests/unit/Server/Backend/Storage/Adapter/InMemoryStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/InMemoryStorageTest.php
@@ -132,7 +132,7 @@ final class InMemoryStorageTest extends TestCase
 
     public function test_list_returns_all_entries(): void
     {
-        $entries = iterator_to_array($this->subject->list(StorageListOptions::matchAll(new Dn(''), true))->entries);
+        $entries = iterator_to_array($this->subject->list(StorageListOptions::matchAll(new Dn(''), true))->entries());
 
         self::assertCount(
             1,
@@ -151,7 +151,7 @@ final class InMemoryStorageTest extends TestCase
         $grandchild = new Entry(new Dn('cn=Sub,cn=Bob,dc=example,dc=com'), new Attribute('cn', 'Sub'));
         $storage = new InMemoryStorage([$parent, $child, $grandchild]);
 
-        $entries = iterator_to_array($storage->list(StorageListOptions::matchAll(new Dn('dc=example,dc=com'), false))->entries);
+        $entries = iterator_to_array($storage->list(StorageListOptions::matchAll(new Dn('dc=example,dc=com'), false))->entries());
 
         self::assertCount(
             1,
@@ -174,7 +174,7 @@ final class InMemoryStorageTest extends TestCase
             $storage->list(StorageListOptions::matchAll(
                 new Dn('dc=example,dc=com'),
                 true,
-            ))->entries,
+            ))->entries(),
         );
 
         $dns = array_map(
@@ -214,7 +214,7 @@ final class InMemoryStorageTest extends TestCase
         $entries = iterator_to_array($storage->list(StorageListOptions::matchAll(
             new Dn('John,dc=example,dc=com'),
             true,
-        ))->entries);
+        ))->entries());
 
         self::assertCount(
             0,
@@ -277,7 +277,7 @@ final class InMemoryStorageTest extends TestCase
                         new Dn(''),
                         true,
                     ),
-                )->entries,
+                )->entries(),
             ),
         );
     }
@@ -296,7 +296,7 @@ final class InMemoryStorageTest extends TestCase
 
         self::assertCount(
             0,
-            iterator_to_array($storage->list(StorageListOptions::matchAll(new Dn(''), true))->entries),
+            iterator_to_array($storage->list(StorageListOptions::matchAll(new Dn(''), true))->entries()),
         );
     }
 
@@ -310,7 +310,7 @@ final class InMemoryStorageTest extends TestCase
             $storage->list(StorageListOptions::matchAll(
                 new Dn('dc=example,dc=com'),
                 true,
-            ))->entries,
+            ))->entries(),
         );
 
         self::assertCount(2, $entries);
@@ -327,7 +327,7 @@ final class InMemoryStorageTest extends TestCase
                 new Dn('dc=example,dc=com'),
                 true,
                 deadline: microtime(true) + 60,
-            ))->entries,
+            ))->entries(),
         );
 
         self::assertCount(2, $entries);

--- a/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/PdoStorageTest.php
@@ -128,7 +128,7 @@ final class PdoStorageTest extends TestCase
             subtree: true,
             filter: Filters::present('sn'),
             sortKeys: [new SortKey('sn')],
-        ))->entries);
+        ))->entries());
 
         self::assertSame(
             ['cn=spaced, dc=example,dc=com', 'cn=plain,dc=example,dc=com'],
@@ -161,7 +161,7 @@ final class PdoStorageTest extends TestCase
                 subtree: true,
                 filter: Filters::equal('sn', 'x'),
                 maxEntries: $maxEntries,
-            ))->entries);
+            ))->entries());
         }
 
         self::assertCount(
@@ -183,7 +183,7 @@ final class PdoStorageTest extends TestCase
             subtree: true,
             filter: Filters::equal('sn', 'x'),
             attributes: [],
-        ))->entries);
+        ))->entries());
 
         self::assertCount(
             1,
@@ -368,7 +368,7 @@ final class PdoStorageTest extends TestCase
             baseDn: new Dn('dc=example,dc=com'),
             subtree: true,
             filter: Filters::equal('pwdChangedTime', '20260101120000Z'),
-        ))->entries);
+        ))->entries());
 
         self::assertCount(1, $entries);
     }
@@ -500,7 +500,7 @@ final class PdoStorageTest extends TestCase
             baseDn: new Dn('dc=example,dc=com'),
             subtree: true,
             filter: Filters::contains('sn', 'needle'),
-        ))->entries);
+        ))->entries());
 
         self::assertSame(
             ['cn=late,dc=example,dc=com'],
@@ -533,7 +533,7 @@ final class PdoStorageTest extends TestCase
             baseDn: new Dn('dc=example,dc=com'),
             subtree: true,
             filter: Filters::contains('sn', 'needle'),
-        ))->entries);
+        ))->entries());
 
         self::assertSame(
             ['cn=hit,dc=example,dc=com'],
@@ -812,7 +812,7 @@ final class PdoStorageTest extends TestCase
         $results = iterator_to_array($this->subject->search(
             $request,
             SubentryVisibility::All,
-        )->entries);
+        )->entries());
 
         self::assertCount(1, $results);
         self::assertSame(
@@ -832,7 +832,7 @@ final class PdoStorageTest extends TestCase
         $results = iterator_to_array($this->subject->search(
             $request,
             SubentryVisibility::All,
-        )->entries);
+        )->entries());
 
         $dns = array_map(
             static fn(Entry $entry): string => $entry->getDn()->toString(),
@@ -861,7 +861,7 @@ final class PdoStorageTest extends TestCase
     {
         // Test the storage interface directly with an empty base DN (root listing).
         // StorageReadBackend requires the base DN to exist, so bypass it here.
-        $results = iterator_to_array($this->storage->list(StorageListOptions::matchAll(new Dn(''), true))->entries);
+        $results = iterator_to_array($this->storage->list(StorageListOptions::matchAll(new Dn(''), true))->entries());
 
         self::assertCount(2, $results);
     }
@@ -882,7 +882,7 @@ final class PdoStorageTest extends TestCase
                 subtree: true,
                 filter: new AndFilter(),
                 attributes: ['cn'],
-            ))->entries,
+            ))->entries(),
             'cn=narrow,dc=example,dc=com',
         );
 
@@ -911,7 +911,7 @@ final class PdoStorageTest extends TestCase
                 baseDn: new Dn(''),
                 subtree: true,
                 filter: new AndFilter(),
-            ))->entries,
+            ))->entries(),
             'cn=full,dc=example,dc=com',
         );
 
@@ -935,7 +935,7 @@ final class PdoStorageTest extends TestCase
         $outerIterator = $this->storage->list(StorageListOptions::matchAll(
             new Dn('dc=example,dc=com'),
             true,
-        ))->entries;
+        ))->entries();
 
         $outerIterator->current();
         $outerIterator->next();
@@ -943,7 +943,7 @@ final class PdoStorageTest extends TestCase
         $inner = iterator_to_array($this->storage->list(StorageListOptions::matchAll(
             new Dn('dc=example,dc=com'),
             true,
-        ))->entries);
+        ))->entries());
 
         $remaining = [];
         while ($outerIterator->valid()) {
@@ -1060,7 +1060,7 @@ final class PdoStorageTest extends TestCase
         $results = iterator_to_array($this->subject->search(
             $request,
             SubentryVisibility::All,
-        )->entries);
+        )->entries());
 
         self::assertCount(1, $results);
         self::assertSame(
@@ -1086,7 +1086,7 @@ final class PdoStorageTest extends TestCase
         iterator_to_array($backend->search(
             $request,
             SubentryVisibility::All,
-        )->entries);
+        )->entries());
     }
 
     public function test_search_exact_filter_within_the_lookthrough_limit_returns_every_match(): void
@@ -1109,7 +1109,7 @@ final class PdoStorageTest extends TestCase
             iterator_to_array($backend->search(
                 $request,
                 SubentryVisibility::All,
-            )->entries),
+            )->entries()),
         );
     }
 
@@ -1133,7 +1133,7 @@ final class PdoStorageTest extends TestCase
         iterator_to_array($backend->search(
             $request,
             SubentryVisibility::All,
-        )->entries);
+        )->entries());
     }
 
     public function test_atomic_rolls_back_on_exception(): void
@@ -1383,7 +1383,7 @@ final class PdoStorageTest extends TestCase
         $this->expectException(StorageIoException::class);
 
         iterator_to_array(
-            $storage->list(StorageListOptions::matchAll(new Dn('dc=example,dc=com'), false))->entries,
+            $storage->list(StorageListOptions::matchAll(new Dn('dc=example,dc=com'), false))->entries(),
         );
     }
 
@@ -1452,7 +1452,7 @@ final class PdoStorageTest extends TestCase
         iterator_to_array($backend->search(
             $request,
             SubentryVisibility::All,
-        )->entries);
+        )->entries());
     }
 
     public function test_subtree_includes_entries_with_escaped_comma_under_correct_parent(): void
@@ -1475,7 +1475,7 @@ final class PdoStorageTest extends TestCase
         $results = iterator_to_array($backend->search(
             $request,
             SubentryVisibility::All,
-        )->entries);
+        )->entries());
 
         self::assertCount(2, $results);
     }
@@ -1758,7 +1758,7 @@ final class PdoStorageTest extends TestCase
             baseDn: new Dn('dc=example,dc=com'),
             subtree: true,
             filter: $filter,
-        ))->entries;
+        ))->entries();
 
         $dns = [];
         foreach ($entries as $entry) {
@@ -1801,7 +1801,7 @@ final class PdoStorageTest extends TestCase
             ->useSubtreeScope();
 
         $dns = [];
-        foreach ($this->subject->search($request, SubentryVisibility::All)->entries as $entry) {
+        foreach ($this->subject->search($request, SubentryVisibility::All)->entries() as $entry) {
             $dns[] = $entry->getDn()->toString();
         }
 

--- a/tests/unit/Server/Backend/Storage/Adapter/SubstringIndex/Fts5SubstringIndexTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/SubstringIndex/Fts5SubstringIndexTest.php
@@ -124,7 +124,7 @@ final class Fts5SubstringIndexTest extends TestCase
         ));
 
         $dns = [];
-        foreach ($stream->entries as $entry) {
+        foreach ($stream->entries() as $entry) {
             $dns[] = $entry->getDn()->toString();
         }
 

--- a/tests/unit/Server/Backend/Storage/Adapter/WriteSerializingStorageTest.php
+++ b/tests/unit/Server/Backend/Storage/Adapter/WriteSerializingStorageTest.php
@@ -108,7 +108,7 @@ final class WriteSerializingStorageTest extends TestCase
             baseDn: new Dn('dc=example,dc=com'),
             subtree: true,
         );
-        $stream = new EntryStream(
+        $stream = EntryStream::of(
             (function (): Generator {
                 yield from [];
 

--- a/tests/unit/Server/Backend/Storage/Export/DirectoryDumperTest.php
+++ b/tests/unit/Server/Backend/Storage/Export/DirectoryDumperTest.php
@@ -154,7 +154,7 @@ final class DirectoryDumperTest extends TestCase
             ['cn' => 'bob'],
         );
         $storage = $this->createMock(EntryStorageInterface::class);
-        $storage->method('list')->willReturn(new EntryStream(
+        $storage->method('list')->willReturn(EntryStream::of(
             entries: (function () use ($alice, $bob): Generator {
                 yield $alice;
                 yield $bob;
@@ -194,7 +194,7 @@ final class DirectoryDumperTest extends TestCase
     {
         $alice = Entry::create('cn=alice,dc=foo,dc=bar', ['cn' => 'alice']);
         $storage = $this->createMock(EntryStorageInterface::class);
-        $storage->method('list')->willReturn(new EntryStream(
+        $storage->method('list')->willReturn(EntryStream::of(
             entries: (function () use ($alice): Generator {
                 yield $alice;
 
@@ -226,7 +226,7 @@ final class DirectoryDumperTest extends TestCase
                 fn(StorageListOptions $opts): bool
                     => $opts->subtree === true && $opts->baseDn->toString() === 'dc=foo,dc=bar',
             ))
-            ->willReturn(new EntryStream(
+            ->willReturn(EntryStream::of(
                 entries: (function (): Generator {
                     yield from [];
 

--- a/tests/unit/Server/Backend/StorageReadBackendTest.php
+++ b/tests/unit/Server/Backend/StorageReadBackendTest.php
@@ -104,7 +104,7 @@ final class StorageReadBackendTest extends TestCase
         $request = (new SearchRequest(new PresentFilter('objectClass')))
             ->base('dc=example,dc=com')
             ->useBaseScope();
-        $entries = iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries);
+        $entries = iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries());
 
         self::assertCount(
             1,
@@ -121,7 +121,7 @@ final class StorageReadBackendTest extends TestCase
         $request = (new SearchRequest(new PresentFilter('objectClass')))
             ->base('dc=example,dc=com')
             ->useSingleLevelScope();
-        $entries = iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries);
+        $entries = iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries());
 
         // Only alice is a direct child of dc=example,dc=com; bob is under ou=People
         self::assertCount(
@@ -139,7 +139,7 @@ final class StorageReadBackendTest extends TestCase
         $request = (new SearchRequest(new PresentFilter('objectClass')))
             ->base('dc=example,dc=com')
             ->useSubtreeScope();
-        $entries = iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries);
+        $entries = iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries());
 
         $dns = array_map(
             static fn(Entry $entry): string => $entry->getDn()->toString(),
@@ -203,7 +203,7 @@ final class StorageReadBackendTest extends TestCase
         $storage = $this->createMock(EntryStorageInterface::class);
         $storage->method('exists')->willReturn(true);
         $storage->method('list')->willReturn(
-            new EntryStream($this->makeTimeLimitStream()),
+            EntryStream::of($this->makeTimeLimitStream()),
         );
 
         $subject = $this->backendFor($storage);
@@ -214,7 +214,7 @@ final class StorageReadBackendTest extends TestCase
         $request = (new SearchRequest(new PresentFilter('objectClass')))
             ->base('dc=example,dc=com')
             ->useSingleLevelScope();
-        iterator_to_array($subject->search($request, SubentryVisibility::All)->entries);
+        iterator_to_array($subject->search($request, SubentryVisibility::All)->entries());
     }
 
     public function test_search_trips_lookthrough_limit_when_examined_exceeds_cap(): void
@@ -231,7 +231,7 @@ final class StorageReadBackendTest extends TestCase
         $request = (new SearchRequest(new PresentFilter('objectClass')))
             ->base('dc=example,dc=com')
             ->useSubtreeScope();
-        iterator_to_array($subject->search($request, SubentryVisibility::All)->entries);
+        iterator_to_array($subject->search($request, SubentryVisibility::All)->entries());
     }
 
     public function test_search_does_not_trip_lookthrough_limit_within_cap(): void
@@ -248,7 +248,7 @@ final class StorageReadBackendTest extends TestCase
 
         self::assertCount(
             3,
-            iterator_to_array($subject->search($request, SubentryVisibility::All)->entries),
+            iterator_to_array($subject->search($request, SubentryVisibility::All)->entries()),
         );
     }
 
@@ -260,7 +260,7 @@ final class StorageReadBackendTest extends TestCase
             ->base('cn=ref,dc=example,dc=com')
             ->useBaseScope()
             ->setDereferenceAliases(SearchRequest::DEREF_FINDING_BASE_OBJECT);
-        $entries = iterator_to_array($subject->search($request, SubentryVisibility::All)->entries);
+        $entries = iterator_to_array($subject->search($request, SubentryVisibility::All)->entries());
 
         self::assertCount(1, $entries);
         self::assertSame(
@@ -277,7 +277,7 @@ final class StorageReadBackendTest extends TestCase
             ->base('cn=ref,dc=example,dc=com')
             ->useBaseScope()
             ->setDereferenceAliases(SearchRequest::DEREF_NEVER);
-        $entries = iterator_to_array($subject->search($request, SubentryVisibility::All)->entries);
+        $entries = iterator_to_array($subject->search($request, SubentryVisibility::All)->entries());
 
         self::assertCount(1, $entries);
         self::assertSame(
@@ -304,7 +304,7 @@ final class StorageReadBackendTest extends TestCase
             ->setDereferenceAliases(SearchRequest::DEREF_IN_SEARCHING);
         $dns = array_map(
             static fn(Entry $entry): string => $entry->getDn()->toString(),
-            array_values(iterator_to_array($subject->search($request, SubentryVisibility::All)->entries)),
+            array_values(iterator_to_array($subject->search($request, SubentryVisibility::All)->entries())),
         );
 
         self::assertContains('cn=ref,dc=example,dc=com', $dns);
@@ -320,7 +320,7 @@ final class StorageReadBackendTest extends TestCase
             ->setDereferenceAliases(SearchRequest::DEREF_NEVER);
         $dns = array_map(
             static fn(Entry $entry): string => $entry->getDn()->toString(),
-            iterator_to_array($subject->search($request, SubentryVisibility::All)->entries),
+            iterator_to_array($subject->search($request, SubentryVisibility::All)->entries()),
         );
 
         self::assertContains(
@@ -338,7 +338,7 @@ final class StorageReadBackendTest extends TestCase
 
         self::assertCount(
             3,
-            iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries),
+            iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries()),
         );
     }
 
@@ -363,7 +363,7 @@ final class StorageReadBackendTest extends TestCase
 
         self::assertSame(
             [],
-            iterator_to_array($stream->entries),
+            iterator_to_array($stream->entries()),
         );
     }
 
@@ -383,7 +383,7 @@ final class StorageReadBackendTest extends TestCase
             ->willReturnCallback(function (StorageListOptions $opts) use (&$capturedOptions): EntryStream {
                 $capturedOptions = $opts;
 
-                return new EntryStream($this->makeGenerator());
+                return EntryStream::of($this->makeGenerator());
             });
 
         $subject = $this->backendFor(
@@ -398,7 +398,7 @@ final class StorageReadBackendTest extends TestCase
             ->timeLimit($requestLimit);
 
         $before = microtime(true);
-        iterator_to_array($subject->search($request, SubentryVisibility::All)->entries);
+        iterator_to_array($subject->search($request, SubentryVisibility::All)->entries());
         $after = microtime(true);
 
         self::assertNotNull($capturedOptions?->deadline);
@@ -432,7 +432,7 @@ final class StorageReadBackendTest extends TestCase
             ->useSubtreeScope()
             ->select('+');
 
-        $results = iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries);
+        $results = iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries());
 
         foreach ($results as $entry) {
             self::assertNotNull(
@@ -449,7 +449,7 @@ final class StorageReadBackendTest extends TestCase
             ->useSubtreeScope()
             ->select('hasSubordinates');
 
-        $results = iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries);
+        $results = iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries());
 
         foreach ($results as $entry) {
             self::assertNotNull(
@@ -466,7 +466,7 @@ final class StorageReadBackendTest extends TestCase
             ->useSubtreeScope()
             ->select('cn');
 
-        $results = iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries);
+        $results = iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries());
 
         foreach ($results as $entry) {
             self::assertNull(
@@ -484,7 +484,7 @@ final class StorageReadBackendTest extends TestCase
             ->useBaseScope()
             ->select('+');
 
-        $results = iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries);
+        $results = iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries());
 
         self::assertCount(1, $results);
         self::assertSame(
@@ -501,7 +501,7 @@ final class StorageReadBackendTest extends TestCase
             ->useBaseScope()
             ->select('+');
 
-        $results = iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries);
+        $results = iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries());
 
         self::assertCount(1, $results);
         self::assertSame(
@@ -517,7 +517,7 @@ final class StorageReadBackendTest extends TestCase
             ->useBaseScope()
             ->select('+');
 
-        iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries);
+        iterator_to_array($this->subject->search($request, SubentryVisibility::All)->entries());
 
         // Read the stored entry directly — hasSubordinates must not be persisted.
         $stored = $this->subject->get(new Dn('dc=example,dc=com'));

--- a/tests/unit/Server/Backend/Write/Operation/MoveEntryHandlerTest.php
+++ b/tests/unit/Server/Backend/Write/Operation/MoveEntryHandlerTest.php
@@ -227,7 +227,7 @@ final class MoveEntryHandlerTest extends TestCase
         $storage->method('exists')
             ->willReturn(true);
         $storage->method('list')
-            ->willReturn(new EntryStream($this->oneEntry($alice)));
+            ->willReturn(EntryStream::of($this->oneEntry($alice)));
         $storage->method('atomic')
             ->willThrowException(new StorageIoException('Unable to publish the storage update.'));
         $this->writeGraph($storage);

--- a/tests/unit/Server/Paging/FillingPageTest.php
+++ b/tests/unit/Server/Paging/FillingPageTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Paging;
+
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Server\Backend\Storage\Paging\PageCursor;
+use FreeDSx\Ldap\Server\Paging\FillingPage;
+use FreeDSx\Ldap\Server\Paging\SliceEnd;
+use PHPUnit\Framework\TestCase;
+
+final class FillingPageTest extends TestCase
+{
+    private FillingPage $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new FillingPage(
+            pageLimit: 10,
+            sizeLimit: 0,
+            widestSlice: 1000,
+        );
+    }
+
+    public function test_the_first_read_asks_only_for_what_the_page_can_hold(): void
+    {
+        self::assertSame(
+            10,
+            $this->subject->nextSlice(true, null)->limit,
+        );
+    }
+
+    public function test_a_later_read_is_widened_by_what_a_match_has_cost_so_far(): void
+    {
+        $this->subject->nextSlice(true, null);
+        $this->subject->readCandidates(100);
+        $this->take(1);
+
+        // Nine still wanted, at a hundred candidates per match.
+        self::assertSame(
+            900,
+            $this->subject->nextSlice(true, null)->limit,
+        );
+    }
+
+    public function test_a_later_read_is_never_wider_than_the_widest_slice(): void
+    {
+        $this->subject->nextSlice(true, null);
+        $this->subject->readCandidates(5000);
+        $this->take(1);
+
+        self::assertSame(
+            1000,
+            $this->subject->nextSlice(true, null)->limit,
+        );
+    }
+
+    public function test_a_later_read_takes_the_widest_slice_when_nothing_has_matched_yet(): void
+    {
+        $this->subject->nextSlice(true, null);
+        $this->subject->readCandidates(50);
+
+        self::assertSame(
+            1000,
+            $this->subject->nextSlice(true, null)->limit,
+        );
+    }
+
+    public function test_a_read_that_only_probes_for_a_further_match_is_never_widened(): void
+    {
+        $this->subject->nextSlice(true, null);
+        $this->subject->readCandidates(500);
+        $this->take(10);
+
+        self::assertSame(
+            10,
+            $this->subject->nextSlice(false, null)->limit,
+        );
+    }
+
+    public function test_an_unbounded_page_reads_the_widest_slice(): void
+    {
+        $subject = new FillingPage(
+            pageLimit: null,
+            sizeLimit: 0,
+            widestSlice: 250,
+        );
+
+        self::assertSame(
+            250,
+            $subject->nextSlice(true, null)->limit,
+        );
+        self::assertTrue($subject->hasCapacity());
+    }
+
+    public function test_an_entry_with_no_position_is_placed_while_the_read_is_not_widened(): void
+    {
+        $this->subject->nextSlice(true, null);
+
+        self::assertTrue($this->subject->canPlace(null));
+    }
+
+    public function test_an_entry_with_no_position_is_refused_while_the_read_is_widened(): void
+    {
+        $this->subject->nextSlice(true, null);
+        $this->subject->readCandidates(100);
+        $this->take(1);
+        $this->subject->nextSlice(true, null);
+
+        self::assertFalse($this->subject->canPlace(null));
+        self::assertTrue($this->subject->canPlace(PageCursor::afterEntry(7)));
+    }
+
+    public function test_a_read_that_could_not_place_an_entry_stops_the_page_widening_again(): void
+    {
+        $this->subject->nextSlice(true, null);
+        $this->subject->readCandidates(100);
+        $this->take(1);
+        $this->subject->nextSlice(true, null);
+        $this->subject->abandonSlice(SliceEnd::Unplaceable);
+
+        // Back to asking only for the shortfall, which a read can always place.
+        self::assertSame(
+            9,
+            $this->subject->nextSlice(true, null)->limit,
+        );
+        self::assertTrue($this->subject->canPlace(null));
+    }
+
+    public function test_filling_the_page_part_way_through_a_read_does_not_stop_it_widening(): void
+    {
+        $this->subject->nextSlice(true, null);
+        $this->subject->readCandidates(100);
+        $this->take(1);
+        $this->subject->nextSlice(true, null);
+        $this->subject->abandonSlice(SliceEnd::PageFull);
+
+        self::assertSame(
+            900,
+            $this->subject->nextSlice(true, null)->limit,
+        );
+    }
+
+    public function test_the_page_resumes_from_the_last_entry_it_placed(): void
+    {
+        $this->subject->add(
+            Entry::create('cn=1,dc=foo,dc=bar'),
+            PageCursor::afterEntry(4),
+        );
+        $this->subject->add(
+            Entry::create('cn=2,dc=foo,dc=bar'),
+            PageCursor::afterEntry(9),
+        );
+
+        self::assertEquals(
+            PageCursor::afterEntry(9),
+            $this->subject->nextSlice(true, null)->after,
+        );
+    }
+
+    public function test_a_placed_entry_with_no_position_leaves_the_resume_point_alone(): void
+    {
+        $this->subject->add(
+            Entry::create('cn=1,dc=foo,dc=bar'),
+            PageCursor::afterEntry(4),
+        );
+        $this->subject->add(
+            Entry::create('cn=2,dc=foo,dc=bar'),
+            null,
+        );
+
+        self::assertEquals(
+            PageCursor::afterEntry(4),
+            $this->subject->nextSlice(true, null)->after,
+        );
+    }
+
+    public function test_the_page_is_full_once_it_holds_its_limit(): void
+    {
+        $this->take(9);
+        self::assertTrue($this->subject->hasCapacity());
+
+        $this->take(1);
+        self::assertFalse($this->subject->hasCapacity());
+    }
+
+    public function test_the_size_limit_is_only_reachable_once_the_page_holds_that_many(): void
+    {
+        $subject = new FillingPage(
+            pageLimit: 10,
+            sizeLimit: 2,
+            widestSlice: 1000,
+        );
+
+        self::assertFalse($subject->mayExceedSizeLimit());
+
+        $subject->add(Entry::create('cn=1,dc=foo,dc=bar'), null);
+        $subject->add(Entry::create('cn=2,dc=foo,dc=bar'), null);
+
+        self::assertTrue($subject->mayExceedSizeLimit());
+    }
+
+    public function test_it_collects_what_it_placed_with_where_it_stopped(): void
+    {
+        $this->subject->add(
+            Entry::create('cn=1,dc=foo,dc=bar'),
+            PageCursor::afterEntry(3),
+        );
+
+        $collected = $this->subject->collected(false, true);
+
+        self::assertCount(
+            1,
+            $collected->entries,
+        );
+        self::assertFalse($collected->isResultExhausted);
+        self::assertTrue($collected->isSizeLimitExceeded);
+        self::assertEquals(
+            PageCursor::afterEntry(3),
+            $collected->cursor,
+        );
+    }
+
+    private function take(int $count): void
+    {
+        for ($i = 0; $i < $count; $i++) {
+            $this->subject->add(
+                Entry::create("cn=$i,dc=foo,dc=bar"),
+                PageCursor::afterEntry($i + 1),
+            );
+        }
+    }
+}

--- a/tests/unit/Server/PasswordPolicy/PasswordPolicyResolverTest.php
+++ b/tests/unit/Server/PasswordPolicy/PasswordPolicyResolverTest.php
@@ -293,7 +293,7 @@ final class PasswordPolicyResolverTest extends TestCase
                 )
                 : null);
         $backend->method('search')
-            ->willReturn(new EntryStream((static function () use ($subentry): Generator {
+            ->willReturn(EntryStream::of((static function () use ($subentry): Generator {
                 yield $subentry;
 
                 return null;


### PR DESCRIPTION
Two separate fixes here:

1. StartTLS is broken on swoole because it does't properly handle capturing the client cert. We need that to support mTLS / external SASL. This is just a limitation of the swoole hooks. Rather than restructure everything due to this I'm just throwing errors on functionality that runner cannot yet support. That at least makes it work for StartTLS in general. I may revisit it, but getting the runner to work under the actual swoole server (where the cert could be captured) requires much larger changes across the socket library and this repo, and I'm not sure if it's worth it.
2. Making pagination use the key from the fetched entries so it better knows where to resume from. This is a performance fix, but also restructured some paging to separate some of the concerns. Paging is quite complex because it deals with so many things at once (the page / cursor, whether the storage filter was exact, the lookthrough limits / ACL checks, etc) and these all interact with how much and how many pages we respond to based on the size requested. 