### PR TITLE
[1.0.0] Server Runner related fixes / updates.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=8.2",
     "freedsx/asn1": "dev-main#d6cee05",
-    "freedsx/socket": "dev-main#dd2e389",
+    "freedsx/socket": "dev-main#dd3c84a",
     "freedsx/sasl": "dev-main#525d0e9",
     "psr/log": "^3"
   },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "php": ">=8.2",
     "freedsx/asn1": "dev-main#d6cee05",
-    "freedsx/socket": "dev-main#02ed927",
+    "freedsx/socket": "dev-main#dd2e389",
     "freedsx/sasl": "dev-main#525d0e9",
     "psr/log": "^3"
   },

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -26,6 +26,7 @@ LDAP Server Configuration
         * [NetworkConfig:setSslValidateCert](#setsslvalidatecert)
         * [NetworkConfig:setSslAllowSelfSigned](#setsslallowselfsigned)
         * [NetworkConfig:setSslCaCert](#setsslcacert)
+        * [NetworkConfig:setSslHandshakeTimeout](#setsslhandshaketimeout)
 * [Access Control](#access-control)
     * [ServerOptions:setAclRules](#setaclrules)
     * [ServerOptions:setAccessControl](#setaccesscontrol)
@@ -425,6 +426,20 @@ default (not allowed).
 Path to a CA certificate bundle used to verify client certificates when `setSslValidateCert` is enabled.
 
 **Default**: `(null)`
+
+------------------
+#### setSslHandshakeTimeout
+
+Seconds a TLS handshake may take before the connection is dropped. This bounds a client that connects and then stalls,
+which would otherwise hold the connection for the whole idle timeout.
+
+```php
+$options->getNetworkConfig()->setSslHandshakeTimeout(10);
+```
+
+Raise it if legitimate clients on slow links fail to connect.
+
+**Default**: `5`
 
 ## Access Control
 

--- a/docs/Server/Configuration.md
+++ b/docs/Server/Configuration.md
@@ -15,6 +15,7 @@ LDAP Server Configuration
     * [NetworkConfig:setIdleTimeout](#setidletimeout)
     * [NetworkConfig:setWriteTimeout](#setwritetimeout)
     * [NetworkConfig:setSocketAcceptTimeout](#setsocketaccepttimeout)
+    * [NetworkConfig:setMaxConnections](#setmaxconnections)
     * [TLS](#tls)
         * [NetworkConfig:setUseSsl](#setusessl)
         * [NetworkConfig:setSslCert](#setsslcert)
@@ -312,6 +313,21 @@ make the server more responsive to shutdown signals and connection-limit changes
 in the accept loop.
 
 **Default**: `0.5`
+
+------------------
+#### setMaxConnections
+
+The most concurrent client connections to accept. Once reached, further connections are closed without being served,
+and `connectionsRejected` in [cn=monitor](Monitoring.md) counts them. Set `0` for no limit.
+
+```php
+$options->getNetworkConfig()->setMaxConnections(4096);
+```
+
+The Pcntl runner forks a process per connection, so this bounds process count rather than memory alone. Pick a value
+the host can fork, keeping the process limit and open file descriptors (`ulimit -n`) in mind.
+
+**Default**: `1024`
 
 ### TLS
 

--- a/src/FreeDSx/Ldap/Protocol/Queue/ServerQueue.php
+++ b/src/FreeDSx/Ldap/Protocol/Queue/ServerQueue.php
@@ -61,6 +61,15 @@ class ServerQueue extends LdapQueue implements ConnectionControl
      */
     private readonly array $interceptors;
 
+    private bool $isSending = false;
+
+    private bool $isCloseDeferred = false;
+
+    /**
+     * @var LdapMessageResponse[]
+     */
+    private array $deferredMessages = [];
+
     /**
      * @param ResponseInterceptor[] $interceptors applied to every outgoing response, in order.
      */
@@ -131,16 +140,47 @@ class ServerQueue extends LdapQueue implements ConnectionControl
     }
 
     /**
+     * Anything sent while a response is already going out waits for it to finish.
+     *
      * @throws EncoderException
      */
     public function sendMessage(LdapMessageResponse ...$response): self
     {
-        $this->sendLdapMessage(array_map(
-            $this->applyInterceptors(...),
-            $response,
-        ));
+        if ($this->isSending) {
+            array_push(
+                $this->deferredMessages,
+                ...$response,
+            );
+
+            return $this;
+        }
+        $this->isSending = true;
+
+        try {
+            $this->sendLdapMessage(array_map(
+                $this->applyInterceptors(...),
+                $response,
+            ));
+        } finally {
+            $this->isSending = false;
+        }
+        $this->flushDeferred();
 
         return $this;
+    }
+
+    /**
+     * A close that would truncate a response still going out waits until it has been written.
+     */
+    public function close(): void
+    {
+        if ($this->isSending) {
+            $this->isCloseDeferred = true;
+
+            return;
+        }
+
+        parent::close();
     }
 
     /**
@@ -151,7 +191,15 @@ class ServerQueue extends LdapQueue implements ConnectionControl
      */
     public function sendMessages(iterable $responses): self
     {
-        $this->sendLdapMessage($this->interceptLazily($responses));
+        $this->isSending = true;
+
+        try {
+            $this->sendLdapMessage($this->interceptLazily($responses));
+        } finally {
+            $this->isSending = false;
+        }
+
+        $this->flushDeferred();
 
         return $this;
     }
@@ -203,8 +251,33 @@ class ServerQueue extends LdapQueue implements ConnectionControl
     private function interceptLazily(iterable $responses): Generator
     {
         foreach ($responses as $response) {
+            if ($this->isCloseDeferred) {
+                return;
+            }
+
             yield $this->applyInterceptors($response);
         }
+    }
+
+    /**
+     * Sends what was held back, then applies a close that waited with it.
+     *
+     * @throws EncoderException
+     */
+    private function flushDeferred(): void
+    {
+        $deferred = $this->deferredMessages;
+        $this->deferredMessages = [];
+
+        if ($deferred !== []) {
+            $this->sendMessage(...$deferred);
+        }
+        if (!$this->isCloseDeferred) {
+            return;
+        }
+
+        $this->isCloseDeferred = false;
+        $this->close();
     }
 
     private function applyInterceptors(LdapMessageResponse $response): LdapMessageResponse

--- a/src/FreeDSx/Ldap/Server/Config/NetworkConfig.php
+++ b/src/FreeDSx/Ldap/Server/Config/NetworkConfig.php
@@ -75,6 +75,8 @@ final class NetworkConfig
 
     private ?string $sslCaCert = null;
 
+    private int $sslHandshakeTimeout = 5;
+
     /**
      * Convenience constructor for the common case of only choosing the listening port.
      */
@@ -291,6 +293,18 @@ final class NetworkConfig
     public function setSslValidateCert(bool $sslValidateCert): self
     {
         $this->sslValidateCert = $sslValidateCert;
+
+        return $this;
+    }
+
+    public function getSslHandshakeTimeout(): int
+    {
+        return $this->sslHandshakeTimeout;
+    }
+
+    public function setSslHandshakeTimeout(int $sslHandshakeTimeout): self
+    {
+        $this->sslHandshakeTimeout = $sslHandshakeTimeout;
 
         return $this;
     }

--- a/src/FreeDSx/Ldap/Server/Config/NetworkConfig.php
+++ b/src/FreeDSx/Ldap/Server/Config/NetworkConfig.php
@@ -53,9 +53,9 @@ final class NetworkConfig
     private int $maxRequestSize = 5_242_880;
 
     /**
-     * The maximum number of concurrent connections the server will accept; zero (the default) means no limit.
+     * The maximum number of concurrent connections the server will accept; zero means no limit.
      */
-    private int $maxConnections = 0;
+    private int $maxConnections = 1024;
 
     private bool $useSsl = false;
 

--- a/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
+++ b/src/FreeDSx/Ldap/Server/ServerRunner/PcntlServerRunner.php
@@ -150,6 +150,16 @@ class PcntlServerRunner implements ServerRunnerInterface
         }
     }
 
+    private function isConnectionLimitReached(): bool
+    {
+        $maxConnections = $this->options
+            ->getNetworkConfig()
+            ->getMaxConnections();
+
+        return $maxConnections > 0
+            && count($this->childProcesses) >= $maxConnections;
+    }
+
     /**
      * Check each child process we have and see if it is stopped. This will clean up zombie processes.
      */
@@ -292,8 +302,11 @@ class PcntlServerRunner implements ServerRunnerInterface
                 continue;
             }
 
-            $maxConnections = $this->options->getNetworkConfig()->getMaxConnections();
-            if ($maxConnections > 0 && count($this->childProcesses) >= $maxConnections) {
+            if ($this->isConnectionLimitReached()) {
+                $this->cleanUpChildProcesses();
+            }
+
+            if ($this->isConnectionLimitReached()) {
                 $this->logConnectionLimitReached($this->defaultContext);
                 $this->metricsRecorder->connectionObserved(ConnectionObservation::Rejected);
                 $this->publishMetricsSnapshot();

--- a/src/FreeDSx/Ldap/Server/SocketServerFactory.php
+++ b/src/FreeDSx/Ldap/Server/SocketServerFactory.php
@@ -78,6 +78,7 @@ class SocketServerFactory
             ->setSslCapturePeerCert($this->runner !== RunnerMode::Swoole)
             ->setSslAllowSelfSigned($this->network->getSslAllowSelfSigned())
             ->setSslCaCert($this->network->getSslCaCert())
+            ->setTimeoutHandshake($this->network->getSslHandshakeTimeout())
             ->setReusePort($this->reusePort);
 
         return SocketServer::bind(

--- a/tests/integration/Runner/ServerRunnerTestCase.php
+++ b/tests/integration/Runner/ServerRunnerTestCase.php
@@ -13,8 +13,13 @@ declare(strict_types=1);
 
 namespace Tests\Integration\FreeDSx\Ldap\Runner;
 
+use FreeDSx\Ldap\Exception\UnsolicitedNotificationException;
+use FreeDSx\Ldap\Operation\Request\SimpleBindRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use Tests\Integration\FreeDSx\Ldap\Runner\Concern\TlsTestsTrait;
 use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
+use Tests\Support\FreeDSx\Ldap\RawClientQueueTrait;
 
 use function extension_loaded;
 
@@ -24,6 +29,7 @@ use function extension_loaded;
 abstract class ServerRunnerTestCase extends ServerTestCase
 {
     use TlsTestsTrait;
+    use RawClientQueueTrait;
 
     public static function setUpBeforeClass(): void
     {
@@ -50,6 +56,38 @@ abstract class ServerRunnerTestCase extends ServerTestCase
         $this->setServerMode('ldap-server');
 
         parent::setUp();
+    }
+
+    public function testAnIdleConnectionReceivesANoticeOfDisconnectionOnShutdown(): void
+    {
+        $this->createServerProcess(
+            'tcp',
+            ['--shutdown-timeout=10'],
+        );
+
+        $queue = $this->rawQueue();
+        $queue->sendMessage(new LdapMessageRequest(
+            1,
+            new SimpleBindRequest(
+                'cn=user,dc=foo,dc=bar',
+                '12345',
+            ),
+        ));
+        $queue->getMessage(1);
+
+        $this->sendServerSignal(SIGTERM);
+        try {
+            $queue->getMessage();
+            self::fail('The connection ended without a notice of disconnection.');
+        } catch (UnsolicitedNotificationException $e) {
+            self::assertTrue($e->isNoticeOfDisconnection());
+            self::assertSame(
+                ResultCode::UNAVAILABLE,
+                $e->getCode(),
+            );
+        } finally {
+            $queue->close();
+        }
     }
 
     /**

--- a/tests/support/LdapServerCommand.php
+++ b/tests/support/LdapServerCommand.php
@@ -117,6 +117,13 @@ final class LdapServerCommand extends Command
                 '0',
             )
             ->addOption(
+                'shutdown-timeout',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Seconds children are given to end gracefully before they are killed (0 kills them at once)',
+                '0',
+            )
+            ->addOption(
                 'max-search-lookthrough',
                 null,
                 InputOption::VALUE_REQUIRED,
@@ -300,7 +307,7 @@ final class LdapServerCommand extends Command
             ->setSslCertKey(self::SSL_KEY)
             ->setUseSsl($useSsl)
             ->setSocketAcceptTimeout(0.1)
-            ->setShutdownTimeout(0);
+            ->setShutdownTimeout((int) $this->getStringOption($input, 'shutdown-timeout'));
 
         $options = (new ServerOptions($this->createStorageConfig($storageType), $network))
             ->setRunnerConfig(new RunnerConfig($runner === 'swoole' ? RunnerMode::Swoole : RunnerMode::Pcntl))

--- a/tests/unit/Protocol/Queue/ServerQueueTest.php
+++ b/tests/unit/Protocol/Queue/ServerQueueTest.php
@@ -37,6 +37,7 @@ use FreeDSx\Ldap\Server\Metrics\Recorder\InMemoryMetricsRecorder;
 use FreeDSx\Socket\Exception\ConnectionException;
 use FreeDSx\Socket\Queue\Buffer;
 use FreeDSx\Socket\Socket;
+use Generator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Tests\Support\FreeDSx\Ldap\Middleware\CallLog;
@@ -122,6 +123,130 @@ final class ServerQueueTest extends TestCase
         $this->subject->sendMessage(
             new LdapMessageResponse(1, new DeleteResponse(0)),
             new LdapMessageResponse(2, new DeleteResponse(0)),
+        );
+    }
+
+    public function test_a_response_sent_while_another_is_going_out_is_not_written_into_the_middle_of_it(): void
+    {
+        $this->mockEncoder
+            ->method('encode')
+            ->willReturn(str_repeat('f', 8000));
+
+        $log = new CallLog();
+
+        $this->mockSocket
+            ->method('write')
+            ->willReturnCallback(function () use ($log) {
+                $log->record('start');
+
+                // Stands in for the signal handler, which sends from inside the write it interrupted.
+                if (count($log->entries) === 1) {
+                    $this->subject->sendMessage(new LdapMessageResponse(
+                        0,
+                        new DeleteResponse(0),
+                    ));
+                }
+
+                $log->record('end');
+
+                return $this->mockSocket;
+            });
+
+        $this->subject->sendMessage(
+            new LdapMessageResponse(1, new DeleteResponse(0)),
+            new LdapMessageResponse(2, new DeleteResponse(0)),
+        );
+
+        $alternating = [];
+
+        foreach (array_keys($log->entries) as $index) {
+            $alternating[] = $index % 2 === 0
+                ? 'start'
+                : 'end';
+        }
+
+        self::assertSame(
+            $alternating,
+            $log->entries,
+            'A response was written while another was still going out.',
+        );
+    }
+
+    public function test_a_close_while_a_response_is_going_out_waits_until_it_has_been_written(): void
+    {
+        $this->mockEncoder
+            ->method('encode')
+            ->willReturn(str_repeat('f', 8000));
+
+        $log = new CallLog();
+
+        $this->mockSocket
+            ->method('write')
+            ->willReturnCallback(function () use ($log) {
+                $log->record('write');
+
+                if (count($log->entries) === 1) {
+                    $this->subject->close();
+                }
+
+                return $this->mockSocket;
+            });
+        $this->mockSocket
+            ->method('close')
+            ->willReturnCallback(function () use ($log) {
+                $log->record('close');
+
+                return $this->mockSocket;
+            });
+
+        $this->subject->sendMessage(
+            new LdapMessageResponse(1, new DeleteResponse(0)),
+            new LdapMessageResponse(2, new DeleteResponse(0)),
+        );
+
+        self::assertSame(
+            'close',
+            end($log->entries),
+            'The socket was closed while a response was still going out.',
+        );
+        self::assertCount(
+            1,
+            array_keys($log->entries, 'close', true),
+        );
+    }
+
+    public function test_a_close_while_streaming_stops_the_responses_that_have_not_been_sent(): void
+    {
+        $this->mockEncoder
+            ->method('encode')
+            ->willReturn(str_repeat('f', 8000));
+
+        $log = new CallLog();
+        $responses = (function () use ($log): Generator {
+            foreach (range(1, 20) as $id) {
+                $log->record("entry-{$id}");
+
+                yield new LdapMessageResponse(
+                    $id,
+                    new DeleteResponse(0),
+                );
+            }
+        })();
+
+        $this->mockSocket
+            ->method('write')
+            ->willReturnCallback(function () {
+                $this->subject->close();
+
+                return $this->mockSocket;
+            });
+
+        $this->subject->sendMessages($responses);
+
+        self::assertLessThan(
+            20,
+            count($log->entries),
+            'The whole result set was produced even though the session was ending.',
         );
     }
 

--- a/tests/unit/Server/Config/NetworkConfigTest.php
+++ b/tests/unit/Server/Config/NetworkConfigTest.php
@@ -36,16 +36,22 @@ final class NetworkConfigTest extends TestCase
         );
     }
 
-    public function test_max_connections_defaults_to_zero(): void
+    public function test_max_connections_defaults_to_the_maintenance_branch_value(): void
     {
-        self::assertSame(0, $this->subject->getMaxConnections());
+        self::assertSame(
+            1024,
+            $this->subject->getMaxConnections(),
+        );
     }
 
     public function test_it_can_set_max_connections(): void
     {
         $this->subject->setMaxConnections(500);
 
-        self::assertSame(500, $this->subject->getMaxConnections());
+        self::assertSame(
+            500,
+            $this->subject->getMaxConnections(),
+        );
     }
 
     public function test_max_request_size_defaults_to_five_mib(): void

--- a/tests/unit/Server/Config/NetworkConfigTest.php
+++ b/tests/unit/Server/Config/NetworkConfigTest.php
@@ -44,6 +44,24 @@ final class NetworkConfigTest extends TestCase
         );
     }
 
+    public function test_ssl_handshake_timeout_defaults_to_five_seconds(): void
+    {
+        self::assertSame(
+            5,
+            $this->subject->getSslHandshakeTimeout(),
+        );
+    }
+
+    public function test_it_can_set_the_ssl_handshake_timeout(): void
+    {
+        $this->subject->setSslHandshakeTimeout(15);
+
+        self::assertSame(
+            15,
+            $this->subject->getSslHandshakeTimeout(),
+        );
+    }
+
     public function test_it_can_set_max_connections(): void
     {
         $this->subject->setMaxConnections(500);


### PR DESCRIPTION
Several server runner related updates here:

* Add a TLS handshake timeout config.
* Fix notice of disconnects so they are consistently sent.
* Align the max connections logic on main with the maintenance branch per the security advisory.