### PR TITLE
[1.0.0] Various proxy server fixes.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^11",
-    "symplify/easy-coding-standard": "^13.1",
+    "symplify/easy-coding-standard": "^13.3",
     "phpstan/phpstan": "^2.1",
     "symfony/process": "^7.0",
     "symfony/console": "^6.4",

--- a/docs/Server/Access-Control.md
+++ b/docs/Server/Access-Control.md
@@ -455,6 +455,11 @@ the value, and denying the read does not stop the filter. Pair the two to get bo
 An extensible match that names no attribute type is refused with `inappropriateMatching`, since it asserts against
 every attribute at once and it's not possible to make attribute level ACL decisions against it.
 
+`entryDN`, `subschemaSubentry` and `hasSubordinates` are derived per read rather than stored. A read rule strips
+them from a result but does not stop a filter matching on them. `hasSubordinates` is the one worth thinking about: it
+reports whether an entry has children (including children the identity may not be able to see). Deny it with a filter
+rule if that matters to you.
+
 ## Confidential Attributes
 
 An attribute the schema marks `X-CONFIDENTIAL` is withheld from anyone without an explicit grant, both in results and

--- a/docs/Server/General-Usage.md
+++ b/docs/Server/General-Usage.md
@@ -304,6 +304,9 @@ or `ProxyOptions` `useStartTls: true`), and the **downstream** hop on the `Proxy
 [setRequireConfidentiality](Configuration.md#setrequireconfidentiality), which refuses proxied binds that would
 otherwise carry a password to the proxy in the clear.
 
+`ProxyOptions` accepts `setRequireUpstreamConfidentiality`, which refuses to start the proxy unless the upstream hop
+uses LDAPS or StartTLS.
+
 **Note**: only simple and anonymous binds are proxied (SASL is not), and every request is forwarded to the
 single configured upstream.
 

--- a/docs/Server/Monitoring.md
+++ b/docs/Server/Monitoring.md
@@ -55,6 +55,7 @@ off rather than returned empty.
 | `connectionsWriteTimeouts`, `connectionsIdleTimeouts` | Connections closed by the write or idle timeout. |
 | `connectionsRequestSizeExceeded` | Connections dropped because a request exceeded `setMaxRequestSize`. |
 | `connectionsProtocolErrors` | Connections dropped by a malformed/undecodable request PDU (Notice of Disconnection). |
+| `connectionsUnavailable` | Connections dropped because the connection the session depended on was lost (Notice of Disconnection). On a proxy this counts sessions ended with their upstream. |
 | `connectionsMax` | The configured connection limit (`0` is unlimited). |
 | `operationsCompleted`, `operationsFailed` | Total operations and the failed subset. |
 | `operationsByType` | Per-type counts, e.g. `search=1402, bind=210, add=8`. |

--- a/ecs.php
+++ b/ecs.php
@@ -14,7 +14,7 @@ return ECSConfig::configure()
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ])
-    ->withPhpCsFixerSets(perCS30: true)
+    ->withPreparedSets(perCs: true)
     ->withRules([
         BlankLineAfterStrictTypesFixer::class,
         BlankLineAfterOpeningTagFixer::class,

--- a/src/FreeDSx/Ldap/Container.php
+++ b/src/FreeDSx/Ldap/Container.php
@@ -123,6 +123,7 @@ class Container
                             : throw new RuntimeException('A proxy server can only reload into ProxyServerOptions.'),
                         $options->getClientOptions(),
                         $options->getUseStartTls(),
+                        $options->getRequireUpstreamConfidentiality(),
                     ),
                     $shared,
                 ),

--- a/src/FreeDSx/Ldap/Container/Provider/ProxyServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/ProxyServerContainerProvider.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Container\Provider;
 use FreeDSx\Ldap\Container;
 use FreeDSx\Ldap\Container\Contributor\ListenerContributorInterface;
 use FreeDSx\Ldap\Container\Contributor\ProxyListenerContributor;
+use FreeDSx\Ldap\Exception\RuntimeException;
 use FreeDSx\Ldap\ProxyOptions;
 use FreeDSx\Ldap\ProxyServerOptions;
 use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
@@ -47,9 +48,27 @@ final class ProxyServerContainerProvider implements ContainerProviderInterface
 
     private function makeProtocolFactory(Container $container): ServerProtocolFactoryInterface
     {
+        $options = $container->get(ProxyOptions::class);
+        self::assertUpstreamIsConfidentialIfRequired($options);
+
         return new ProxyProtocolFactory(
-            $container->get(ProxyOptions::class),
+            $options,
             $container->get(SleeperInterface::class),
+        );
+    }
+
+    private static function assertUpstreamIsConfidentialIfRequired(ProxyOptions $options): void
+    {
+        if (!$options->getRequireUpstreamConfidentiality()) {
+            return;
+        }
+
+        if ($options->getClientOptions()->isUseSsl() || $options->getUseStartTls()) {
+            return;
+        }
+
+        throw new RuntimeException(
+            'The upstream connection is not encrypted. Set useSsl or useStartTls on it, or unset requireUpstreamConfidentiality.',
         );
     }
 

--- a/src/FreeDSx/Ldap/Container/Provider/ProxyServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/ProxyServerContainerProvider.php
@@ -18,6 +18,9 @@ use FreeDSx\Ldap\Container\Contributor\ListenerContributorInterface;
 use FreeDSx\Ldap\Container\Contributor\ProxyListenerContributor;
 use FreeDSx\Ldap\ProxyOptions;
 use FreeDSx\Ldap\ProxyServerOptions;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\CoroutineSleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
 use FreeDSx\Ldap\Server\Process\BackgroundTask\BackgroundTasksInterface;
 use FreeDSx\Ldap\Server\Process\BackgroundTask\PcntlBackgroundTasks;
 use FreeDSx\Ldap\Server\Process\BackgroundTask\SwooleBackgroundTasks;
@@ -35,10 +38,26 @@ final class ProxyServerContainerProvider implements ContainerProviderInterface
     public function factories(): array
     {
         return [
-            ServerProtocolFactoryInterface::class => static fn(Container $c): ServerProtocolFactoryInterface => new ProxyProtocolFactory($c->get(ProxyOptions::class)),
+            ServerProtocolFactoryInterface::class => $this->makeProtocolFactory(...),
+            SleeperInterface::class => $this->makeSleeper(...),
             BackgroundTasksInterface::class => $this->makeBackgroundTasks(...),
             ListenerContributorInterface::class => static fn(): ListenerContributorInterface => new ProxyListenerContributor(),
         ];
+    }
+
+    private function makeProtocolFactory(Container $container): ServerProtocolFactoryInterface
+    {
+        return new ProxyProtocolFactory(
+            $container->get(ProxyOptions::class),
+            $container->get(SleeperInterface::class),
+        );
+    }
+
+    private function makeSleeper(Container $container): SleeperInterface
+    {
+        return $container->get(ProxyServerOptions::class)->isRunnerMode(RunnerMode::Swoole)
+            ? new CoroutineSleeper()
+            : new BlockingSleeper();
     }
 
     private function makeBackgroundTasks(Container $container): BackgroundTasksInterface

--- a/src/FreeDSx/Ldap/Exception/NoticeOfDisconnectException.php
+++ b/src/FreeDSx/Ldap/Exception/NoticeOfDisconnectException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Exception;
+
+/**
+ * The peer responded and ended the session with a notice of disconnection. This closes the connection but is not a
+ * transport level failure.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class NoticeOfDisconnectException extends ConnectionException {}

--- a/src/FreeDSx/Ldap/LdapClient.php
+++ b/src/FreeDSx/Ldap/LdapClient.php
@@ -501,6 +501,20 @@ class LdapClient
     }
 
     /**
+     * Whether the established connection is encrypted (whether by LDAPS or by a StartTLS already issued on it).
+     */
+    public function isEncrypted(): bool
+    {
+        if ($this->handler === null) {
+            return false;
+        }
+
+        return $this->container
+            ->get(ClientQueueInstantiator::class)
+            ->isInstantiatedAndEncrypted();
+    }
+
+    /**
      * A simple check to determine if this client has an established connection to a server.
      */
     public function isConnected(): bool

--- a/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ClientProtocolHandler.php
@@ -17,6 +17,7 @@ use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\ConnectionException;
+use FreeDSx\Ldap\Exception\NoticeOfDisconnectException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\ReferralException;
 use FreeDSx\Ldap\Exception\UnsolicitedNotificationException;
@@ -25,6 +26,7 @@ use FreeDSx\Ldap\Protocol\Factory\ClientProtocolHandlerFactory;
 use FreeDSx\Ldap\Protocol\Queue\ClientQueue;
 use FreeDSx\Ldap\Protocol\Queue\ClientQueueInstantiator;
 use FreeDSx\Socket\Exception\ConnectionException as SocketException;
+use FreeDSx\Socket\Exception\IdleTimeoutException;
 
 /**
  * Handles client specific protocol communication details.
@@ -78,7 +80,7 @@ class ClientProtocolHandler
             if ($exception->isNoticeOfDisconnection()) {
                 $this->queue()->close();
 
-                throw new ConnectionException(
+                throw new NoticeOfDisconnectException(
                     sprintf(
                         'The remote server has disconnected the session. %s',
                         $exception->getMessage(),
@@ -89,6 +91,11 @@ class ClientProtocolHandler
 
             throw $exception;
         } catch (SocketException $exception) {
+            // A read timeout leaves the socket usable, unlike a transport failure.
+            if (!$exception instanceof IdleTimeoutException) {
+                $this->queue?->close();
+            }
+
             throw new ConnectionException(
                 $exception->getMessage(),
                 $exception->getCode(),

--- a/src/FreeDSx/Ldap/Protocol/DisconnectSender.php
+++ b/src/FreeDSx/Ldap/Protocol/DisconnectSender.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol;
+
+use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Server\Logging\EventContext;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Logging\ServerEvent;
+use Throwable;
+
+/**
+ * Sends the unsolicited notification that ends a client session (RFC 4511 §4.4.1).
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+readonly class DisconnectSender
+{
+    public function __construct(
+        private ServerQueue $queue,
+        private EventLogger $eventLogger,
+        private ResponseFactory $responseFactory = new ResponseFactory(),
+    ) {}
+
+    /**
+     * @throws EncoderException
+     */
+    public function send(
+        string $message = '',
+        int $reasonCode = ResultCode::PROTOCOL_ERROR,
+        ?Throwable $cause = null,
+    ): void {
+        $this->queue->sendMessage($this->responseFactory->getExtendedError(
+            $message,
+            $reasonCode,
+            ExtendedResponse::OID_NOTICE_OF_DISCONNECTION,
+        ));
+        $this->eventLogger->record(
+            ServerEvent::NoticeOfDisconnectSent,
+            [
+                EventContext::REASON_CODE => $reasonCode,
+                EventContext::REASON_MESSAGE => $message,
+            ] + $this->eventLogger->exceptionContextFor($cause),
+        );
+    }
+
+    /**
+     * For a failure that may itself have been the connection going away.
+     *
+     * @throws EncoderException
+     */
+    public function sendIfConnected(
+        string $message = '',
+        int $reasonCode = ResultCode::PROTOCOL_ERROR,
+        ?Throwable $cause = null,
+    ): void {
+        if (!$this->queue->isConnected()) {
+            return;
+        }
+
+        $this->send(
+            $message,
+            $reasonCode,
+            $cause,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Protocol/Factory/ResponseFactory.php
+++ b/src/FreeDSx/Ldap/Protocol/Factory/ResponseFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol\Factory;
 
 use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\LdapUrl;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Operation\Request\BindRequest;
@@ -47,6 +48,7 @@ class ResponseFactory
      * Retrieve the expected response type for the request that was given.
      *
      * @param Dn|null $matchedDn Matched ancestor; emitted as matchedDN when non-null.
+     * @param LdapUrl[] $referrals Where the operation should be retried. For a result code that names somewhere else.
      * @param Control ...$controls Response controls to attach to the resulting message.
      */
     public function getStandardResponse(
@@ -54,6 +56,7 @@ class ResponseFactory
         int $resultCode = ResultCode::SUCCESS,
         string $diagnostic = '',
         ?Dn $matchedDn = null,
+        array $referrals = [],
         Control ...$controls,
     ): LdapMessageResponse {
         $request = $message->getRequest();
@@ -65,37 +68,44 @@ class ResponseFactory
                     $resultCode,
                     $dn,
                     $diagnostic,
+                    ...$referrals,
                 ),
             ),
             $request instanceof SearchRequest => new SearchResultDone(
                 $resultCode,
                 $dn,
                 $diagnostic,
+                ...$referrals,
             ),
             $request instanceof AddRequest => new AddResponse(
                 $resultCode,
                 $dn,
                 $diagnostic,
+                ...$referrals,
             ),
             $request instanceof CompareRequest => new CompareResponse(
                 $resultCode,
                 $dn,
                 $diagnostic,
+                ...$referrals,
             ),
             $request instanceof DeleteRequest => new DeleteResponse(
                 $resultCode,
                 $dn,
                 $diagnostic,
+                ...$referrals,
             ),
             $request instanceof ModifyDnRequest => new ModifyDnResponse(
                 $resultCode,
                 $dn,
                 $diagnostic,
+                ...$referrals,
             ),
             $request instanceof ModifyRequest => new ModifyResponse(
                 $resultCode,
                 $dn,
                 $diagnostic,
+                ...$referrals,
             ),
             // RFC 4511 4.12 makes the name optional, and the operations built on it require it absent on error.
             $request instanceof ExtendedRequest => new ExtendedResponse(
@@ -103,6 +113,7 @@ class ResponseFactory
                     $resultCode,
                     $dn,
                     $diagnostic,
+                    ...$referrals,
                 ),
             ),
             default => null,

--- a/src/FreeDSx/Ldap/Protocol/Queue/ClientQueueInstantiator.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/ClientQueueInstantiator.php
@@ -47,6 +47,16 @@ class ClientQueueInstantiator
     }
 
     /**
+     * Whether the queue exists and its connection has been upgraded.
+     */
+    public function isInstantiatedAndEncrypted(): bool
+    {
+        return $this->clientQueue !== null
+            && $this->clientQueue->isConnected()
+            && $this->clientQueue->isEncrypted();
+    }
+
+    /**
      * Close the connection socket if the queue was instantiated. It will reconnect on next use.
      */
     public function close(): void

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -14,15 +14,9 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol;
 
 use FreeDSx\Asn1\Exception\EncoderException;
-use FreeDSx\Ldap\Exception\ConnectionException as LdapConnectionException;
 use FreeDSx\Ldap\Exception\MessageDecodeException;
 use FreeDSx\Ldap\Exception\OperationException;
-use FreeDSx\Ldap\Exception\ProtocolException;
-use FreeDSx\Ldap\Exception\RequestSizeExceededException;
-use FreeDSx\Ldap\Exception\RequestValidationException;
 use FreeDSx\Ldap\Exception\ResponseAlreadySentException;
-use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
-use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
@@ -32,9 +26,6 @@ use FreeDSx\Ldap\Server\Logging\ServerEvent;
 use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
-use FreeDSx\Socket\Exception\ConnectionException;
-use FreeDSx\Socket\Exception\IdleTimeoutException;
-use FreeDSx\Socket\Exception\WriteTimeoutException;
 use Throwable;
 
 /**
@@ -47,6 +38,7 @@ readonly class ServerProtocolHandler
     public function __construct(
         private ServerQueue $queue,
         private MiddlewareHandlerInterface $requestPipeline,
+        private SessionEndPolicy $sessionEndPolicy,
         private EventLogger $eventLogger = new EventLogger(null),
         private ResponseFactory $responseFactory = new ResponseFactory(),
         private ConnectionContext $connectionContext = new ConnectionContext(),
@@ -61,83 +53,15 @@ readonly class ServerProtocolHandler
      */
     public function handle(): ?ConnectionObservation
     {
-        $closeReason = null;
-
         try {
-            while (true) {
-                try {
-                    $message = $this->queue->getMessage();
-                } catch (MessageDecodeException $e) {
-                    # The envelope parsed, so this message can be answered by its ID and the session continues. The
-                    # PDU was consumed before its contents were decoded, so the stream is already past it.
-                    if (!$this->answerDecodeFailure($e)) {
-                        $this->sendNoticeOfDisconnect('The message could not be processed.');
-                        $closeReason = ConnectionObservation::ProtocolError;
-
-                        break;
-                    }
-
-                    continue;
-                }
-
-                $this->dispatchRequest($message);
-                # If a protocol handler closed the TCP connection, then just break here...
-                if (!$this->queue->isConnected()) {
-                    break;
-                }
-            }
-        } catch (RequestValidationException $e) {
-            # The message ID could not be used (zero or reused). Per RFC 4511 §4.1.1 the server cannot frame a
-            # solicited response, so it sends a Notice of Disconnection and terminates the session.
-            $this->sendNoticeOfDisconnect($e->getMessage());
-        } catch (WriteTimeoutException $e) {
-            # The client stopped reading mid-response; nothing further can be sent. Record it and close.
-            $this->eventLogger->record(
-                ServerEvent::WriteTimeout,
-                [EventContext::REASON_MESSAGE => $e->getMessage()],
-            );
-            $closeReason = ConnectionObservation::WriteTimeout;
-        } catch (IdleTimeoutException $e) {
-            # The client sent nothing within the read timeout. Record it and close; there is nothing to send back.
-            $this->eventLogger->record(
-                ServerEvent::IdleTimeout,
-                [EventContext::REASON_MESSAGE => $e->getMessage()],
-            );
-            $closeReason = ConnectionObservation::IdleTimeout;
-        } catch (ConnectionException) {
-            # Connection closure is recorded by the runner's lifecycle logging; no audit event for normal client disconnects.
-        } catch (RequestSizeExceededException $e) {
-            # The client sent a PDU larger than the configured maximum. Per RFC 4511 §4.1.1 answer with a Notice of
-            # Disconnection, passing the cause so the log identifies the size violation, then record it and close.
-            $this->sendNoticeOfDisconnect(
-                $e->getMessage(),
-                cause: $e,
-            );
-            $closeReason = ConnectionObservation::RequestSizeExceeded;
-        } catch (EncoderException|ProtocolException) {
-            # Per RFC 4511 §4.1.1, a PDU that cannot be processed (malformed) warrants a disconnect with a protocol
-            # error. The NoticeOfDisconnectSent event records the specific reason.
-            $this->sendNoticeOfDisconnect('The message could not be processed.');
-            $closeReason = ConnectionObservation::ProtocolError;
-        } catch (LdapConnectionException $e) {
-            # The connection this session depended on is gone, which no result code can answer (RFC 4511 §4.4.1).
-            $this->sendNoticeOfDisconnect(
-                $e->getMessage(),
-                ResultCode::UNAVAILABLE,
-                $e,
-            );
-            $closeReason = ConnectionObservation::Unavailable;
+            return $this->readMessages();
         } catch (Throwable $e) {
-            if ($this->queue->isConnected()) {
-                $this->sendNoticeOfDisconnect(cause: $e);
-            }
+            return $this->sessionEndPolicy->end($e);
         } finally {
             if ($this->queue->isConnected()) {
                 $this->queue->close();
             }
         }
-
-        return $closeReason;
     }
 
     /**
@@ -147,11 +71,36 @@ readonly class ServerProtocolHandler
      */
     public function shutdown(): void
     {
-        $this->sendNoticeOfDisconnect(
-            'The server is shutting down.',
-            ResultCode::UNAVAILABLE,
-        );
+        $this->sessionEndPolicy->shuttingDown();
         $this->queue->close();
+    }
+
+    /**
+     * Reads and dispatches messages until the session ends, reporting whatever about the close is worth counting.
+     *
+     * @throws EncoderException
+     */
+    private function readMessages(): ?ConnectionObservation
+    {
+        while (true) {
+            try {
+                $message = $this->queue->getMessage();
+            } catch (MessageDecodeException $e) {
+                # The envelope parsed, so this message can be answered by its ID and the session continues. The
+                # PDU was consumed before its contents were decoded, so the stream is already past it.
+                if ($this->answerDecodeFailure($e)) {
+                    continue;
+                }
+
+                return $this->sessionEndPolicy->end($e);
+            }
+
+            $this->dispatchRequest($message);
+            # If a protocol handler closed the TCP connection, then just break here...
+            if (!$this->queue->isConnected()) {
+                return null;
+            }
+        }
     }
 
     /**
@@ -217,27 +166,5 @@ readonly class ServerProtocolHandler
         $this->queue->sendMessage($response);
 
         return true;
-    }
-
-    /**
-     * @throws EncoderException
-     */
-    private function sendNoticeOfDisconnect(
-        string $message = '',
-        int $reasonCode = ResultCode::PROTOCOL_ERROR,
-        ?Throwable $cause = null,
-    ): void {
-        $this->queue->sendMessage($this->responseFactory->getExtendedError(
-            $message,
-            $reasonCode,
-            ExtendedResponse::OID_NOTICE_OF_DISCONNECTION,
-        ));
-        $this->eventLogger->record(
-            ServerEvent::NoticeOfDisconnectSent,
-            [
-                EventContext::REASON_CODE => $reasonCode,
-                EventContext::REASON_MESSAGE => $message,
-            ] + $this->eventLogger->exceptionContextFor($cause),
-        );
     }
 }

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Protocol;
 
 use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Ldap\Exception\ConnectionException as LdapConnectionException;
 use FreeDSx\Ldap\Exception\MessageDecodeException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\Exception\ProtocolException;
@@ -118,6 +119,14 @@ readonly class ServerProtocolHandler
             # error. The NoticeOfDisconnectSent event records the specific reason.
             $this->sendNoticeOfDisconnect('The message could not be processed.');
             $closeReason = ConnectionObservation::ProtocolError;
+        } catch (LdapConnectionException $e) {
+            # The connection this session depended on is gone, which no result code can answer (RFC 4511 §4.4.1).
+            $this->sendNoticeOfDisconnect(
+                $e->getMessage(),
+                ResultCode::UNAVAILABLE,
+                $e,
+            );
+            $closeReason = ConnectionObservation::Unavailable;
         } catch (Throwable $e) {
             if ($this->queue->isConnected()) {
                 $this->sendNoticeOfDisconnect(cause: $e);

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerDispatchHandler.php
@@ -148,6 +148,7 @@ readonly class ServerDispatchHandler implements ServerProtocolHandlerInterface
                 ResultCode::SUCCESS,
                 '',
                 null,
+                [],
                 ...$this->successControls($preRead, $postRead),
             )],
             WriteOperationResult::success(

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerMonitorHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerMonitorHandler.php
@@ -88,6 +88,7 @@ class ServerMonitorHandler implements ServerProtocolHandlerInterface
             'connectionsIdleTimeouts' => [(string) $connections->idleTimeouts],
             'connectionsRequestSizeExceeded' => [(string) $connections->requestSizeExceeded],
             'connectionsProtocolErrors' => [(string) $connections->protocolErrors],
+            'connectionsUnavailable' => [(string) $connections->unavailable],
             'connectionsMax' => [(string) $this->options->getNetworkConfig()->getMaxConnections()],
             'operationsCompleted' => [(string) $operations->total()],
             'operationsFailed' => [(string) $operations->totalErrors()],

--- a/src/FreeDSx/Ldap/Protocol/SessionEndPolicy.php
+++ b/src/FreeDSx/Ldap/Protocol/SessionEndPolicy.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Protocol;
+
+use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Ldap\Exception\ConnectionException as LdapConnectionException;
+use FreeDSx\Ldap\Exception\ProtocolException;
+use FreeDSx\Ldap\Exception\RequestSizeExceededException;
+use FreeDSx\Ldap\Exception\RequestValidationException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Server\Logging\EventContext;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Logging\ServerEvent;
+use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
+use FreeDSx\Socket\Exception\ConnectionException;
+use FreeDSx\Socket\Exception\IdleTimeoutException;
+use FreeDSx\Socket\Exception\WriteTimeoutException;
+use Throwable;
+
+/**
+ * Decides how a failure that ended the read loop closes the client session.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+readonly class SessionEndPolicy
+{
+    public function __construct(
+        private DisconnectSender $disconnectSender,
+        private EventLogger $eventLogger,
+    ) {}
+
+    /**
+     * What to report about the close, or null when it is not worth counting.
+     *
+     * Note: The order is important here.
+     *
+     * @throws EncoderException
+     */
+    public function end(Throwable $exception): ?ConnectionObservation
+    {
+        return match (true) {
+            // RFC 4511 §4.1.1: a message ID that is zero or reused cannot frame a solicited response.
+            $exception instanceof RequestValidationException => $this->disconnect($exception->getMessage()),
+            // The client stopped reading mid-response, so nothing further can be sent.
+            $exception instanceof WriteTimeoutException => $this->timedOut(
+                ServerEvent::WriteTimeout,
+                $exception,
+                ConnectionObservation::WriteTimeout,
+            ),
+            // The client sent nothing within the read timeout, and there is nothing to send back.
+            $exception instanceof IdleTimeoutException => $this->timedOut(
+                ServerEvent::IdleTimeout,
+                $exception,
+                ConnectionObservation::IdleTimeout,
+            ),
+            // An ordinary client disconnect, which the runner's lifecycle logging already records.
+            $exception instanceof ConnectionException => null,
+            // RFC 4511 §4.1.1, carrying the cause so the log identifies the size violation.
+            $exception instanceof RequestSizeExceededException => $this->disconnect(
+                $exception->getMessage(),
+                cause: $exception,
+                closeReason: ConnectionObservation::RequestSizeExceeded,
+            ),
+            // RFC 4511 §4.1.1: a malformed PDU cannot be processed. The recorded event names the specific reason.
+            $exception instanceof EncoderException,
+            $exception instanceof ProtocolException => $this->disconnect(
+                'The message could not be processed.',
+                closeReason: ConnectionObservation::ProtocolError,
+            ),
+            // RFC 4511 §4.4.1: the connection this session depended on is gone, which no result code can answer.
+            $exception instanceof LdapConnectionException => $this->disconnect(
+                $exception->getMessage(),
+                ResultCode::UNAVAILABLE,
+                $exception,
+                ConnectionObservation::Unavailable,
+            ),
+            default => $this->unexpectedFailure($exception),
+        };
+    }
+
+    /**
+     * Ends the session because the server is going away rather than because anything about it failed.
+     *
+     * @throws EncoderException
+     */
+    public function shuttingDown(): void
+    {
+        $this->disconnectSender->send(
+            'The server is shutting down.',
+            ResultCode::UNAVAILABLE,
+        );
+    }
+
+    /**
+     * @throws EncoderException
+     */
+    private function disconnect(
+        string $message = '',
+        int $reasonCode = ResultCode::PROTOCOL_ERROR,
+        ?Throwable $cause = null,
+        ?ConnectionObservation $closeReason = null,
+    ): ?ConnectionObservation {
+        $this->disconnectSender->send(
+            $message,
+            $reasonCode,
+            $cause,
+        );
+
+        return $closeReason;
+    }
+
+    /**
+     * A timeout has no answer to send.
+     */
+    private function timedOut(
+        ServerEvent $event,
+        Throwable $exception,
+        ConnectionObservation $closeReason,
+    ): ConnectionObservation {
+        $this->eventLogger->record(
+            $event,
+            [EventContext::REASON_MESSAGE => $exception->getMessage()],
+        );
+
+        return $closeReason;
+    }
+
+    /**
+     * @throws EncoderException
+     */
+    private function unexpectedFailure(Throwable $exception): null
+    {
+        $this->disconnectSender->sendIfConnected(cause: $exception);
+
+        return null;
+    }
+}

--- a/src/FreeDSx/Ldap/ProxyOptions.php
+++ b/src/FreeDSx/Ldap/ProxyOptions.php
@@ -26,6 +26,7 @@ final class ProxyOptions
         private ProxyServerOptions $serverOptions,
         private ClientOptions $clientOptions = new ClientOptions(),
         private bool $useStartTls = false,
+        private bool $requireUpstreamConfidentiality = false,
     ) {}
 
     /**
@@ -62,6 +63,21 @@ final class ProxyOptions
     public function setUseStartTls(bool $useStartTls): self
     {
         $this->useStartTls = $useStartTls;
+
+        return $this;
+    }
+
+    /**
+     * Whether the proxy refuses to start unless the upstream hop is encrypted.
+     */
+    public function getRequireUpstreamConfidentiality(): bool
+    {
+        return $this->requireUpstreamConfidentiality;
+    }
+
+    public function setRequireUpstreamConfidentiality(bool $requireUpstreamConfidentiality): self
+    {
+        $this->requireUpstreamConfidentiality = $requireUpstreamConfidentiality;
 
         return $this;
     }

--- a/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
+++ b/src/FreeDSx/Ldap/Server/ConnectionHandlerBuilder.php
@@ -199,6 +199,10 @@ final class ConnectionHandlerBuilder implements ConnectionHandlerBuilderInterfac
                 $backend,
                 $handlerProvider,
             ),
+            sessionEndPolicy: $this->makeSessionEndPolicy(
+                $serverQueue,
+                $eventLogger,
+            ),
             eventLogger: $eventLogger,
             connectionContext: $context,
         );

--- a/src/FreeDSx/Ldap/Server/Metrics/Observation/ConnectionObservation.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Observation/ConnectionObservation.php
@@ -33,4 +33,6 @@ enum ConnectionObservation: string
     case RequestSizeExceeded = 'request_size_exceeded';
 
     case ProtocolError = 'protocol_error';
+
+    case Unavailable = 'unavailable';
 }

--- a/src/FreeDSx/Ldap/Server/Metrics/Recorder/InMemoryMetricsRecorder.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Recorder/InMemoryMetricsRecorder.php
@@ -81,6 +81,11 @@ final class InMemoryMetricsRecorder implements MetricsRecorderInterface, Metrics
     private int $protocolErrors = 0;
 
     /**
+     * @var int<0, max>
+     */
+    private int $unavailable = 0;
+
+    /**
      * @var array<string, int<0, max>>
      */
     private array $operationCounts = [];
@@ -183,6 +188,7 @@ final class InMemoryMetricsRecorder implements MetricsRecorderInterface, Metrics
             ConnectionObservation::IdleTimeout => $this->idleTimeouts++,
             ConnectionObservation::RequestSizeExceeded => $this->requestSizeExceeded++,
             ConnectionObservation::ProtocolError => $this->protocolErrors++,
+            ConnectionObservation::Unavailable => $this->unavailable++,
         };
     }
 
@@ -213,6 +219,7 @@ final class InMemoryMetricsRecorder implements MetricsRecorderInterface, Metrics
                 $this->idleTimeouts,
                 $this->requestSizeExceeded,
                 $this->protocolErrors,
+                $this->unavailable,
             ),
             $this->operationMetrics(),
             $this->operationsInProgress,

--- a/src/FreeDSx/Ldap/Server/Metrics/Recorder/SwooleTableMetricsRecorder.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Recorder/SwooleTableMetricsRecorder.php
@@ -71,6 +71,8 @@ final class SwooleTableMetricsRecorder implements MetricsRecorderInterface, Metr
 
     private const CONNECTIONS_PROTOCOL_ERRORS = 'conn.protocolErrors';
 
+    private const CONNECTIONS_UNAVAILABLE = 'conn.unavailable';
+
     private const TRAFFIC_SENT = 'traffic.sent';
 
     private const TRAFFIC_RECEIVED = 'traffic.received';
@@ -192,6 +194,7 @@ final class SwooleTableMetricsRecorder implements MetricsRecorderInterface, Metr
             ConnectionObservation::IdleTimeout => $this->add(self::CONNECTIONS_IDLE_TIMEOUTS, 1),
             ConnectionObservation::RequestSizeExceeded => $this->add(self::CONNECTIONS_REQUEST_SIZE, 1),
             ConnectionObservation::ProtocolError => $this->add(self::CONNECTIONS_PROTOCOL_ERRORS, 1),
+            ConnectionObservation::Unavailable => $this->add(self::CONNECTIONS_UNAVAILABLE, 1),
         };
     }
 
@@ -266,6 +269,7 @@ final class SwooleTableMetricsRecorder implements MetricsRecorderInterface, Metr
                 idleTimeouts: $this->get(self::CONNECTIONS_IDLE_TIMEOUTS),
                 requestSizeExceeded: $this->get(self::CONNECTIONS_REQUEST_SIZE),
                 protocolErrors: $this->get(self::CONNECTIONS_PROTOCOL_ERRORS),
+                unavailable: $this->get(self::CONNECTIONS_UNAVAILABLE),
             ),
             operations: new OperationMetrics(
                 counts: $counts,

--- a/src/FreeDSx/Ldap/Server/Metrics/Snapshot/ConnectionMetrics.php
+++ b/src/FreeDSx/Ldap/Server/Metrics/Snapshot/ConnectionMetrics.php
@@ -28,6 +28,7 @@ final readonly class ConnectionMetrics
         public int $idleTimeouts = 0,
         public int $requestSizeExceeded = 0,
         public int $protocolErrors = 0,
+        public int $unavailable = 0,
     ) {}
 
     /**
@@ -43,6 +44,7 @@ final readonly class ConnectionMetrics
             'idle_timeouts' => $this->idleTimeouts,
             'request_size_exceeded' => $this->requestSizeExceeded,
             'protocol_errors' => $this->protocolErrors,
+            'unavailable' => $this->unavailable,
         ];
     }
 
@@ -59,6 +61,7 @@ final readonly class ConnectionMetrics
             idleTimeouts: SnapshotValue::toInt($data['idle_timeouts'] ?? null),
             requestSizeExceeded: SnapshotValue::toInt($data['request_size_exceeded'] ?? null),
             protocolErrors: SnapshotValue::toInt($data['protocol_errors'] ?? null),
+            unavailable: SnapshotValue::toInt($data['unavailable'] ?? null),
         );
     }
 }

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyAuthenticator.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyAuthenticator.php
@@ -17,7 +17,6 @@ use FreeDSx\Ldap\Exception\BindException;
 use FreeDSx\Ldap\Exception\ConnectionException;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Exception\OperationException;
-use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
 use FreeDSx\Ldap\Server\Backend\Auth\SaslIdentity;
 use FreeDSx\Ldap\Server\Token\AuthenticatedTokenInterface;
@@ -33,8 +32,7 @@ use SensitiveParameter;
 final readonly class ProxyAuthenticator implements PasswordAuthenticatableInterface
 {
     public function __construct(
-        private LdapClient $client,
-        private bool $useStartTls = false,
+        private ProxyUpstreamSession $session,
     ) {}
 
     public function authenticate(
@@ -43,12 +41,7 @@ final readonly class ProxyAuthenticator implements PasswordAuthenticatableInterf
         string $password,
     ): AuthenticatedTokenInterface {
         try {
-            // Re-issuing it on a connection already upgraded is an operations error the upstream answers by hanging up.
-            if ($this->useStartTls && !$this->client->isEncrypted()) {
-                $this->client->startTls();
-            }
-
-            $this->client->bind(
+            $this->session->bind(
                 $name,
                 $password,
             );

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyAuthenticator.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyAuthenticator.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\Proxy;
 
 use FreeDSx\Ldap\Exception\BindException;
+use FreeDSx\Ldap\Exception\ConnectionException;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Server\Backend\Auth\PasswordAuthenticatableInterface;
@@ -40,11 +42,12 @@ final readonly class ProxyAuthenticator implements PasswordAuthenticatableInterf
         #[SensitiveParameter]
         string $password,
     ): AuthenticatedTokenInterface {
-        if ($this->useStartTls) {
-            $this->client->startTls();
-        }
-
         try {
+            // Re-issuing it on a connection already upgraded is an operations error the upstream answers by hanging up.
+            if ($this->useStartTls && !$this->client->isEncrypted()) {
+                $this->client->startTls();
+            }
+
             $this->client->bind(
                 $name,
                 $password,
@@ -53,6 +56,11 @@ final readonly class ProxyAuthenticator implements PasswordAuthenticatableInterf
             throw new OperationException(
                 $e->getMessage(),
                 $e->getCode(),
+            );
+        } catch (ConnectionException) {
+            throw new OperationException(
+                'The upstream LDAP server is unavailable.',
+                ResultCode::UNAVAILABLE,
             );
         }
 

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyBindResetMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyBindResetMiddleware.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Proxy;
+
+use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
+use FreeDSx\Ldap\Protocol\ServerAuthorization;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareHandlerInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareInterface;
+use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
+
+/**
+ * Ends the upstream session for a bind the proxy did not carry through.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class ProxyBindResetMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private ServerAuthorization $authorization,
+        private ProxyUpstreamSession $session,
+    ) {}
+
+    /**
+     * {@inheritDoc}
+     */
+    public function process(
+        ServerRequestContext $context,
+        MiddlewareHandlerInterface $next,
+    ): ResponseStream {
+        if (!$this->authorization->isAuthenticationRequest($context->message->getRequest())) {
+            return $next->handle($context);
+        }
+
+        try {
+            return $next->handle($context);
+        } finally {
+            // RFC 4511 §4.2.1 leaves a session anonymous when its bind does not succeed.
+            if (!$this->authorization->isAuthenticated()) {
+                $this->session->reset();
+            }
+        }
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyProtocolFactory.php
@@ -28,6 +28,8 @@ use FreeDSx\Ldap\Server\Middleware\BindMiddleware;
 use FreeDSx\Ldap\Server\Middleware\ConfidentialityMiddleware;
 use FreeDSx\Ldap\Server\Middleware\CriticalControlValidator;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareChain;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
 use FreeDSx\Ldap\Server\Middleware\RequestValidationMiddleware;
 use FreeDSx\Ldap\Server\ServerConnectionScaffoldingTrait;
 use FreeDSx\Ldap\Server\ServerProtocolFactoryInterface;
@@ -47,6 +49,7 @@ final class ProxyProtocolFactory implements ServerProtocolFactoryInterface
 
     public function __construct(
         private readonly ProxyOptions $proxyOptions,
+        private readonly SleeperInterface $sleeper = new BlockingSleeper(),
     ) {
         $this->options = $proxyOptions->getServerOptions();
     }
@@ -59,14 +62,16 @@ final class ProxyProtocolFactory implements ServerProtocolFactoryInterface
         $eventLogger = $this->makeEventLogger($context);
         $upstream = new LdapClient($this->proxyOptions->getClientOptions());
         $serverAuthorization = new ServerAuthorization($this->options);
+        $session = new ProxyUpstreamSession(
+            client: $upstream,
+            useStartTls: $this->proxyOptions->getUseStartTls(),
+            sleeper: $this->sleeper,
+        );
 
         $authenticators = [
             new SimpleBind(
                 queue: $queue,
-                authenticator: new ProxyAuthenticator(
-                    $upstream,
-                    $this->proxyOptions->getUseStartTls(),
-                ),
+                authenticator: new ProxyAuthenticator($session),
                 eventLogger: $eventLogger,
             ),
             $this->makeAnonymousBind(
@@ -82,6 +87,10 @@ final class ProxyProtocolFactory implements ServerProtocolFactoryInterface
                 new ConfidentialityMiddleware(
                     $this->options,
                     $queue,
+                ),
+                new ProxyBindResetMiddleware(
+                    $serverAuthorization,
+                    $session,
                 ),
                 new BindMiddleware(
                     $serverAuthorization,
@@ -101,6 +110,7 @@ final class ProxyProtocolFactory implements ServerProtocolFactoryInterface
                 new ProxyRequestForwarder(
                     $upstream,
                     $queue,
+                    $session,
                 ),
                 new ResponseWriter($queue),
             ),

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyProtocolFactory.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyProtocolFactory.php
@@ -119,6 +119,10 @@ final class ProxyProtocolFactory implements ServerProtocolFactoryInterface
         return new ServerProtocolHandler(
             queue: $queue,
             requestPipeline: $pipeline,
+            sessionEndPolicy: $this->makeSessionEndPolicy(
+                $queue,
+                $eventLogger,
+            ),
             eventLogger: $eventLogger,
             connectionContext: $context,
         );

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyRequestForwarder.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyRequestForwarder.php
@@ -16,6 +16,7 @@ namespace FreeDSx\Ldap\Server\Proxy;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Exception\ConnectionException;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Exception\ReferralException;
 use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
@@ -89,6 +90,17 @@ final readonly class ProxyRequestForwarder implements MiddlewareHandlerInterface
             ));
 
             return ResponseStream::resolved(OperationOutcomeResult::failed($e->getCode()));
+        } catch (ReferralException $e) {
+            // Only a search treats a referral as an ordinary result.
+            $this->queue->sendMessage($this->responseFactory->getStandardResponse(
+                $message,
+                ResultCode::REFERRAL,
+                $e->getMessage(),
+                null,
+                $e->getReferrals(),
+            ));
+
+            return ResponseStream::resolved(OperationOutcomeResult::failed(ResultCode::REFERRAL));
         }
 
         if ($request instanceof SearchRequest) {

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyRequestForwarder.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyRequestForwarder.php
@@ -123,6 +123,8 @@ final readonly class ProxyRequestForwarder implements MiddlewareHandlerInterface
         array $controls,
     ): LdapMessageResponse {
         try {
+            $this->session->ensureEncrypted();
+
             return $this->client->sendAndReceive(
                 $request,
                 ...$controls,

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyRequestForwarder.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyRequestForwarder.php
@@ -46,6 +46,7 @@ final readonly class ProxyRequestForwarder implements MiddlewareHandlerInterface
     public function __construct(
         private LdapClient $client,
         private ServerQueue $queue,
+        private ProxyUpstreamSession $session,
         private ResponseFactory $responseFactory = new ResponseFactory(),
     ) {}
 
@@ -114,6 +115,7 @@ final readonly class ProxyRequestForwarder implements MiddlewareHandlerInterface
 
     /**
      * @param array<int, Control> $controls
+     * @throws ConnectionException When a bound session loses the upstream identity it was answering for.
      * @throws OperationException
      */
     private function sendUpstream(
@@ -125,7 +127,13 @@ final readonly class ProxyRequestForwarder implements MiddlewareHandlerInterface
                 $request,
                 ...$controls,
             );
-        } catch (ConnectionException) {
+        } catch (ConnectionException $e) {
+            // Reconnecting returns an anonymous session
+            // Ending it beats answering as an identity we no longer are.
+            if ($this->session->isBound()) {
+                throw $e;
+            }
+
             throw new OperationException(
                 'The upstream LDAP server is unavailable.',
                 ResultCode::UNAVAILABLE,

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyRequestForwarder.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyRequestForwarder.php
@@ -20,10 +20,11 @@ use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
 use FreeDSx\Ldap\Operation\Request\SearchRequest;
+use FreeDSx\Ldap\Search\Result\EntryResult;
+use FreeDSx\Ldap\Search\Result\ReferralResult;
 use FreeDSx\Ldap\Operation\Request\UnbindRequest;
 use FreeDSx\Ldap\Operation\Response\SearchResponse;
 use FreeDSx\Ldap\Operation\Response\SearchResultDone;
-use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
@@ -65,6 +66,13 @@ final readonly class ProxyRequestForwarder implements MiddlewareHandlerInterface
         // Synchronous, sequential forwarding means nothing is ever in flight upstream to abandon.
         if ($request instanceof AbandonRequest) {
             return ResponseStream::resolved(OperationOutcomeResult::succeeded());
+        }
+
+        if ($request instanceof SearchRequest) {
+            $this->relayResultsAsTheyArrive(
+                $request,
+                $message->getMessageId(),
+            );
         }
 
         try {
@@ -124,6 +132,43 @@ final readonly class ProxyRequestForwarder implements MiddlewareHandlerInterface
         ));
     }
 
+    /**
+     * An upstream PDU carried over under this client's message id, keeping whatever controls it arrived with.
+     */
+    private function relayed(
+        int $messageId,
+        LdapMessageResponse $upstream,
+    ): LdapMessageResponse {
+        return new LdapMessageResponse(
+            $messageId,
+            $upstream->getResponse(),
+            ...$upstream->controls()->toArray(),
+        );
+    }
+
+    /**
+     * Hands each result to the client as it arrives, rather than collecting the whole set first.
+     */
+    private function relayResultsAsTheyArrive(
+        SearchRequest $request,
+        int $messageId,
+    ): void {
+        // Taken from the upstream message rather than the bare entry, so per-entry controls survive the hop.
+        $request->useEntryHandler(function (EntryResult $result) use ($messageId): void {
+            $this->queue->sendMessage($this->relayed(
+                $messageId,
+                $result->getMessage(),
+            ));
+        });
+
+        $request->useReferralHandler(function (ReferralResult $result) use ($messageId): void {
+            $this->queue->sendMessage($this->relayed(
+                $messageId,
+                $result->getMessage(),
+            ));
+        });
+    }
+
     private function relaySearch(
         LdapMessageRequest $message,
         LdapMessageResponse $response,
@@ -136,26 +181,15 @@ final readonly class ProxyRequestForwarder implements MiddlewareHandlerInterface
             return;
         }
 
-        $messageId = $message->getMessageId();
-        $messages = [];
-
-        foreach ($searchResponse->getEntries() as $entry) {
-            $messages[] = new LdapMessageResponse(
-                $messageId,
-                new SearchResultEntry($entry),
-            );
-        }
-
-        $messages[] = new LdapMessageResponse(
-            $messageId,
+        // Only the terminal message is left to send.
+        $this->queue->sendMessage(new LdapMessageResponse(
+            $message->getMessageId(),
             new SearchResultDone(
                 $searchResponse->getResultCode(),
                 $searchResponse->getDn(),
                 $searchResponse->getDiagnosticMessage(),
             ),
             ...$response->controls()->toArray(),
-        );
-
-        $this->queue->sendMessages($messages);
+        ));
     }
 }

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyUpstreamSession.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyUpstreamSession.php
@@ -85,6 +85,21 @@ final class ProxyUpstreamSession
     }
 
     /**
+     * Upgrades the upstream link before anything crosses it.
+     *
+     * @throws ConnectionException
+     */
+    public function ensureEncrypted(): void
+    {
+        // Re-issuing it on a connection already upgraded is an operations error the upstream answers by hanging up.
+        if (!$this->useStartTls || $this->client->isEncrypted()) {
+            return;
+        }
+
+        $this->client->startTls();
+    }
+
+    /**
      * Ends the upstream session so it cannot keep serving an identity the proxy no longer holds.
      */
     public function reset(): void
@@ -126,10 +141,7 @@ final class ProxyUpstreamSession
         #[SensitiveParameter]
         string $password,
     ): void {
-        // Re-issuing it on a connection already upgraded is an operations error the upstream answers by hanging up.
-        if ($this->useStartTls && !$this->client->isEncrypted()) {
-            $this->client->startTls();
-        }
+        $this->ensureEncrypted();
 
         $this->client->bind(
             $name,

--- a/src/FreeDSx/Ldap/Server/Proxy/ProxyUpstreamSession.php
+++ b/src/FreeDSx/Ldap/Server/Proxy/ProxyUpstreamSession.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Proxy;
+
+use FreeDSx\Ldap\Exception\BindException;
+use FreeDSx\Ldap\Exception\ConnectionException;
+use FreeDSx\Ldap\Exception\NoticeOfDisconnectException;
+use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
+use FreeDSx\Ldap\Server\Utility\ExponentialBackoff;
+use SensitiveParameter;
+
+/**
+ * Owns the identity of the upstream connection backing one proxied session.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final class ProxyUpstreamSession
+{
+    private bool $isBound = false;
+
+    public function __construct(
+        private readonly LdapClient $client,
+        private readonly bool $useStartTls = false,
+        private readonly SleeperInterface $sleeper = new BlockingSleeper(),
+        private readonly int $maxAttempts = 3,
+        private readonly ExponentialBackoff $backoff = new ExponentialBackoff(
+            base: 0.05,
+            max: 1.0,
+        ),
+    ) {}
+
+    /**
+     * Whether an identity is currently established upstream.
+     */
+    public function isBound(): bool
+    {
+        return $this->isBound;
+    }
+
+    /**
+     * Establishes the identity upstream, reissuing only failures that prove the credential never landed.
+     *
+     * @throws BindException
+     * @throws ConnectionException
+     */
+    public function bind(
+        string $name,
+        #[SensitiveParameter]
+        string $password,
+    ): void {
+        $attempt = 0;
+
+        while (true) {
+            try {
+                $this->connectAndBind(
+                    $name,
+                    $password,
+                );
+                $this->isBound = true;
+
+                return;
+            } catch (ConnectionException $e) {
+                $attempt++;
+
+                if (!$this->canRetry($e, $attempt)) {
+                    throw $e;
+                }
+
+                $this->sleeper->sleep($this->backoff->delayFor($attempt));
+            }
+        }
+    }
+
+    /**
+     * Ends the upstream session so it cannot keep serving an identity the proxy no longer holds.
+     */
+    public function reset(): void
+    {
+        if (!$this->isBound) {
+            return;
+        }
+
+        $this->isBound = false;
+
+        if (!$this->client->isConnected()) {
+            return;
+        }
+
+        try {
+            $this->client->unbind();
+        } catch (ConnectionException) {
+            $this->client->disconnect();
+        }
+    }
+
+    /**
+     * Only a true transport failure is worth retrying.
+     */
+    private function canRetry(
+        ConnectionException $exception,
+        int $attempt,
+    ): bool {
+        return !$exception instanceof NoticeOfDisconnectException
+            && $attempt < $this->maxAttempts;
+    }
+
+    /**
+     * @throws BindException
+     * @throws ConnectionException
+     */
+    private function connectAndBind(
+        string $name,
+        #[SensitiveParameter]
+        string $password,
+    ): void {
+        // Re-issuing it on a connection already upgraded is an operations error the upstream answers by hanging up.
+        if ($this->useStartTls && !$this->client->isEncrypted()) {
+            $this->client->startTls();
+        }
+
+        $this->client->bind(
+            $name,
+            $password,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Server/ServerConnectionScaffoldingTrait.php
+++ b/src/FreeDSx/Ldap/Server/ServerConnectionScaffoldingTrait.php
@@ -14,8 +14,11 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server;
 
 use FreeDSx\Ldap\Protocol\Bind\AnonymousBind;
+use FreeDSx\Ldap\Protocol\DisconnectSender;
+use FreeDSx\Ldap\Protocol\Factory\ResponseFactory;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseInterceptor;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\SessionEndPolicy;
 use FreeDSx\Ldap\Server\Logging\ConnectionContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Metrics\MetricsRecorderInterface;
@@ -45,6 +48,21 @@ trait ServerConnectionScaffoldingTrait
             maxReceiveSize: $this->serverOptions()->getNetworkConfig()->getMaxRequestSize(),
             interceptors: $interceptors,
             metricsRecorder: $metricsRecorder,
+        );
+    }
+
+    private function makeSessionEndPolicy(
+        ServerQueue $queue,
+        EventLogger $eventLogger,
+        ResponseFactory $responseFactory = new ResponseFactory(),
+    ): SessionEndPolicy {
+        return new SessionEndPolicy(
+            new DisconnectSender(
+                $queue,
+                $eventLogger,
+                $responseFactory,
+            ),
+            $eventLogger,
         );
     }
 

--- a/tests/bin/ldap-proxy.php
+++ b/tests/bin/ldap-proxy.php
@@ -2,54 +2,16 @@
 
 declare(strict_types=1);
 
-use FreeDSx\Ldap\ClientOptions;
-use FreeDSx\Ldap\LdapProxyServer;
-use FreeDSx\Ldap\ProxyOptions;
-use FreeDSx\Ldap\ProxyServerOptions;
-use FreeDSx\Ldap\Server\Config\NetworkConfig;
-use Symfony\Component\Process\Process;
-use Tests\Support\FreeDSx\Ldap\TestWorker;
+use Symfony\Component\Console\Application;
+use Tests\Support\FreeDSx\Ldap\LdapProxyCommand;
 
 require __DIR__ . '/../../vendor/autoload.php';
 
-$upstreamPort = TestWorker::port(TestWorker::OFFSET_UPSTREAM);
-
-$upstream = new Process([
-    'php',
-    '-dpcov.enabled=0',
-    __DIR__ . '/ldap-server.php',
-    '--transport=ssl',
-    '--port=' . $upstreamPort,
-    '--entries=12',
-]);
-$upstream->start();
-
-$deadline = microtime(true) + 10.0;
-while ($upstream->isRunning()) {
-    if (str_contains($upstream->getOutput(), 'server starting...')) {
-        break;
-    }
-    if (microtime(true) >= $deadline) {
-        break;
-    }
-    usleep(50_000);
-}
-
-register_shutdown_function(static fn() => $upstream->stop());
-
-$server = new LdapProxyServer(new ProxyOptions(
-    serverOptions: (new ProxyServerOptions((new NetworkConfig())
-        ->setPort(TestWorker::port())
-        ->setSslCert(__DIR__ . '/../resources/cert/slapd.crt')
-        ->setSslCertKey(__DIR__ . '/../resources/cert/slapd.key')
-        ->setSocketAcceptTimeout(0.1)))
-        ->setOnServerReady(fn() => fwrite(STDOUT, 'server starting...' . PHP_EOL)),
-    clientOptions: (new ClientOptions())
-        ->setServers(['127.0.0.1'])
-        ->setPort($upstreamPort)
-        ->setUseSsl(true)
-        ->setSslValidateCert(false)
-        ->setSslAllowSelfSigned(true),
-));
-
-$server->run();
+$command = new LdapProxyCommand();
+$app = new Application('LDAP test proxy');
+$app->add($command);
+$app->setDefaultCommand(
+    (string) $command->getName(),
+    true,
+);
+$app->run();

--- a/tests/integration/LdapProxyTest.php
+++ b/tests/integration/LdapProxyTest.php
@@ -219,6 +219,38 @@ final class LdapProxyTest extends ServerTestCase
         );
     }
 
+    public function testItProtectsTheUpstreamHopBeforeForwardingAnythingUnbound(): void
+    {
+        $this->createServerProcess(
+            'tcp',
+            [
+                '--upstream-start-tls',
+                '--upstream-require-confidentiality=all',
+            ],
+        );
+
+        // The upstream refuses every unprotected operation, so an answer at all proves the hop was upgraded first.
+        self::assertNull($this->ldapClient()->whoami());
+    }
+
+    public function testItProtectsTheUpstreamHopForABindThatFollowsNoOtherOperation(): void
+    {
+        $this->createServerProcess(
+            'tcp',
+            [
+                '--upstream-start-tls',
+                '--upstream-require-confidentiality=all',
+            ],
+        );
+
+        $this->authenticateAdmin();
+
+        self::assertSame(
+            'dn:cn=admin,dc=foo,dc=bar',
+            $this->ldapClient()->whoami(),
+        );
+    }
+
     /**
      * Ends the forked upstream sessions while leaving its listener accepting, so only the proxied hop is lost.
      */

--- a/tests/integration/LdapProxyTest.php
+++ b/tests/integration/LdapProxyTest.php
@@ -18,8 +18,12 @@ use FreeDSx\Ldap\Control\ReadEntry\PostReadResponseControl;
 use FreeDSx\Ldap\Controls;
 use FreeDSx\Ldap\Entry\Change;
 use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\BindException;
+use FreeDSx\Ldap\Exception\ConnectionException;
+use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Operations;
 use FreeDSx\Ldap\Search\Filters;
+use Tests\Support\FreeDSx\Ldap\TestWorker;
 
 final class LdapProxyTest extends ServerTestCase
 {
@@ -157,5 +161,84 @@ final class LdapProxyTest extends ServerTestCase
             'dn:cn=user,dc=foo,dc=bar',
             $this->ldapClient()->whoami(),
         );
+    }
+
+    public function testARefusedBindLeavesTheUpstreamSessionAnonymous(): void
+    {
+        $this->authenticateAdmin();
+        self::assertSame(
+            'dn:cn=admin,dc=foo,dc=bar',
+            $this->ldapClient()->whoami(),
+        );
+
+        try {
+            $this->ldapClient()->send(Operations::bindAnonymously());
+            self::fail('The proxy was expected to refuse an anonymous bind.');
+        } catch (BindException) {
+        }
+
+        self::assertNull($this->ldapClient()->whoami());
+    }
+
+    public function testLosingTheUpstreamEndsTheProxiedSession(): void
+    {
+        $this->authenticateAdmin();
+        self::assertNotEmpty($this->ldapClient()->search(
+            Operations::search(Filters::equal('objectClass', 'inetOrgPerson'))
+                ->base('dc=foo,dc=bar'),
+        )->toArray());
+
+        self::killUpstreamConnections();
+
+        try {
+            $this->ldapClient()->whoami();
+            self::fail('The proxy was expected to end the session with its upstream.');
+        } catch (ConnectionException $e) {
+            self::assertSame(
+                ResultCode::UNAVAILABLE,
+                $e->getCode(),
+            );
+        }
+    }
+
+    public function testTheClientCanRebuildASessionTheUpstreamEnded(): void
+    {
+        $this->authenticateAdmin();
+        self::killUpstreamConnections();
+
+        try {
+            $this->ldapClient()->whoami();
+        } catch (ConnectionException) {
+        }
+
+        $this->authenticateAdmin();
+
+        self::assertSame(
+            'dn:cn=admin,dc=foo,dc=bar',
+            $this->ldapClient()->whoami(),
+        );
+    }
+
+    /**
+     * Ends the forked upstream sessions while leaving its listener accepting, so only the proxied hop is lost.
+     */
+    private static function killUpstreamConnections(): void
+    {
+        $pattern = sprintf(
+            'ldap-server.php.*--port=%d',
+            TestWorker::port(TestWorker::OFFSET_UPSTREAM),
+        );
+        exec(
+            sprintf('pgrep -f %s', escapeshellarg($pattern)),
+            $pids,
+        );
+        sort($pids);
+
+        // The listener is the oldest of them, and every process forked from it is holding a proxied connection.
+        foreach (array_slice($pids, 1) as $pid) {
+            posix_kill((int) $pid, SIGKILL);
+        }
+
+        usleep(300_000);
     }
 }

--- a/tests/support/LdapProxyCommand.php
+++ b/tests/support/LdapProxyCommand.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\FreeDSx\Ldap;
+
+use FreeDSx\Ldap\ClientOptions;
+use FreeDSx\Ldap\LdapProxyServer;
+use FreeDSx\Ldap\ProxyOptions;
+use FreeDSx\Ldap\ProxyServerOptions;
+use FreeDSx\Ldap\Server\Config\NetworkConfig;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+final class LdapProxyCommand extends Command
+{
+    use ConsoleOptionsTrait;
+
+    private const SSL_KEY = __DIR__ . '/../resources/cert/slapd.key';
+
+    private const SSL_CERT = __DIR__ . '/../resources/cert/slapd.crt';
+
+    private const VALID_CONFIDENTIALITY = ['none', 'bind', 'all'];
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('ldap-proxy')
+            ->setDescription('Run the test LDAP proxy and the upstream it forwards to')
+            ->addOption(
+                'transport',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Transport clients connect to the proxy over (tcp, ssl)',
+                'tcp',
+            )
+            ->addOption(
+                'entries',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Number of extra entries to seed upstream',
+                '12',
+            )
+            ->addOption(
+                'upstream-start-tls',
+                null,
+                InputOption::VALUE_NONE,
+                'Upgrade the upstream hop with StartTLS rather than connecting to it over LDAPS',
+            )
+            ->addOption(
+                'upstream-require-confidentiality',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Confidentiality the upstream demands: none, bind (credential-bearing binds), or all (every operation)',
+                'none',
+            )
+            ->addOption(
+                'require-upstream-confidentiality',
+                null,
+                InputOption::VALUE_NONE,
+                'Refuse to start unless the upstream hop is encrypted',
+            );
+    }
+
+    protected function execute(
+        InputInterface $input,
+        OutputInterface $output,
+    ): int {
+        $upstreamStartTls = $input->getOption('upstream-start-tls') === true;
+        $upstreamConfidentiality = $this->getStringOption($input, 'upstream-require-confidentiality');
+
+        if (!in_array($upstreamConfidentiality, self::VALID_CONFIDENTIALITY, true)) {
+            $output->writeln(sprintf(
+                '<error>Invalid --upstream-require-confidentiality value: %s. Expected one of: %s.</error>',
+                $upstreamConfidentiality,
+                implode(', ', self::VALID_CONFIDENTIALITY),
+            ));
+
+            return Command::FAILURE;
+        }
+
+        $upstreamPort = TestWorker::port(TestWorker::OFFSET_UPSTREAM);
+        $upstream = $this->startUpstream(
+            $upstreamPort,
+            $upstreamStartTls,
+            $upstreamConfidentiality,
+            $this->getStringOption($input, 'entries'),
+        );
+
+        register_shutdown_function(static fn() => $upstream->stop());
+
+        $server = new LdapProxyServer(new ProxyOptions(
+            serverOptions: $this->makeServerOptions(
+                $output,
+                $this->getStringOption($input, 'transport') === 'ssl',
+            ),
+            clientOptions: (new ClientOptions())
+                ->setServers(['127.0.0.1'])
+                ->setPort($upstreamPort)
+                ->setUseSsl(!$upstreamStartTls)
+                ->setSslValidateCert(false)
+                ->setSslAllowSelfSigned(true),
+            useStartTls: $upstreamStartTls,
+            requireUpstreamConfidentiality: $input->getOption('require-upstream-confidentiality') === true,
+        ));
+        $server->run();
+
+        return Command::SUCCESS;
+    }
+
+    private function makeServerOptions(
+        OutputInterface $output,
+        bool $useSsl,
+    ): ProxyServerOptions {
+        return (new ProxyServerOptions((new NetworkConfig())
+            ->setPort(TestWorker::port())
+            ->setUseSsl($useSsl)
+            ->setSslCert(self::SSL_CERT)
+            ->setSslCertKey(self::SSL_KEY)
+            ->setSocketAcceptTimeout(0.1)))
+            ->setOnServerReady(fn() => $output->writeln('server starting...'));
+    }
+
+    /**
+     * The proxy owns its upstream, so tests get both from one process tree.
+     */
+    private function startUpstream(
+        int $port,
+        bool $useStartTls,
+        string $confidentiality,
+        string $entries,
+    ): Process {
+        $upstream = new Process([
+            'php',
+            '-dpcov.enabled=0',
+            __DIR__ . '/../bin/ldap-server.php',
+            // StartTLS upgrades a cleartext listener, while LDAPS needs the socket encrypted from the start.
+            '--transport=' . ($useStartTls ? 'tcp' : 'ssl'),
+            '--port=' . $port,
+            '--entries=' . $entries,
+            '--require-confidentiality=' . $confidentiality,
+        ]);
+        $upstream->start();
+
+        $deadline = microtime(true) + 10.0;
+        while ($upstream->isRunning()) {
+            if (str_contains($upstream->getOutput(), 'server starting...')) {
+                break;
+            }
+            if (microtime(true) >= $deadline) {
+                break;
+            }
+            usleep(50_000);
+        }
+
+        return $upstream;
+    }
+}

--- a/tests/unit/ContainerTest.php
+++ b/tests/unit/ContainerTest.php
@@ -20,6 +20,7 @@ use FreeDSx\Ldap\Server\Config\Storage\InMemoryStorageConfig;
 use FreeDSx\Ldap\Server\Config\Storage\PdoConfig;
 use FreeDSx\Ldap\Server\ServerRunner\RunnerMode;
 use FreeDSx\Ldap\Container;
+use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Protocol\ClientProtocolHandler;
 use FreeDSx\Ldap\Protocol\Factory\ClientProtocolHandlerFactory;
@@ -147,6 +148,47 @@ class ContainerTest extends TestCase
     public function test_a_proxy_container_uses_the_proxy_protocol_factory(): void
     {
         $container = Container::forProxy(new ProxyOptions(new ProxyServerOptions()));
+
+        self::assertInstanceOf(
+            ProxyProtocolFactory::class,
+            $container->get(ServerProtocolFactoryInterface::class),
+        );
+    }
+
+    public function test_a_proxy_is_refused_when_it_requires_an_upstream_that_cannot_be_encrypted(): void
+    {
+        $container = Container::forProxy(new ProxyOptions(
+            serverOptions: new ProxyServerOptions(),
+            requireUpstreamConfidentiality: true,
+        ));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The upstream connection is not encrypted.');
+
+        $container->get(ServerProtocolFactoryInterface::class);
+    }
+
+    public function test_a_proxy_requiring_upstream_confidentiality_accepts_an_upstream_using_start_tls(): void
+    {
+        $container = Container::forProxy(new ProxyOptions(
+            serverOptions: new ProxyServerOptions(),
+            useStartTls: true,
+            requireUpstreamConfidentiality: true,
+        ));
+
+        self::assertInstanceOf(
+            ProxyProtocolFactory::class,
+            $container->get(ServerProtocolFactoryInterface::class),
+        );
+    }
+
+    public function test_a_proxy_requiring_upstream_confidentiality_accepts_an_upstream_using_ldaps(): void
+    {
+        $container = Container::forProxy(new ProxyOptions(
+            serverOptions: new ProxyServerOptions(),
+            clientOptions: (new ClientOptions())->setUseSsl(true),
+            requireUpstreamConfidentiality: true,
+        ));
 
         self::assertInstanceOf(
             ProxyProtocolFactory::class,

--- a/tests/unit/Protocol/ClientProtocolHandlerTest.php
+++ b/tests/unit/Protocol/ClientProtocolHandlerTest.php
@@ -15,6 +15,7 @@ namespace Tests\Unit\FreeDSx\Ldap\Protocol;
 
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Exception\ConnectionException;
+use FreeDSx\Ldap\Exception\NoticeOfDisconnectException;
 use FreeDSx\Ldap\Exception\UnsolicitedNotificationException;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Operation\Request\UnbindRequest;
@@ -28,6 +29,7 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ClientQueue;
 use FreeDSx\Ldap\Protocol\Queue\ClientQueueInstantiator;
+use FreeDSx\Socket\Exception\IdleTimeoutException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Tests\Unit\FreeDSx\Ldap\TestFactoryTrait;
@@ -116,6 +118,57 @@ final class ClientProtocolHandlerTest extends TestCase
             ->willThrowException(new \FreeDSx\Socket\Exception\ConnectionException(
                 'foo',
             ));
+
+        $this->subject->send(new DeleteRequest('foo'));
+    }
+
+    public function test_it_should_raise_a_notice_of_disconnect_exception_when_the_peer_ends_the_session(): void
+    {
+        $this->expectException(NoticeOfDisconnectException::class);
+
+        $this->mockRequestHandler
+            ->expects($this->any())
+            ->method('handleRequest')
+            ->willThrowException(
+                new UnsolicitedNotificationException(
+                    'foo',
+                    0,
+                    null,
+                    ExtendedResponse::OID_NOTICE_OF_DISCONNECTION,
+                ),
+            );
+
+        $this->subject->send(new DeleteRequest('foo'));
+    }
+
+    public function test_it_should_close_the_queue_on_a_transport_failure_so_the_next_request_reconnects(): void
+    {
+        $this->expectException(ConnectionException::class);
+
+        $this->mockRequestHandler
+            ->expects($this->any())
+            ->method('handleRequest')
+            ->willThrowException(new \FreeDSx\Socket\Exception\ConnectionException('foo'));
+
+        $this->mockQueue
+            ->expects($this->once())
+            ->method('close');
+
+        $this->subject->send(new DeleteRequest('foo'));
+    }
+
+    public function test_it_should_keep_the_queue_open_when_only_the_read_timed_out(): void
+    {
+        $this->expectException(ConnectionException::class);
+
+        $this->mockRequestHandler
+            ->expects($this->any())
+            ->method('handleRequest')
+            ->willThrowException(new IdleTimeoutException('foo'));
+
+        $this->mockQueue
+            ->expects($this->never())
+            ->method('close');
 
         $this->subject->send(new DeleteRequest('foo'));
     }

--- a/tests/unit/Protocol/Factory/ResponseFactoryTest.php
+++ b/tests/unit/Protocol/Factory/ResponseFactoryTest.php
@@ -289,6 +289,7 @@ final class ResponseFactoryTest extends TestCase
             ResultCode::SUCCESS,
             '',
             null,
+            [],
             $control,
         );
 

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerMonitorHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerMonitorHandlerTest.php
@@ -275,6 +275,19 @@ final class ServerMonitorHandlerTest extends TestCase
         );
     }
 
+    public function test_it_reports_connections_closed_by_a_lost_dependency(): void
+    {
+        $this->metrics->connectionObserved(ConnectionObservation::Unavailable);
+        $this->metrics->connectionObserved(ConnectionObservation::Unavailable);
+
+        $entry = $this->handleAndCaptureEntry();
+
+        self::assertSame(
+            ['2'],
+            $entry->get('connectionsUnavailable')?->getValues(),
+        );
+    }
+
     public function test_it_reports_traffic_totals(): void
     {
         $this->metrics->trafficObserved(new TrafficObservation(

--- a/tests/unit/Protocol/ServerProtocolHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandlerTest.php
@@ -27,7 +27,9 @@ use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\DisconnectSender;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler;
+use FreeDSx\Ldap\Protocol\SessionEndPolicy;
 use FreeDSx\Ldap\Server\Logging\EventContext;
 use FreeDSx\Ldap\Server\Logging\EventLogger;
 use FreeDSx\Ldap\Server\Logging\EventLogPolicy;
@@ -402,10 +404,19 @@ final class ServerProtocolHandlerTest extends TestCase
         MiddlewareHandlerInterface $pipeline,
         ?EventLogger $eventLogger = null,
     ): ServerProtocolHandler {
+        $eventLogger ??= new EventLogger(null);
+
         return new ServerProtocolHandler(
             $this->mockQueue,
             $pipeline,
-            $eventLogger ?? new EventLogger(null),
+            new SessionEndPolicy(
+                new DisconnectSender(
+                    $this->mockQueue,
+                    $eventLogger,
+                ),
+                $eventLogger,
+            ),
+            $eventLogger,
         );
     }
 

--- a/tests/unit/Protocol/SessionEndPolicyTest.php
+++ b/tests/unit/Protocol/SessionEndPolicyTest.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\FreeDSx\Ldap\Protocol;
+
+use FreeDSx\Asn1\Exception\EncoderException;
+use FreeDSx\Ldap\Exception\ConnectionException as LdapConnectionException;
+use FreeDSx\Ldap\Exception\MessageDecodeException;
+use FreeDSx\Ldap\Exception\ProtocolException;
+use FreeDSx\Ldap\Exception\RequestSizeExceededException;
+use FreeDSx\Ldap\Exception\RequestValidationException;
+use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\DisconnectSender;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
+use FreeDSx\Ldap\Protocol\SessionEndPolicy;
+use FreeDSx\Ldap\Server\Logging\EventLogger;
+use FreeDSx\Ldap\Server\Metrics\Observation\ConnectionObservation;
+use FreeDSx\Socket\Exception\ConnectionException;
+use FreeDSx\Socket\Exception\IdleTimeoutException;
+use FreeDSx\Socket\Exception\WriteTimeoutException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Throwable;
+
+final class SessionEndPolicyTest extends TestCase
+{
+    private ServerQueue&MockObject $queue;
+
+    private SessionEndPolicy $subject;
+
+    /**
+     * @var list<LdapMessageResponse>
+     */
+    private array $sent = [];
+
+    protected function setUp(): void
+    {
+        $this->queue = $this->createMock(ServerQueue::class);
+        $this->sent = [];
+
+        $this->queue
+            ->method('sendMessage')
+            ->willReturnCallback(function (LdapMessageResponse ...$messages): ServerQueue {
+                foreach ($messages as $message) {
+                    $this->sent[] = $message;
+                }
+
+                return $this->queue;
+            });
+
+        $eventLogger = new EventLogger(null);
+        $this->subject = new SessionEndPolicy(
+            new DisconnectSender(
+                $this->queue,
+                $eventLogger,
+            ),
+            $eventLogger,
+        );
+    }
+
+    /**
+     * @return iterable<string, array{Throwable, ?ConnectionObservation}>
+     */
+    public static function closeReasonProvider(): iterable
+    {
+        yield 'an unusable message id' => [
+            new RequestValidationException('bad id'),
+            null,
+        ];
+
+        yield 'the client stopped reading' => [
+            new WriteTimeoutException('write timed out'),
+            ConnectionObservation::WriteTimeout,
+        ];
+
+        yield 'the client went quiet' => [
+            new IdleTimeoutException('idle too long'),
+            ConnectionObservation::IdleTimeout,
+        ];
+
+        yield 'an ordinary disconnect' => [
+            new ConnectionException('client hung up'),
+            null,
+        ];
+
+        yield 'an oversized request' => [
+            new RequestSizeExceededException('too big'),
+            ConnectionObservation::RequestSizeExceeded,
+        ];
+
+        yield 'an undecodable pdu' => [
+            new ProtocolException('malformed'),
+            ConnectionObservation::ProtocolError,
+        ];
+
+        yield 'an encoding failure' => [
+            new EncoderException('cannot encode'),
+            ConnectionObservation::ProtocolError,
+        ];
+
+        yield 'a lost dependency' => [
+            new LdapConnectionException('upstream gone'),
+            ConnectionObservation::Unavailable,
+        ];
+
+        yield 'anything else' => [
+            new RuntimeException('unexpected'),
+            null,
+        ];
+    }
+
+    #[DataProvider('closeReasonProvider')]
+    public function test_it_reports_the_close_reason(
+        Throwable $exception,
+        ?ConnectionObservation $expected,
+    ): void {
+        self::assertSame(
+            $expected,
+            $this->subject->end($exception),
+        );
+    }
+
+    public function test_it_answers_an_unusable_message_id_with_its_own_diagnostic(): void
+    {
+        $this->subject->end(new RequestValidationException('the message id was reused'));
+
+        self::assertSame(
+            'the message id was reused',
+            $this->diagnosticOfOnlyNotice(),
+        );
+    }
+
+    public function test_it_does_not_leak_a_malformed_pdu_diagnostic_to_the_client(): void
+    {
+        $this->subject->end(new ProtocolException('BER tag 0x99 at offset 14'));
+
+        self::assertSame(
+            'The message could not be processed.',
+            $this->diagnosticOfOnlyNotice(),
+        );
+    }
+
+    public function test_it_answers_a_lost_dependency_as_unavailable(): void
+    {
+        $this->subject->end(new LdapConnectionException('the upstream is gone'));
+
+        self::assertSame(
+            ResultCode::UNAVAILABLE,
+            $this->resultCodeOfOnlyNotice(),
+        );
+    }
+
+    public function test_it_answers_every_other_disconnect_as_a_protocol_error(): void
+    {
+        $this->subject->end(new RequestSizeExceededException('too big'));
+
+        self::assertSame(
+            ResultCode::PROTOCOL_ERROR,
+            $this->resultCodeOfOnlyNotice(),
+        );
+    }
+
+    public function test_it_sends_nothing_for_a_timeout_or_an_ordinary_disconnect(): void
+    {
+        $this->subject->end(new WriteTimeoutException('write timed out'));
+        $this->subject->end(new IdleTimeoutException('idle too long'));
+        $this->subject->end(new ConnectionException('client hung up'));
+
+        self::assertSame(
+            [],
+            $this->sent,
+        );
+    }
+
+    public function test_it_keeps_quiet_about_an_unexpected_failure_once_the_connection_is_gone(): void
+    {
+        $this->queue
+            ->method('isConnected')
+            ->willReturn(false);
+
+        $this->subject->end(new RuntimeException('unexpected'));
+
+        self::assertSame(
+            [],
+            $this->sent,
+        );
+    }
+
+    public function test_it_still_answers_an_unexpected_failure_while_the_connection_holds(): void
+    {
+        $this->queue
+            ->method('isConnected')
+            ->willReturn(true);
+
+        $this->subject->end(new RuntimeException('unexpected'));
+
+        self::assertSame(
+            ResultCode::PROTOCOL_ERROR,
+            $this->resultCodeOfOnlyNotice(),
+        );
+    }
+
+    public function test_it_treats_a_decode_failure_as_an_undecodable_pdu(): void
+    {
+        $reason = $this->subject->end(new MessageDecodeException(
+            1,
+            3,
+            'bad contents',
+        ));
+
+        self::assertSame(
+            ConnectionObservation::ProtocolError,
+            $reason,
+        );
+        self::assertSame(
+            'The message could not be processed.',
+            $this->diagnosticOfOnlyNotice(),
+        );
+    }
+
+    public function test_it_ends_a_shutdown_as_unavailable(): void
+    {
+        $this->subject->shuttingDown();
+
+        self::assertSame(
+            ResultCode::UNAVAILABLE,
+            $this->resultCodeOfOnlyNotice(),
+        );
+        self::assertSame(
+            'The server is shutting down.',
+            $this->diagnosticOfOnlyNotice(),
+        );
+    }
+
+    private function onlyNotice(): ExtendedResponse
+    {
+        self::assertCount(
+            1,
+            $this->sent,
+        );
+        $response = $this->sent[0]->getResponse();
+        self::assertInstanceOf(
+            ExtendedResponse::class,
+            $response,
+        );
+        self::assertSame(
+            ExtendedResponse::OID_NOTICE_OF_DISCONNECTION,
+            $response->getName(),
+        );
+
+        return $response;
+    }
+
+    private function resultCodeOfOnlyNotice(): int
+    {
+        return $this->onlyNotice()->getResultCode();
+    }
+
+    private function diagnosticOfOnlyNotice(): string
+    {
+        return $this->onlyNotice()->getDiagnosticMessage();
+    }
+}

--- a/tests/unit/Server/AccessControl/WithheldFilterRewriterTest.php
+++ b/tests/unit/Server/AccessControl/WithheldFilterRewriterTest.php
@@ -167,6 +167,18 @@ final class WithheldFilterRewriterTest extends TestCase
         );
     }
 
+    public function test_a_filter_deny_covers_a_derived_attribute(): void
+    {
+        $subject = $this->rewriterDenyingFilterOn('hasSubordinates');
+
+        $rewritten = $subject->rewrite(
+            Filters::equal('hasSubordinates', 'TRUE'),
+            $this->token,
+        );
+
+        self::assertTrue($subject->isAbsoluteFalse($rewritten));
+    }
+
     public function test_a_filter_deny_leaves_every_other_attribute_alone(): void
     {
         $subject = $this->rewriterDenyingFilterOn('telephoneNumber');

--- a/tests/unit/Server/Proxy/ProxyAuthenticatorTest.php
+++ b/tests/unit/Server/Proxy/ProxyAuthenticatorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Server\Proxy;
 
 use FreeDSx\Ldap\Exception\BindException;
+use FreeDSx\Ldap\Exception\ConnectionException;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Operation\ResultCode;
@@ -47,6 +48,54 @@ final class ProxyAuthenticatorTest extends TestCase
         $this->client
             ->expects(self::once())
             ->method('bind');
+
+        (new ProxyAuthenticator($this->client, true))->authenticate(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+    }
+
+    public function test_it_does_not_re_issue_start_tls_on_a_connection_already_upgraded(): void
+    {
+        $this->client
+            ->method('isEncrypted')
+            ->willReturn(true);
+        $this->client
+            ->expects(self::never())
+            ->method('startTls');
+        $this->client
+            ->expects(self::once())
+            ->method('bind');
+
+        (new ProxyAuthenticator($this->client, true))->authenticate(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+    }
+
+    public function test_it_answers_rather_than_raises_when_the_upstream_is_gone(): void
+    {
+        $this->client
+            ->method('bind')
+            ->willThrowException(new ConnectionException('gone'));
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::UNAVAILABLE);
+
+        (new ProxyAuthenticator($this->client))->authenticate(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+    }
+
+    public function test_it_answers_rather_than_raises_when_start_tls_cannot_be_issued(): void
+    {
+        $this->client
+            ->method('startTls')
+            ->willThrowException(new ConnectionException('gone'));
+
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::UNAVAILABLE);
 
         (new ProxyAuthenticator($this->client, true))->authenticate(
             'cn=user,dc=foo,dc=bar',

--- a/tests/unit/Server/Proxy/ProxyAuthenticatorTest.php
+++ b/tests/unit/Server/Proxy/ProxyAuthenticatorTest.php
@@ -10,16 +10,30 @@ use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Server\Proxy\ProxyAuthenticator;
+use FreeDSx\Ldap\Server\Proxy\ProxyUpstreamSession;
+use FreeDSx\Ldap\Server\Utility\ExponentialBackoff;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Server\Clock\RecordingSleeper;
 
 final class ProxyAuthenticatorTest extends TestCase
 {
     private LdapClient&MockObject $client;
 
+    private ProxyAuthenticator $subject;
+
     protected function setUp(): void
     {
         $this->client = $this->createMock(LdapClient::class);
+        $this->subject = new ProxyAuthenticator(new ProxyUpstreamSession(
+            client: $this->client,
+            sleeper: new RecordingSleeper(),
+            maxAttempts: 1,
+            backoff: new ExponentialBackoff(
+                base: 0.01,
+                max: 0.02,
+            ),
+        ));
     }
 
     public function test_it_binds_upstream_and_returns_a_token(): void
@@ -28,49 +42,13 @@ final class ProxyAuthenticatorTest extends TestCase
             ->expects(self::once())
             ->method('bind')
             ->with('cn=user,dc=foo,dc=bar', '12345');
-        $this->client
-            ->expects(self::never())
-            ->method('startTls');
 
-        $token = (new ProxyAuthenticator($this->client))->authenticate(
+        $token = $this->subject->authenticate(
             'cn=user,dc=foo,dc=bar',
             '12345',
         );
 
         self::assertSame('cn=user,dc=foo,dc=bar', $token->getUsername());
-    }
-
-    public function test_it_issues_start_tls_before_binding_when_configured(): void
-    {
-        $this->client
-            ->expects(self::once())
-            ->method('startTls');
-        $this->client
-            ->expects(self::once())
-            ->method('bind');
-
-        (new ProxyAuthenticator($this->client, true))->authenticate(
-            'cn=user,dc=foo,dc=bar',
-            '12345',
-        );
-    }
-
-    public function test_it_does_not_re_issue_start_tls_on_a_connection_already_upgraded(): void
-    {
-        $this->client
-            ->method('isEncrypted')
-            ->willReturn(true);
-        $this->client
-            ->expects(self::never())
-            ->method('startTls');
-        $this->client
-            ->expects(self::once())
-            ->method('bind');
-
-        (new ProxyAuthenticator($this->client, true))->authenticate(
-            'cn=user,dc=foo,dc=bar',
-            '12345',
-        );
     }
 
     public function test_it_answers_rather_than_raises_when_the_upstream_is_gone(): void
@@ -82,22 +60,7 @@ final class ProxyAuthenticatorTest extends TestCase
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::UNAVAILABLE);
 
-        (new ProxyAuthenticator($this->client))->authenticate(
-            'cn=user,dc=foo,dc=bar',
-            '12345',
-        );
-    }
-
-    public function test_it_answers_rather_than_raises_when_start_tls_cannot_be_issued(): void
-    {
-        $this->client
-            ->method('startTls')
-            ->willThrowException(new ConnectionException('gone'));
-
-        $this->expectException(OperationException::class);
-        $this->expectExceptionCode(ResultCode::UNAVAILABLE);
-
-        (new ProxyAuthenticator($this->client, true))->authenticate(
+        $this->subject->authenticate(
             'cn=user,dc=foo,dc=bar',
             '12345',
         );
@@ -112,9 +75,31 @@ final class ProxyAuthenticatorTest extends TestCase
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::INVALID_CREDENTIALS);
 
-        (new ProxyAuthenticator($this->client))->authenticate(
+        $this->subject->authenticate(
             'cn=user,dc=foo,dc=bar',
             'wrong',
         );
+    }
+
+    public function test_it_does_not_hold_a_session_after_a_failed_bind(): void
+    {
+        $session = new ProxyUpstreamSession(
+            client: $this->client,
+            sleeper: new RecordingSleeper(),
+            maxAttempts: 1,
+        );
+        $this->client
+            ->method('bind')
+            ->willThrowException(new BindException('Invalid credentials.', ResultCode::INVALID_CREDENTIALS));
+
+        try {
+            (new ProxyAuthenticator($session))->authenticate(
+                'cn=user,dc=foo,dc=bar',
+                'wrong',
+            );
+        } catch (OperationException) {
+        }
+
+        self::assertFalse($session->isBound());
     }
 }

--- a/tests/unit/Server/Proxy/ProxyRequestForwarderTest.php
+++ b/tests/unit/Server/Proxy/ProxyRequestForwarderTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\FreeDSx\Ldap\Server\Proxy;
 use FreeDSx\Ldap\Control\Control;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
+use FreeDSx\Ldap\Exception\ReferralException;
 use FreeDSx\Ldap\LdapClient;
 use FreeDSx\Ldap\LdapUrl;
 use FreeDSx\Ldap\Operation\Request\AbandonRequest;
@@ -122,6 +123,30 @@ final class ProxyRequestForwarderTest extends TestCase
         ));
 
         self::assertSame(OperationOutcome::Failed, $result->outcome()->outcome());
+    }
+
+    public function test_it_answers_an_upstream_referral_on_a_non_search_operation(): void
+    {
+        $referral = new LdapUrl('ldap://other.example.com/dc=sub,dc=foo,dc=bar');
+
+        $this->client
+            ->method('sendAndReceive')
+            ->willThrowException(new ReferralException('go elsewhere', $referral));
+
+        $this->subject->handle($this->contextFor(
+            7,
+            new DeleteRequest('cn=foo,dc=bar'),
+        ));
+
+        self::assertEquals(
+            new DeleteResponse(
+                ResultCode::REFERRAL,
+                '',
+                'go elsewhere',
+                $referral,
+            ),
+            $this->relayed[0]->getResponse(),
+        );
     }
 
     public function test_it_closes_both_connections_on_unbind(): void

--- a/tests/unit/Server/Proxy/ProxyRequestForwarderTest.php
+++ b/tests/unit/Server/Proxy/ProxyRequestForwarderTest.php
@@ -31,6 +31,7 @@ use FreeDSx\Ldap\Protocol\Queue\ServerQueue;
 use FreeDSx\Ldap\Server\Middleware\Pipeline\ServerRequestContext;
 use FreeDSx\Ldap\Server\Operation\OperationOutcome;
 use FreeDSx\Ldap\Server\Proxy\ProxyRequestForwarder;
+use FreeDSx\Ldap\Server\Proxy\ProxyUpstreamSession;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -43,6 +44,8 @@ final class ProxyRequestForwarderTest extends TestCase
     private ServerQueue&MockObject $queue;
 
     private TokenInterface&MockObject $token;
+
+    private ProxyUpstreamSession $session;
 
     private ProxyRequestForwarder $subject;
 
@@ -68,9 +71,11 @@ final class ProxyRequestForwarderTest extends TestCase
                 return $this->queue;
             });
 
+        $this->session = new ProxyUpstreamSession($this->client);
         $this->subject = new ProxyRequestForwarder(
             $this->client,
             $this->queue,
+            $this->session,
         );
     }
 

--- a/tests/unit/Server/Proxy/ProxyRequestForwarderTest.php
+++ b/tests/unit/Server/Proxy/ProxyRequestForwarderTest.php
@@ -79,6 +79,33 @@ final class ProxyRequestForwarderTest extends TestCase
         );
     }
 
+    public function test_it_upgrades_the_upstream_link_before_forwarding_anything(): void
+    {
+        $forwarder = new ProxyRequestForwarder(
+            $this->client,
+            $this->queue,
+            new ProxyUpstreamSession(
+                client: $this->client,
+                useStartTls: true,
+            ),
+        );
+        $this->client
+            ->method('sendAndReceive')
+            ->willReturn(new LdapMessageResponse(
+                99,
+                new DeleteResponse(ResultCode::SUCCESS),
+            ));
+
+        $this->client
+            ->expects(self::once())
+            ->method('startTls');
+
+        $forwarder->handle($this->contextFor(
+            7,
+            new DeleteRequest('cn=foo,dc=bar'),
+        ));
+    }
+
     public function test_it_relays_a_single_response_under_the_original_message_id(): void
     {
         $this->client

--- a/tests/unit/Server/Proxy/ProxyRequestForwarderTest.php
+++ b/tests/unit/Server/Proxy/ProxyRequestForwarderTest.php
@@ -4,13 +4,24 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Server\Proxy;
 
+use FreeDSx\Ldap\Control\Control;
+use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Ldap\LdapUrl;
 use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\DeleteRequest;
 use FreeDSx\Ldap\Operation\Request\RequestInterface;
+use FreeDSx\Ldap\Operation\Request\SearchRequest;
 use FreeDSx\Ldap\Operation\Request\UnbindRequest;
 use FreeDSx\Ldap\Operation\Response\DeleteResponse;
+use FreeDSx\Ldap\Operation\Response\SearchResponse;
+use FreeDSx\Ldap\Operation\Response\SearchResultDone;
+use FreeDSx\Ldap\Operation\Response\SearchResultEntry;
+use FreeDSx\Ldap\Operation\Response\SearchResultReference;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Search\Result\EntryResult;
+use FreeDSx\Ldap\Search\Result\ReferralResult;
 use FreeDSx\Ldap\Operation\LdapResult;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
@@ -22,6 +33,7 @@ use FreeDSx\Ldap\Server\Proxy\ProxyRequestForwarder;
 use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 final class ProxyRequestForwarderTest extends TestCase
 {
@@ -33,11 +45,28 @@ final class ProxyRequestForwarderTest extends TestCase
 
     private ProxyRequestForwarder $subject;
 
+    /**
+     * @var list<LdapMessageResponse>
+     */
+    private array $relayed = [];
+
     protected function setUp(): void
     {
         $this->client = $this->createMock(LdapClient::class);
         $this->queue = $this->createMock(ServerQueue::class);
         $this->token = $this->createMock(TokenInterface::class);
+        $this->relayed = [];
+
+        $this->queue
+            ->method('sendMessage')
+            ->willReturnCallback(function (LdapMessageResponse ...$messages): ServerQueue {
+                foreach ($messages as $message) {
+                    $this->relayed[] = $message;
+                }
+
+                return $this->queue;
+            });
+
         $this->subject = new ProxyRequestForwarder(
             $this->client,
             $this->queue,
@@ -122,6 +151,136 @@ final class ProxyRequestForwarderTest extends TestCase
         ));
 
         self::assertSame(OperationOutcome::Succeeded, $result->outcome()->outcome());
+    }
+
+    public function test_it_relays_the_controls_an_entry_arrived_with(): void
+    {
+        $control = new Control('1.3.6.1.4.1.4203.1.9.1.2');
+        $this->upstreamStreams(
+            [
+                new LdapMessageResponse(
+                    99,
+                    new SearchResultEntry(Entry::create('cn=alice,dc=foo,dc=bar')),
+                    $control,
+                ),
+            ],
+            ResultCode::SUCCESS,
+        );
+
+        $this->subject->handle($this->contextFor(
+            7,
+            $this->searchRequest(),
+        ));
+
+        self::assertEquals(
+            [$control],
+            $this->relayed[0]->controls()->toArray(),
+        );
+    }
+
+    public function test_it_relays_a_search_result_reference(): void
+    {
+        $this->upstreamStreams(
+            [
+                new LdapMessageResponse(
+                    99,
+                    new SearchResultReference(new LdapUrl('ldap://elsewhere/dc=foo,dc=bar')),
+                ),
+            ],
+            ResultCode::SUCCESS,
+        );
+
+        $this->subject->handle($this->contextFor(
+            7,
+            $this->searchRequest(),
+        ));
+
+        self::assertInstanceOf(
+            SearchResultReference::class,
+            $this->relayed[0]->getResponse(),
+        );
+        self::assertInstanceOf(
+            SearchResultDone::class,
+            $this->relayed[1]->getResponse(),
+        );
+    }
+
+    public function test_it_keeps_the_entries_a_limit_exceeded_search_returned(): void
+    {
+        $this->upstreamStreams(
+            [
+                new LdapMessageResponse(
+                    99,
+                    new SearchResultEntry(Entry::create('cn=alice,dc=foo,dc=bar')),
+                ),
+            ],
+            ResultCode::SIZE_LIMIT_EXCEEDED,
+        );
+
+        $this->subject->handle($this->contextFor(
+            7,
+            $this->searchRequest(),
+        ));
+
+        self::assertInstanceOf(
+            SearchResultEntry::class,
+            $this->relayed[0]->getResponse(),
+        );
+        self::assertEquals(
+            new SearchResultDone(
+                ResultCode::SIZE_LIMIT_EXCEEDED,
+                '',
+                'Size limit exceeded.',
+            ),
+            $this->relayed[1]->getResponse(),
+        );
+    }
+
+    /**
+     * Stands in for the client, which hands each result to the request's handler before raising the result code.
+     *
+     * @param LdapMessageResponse[] $results
+     */
+    private function upstreamStreams(
+        array $results,
+        int $resultCode,
+    ): void {
+        $this->client
+            ->method('sendAndReceive')
+            ->willReturnCallback(
+                static function (SearchRequest $request) use ($results, $resultCode): LdapMessageResponse {
+                    foreach ($results as $result) {
+                        $response = $result->getResponse();
+
+                        if ($response instanceof SearchResultReference) {
+                            $referralHandler = $request->getReferralHandler()
+                                ?? throw new RuntimeException('The forwarder installed no referral handler.');
+                            $referralHandler(new ReferralResult($result));
+
+                            continue;
+                        }
+
+                        $entryHandler = $request->getEntryHandler()
+                            ?? throw new RuntimeException('The forwarder installed no entry handler.');
+                        $entryHandler(new EntryResult($result));
+                    }
+
+                    if ($resultCode !== ResultCode::SUCCESS) {
+                        throw new OperationException('Size limit exceeded.', $resultCode);
+                    }
+
+                    return new LdapMessageResponse(
+                        99,
+                        new SearchResponse(new LdapResult($resultCode)),
+                    );
+                },
+            );
+    }
+
+    private function searchRequest(): SearchRequest
+    {
+        return (new SearchRequest(Filters::present('objectClass')))
+            ->base('dc=foo,dc=bar');
     }
 
     private function contextFor(

--- a/tests/unit/Server/Proxy/ProxyUpstreamSessionTest.php
+++ b/tests/unit/Server/Proxy/ProxyUpstreamSessionTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Proxy;
+
+use FreeDSx\Ldap\Exception\BindException;
+use FreeDSx\Ldap\Exception\ConnectionException;
+use FreeDSx\Ldap\Exception\NoticeOfDisconnectException;
+use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Ldap\Operation\LdapResult;
+use FreeDSx\Ldap\Operation\Response\BindResponse;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessageResponse;
+use FreeDSx\Ldap\Server\Proxy\ProxyUpstreamSession;
+use FreeDSx\Ldap\Server\Utility\ExponentialBackoff;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\Server\Clock\RecordingSleeper;
+
+final class ProxyUpstreamSessionTest extends TestCase
+{
+    private LdapClient&MockObject $client;
+
+    private RecordingSleeper $sleeper;
+
+    private ProxyUpstreamSession $subject;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createMock(LdapClient::class);
+        $this->sleeper = new RecordingSleeper();
+        $this->subject = $this->makeSession();
+    }
+
+    public function test_it_is_not_bound_before_a_bind(): void
+    {
+        self::assertFalse($this->subject->isBound());
+    }
+
+    public function test_it_is_bound_after_binding_upstream(): void
+    {
+        $this->client
+            ->expects(self::once())
+            ->method('bind')
+            ->with('cn=user,dc=foo,dc=bar', '12345');
+
+        $this->subject->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+
+        self::assertTrue($this->subject->isBound());
+    }
+
+    public function test_it_issues_start_tls_before_binding_when_configured(): void
+    {
+        $this->client
+            ->expects(self::once())
+            ->method('startTls');
+        $this->client
+            ->expects(self::once())
+            ->method('bind');
+
+        $this->makeSession(useStartTls: true)->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+    }
+
+    public function test_it_does_not_re_issue_start_tls_on_a_connection_already_upgraded(): void
+    {
+        $this->client
+            ->method('isEncrypted')
+            ->willReturn(true);
+        $this->client
+            ->expects(self::never())
+            ->method('startTls');
+        $this->client
+            ->expects(self::once())
+            ->method('bind');
+
+        $this->makeSession(useStartTls: true)->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+    }
+
+    public function test_it_reissues_a_bind_that_failed_on_the_transport(): void
+    {
+        $attempts = 0;
+        $this->client
+            ->method('bind')
+            ->willReturnCallback(function () use (&$attempts): LdapMessageResponse {
+                $attempts++;
+
+                if ($attempts < 3) {
+                    throw new ConnectionException('gone');
+                }
+
+                return new LdapMessageResponse(
+                    1,
+                    new BindResponse(new LdapResult(ResultCode::SUCCESS)),
+                );
+            });
+
+        $this->subject->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+
+        self::assertSame(
+            3,
+            $attempts,
+        );
+        self::assertCount(
+            2,
+            $this->sleeper->durations,
+        );
+        self::assertTrue($this->subject->isBound());
+    }
+
+    public function test_it_gives_up_once_the_attempts_are_spent(): void
+    {
+        $this->client
+            ->method('bind')
+            ->willThrowException(new ConnectionException('gone'));
+
+        $this->expectException(ConnectionException::class);
+
+        try {
+            $this->subject->bind(
+                'cn=user,dc=foo,dc=bar',
+                '12345',
+            );
+        } finally {
+            self::assertCount(
+                2,
+                $this->sleeper->durations,
+            );
+            self::assertFalse($this->subject->isBound());
+        }
+    }
+
+    public function test_it_does_not_reissue_a_bind_the_upstream_answered_by_disconnecting(): void
+    {
+        $attempts = 0;
+        $this->client
+            ->method('bind')
+            ->willReturnCallback(function () use (&$attempts): never {
+                $attempts++;
+
+                throw new NoticeOfDisconnectException('the peer said so');
+            });
+
+        $this->expectException(NoticeOfDisconnectException::class);
+
+        try {
+            $this->subject->bind(
+                'cn=user,dc=foo,dc=bar',
+                '12345',
+            );
+        } finally {
+            self::assertSame(
+                1,
+                $attempts,
+            );
+            self::assertSame(
+                [],
+                $this->sleeper->durations,
+            );
+        }
+    }
+
+    public function test_it_does_not_reissue_a_bind_the_upstream_refused(): void
+    {
+        $attempts = 0;
+        $this->client
+            ->method('bind')
+            ->willReturnCallback(function () use (&$attempts): never {
+                $attempts++;
+
+                throw new BindException('Invalid credentials.', ResultCode::INVALID_CREDENTIALS);
+            });
+
+        $this->expectException(BindException::class);
+
+        try {
+            $this->subject->bind(
+                'cn=user,dc=foo,dc=bar',
+                'wrong',
+            );
+        } finally {
+            self::assertSame(
+                1,
+                $attempts,
+            );
+        }
+    }
+
+    public function test_it_unbinds_upstream_when_reset_while_bound(): void
+    {
+        $this->client
+            ->method('isConnected')
+            ->willReturn(true);
+        $this->client
+            ->expects(self::once())
+            ->method('unbind');
+
+        $this->subject->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+        $this->subject->reset();
+
+        self::assertFalse($this->subject->isBound());
+    }
+
+    public function test_it_leaves_an_unbound_session_alone_when_reset(): void
+    {
+        $this->client
+            ->expects(self::never())
+            ->method('unbind');
+
+        $this->subject->reset();
+
+        self::assertFalse($this->subject->isBound());
+    }
+
+    public function test_it_closes_the_connection_when_the_upstream_unbind_cannot_be_sent(): void
+    {
+        $this->client
+            ->method('isConnected')
+            ->willReturn(true);
+        $this->client
+            ->method('unbind')
+            ->willThrowException(new ConnectionException('gone'));
+        $this->client
+            ->expects(self::once())
+            ->method('disconnect');
+
+        $this->subject->bind(
+            'cn=user,dc=foo,dc=bar',
+            '12345',
+        );
+        $this->subject->reset();
+
+        self::assertFalse($this->subject->isBound());
+    }
+
+    private function makeSession(bool $useStartTls = false): ProxyUpstreamSession
+    {
+        return new ProxyUpstreamSession(
+            client: $this->client,
+            useStartTls: $useStartTls,
+            sleeper: $this->sleeper,
+            maxAttempts: 3,
+            backoff: new ExponentialBackoff(
+                base: 0.01,
+                max: 0.02,
+            ),
+        );
+    }
+}

--- a/tests/unit/Server/Proxy/ProxyUpstreamSessionTest.php
+++ b/tests/unit/Server/Proxy/ProxyUpstreamSessionTest.php
@@ -86,6 +86,36 @@ final class ProxyUpstreamSessionTest extends TestCase
         );
     }
 
+    public function test_it_upgrades_the_link_before_anything_that_is_not_a_bind(): void
+    {
+        $this->client
+            ->expects(self::once())
+            ->method('startTls');
+
+        $this->makeSession(useStartTls: true)->ensureEncrypted();
+    }
+
+    public function test_it_leaves_the_link_alone_when_start_tls_is_not_configured(): void
+    {
+        $this->client
+            ->expects(self::never())
+            ->method('startTls');
+
+        $this->subject->ensureEncrypted();
+    }
+
+    public function test_it_does_not_upgrade_a_link_already_encrypted(): void
+    {
+        $this->client
+            ->method('isEncrypted')
+            ->willReturn(true);
+        $this->client
+            ->expects(self::never())
+            ->method('startTls');
+
+        $this->makeSession(useStartTls: true)->ensureEncrypted();
+    }
+
     public function test_it_reissues_a_bind_that_failed_on_the_transport(): void
     {
         $attempts = 0;


### PR DESCRIPTION
This is mostly a set of fixes / improvements aimed at the proxy server (which was separated from the main LdapServer during the refactor). A few notable things:

* Refactor entry handling to stream results on searches rather than waiting on all entries than iterating them out.
* A few fixes related to better handling of client session changes / disconnects / bind state.
* Add an option to require upstream confidentiality to be set (so there's no mismatch between client and server).