### PR TITLE
[1.0.0] Add a filter access rule and refuse an attributeless extensible match.

### DIFF
--- a/docs/Server/Access-Control.md
+++ b/docs/Server/Access-Control.md
@@ -14,6 +14,7 @@ Access Control
 * [Subject Reference](#subject-reference)
 * [Target Reference](#target-reference)
 * [Attribute Rules](#attribute-rules)
+* [Filter Rules](#filter-rules)
 * [Confidential Attributes](#confidential-attributes)
 * [Control Rules](#control-rules)
 * [Extended Operation Rules](#extended-operation-rules)
@@ -215,6 +216,7 @@ The defaults are fixed rather than configurable:
 - Operations that match no rule are denied.
 - Attribute writes that match no rule are denied.
 - Attribute reads that match no rule are allowed, so a search still returns attributes you wrote no rule for.
+- Filter rules that match no rule are allowed, so any attribute may be named in a filter unless one denies it.
 - Controls and extended operations that match no rule are denied, so privileged controls are off unless granted.
 - Relocations that match no rule are denied. Moving an entry between containers needs a grant.
 
@@ -398,6 +400,9 @@ Attribute rules are enforced in three places:
 - **Compare**: a Compare request is rejected if the bound user is denied access to the compared attribute.
 - **Add / Modify**: the request is rejected if the bound user is denied access to any attribute being written.
 
+A read deny strips the value, but does not stop the attribute being named in a filter. To also stop that, pair it
+with a [Filter Rule](#filter-rules), or mark the attribute [confidential](#confidential-attributes), which does both.
+
 ```php
 AclRules::fromEmpty()->replaceAttributeRules(
     // Only admins can see or write userPassword.
@@ -418,6 +423,37 @@ AclRules::fromEmpty()->replaceAttributeRules(
     ),
 )
 ```
+
+## Filter Rules
+
+`FilterAccessRule` gates which attributes an identity may name in a search filter. Filtering is allowed by default, so
+nothing changes until a rule denies it.
+
+Unlike the other rules this carries no target. A filter is answered before a search runs, when no entry is in hand, so
+it can only depend on the subject. A subject that needs an entry, such as `Subject::self()`, is refused.
+
+```php
+$rules = AclRules::secureDefault($admins)->prependFilterAccess(
+    FilterAccessRule::deny(
+        Subject::anyone(),
+        'telephoneNumber',
+    ),
+);
+```
+
+A denied assertion is folded away before the query runs, so the attribute behaves as though it is not present:
+
+```
+(telephoneNumber=555-0100)                -> no entries
+(!(telephoneNumber=555-0100))             -> every entry, whatever the guess
+(|(cn=bob)(telephoneNumber=555-0100))     -> the cn=bob match, the other branch drops
+```
+
+This is what stops a value being recovered a guess at a time. Reads are unaffected: denying the filter does not strip
+the value, and denying the read does not stop the filter. Pair the two to get both.
+
+An extensible match that names no attribute type is refused with `inappropriateMatching`, since it asserts against
+every attribute at once and it's not possible to make attribute level ACL decisions against it.
 
 ## Confidential Attributes
 

--- a/src/FreeDSx/Ldap/Container/Provider/ConnectionGraphContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/ConnectionGraphContainerProvider.php
@@ -24,11 +24,11 @@ use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
 use FreeDSx\Ldap\Server\Metrics\Rollup\OperationRollupCoordinator;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
-use FreeDSx\Ldap\Server\AccessControl\ConfidentialAttributePolicy;
-use FreeDSx\Ldap\Server\AccessControl\ConfidentialFilterRewriter;
+use FreeDSx\Ldap\Server\AccessControl\WithheldAttributePolicy;
+use FreeDSx\Ldap\Server\AccessControl\WithheldFilterRewriter;
 use FreeDSx\Ldap\Server\Middleware\AliasDereferenceMiddleware;
 use FreeDSx\Ldap\Server\Middleware\AssertionMiddleware;
-use FreeDSx\Ldap\Server\Middleware\ConfidentialAttributeMiddleware;
+use FreeDSx\Ldap\Server\Middleware\WithheldAttributeMiddleware;
 use FreeDSx\Ldap\Server\Middleware\CriticalControlMiddleware;
 use FreeDSx\Ldap\Server\Middleware\CriticalControlValidator;
 use FreeDSx\Ldap\Server\Middleware\MetricsMiddleware;
@@ -66,7 +66,7 @@ final class ConnectionGraphContainerProvider implements ContainerProviderInterfa
             CriticalControlMiddleware::class => $this->makeCriticalControlMiddleware(...),
             OperationAuthorizationMiddleware::class => $this->makeOperationAuthorizationMiddleware(...),
             AliasDereferenceMiddleware::class => $this->makeAliasDereferenceMiddleware(...),
-            ConfidentialAttributeMiddleware::class => $this->makeConfidentialAttributeMiddleware(...),
+            WithheldAttributeMiddleware::class => $this->makeWithheldAttributeMiddleware(...),
             AssertionMiddleware::class => $this->makeAssertionMiddleware(...),
             ResourceLimitMiddleware::class => $this->makeResourceLimitMiddleware(...),
         ];
@@ -160,10 +160,10 @@ final class ConnectionGraphContainerProvider implements ContainerProviderInterfa
         );
     }
 
-    private function makeConfidentialAttributeMiddleware(Container $container): ConfidentialAttributeMiddleware
+    private function makeWithheldAttributeMiddleware(Container $container): WithheldAttributeMiddleware
     {
-        return new ConfidentialAttributeMiddleware(new ConfidentialFilterRewriter(
-            new ConfidentialAttributePolicy(
+        return new WithheldAttributeMiddleware(new WithheldFilterRewriter(
+            new WithheldAttributePolicy(
                 $container->get(AccessControlInterface::class),
                 $container->get(ServerOptions::class)->getSchema(),
             ),

--- a/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
@@ -24,7 +24,7 @@ use FreeDSx\Ldap\Schema\Validation\SchemaValidator;
 use FreeDSx\Ldap\Schema\Validation\Syntax\AttributeSyntaxResolver;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\ConfidentialAttributeAccessControl;
-use FreeDSx\Ldap\Server\AccessControl\ConfidentialAttributePolicy;
+use FreeDSx\Ldap\Server\AccessControl\WithheldAttributePolicy;
 use FreeDSx\Ldap\Server\AccessControl\PrivilegedBypassAccessControl;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\Pdo\PdoBackend;
 use FreeDSx\Ldap\Server\Backend\Storage\Derived\DerivedResolver;
@@ -191,7 +191,7 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
 
         $acl = new PrivilegedBypassAccessControl(new ConfidentialAttributeAccessControl(
             $configured,
-            new ConfidentialAttributePolicy(
+            new WithheldAttributePolicy(
                 $configured,
                 $options->getSchema(),
             ),

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerSearchTrait.php
@@ -36,6 +36,7 @@ use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
 use FreeDSx\Ldap\Schema\Definition\MatchingRuleOid;
 use FreeDSx\Ldap\Schema\Schema;
+use FreeDSx\Ldap\Search\Filter\FilterAttributes;
 use FreeDSx\Ldap\Server\Subentry\SubentryVisibility;
 use Generator;
 
@@ -111,8 +112,28 @@ trait ServerSearchTrait
 
         $this->assertSearchParametersInRange($request);
         $this->assertBaseDnParses($request);
+        $this->assertEveryAssertionNamesAnAttribute($request);
 
         return $request;
+    }
+
+    /**
+     * An extensible match may omit the attribute type which asserts against every attribute at once.
+     *
+     * Not supported: the assertion cannot be weighed against the rules that govern an attribute.
+     *
+     * @throws OperationException
+     */
+    private function assertEveryAssertionNamesAnAttribute(SearchRequest $request): void
+    {
+        if (FilterAttributes::referenced($request->getFilter()) !== null) {
+            return;
+        }
+
+        throw new OperationException(
+            'An extensible match must name an attribute type.',
+            ResultCode::INAPPROPRIATE_MATCHING,
+        );
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/AccessControl/AccessControlInterface.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/AccessControlInterface.php
@@ -109,6 +109,16 @@ interface AccessControlInterface
     ): bool;
 
     /**
+     * Whether $token may name an attribute in a search filter. Separate from read access, which only strips values.
+     *
+     * Target-independent by design: this is answered before a search runs, when no entry is in hand yet.
+     */
+    public function mayFilterOnAttribute(
+        TokenInterface $token,
+        string $attribute,
+    ): bool;
+
+    /**
      * Return $entry with unreadable attributes removed, or null to suppress the entry entirely.
      */
     public function filterEntry(

--- a/src/FreeDSx/Ldap/Server/AccessControl/AclRules.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/AclRules.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ConfidentialAccessRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ExtendedOperationRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\FilterAccessRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
@@ -63,6 +64,7 @@ final readonly class AclRules
      * @param ExtendedOperationRule[] $extendedOps Evaluated per extended operation in order; first match wins.
      * @param ConfidentialAccessRule[] $confidential Evaluated per confidential attribute in order; first match wins.
      * @param RelocationRule[] $relocations Evaluated per container and direction in order; first match wins.
+     * @param FilterAccessRule[] $filters Evaluated per filter attribute in order; first match wins.
      */
     private function __construct(
         public array $operations = [],
@@ -71,6 +73,7 @@ final readonly class AclRules
         public array $extendedOps = [],
         public array $confidential = [],
         public array $relocations = [],
+        public array $filters = [],
     ) {}
 
     /**
@@ -84,6 +87,7 @@ final readonly class AclRules
      * @param ExtendedOperationRule[] $extendedOps
      * @param ConfidentialAccessRule[] $confidential
      * @param RelocationRule[] $relocations
+     * @param FilterAccessRule[] $filters
      */
     public static function fromEmpty(
         array $operations = [],
@@ -92,6 +96,7 @@ final readonly class AclRules
         array $extendedOps = [],
         array $confidential = [],
         array $relocations = [],
+        array $filters = [],
     ): self {
         return new self(
             $operations,
@@ -100,6 +105,7 @@ final readonly class AclRules
             $extendedOps,
             $confidential,
             $relocations,
+            $filters,
         );
     }
 
@@ -115,6 +121,7 @@ final readonly class AclRules
             $this->extendedOps,
             $this->confidential,
             $this->relocations,
+            $this->filters,
         );
     }
 
@@ -130,6 +137,7 @@ final readonly class AclRules
             $this->extendedOps,
             $this->confidential,
             $this->relocations,
+            $this->filters,
         );
     }
 
@@ -145,6 +153,7 @@ final readonly class AclRules
             $this->extendedOps,
             $this->confidential,
             $this->relocations,
+            $this->filters,
         );
     }
 
@@ -160,6 +169,7 @@ final readonly class AclRules
             $extendedOps,
             $this->confidential,
             $this->relocations,
+            $this->filters,
         );
     }
 
@@ -177,6 +187,7 @@ final readonly class AclRules
             $this->extendedOps,
             $confidential,
             $this->relocations,
+            $this->filters,
         );
     }
 
@@ -194,6 +205,25 @@ final readonly class AclRules
             $this->extendedOps,
             $this->confidential,
             $relocations,
+            $this->filters,
+        );
+    }
+
+    /**
+     * Rules gating which attributes may be named in a search filter; anything unmatched stays filterable.
+     *
+     * Discards every filter rule already present.
+     */
+    public function replaceFilterAccess(FilterAccessRule ...$filters): self
+    {
+        return new self(
+            $this->operations,
+            $this->attributes,
+            $this->controls,
+            $this->extendedOps,
+            $this->confidential,
+            $this->relocations,
+            $filters,
         );
     }
 
@@ -249,6 +279,17 @@ final readonly class AclRules
         return $this->replaceConfidentialAccess(
             ...$this->confidential,
             ...$confidential,
+        );
+    }
+
+    /**
+     * Append filter access rules, so anything already present matches first.
+     */
+    public function appendFilterAccess(FilterAccessRule ...$filters): self
+    {
+        return $this->replaceFilterAccess(
+            ...$this->filters,
+            ...$filters,
         );
     }
 
@@ -315,6 +356,17 @@ final readonly class AclRules
         return $this->replaceConfidentialAccess(
             ...$confidential,
             ...$this->confidential,
+        );
+    }
+
+    /**
+     * Prepend filter access rules. These match ahead of anything already present.
+     */
+    public function prependFilterAccess(FilterAccessRule ...$filters): self
+    {
+        return $this->replaceFilterAccess(
+            ...$filters,
+            ...$this->filters,
         );
     }
 

--- a/src/FreeDSx/Ldap/Server/AccessControl/ConfidentialAttributeAccessControl.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/ConfidentialAttributeAccessControl.php
@@ -32,7 +32,7 @@ final readonly class ConfidentialAttributeAccessControl implements AccessControl
 {
     public function __construct(
         private AccessControlInterface $inner,
-        private ConfidentialAttributePolicy $policy,
+        private WithheldAttributePolicy $policy,
     ) {}
 
     public function setBackend(ReadBackendInterface $backend): void
@@ -143,6 +143,16 @@ final readonly class ConfidentialAttributeAccessControl implements AccessControl
         );
     }
 
+    public function mayFilterOnAttribute(
+        TokenInterface $token,
+        string $attribute,
+    ): bool {
+        return $this->inner->mayFilterOnAttribute(
+            $token,
+            $attribute,
+        );
+    }
+
     public function isEntryVisible(
         TokenInterface $token,
         Entry $entry,
@@ -161,7 +171,7 @@ final readonly class ConfidentialAttributeAccessControl implements AccessControl
         $kept = [];
 
         foreach ($all as $attribute) {
-            if (!$this->policy->isWithheld($attribute->getName(), $token)) {
+            if (!$this->policy->isWithheldFromResult($attribute->getName(), $token)) {
                 $kept[] = $attribute;
             }
         }

--- a/src/FreeDSx/Ldap/Server/AccessControl/PrivilegedBypassAccessControl.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/PrivilegedBypassAccessControl.php
@@ -140,6 +140,17 @@ final readonly class PrivilegedBypassAccessControl implements AccessControlInter
             );
     }
 
+    public function mayFilterOnAttribute(
+        TokenInterface $token,
+        string $attribute,
+    ): bool {
+        return $token instanceof PrivilegedTokenInterface
+            || $this->inner->mayFilterOnAttribute(
+                $token,
+                $attribute,
+            );
+    }
+
     public function filterEntry(
         TokenInterface $token,
         Entry $entry,

--- a/src/FreeDSx/Ldap/Server/AccessControl/Rule/FilterAccessRule.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/Rule/FilterAccessRule.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\AccessControl\Rule;
+
+use FreeDSx\Ldap\Server\AccessControl\Subject\SubjectMatcherInterface;
+
+/**
+ * An ordered access control rule gating whether an attribute may be named in a search filter.
+ *
+ * Separate from a read deny, which strips the value but leaves the attribute usable in a filter.
+ *
+ * Carries no target since a filter is answered before a search runs.
+ *
+ * @api
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class FilterAccessRule
+{
+    use TargetlessSubjectTrait;
+
+    /**
+     * @param string[] $attributes Attribute names. Empty matches every attribute.
+     */
+    private function __construct(
+        public Effect $effect,
+        public SubjectMatcherInterface $subject,
+        public array $attributes,
+    ) {
+        self::assertSubjectNeedsNoTarget($subject);
+    }
+
+    public static function allow(
+        SubjectMatcherInterface $subject,
+        string ...$attributes,
+    ): self {
+        return new self(
+            Effect::Allow,
+            $subject,
+            $attributes,
+        );
+    }
+
+    public static function deny(
+        SubjectMatcherInterface $subject,
+        string ...$attributes,
+    ): self {
+        return new self(
+            Effect::Deny,
+            $subject,
+            $attributes,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/AccessControl/RuleBasedAccessControl.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/RuleBasedAccessControl.php
@@ -55,6 +55,7 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
             ...$this->rules->controls,
             ...$this->rules->extendedOps,
             ...$this->rules->confidential,
+            ...$this->rules->filters,
         ];
 
         foreach ($allRules as $rule) {
@@ -165,6 +166,26 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
             $token,
             Effect::Deny,
         ) === Effect::Allow;
+    }
+
+    public function mayFilterOnAttribute(
+        TokenInterface $token,
+        string $attribute,
+    ): bool {
+        // Unlike the grant-style questions this defaults to allow, so an anonymous identity is bound by a deny too.
+        foreach ($this->rules->filters as $rule) {
+            if (!$this->namesAttribute($rule->attributes, $attribute)) {
+                continue;
+            }
+
+            if (!$this->subjectMatches($rule->subject, $rule->effect, $token, null)) {
+                continue;
+            }
+
+            return $rule->effect === Effect::Allow;
+        }
+
+        return true;
     }
 
     public function filterEntry(
@@ -327,11 +348,26 @@ final readonly class RuleBasedAccessControl implements AccessControlInterface, B
         ConfidentialAccessRule $rule,
         string $attribute,
     ): bool {
-        if ($rule->attributes === []) {
+        return $this->namesAttribute(
+            $rule->attributes,
+            $attribute,
+        );
+    }
+
+    /**
+     * Whether a targetless rule's attribute list covers this attribute (an empty list meaning every one).
+     *
+     * @param string[] $attributes
+     */
+    private function namesAttribute(
+        array $attributes,
+        string $attribute,
+    ): bool {
+        if ($attributes === []) {
             return true;
         }
 
-        foreach ($rule->attributes as $name) {
+        foreach ($attributes as $name) {
             if (strcasecmp($name, $attribute) === 0) {
                 return true;
             }

--- a/src/FreeDSx/Ldap/Server/AccessControl/WithheldAttributePolicy.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/WithheldAttributePolicy.php
@@ -24,7 +24,7 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final readonly class ConfidentialAttributePolicy
+final readonly class WithheldAttributePolicy
 {
     public function __construct(
         private AccessControlInterface $accessControl,
@@ -32,9 +32,9 @@ final readonly class ConfidentialAttributePolicy
     ) {}
 
     /**
-     * Whether the schema marks the attribute confidential and the token holds no grant over it.
+     * Whether the schema marks the attribute confidential, and the token holds no grant over it.
      */
-    public function isWithheld(
+    public function isWithheldFromResult(
         string $attribute,
         TokenInterface $token,
     ): bool {
@@ -48,6 +48,23 @@ final readonly class ConfidentialAttributePolicy
         return !$this->accessControl->hasConfidentialAccess(
             $token,
             $name,
+        );
+    }
+
+    /**
+     * Whether the attribute is withheld from a filter.
+     */
+    public function isWithheldFromFilter(
+        string $attribute,
+        TokenInterface $token,
+    ): bool {
+        if ($this->isWithheldFromResult($attribute, $token)) {
+            return true;
+        }
+
+        return !$this->accessControl->mayFilterOnAttribute(
+            $token,
+            Attribute::normalizeName($attribute),
         );
     }
 }

--- a/src/FreeDSx/Ldap/Server/AccessControl/WithheldFilterRewriter.php
+++ b/src/FreeDSx/Ldap/Server/AccessControl/WithheldFilterRewriter.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace FreeDSx\Ldap\Server\AccessControl;
 
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Search\Filter\AndFilter;
 use FreeDSx\Ldap\Search\Filter\FilterAttributeInterface;
 use FreeDSx\Ldap\Search\Filter\FilterAttributes;
@@ -24,7 +26,7 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
 use function count;
 
 /**
- * Folds assertions on withheld confidential attributes out of a filter, so their values never select candidates.
+ * Folds assertions on withheld attributes out of a filter so their values never select candidates.
  *
  * A withheld attribute is treated as absent, matching the per-entry redaction, which makes its assertion false
  * and collapses the surrounding tree by boolean algebra. Constants are the RFC 4526 absolute filters.
@@ -33,12 +35,14 @@ use function count;
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final readonly class ConfidentialFilterRewriter
+final readonly class WithheldFilterRewriter
 {
-    public function __construct(private ConfidentialAttributePolicy $policy) {}
+    public function __construct(private WithheldAttributePolicy $policy) {}
 
     /**
      * The filter with withheld assertions folded away, or the original when none apply.
+     *
+     * @throws OperationException when an assertion names no attribute to fold against.
      */
     public function rewrite(
         FilterInterface $filter,
@@ -59,14 +63,27 @@ final readonly class ConfidentialFilterRewriter
     }
 
     /**
-     * A null referenced set is indeterminate, so there is nothing to fold on.
+     * An indeterminate set names an assertion reaching every attribute, which nothing here can fold against one.
+     *
+     * Refused with the same code request validation uses, so which one answers first cannot matter.
+     *
+     * @throws OperationException
      */
     private function hasWithheldAttribute(
         FilterInterface $filter,
         TokenInterface $token,
     ): bool {
-        foreach (FilterAttributes::referenced($filter) ?? [] as $attribute) {
-            if ($this->policy->isWithheld($attribute, $token)) {
+        $referenced = FilterAttributes::referenced($filter);
+
+        if ($referenced === null) {
+            throw new OperationException(
+                'An extensible match must name an attribute type.',
+                ResultCode::INAPPROPRIATE_MATCHING,
+            );
+        }
+
+        foreach ($referenced as $attribute) {
+            if ($this->policy->isWithheldFromFilter($attribute, $token)) {
                 return true;
             }
         }
@@ -159,7 +176,7 @@ final readonly class ConfidentialFilterRewriter
             return $filter;
         }
 
-        return $this->policy->isWithheld($attribute, $token)
+        return $this->policy->isWithheldFromFilter($attribute, $token)
             ? self::never()
             : $filter;
     }

--- a/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
+++ b/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
@@ -55,7 +55,7 @@ use FreeDSx\Ldap\Server\Middleware\AliasDereferenceMiddleware;
 use FreeDSx\Ldap\Server\Middleware\AssertionMiddleware;
 use FreeDSx\Ldap\Server\Middleware\AuthorizationResolutionMiddleware;
 use FreeDSx\Ldap\Server\Middleware\BindMiddleware;
-use FreeDSx\Ldap\Server\Middleware\ConfidentialAttributeMiddleware;
+use FreeDSx\Ldap\Server\Middleware\WithheldAttributeMiddleware;
 use FreeDSx\Ldap\Server\Middleware\ConfidentialityMiddleware;
 use FreeDSx\Ldap\Server\Middleware\CriticalControlMiddleware;
 use FreeDSx\Ldap\Server\Middleware\CriticalControlValidator;
@@ -424,7 +424,7 @@ final class ConnectionHandlerBuilder implements ConnectionHandlerBuilderInterfac
                 $this->container->get(AliasDereferenceMiddleware::class),
                 $this->container->get(OperationAuthorizationMiddleware::class),
                 // Below the authorization gate, so an assertion the identity cannot satisfy never reaches storage.
-                $this->container->get(ConfidentialAttributeMiddleware::class),
+                $this->container->get(WithheldAttributeMiddleware::class),
                 $this->container->get(AssertionMiddleware::class),
             ],
             new HandlerInvoker($handlerProvider),

--- a/src/FreeDSx/Ldap/Server/Middleware/WithheldAttributeMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/WithheldAttributeMiddleware.php
@@ -17,7 +17,7 @@ use FreeDSx\Ldap\Operation\Request\CompareRequest;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
-use FreeDSx\Ldap\Server\AccessControl\ConfidentialFilterRewriter;
+use FreeDSx\Ldap\Server\AccessControl\WithheldFilterRewriter;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
@@ -25,19 +25,16 @@ use FreeDSx\Ldap\Server\Operation\CompareOperationResult;
 use FreeDSx\Ldap\Server\Operation\OperationOutcomeResult;
 
 /**
- * Withholds confidential attributes from assertions before the request reaches storage.
- *
- * An assertion the requester cannot satisfy is answered here, so the value never selects candidates and a
- * guess costs the same whether or not it was right.
+ * Withholds attributes from assertions before the request reaches storage.
  *
  * @internal
  *
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
  */
-final readonly class ConfidentialAttributeMiddleware implements MiddlewareInterface
+final readonly class WithheldAttributeMiddleware implements MiddlewareInterface
 {
     public function __construct(
-        private ConfidentialFilterRewriter $rewriter,
+        private WithheldFilterRewriter $rewriter,
         private ResponseFactory $responseFactory = new ResponseFactory(),
     ) {}
 

--- a/tests/integration/Security/AclIntegrationTest.php
+++ b/tests/integration/Security/AclIntegrationTest.php
@@ -23,7 +23,10 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\Search\Filter\FilterInterface;
 use FreeDSx\Ldap\Search\Filters;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
 use Tests\Support\FreeDSx\Ldap\LdapAclCommand;
 
@@ -611,6 +614,150 @@ final class AclIntegrationTest extends ServerTestCase
         );
     }
 
+    /**
+     * @param callable(string): FilterInterface $assertion
+     */
+    #[DataProvider('filterDeniedAssertionProvider')]
+    public function testNegatingAFilterDeniedAssertionCannotTellACorrectGuessFromAWrongOne(
+        callable $assertion,
+        string $matching,
+        string $notMatching,
+    ): void {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        // uid=bob2 alone holds telephoneNumber, and cn=user may neither read nor filter on it.
+        self::assertSame(
+            $this->countMatching(Filters::not($assertion($notMatching))),
+            $this->countMatching(Filters::not($assertion($matching))),
+            'A correct guess must return the same entries as a wrong one.',
+        );
+    }
+
+    /**
+     * @return Generator<string, array{callable(string): FilterInterface, string, string}>
+     */
+    public static function filterDeniedAssertionProvider(): Generator
+    {
+        yield 'equality' => [
+            static fn(string $value): FilterInterface => Filters::equal(
+                'telephoneNumber',
+                $value,
+            ),
+            '555-0100',
+            '555-9999',
+        ];
+
+        yield 'substring' => [
+            static fn(string $value): FilterInterface => Filters::startsWith(
+                'telephoneNumber',
+                $value,
+            ),
+            '555-01',
+            '555-02',
+        ];
+
+        yield 'greater or equal' => [
+            static fn(string $value): FilterInterface => Filters::gte(
+                'telephoneNumber',
+                $value,
+            ),
+            '555-0100',
+            '999-9999',
+        ];
+
+        yield 'less or equal' => [
+            static fn(string $value): FilterInterface => Filters::lte(
+                'telephoneNumber',
+                $value,
+            ),
+            '555-0100',
+            '111-1111',
+        ];
+
+        yield 'approximate' => [
+            static fn(string $value): FilterInterface => Filters::approximate(
+                'telephoneNumber',
+                $value,
+            ),
+            '555-0100',
+            '555-9999',
+        ];
+
+        yield 'extensible match' => [
+            static fn(string $value): FilterInterface => Filters::extensible(
+                'telephoneNumber',
+                $value,
+                'caseIgnoreMatch',
+            ),
+            '555-0100',
+            '555-9999',
+        ];
+
+    }
+
+    public function testNegatingThePresenceOfAFilterDeniedAttributeSinglesOutNobody(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        self::assertSame(
+            $this->countMatching(Filters::present('objectClass')),
+            $this->countMatching(Filters::not(Filters::present('telephoneNumber'))),
+            'A withheld attribute is absent everywhere, so negating its presence matches every visible entry.',
+        );
+    }
+
+    public function testFilteringOnAFilterDeniedAttributeMatchesNothing(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        self::assertSame(
+            0,
+            $this->countMatching(Filters::equal('telephoneNumber', '555-0100')),
+        );
+    }
+
+    /**
+     * A withheld branch folds away rather than taking the whole disjunction with it.
+     */
+    public function testADisjunctionKeepsTheBranchThatDoesNotNameAFilterDeniedAttribute(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        $readableBranch = $this->countMatching(Filters::equal('cn', 'bob2'));
+        $disjunction = $this->countMatching(Filters::or(
+            Filters::equal('cn', 'bob2'),
+            Filters::equal('telephoneNumber', '555-0100'),
+        ));
+
+        self::assertGreaterThan(
+            0,
+            $readableBranch,
+        );
+        self::assertSame(
+            $readableBranch,
+            $disjunction,
+        );
+    }
+
+    public function testAnExtensibleMatchNamingNoAttributeIsRefused(): void
+    {
+        $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
+
+        try {
+            $this->ldapClient()->search(
+                Operations::search(Filters::extensible(null, '555-0100', 'caseIgnoreMatch'))
+                    ->base('dc=foo,dc=bar')
+                    ->useSubtreeScope(),
+            );
+            self::fail('Expected the search to be refused.');
+        } catch (OperationException $e) {
+            self::assertSame(
+                ResultCode::INAPPROPRIATE_MATCHING,
+                $e->getCode(),
+            );
+        }
+    }
+
     public function testFilteringOnAPasswordPrefixMatchesNothing(): void
     {
         $this->ldapClient()->bind('cn=user,dc=foo,dc=bar', '12345');
@@ -1033,5 +1180,14 @@ final class AclIntegrationTest extends ServerTestCase
     private static function alicePasswordHash(): string
     {
         return '{SHA}' . base64_encode(sha1('alicepass', true));
+    }
+
+    private function countMatching(FilterInterface $filter): int
+    {
+        return count($this->ldapClient()->search(
+            Operations::search($filter)
+                ->base('dc=foo,dc=bar')
+                ->useSubtreeScope(),
+        )->toArray());
     }
 }

--- a/tests/support/LdapAclCommand.php
+++ b/tests/support/LdapAclCommand.php
@@ -14,6 +14,7 @@ use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ConfidentialAccessRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\FilterAccessRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;
 use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
@@ -261,6 +262,13 @@ class LdapAclCommand extends Command
                             ConfidentialAccessRule::allow(
                                 Subject::group('cn=admins,dc=foo,dc=bar'),
                                 'userPassword',
+                            ),
+                        )
+                        // The read deny above still leaves the value guessable through a filter, so pair it with this.
+                        ->replaceFilterAccess(
+                            FilterAccessRule::deny(
+                                Subject::anyone(),
+                                'telephoneNumber',
                             ),
                         ),
                 );

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerSearchHandlerTest.php
@@ -142,6 +142,46 @@ final class ServerSearchHandlerTest extends TestCase
         );
     }
 
+    public function test_it_rejects_an_extensible_match_that_names_no_attribute(): void
+    {
+        $this->mockBackend
+            ->expects(self::never())
+            ->method('search');
+
+        self::expectExceptionObject(new OperationException(
+            'An extensible match must name an attribute type.',
+            ResultCode::INAPPROPRIATE_MATCHING,
+        ));
+
+        $this->subject->handleRequest(
+            new LdapMessageRequest(
+                2,
+                self::searchRequest()->setFilter(
+                    Filters::extensible(null, 'secret', 'caseIgnoreMatch'),
+                ),
+            ),
+            $this->mockToken,
+        );
+    }
+
+    public function test_it_accepts_an_extensible_match_that_names_an_attribute(): void
+    {
+        $this->mockBackend
+            ->expects(self::once())
+            ->method('search')
+            ->willReturn(EntryStream::of($this->makeGenerator()));
+
+        $this->subject->handleRequest(
+            new LdapMessageRequest(
+                2,
+                self::searchRequest()->setFilter(
+                    Filters::extensible('cn', 'secret', 'caseIgnoreMatch'),
+                ),
+            ),
+            $this->mockToken,
+        );
+    }
+
     #[DataProvider('outOfRangeParameterProvider')]
     public function test_it_rejects_a_search_parameter_outside_its_permitted_range(
         SearchRequest $request,

--- a/tests/unit/Server/AccessControl/Rule/FilterAccessRuleTest.php
+++ b/tests/unit/Server/AccessControl/Rule/FilterAccessRuleTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl\Rule;
+
+use FreeDSx\Ldap\Exception\InvalidArgumentException;
+use FreeDSx\Ldap\Server\AccessControl\Rule\Effect;
+use FreeDSx\Ldap\Server\AccessControl\Rule\FilterAccessRule;
+use FreeDSx\Ldap\Server\AccessControl\Subject\AnySubjectMatcher;
+use FreeDSx\Ldap\Server\AccessControl\Subject\CallbackSubjectMatcher;
+use FreeDSx\Ldap\Server\AccessControl\Subject\SelfSubjectMatcher;
+use PHPUnit\Framework\TestCase;
+
+final class FilterAccessRuleTest extends TestCase
+{
+    public function test_a_self_subject_is_refused(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        FilterAccessRule::deny(
+            new SelfSubjectMatcher(),
+            'telephoneNumber',
+        );
+    }
+
+    public function test_a_callback_subject_is_refused(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        FilterAccessRule::allow(
+            new CallbackSubjectMatcher(static fn(): bool => true),
+            'telephoneNumber',
+        );
+    }
+
+    public function test_a_subject_needing_no_target_is_accepted(): void
+    {
+        $rule = FilterAccessRule::deny(
+            new AnySubjectMatcher(),
+            'telephoneNumber',
+        );
+
+        self::assertSame(
+            Effect::Deny,
+            $rule->effect,
+        );
+        self::assertSame(
+            ['telephoneNumber'],
+            $rule->attributes,
+        );
+    }
+
+    public function test_an_empty_attribute_list_is_kept_for_every_attribute(): void
+    {
+        $rule = FilterAccessRule::deny(new AnySubjectMatcher());
+
+        self::assertSame(
+            [],
+            $rule->attributes,
+        );
+    }
+}

--- a/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
+++ b/tests/unit/Server/AccessControl/RuleBasedAccessControlTest.php
@@ -23,6 +23,7 @@ use FreeDSx\Ldap\Operation\OperationType;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ConfidentialAccessRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\FilterAccessRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ControlRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\OperationRule;
 use FreeDSx\Ldap\Server\AccessControl\Rule\RelocationAccess;
@@ -796,6 +797,90 @@ final class RuleBasedAccessControlTest extends TestCase
         ));
     }
 
+    public function test_an_attribute_is_filterable_when_no_rule_denies_it(): void
+    {
+        $subject = new RuleBasedAccessControl(AclRules::fromEmpty());
+
+        self::assertTrue($subject->mayFilterOnAttribute(
+            $this->bindToken,
+            'telephoneNumber',
+        ));
+    }
+
+    public function test_a_filter_deny_naming_the_attribute_refuses_it(): void
+    {
+        $subject = new RuleBasedAccessControl($this->rulesDenyingFilterOn('telephoneNumber'));
+
+        self::assertFalse($subject->mayFilterOnAttribute(
+            $this->bindToken,
+            'telephoneNumber',
+        ));
+    }
+
+    public function test_a_filter_deny_leaves_every_other_attribute_alone(): void
+    {
+        $subject = new RuleBasedAccessControl($this->rulesDenyingFilterOn('telephoneNumber'));
+
+        self::assertTrue($subject->mayFilterOnAttribute(
+            $this->bindToken,
+            'sn',
+        ));
+    }
+
+    public function test_a_filter_deny_naming_nothing_refuses_every_attribute(): void
+    {
+        $subject = new RuleBasedAccessControl($this->rulesDenyingFilterOn());
+
+        self::assertFalse($subject->mayFilterOnAttribute(
+            $this->bindToken,
+            'sn',
+        ));
+    }
+
+    /**
+     * Unlike the grant-style questions, which consider only authenticated identities.
+     */
+    public function test_a_filter_deny_binds_an_anonymous_identity_too(): void
+    {
+        $subject = new RuleBasedAccessControl($this->rulesDenyingFilterOn('telephoneNumber'));
+
+        self::assertFalse($subject->mayFilterOnAttribute(
+            new AnonToken(),
+            'telephoneNumber',
+        ));
+    }
+
+    public function test_an_allow_ahead_of_a_deny_keeps_the_attribute_filterable(): void
+    {
+        $subject = new RuleBasedAccessControl(AclRules::fromEmpty(
+            filters: [
+                FilterAccessRule::allow(
+                    new AnySubjectMatcher(),
+                    'telephoneNumber',
+                ),
+                FilterAccessRule::deny(
+                    new AnySubjectMatcher(),
+                    'telephoneNumber',
+                ),
+            ],
+        ));
+
+        self::assertTrue($subject->mayFilterOnAttribute(
+            $this->bindToken,
+            'telephoneNumber',
+        ));
+    }
+
+    public function test_a_filter_deny_governs_the_attribute_however_it_is_spelled(): void
+    {
+        $subject = new RuleBasedAccessControl($this->rulesDenyingFilterOn('TelephoneNumber'));
+
+        self::assertFalse($subject->mayFilterOnAttribute(
+            $this->bindToken,
+            'telephonenumber',
+        ));
+    }
+
     public function test_a_deny_still_applies_when_its_subject_cannot_be_decided(): void
     {
         $subject = new RuleBasedAccessControl(AclRules::fromEmpty(
@@ -1023,6 +1108,18 @@ final class RuleBasedAccessControlTest extends TestCase
             $this->bindToken,
             $this->dn,
             RelocationAccess::Out,
+        );
+    }
+
+    private function rulesDenyingFilterOn(string ...$attributes): AclRules
+    {
+        return AclRules::fromEmpty(
+            filters: [
+                FilterAccessRule::deny(
+                    new AnySubjectMatcher(),
+                    ...$attributes,
+                ),
+            ],
         );
     }
 }

--- a/tests/unit/Server/AccessControl/WithheldFilterRewriterTest.php
+++ b/tests/unit/Server/AccessControl/WithheldFilterRewriterTest.php
@@ -13,30 +13,34 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Server\AccessControl;
 
+use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Schema\SchemaResource;
 use FreeDSx\Ldap\Search\Filter\AndFilter;
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\AccessControl\AclRules;
-use FreeDSx\Ldap\Server\AccessControl\ConfidentialAttributePolicy;
-use FreeDSx\Ldap\Server\AccessControl\ConfidentialFilterRewriter;
+use FreeDSx\Ldap\Server\AccessControl\WithheldAttributePolicy;
+use FreeDSx\Ldap\Server\AccessControl\WithheldFilterRewriter;
 use FreeDSx\Ldap\Server\AccessControl\Rule\ConfidentialAccessRule;
+use FreeDSx\Ldap\Server\AccessControl\Rule\FilterAccessRule;
 use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
+use FreeDSx\Ldap\Server\AccessControl\Subject\AnySubjectMatcher;
 use FreeDSx\Ldap\Server\AccessControl\Subject\Subject;
 use FreeDSx\Ldap\Server\Token\BindToken;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\TestCase;
 
-final class ConfidentialFilterRewriterTest extends TestCase
+final class WithheldFilterRewriterTest extends TestCase
 {
-    private ConfidentialFilterRewriter $subject;
+    private WithheldFilterRewriter $subject;
 
     private TokenInterface $token;
 
     protected function setUp(): void
     {
         $this->token = BindToken::fromDn('cn=user,dc=foo,dc=bar');
-        $this->subject = new ConfidentialFilterRewriter(new ConfidentialAttributePolicy(
+        $this->subject = new WithheldFilterRewriter(new WithheldAttributePolicy(
             new RuleBasedAccessControl(AclRules::fromEmpty()),
             SchemaResource::Core->load(),
         ));
@@ -133,6 +137,57 @@ final class ConfidentialFilterRewriterTest extends TestCase
         self::assertTrue($this->subject->isAbsoluteFalse($rewritten));
     }
 
+    public function test_an_assertion_on_a_filter_denied_attribute_collapses_to_absolute_false(): void
+    {
+        $subject = $this->rewriterDenyingFilterOn('telephoneNumber');
+
+        $rewritten = $subject->rewrite(
+            Filters::equal('telephoneNumber', '555-0100'),
+            $this->token,
+        );
+
+        self::assertTrue($subject->isAbsoluteFalse($rewritten));
+    }
+
+    /**
+     * The shape a read deny alone leaves open, where a correct guess is distinguishable from a wrong one.
+     */
+    public function test_negating_a_filter_denied_assertion_matches_every_entry(): void
+    {
+        $subject = $this->rewriterDenyingFilterOn('telephoneNumber');
+
+        $rewritten = $subject->rewrite(
+            Filters::not(Filters::equal('telephoneNumber', '555-0100')),
+            $this->token,
+        );
+
+        self::assertEquals(
+            Filters::and(),
+            $rewritten,
+        );
+    }
+
+    public function test_a_filter_deny_leaves_every_other_attribute_alone(): void
+    {
+        $subject = $this->rewriterDenyingFilterOn('telephoneNumber');
+        $filter = Filters::equal('sn', 'Bob');
+
+        self::assertSame(
+            $filter,
+            $subject->rewrite($filter, $this->token),
+        );
+    }
+
+    public function test_an_assertion_naming_no_attribute_is_refused_rather_than_passed_through(): void
+    {
+        self::expectExceptionObject(new OperationException(
+            'An extensible match must name an attribute type.',
+            ResultCode::INAPPROPRIATE_MATCHING,
+        ));
+
+        $this->rewrite(Filters::extensible(null, 'secret', 'caseIgnoreMatch'));
+    }
+
     public function test_a_filter_touching_no_confidential_attribute_is_returned_unchanged(): void
     {
         $filter = Filters::and(
@@ -148,7 +203,7 @@ final class ConfidentialFilterRewriterTest extends TestCase
 
     public function test_a_granted_token_keeps_the_filter_unchanged(): void
     {
-        $subject = new ConfidentialFilterRewriter(new ConfidentialAttributePolicy(
+        $subject = new WithheldFilterRewriter(new WithheldAttributePolicy(
             new RuleBasedAccessControl(AclRules::fromEmpty(
                 confidential: [ConfidentialAccessRule::allowAny(Subject::authenticated())],
             )),
@@ -164,7 +219,7 @@ final class ConfidentialFilterRewriterTest extends TestCase
 
     public function test_without_a_schema_nothing_is_treated_as_confidential(): void
     {
-        $subject = new ConfidentialFilterRewriter(new ConfidentialAttributePolicy(
+        $subject = new WithheldFilterRewriter(new WithheldAttributePolicy(
             new RuleBasedAccessControl(AclRules::fromEmpty()),
         ));
         $filter = Filters::equal('userPassword', 'secret');
@@ -181,5 +236,20 @@ final class ConfidentialFilterRewriterTest extends TestCase
             $filter,
             $this->token,
         );
+    }
+
+    private function rewriterDenyingFilterOn(string $attribute): WithheldFilterRewriter
+    {
+        return new WithheldFilterRewriter(new WithheldAttributePolicy(
+            new RuleBasedAccessControl(AclRules::fromEmpty(
+                filters: [
+                    FilterAccessRule::deny(
+                        new AnySubjectMatcher(),
+                        $attribute,
+                    ),
+                ],
+            )),
+            SchemaResource::Core->load(),
+        ));
     }
 }

--- a/tests/unit/Server/Middleware/WithheldAttributeMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/WithheldAttributeMiddlewareTest.php
@@ -21,10 +21,10 @@ use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Schema\SchemaResource;
 use FreeDSx\Ldap\Search\Filters;
 use FreeDSx\Ldap\Server\AccessControl\AclRules;
-use FreeDSx\Ldap\Server\AccessControl\ConfidentialAttributePolicy;
-use FreeDSx\Ldap\Server\AccessControl\ConfidentialFilterRewriter;
+use FreeDSx\Ldap\Server\AccessControl\WithheldAttributePolicy;
+use FreeDSx\Ldap\Server\AccessControl\WithheldFilterRewriter;
 use FreeDSx\Ldap\Server\AccessControl\RuleBasedAccessControl;
-use FreeDSx\Ldap\Server\Middleware\ConfidentialAttributeMiddleware;
+use FreeDSx\Ldap\Server\Middleware\WithheldAttributeMiddleware;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
 use FreeDSx\Ldap\Server\Operation\OperationOutcome;
@@ -34,20 +34,20 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-final class ConfidentialAttributeMiddlewareTest extends TestCase
+final class WithheldAttributeMiddlewareTest extends TestCase
 {
     private MiddlewareHandlerInterface&MockObject $next;
 
     private TokenInterface $token;
 
-    private ConfidentialAttributeMiddleware $subject;
+    private WithheldAttributeMiddleware $subject;
 
     protected function setUp(): void
     {
         $this->next = $this->createMock(MiddlewareHandlerInterface::class);
         $this->token = BindToken::fromDn('cn=user,dc=foo,dc=bar');
-        $this->subject = new ConfidentialAttributeMiddleware(new ConfidentialFilterRewriter(
-            new ConfidentialAttributePolicy(
+        $this->subject = new WithheldAttributeMiddleware(new WithheldFilterRewriter(
+            new WithheldAttributePolicy(
                 new RuleBasedAccessControl(AclRules::fromEmpty()),
                 SchemaResource::Core->load(),
             ),


### PR DESCRIPTION
This adds a filter level access rule for attributes. Other implementations consider this as a rule for whether or not you can include the attribute in a search, which is distinct from read access for an entry. The basic idea is that an attribute not allowed to be filtered on passes through the filter middleware that strips it entirely and treats it as undefined / compareFalse. This is somewhat similar to how confidential works, but they are still slightly different. Confidential is schema stamped on an attribute and applies to admins / globally. Otherwise the semantics of apply attribute read deny+ filter + deny are very similar.

This also changes attributeless extensible matches to be  un-allowed. They genuinely conflict with ACL permissions against attributes in things like searches.