### PR TITLE
[1.0.0] Make the password policy forward use entryUUID.

### DIFF
--- a/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/DirectoryServerContainerProvider.php
@@ -35,6 +35,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluator;
 use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Directory\EntryLocator;
+use FreeDSx\Ldap\Server\Backend\Storage\Directory\EntryUuidLocator;
 use FreeDSx\Ldap\Server\Backend\Storage\Directory\SubtreeEnumerator;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeRecorder;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\SubtreeMoveRecorder;
@@ -65,9 +66,11 @@ use FreeDSx\Ldap\Server\Backend\Storage\Search\StorageListOptionsFactory;
 use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\StorageReadBackend;
 use FreeDSx\Ldap\Server\Clock\ClockInterface;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BackoffSleeper;
 use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
 use FreeDSx\Ldap\Server\Clock\Sleeper\CoroutineSleeper;
 use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
+use FreeDSx\Ldap\Server\Config\Replication\ConsumerConfig;
 use FreeDSx\Ldap\Server\Clock\SystemClock;
 use FreeDSx\Ldap\Server\Config\Storage\PdoConfig;
 use FreeDSx\Ldap\Server\ConnectionHandlerBuilderInterface;
@@ -91,6 +94,7 @@ use FreeDSx\Ldap\Server\Middleware\Pipeline\MiddlewareChain;
 use FreeDSx\Ldap\Server\Middleware\ReadOnlyMiddleware;
 use FreeDSx\Ldap\Server\Middleware\RequestValidationMiddleware;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\LdapClientForwardStateSender;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\PasswordPolicyForwarder;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\PasswordPolicyForwardWorker;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
 use FreeDSx\Ldap\Server\Process\BackgroundTask\BackgroundTasksInterface;
@@ -106,6 +110,8 @@ use FreeDSx\Ldap\Ldif\LdifParser;
 use FreeDSx\Ldap\ServerOptions;
 use FreeDSx\Ldap\Sync\Consumer\LdapReplica;
 use FreeDSx\Ldap\Sync\Consumer\PrimaryConnectionFactory;
+use FreeDSx\Ldap\Sync\Consumer\ReconcilingChangeApplier;
+use FreeDSx\Ldap\Sync\Consumer\VerbatimStorageApplier;
 use Psr\Log\NullLogger;
 
 /**
@@ -132,6 +138,10 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
             LdifParser::class => static fn(): LdifParser => new LdifParser(),
             EntryLocator::class => static fn(Container $c): EntryLocator => new EntryLocator(
                 $c->get(EntryStorageInterface::class),
+            ),
+            EntryUuidLocator::class => static fn(Container $c): EntryUuidLocator => new EntryUuidLocator(
+                $c->get(EntryStorageInterface::class),
+                $c->get(FilterEvaluatorInterface::class),
             ),
             SubtreeEnumerator::class => static fn(Container $c): SubtreeEnumerator => new SubtreeEnumerator(
                 $c->get(EntryStorageInterface::class),
@@ -727,10 +737,17 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
             return null;
         }
 
-        return new PasswordPolicyForwardWorker(
+        $forwarder = new PasswordPolicyForwarder(
             $container->get(ReplicaPasswordStateStoreInterface::class),
             new LdapClientForwardStateSender(new PrimaryConnectionFactory($config)),
+            $container->get(ReadBackendInterface::class),
+            $options->getLogger(),
+        );
+
+        return new PasswordPolicyForwardWorker(
+            $forwarder,
             $container->get(SleeperInterface::class),
+            $this->makeBackoffSleeper($container, $config),
             interval: $config->getForwardInterval(),
             signals: $useCoroutineSleeper
                 ? null
@@ -755,24 +772,41 @@ final class DirectoryServerContainerProvider implements ContainerProviderInterfa
             return null;
         }
 
-        $storage = $container->get(EntryStorageInterface::class);
+        // listen() must not time out its blocking read, or the persist phase would abort each interval.
+        $config->getPrimary()
+            ->setTimeoutRead(-1);
 
-        // Pair reconciliation with forwarding: the store drops forwarded state once the primary's entry replicates back.
-        $passwordStateStore = $container->get(ReplicaPasswordStateStoreInterface::class);
+        $applier = new VerbatimStorageApplier(
+            $container->get(EntryStorageInterface::class),
+            $container->get(EntryUuidLocator::class),
+        );
 
-        return $hostManagedShutdown
-            ? LdapReplica::forSwoole(
-                $config,
-                $storage,
-                $options->getLogger(),
-                signals: null,
-                passwordStateStore: $passwordStateStore,
-            )
-            : LdapReplica::forPcntl(
-                $config,
-                $storage,
-                $options->getLogger(),
-                passwordStateStore: $passwordStateStore,
-            );
+        return new LdapReplica(
+            connectionFactory: new PrimaryConnectionFactory($config),
+            // Pair reconciliation with forwarding: the store drops forwarded state once the primary's entry replicates back.
+            applier: new ReconcilingChangeApplier(
+                $applier,
+                $container->get(ReplicaPasswordStateStoreInterface::class),
+            ),
+            checkpoint: $config->getCheckpoint(),
+            backoff: $this->makeBackoffSleeper($container, $config),
+            signals: $hostManagedShutdown
+                ? null
+                : new PcntlShutdownSignals(),
+            logger: $options->getLogger(),
+        );
+    }
+
+    /**
+     * A fresh backoff sleeper over the configured policy, since each daemon tracks its own delay.
+     */
+    private function makeBackoffSleeper(
+        Container $container,
+        ConsumerConfig $config,
+    ): BackoffSleeper {
+        return new BackoffSleeper(
+            $config->getReconnectBackoff(),
+            $container->get(SleeperInterface::class),
+        );
     }
 }

--- a/src/FreeDSx/Ldap/Container/Provider/HandlerContainerProvider.php
+++ b/src/FreeDSx/Ldap/Container/Provider/HandlerContainerProvider.php
@@ -40,6 +40,7 @@ use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Capture\ChangeJournalingInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\ChangeJournalInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Directory\EntryUuidLocator;
 use FreeDSx\Ldap\Server\Backend\Storage\Journal\Read\ChangeStream;
 use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteOperationDispatcher;
@@ -142,7 +143,7 @@ final class HandlerContainerProvider implements ContainerProviderInterface
     private function makeForwardHandler(Container $container): ServerProtocolHandlerInterface
     {
         return new ServerPasswordPolicyForwardHandler(
-            backend: $container->get(ReadBackendInterface::class),
+            locator: $container->get(EntryUuidLocator::class),
             writes: $container->get(WriteOperationDispatcher::class),
             policyResolver: $container->get(PasswordPolicyResolver::class),
             engine: $container->get(PasswordPolicyEngine::class),

--- a/src/FreeDSx/Ldap/Operation/Request/ForwardPasswordPolicyStateRequest.php
+++ b/src/FreeDSx/Ldap/Operation/Request/ForwardPasswordPolicyStateRequest.php
@@ -22,10 +22,10 @@ use FreeDSx\Asn1\Type\IncompleteType;
 use FreeDSx\Asn1\Type\OctetStringType;
 use FreeDSx\Asn1\Type\SequenceType;
 use FreeDSx\Asn1\Type\SetType;
-use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Exception\ProtocolException;
 use FreeDSx\Ldap\Protocol\LdapEncoder;
 use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
+use FreeDSx\Ldap\Schema\Validation\Syntax\UuidSyntaxValidator;
 use Throwable;
 
 use function array_map;
@@ -40,7 +40,6 @@ use function is_string;
  * carries nothing but bind state, so it cannot express any other modification.
  *
  * ForwardPasswordPolicyStateValue ::= SEQUENCE {
- *     dn            OCTET STRING,
  *     entryUuid     OCTET STRING,
  *     failureTimes  SET OF OCTET STRING,
  *     lastSuccess   [0] OCTET STRING OPTIONAL }
@@ -49,8 +48,6 @@ use function is_string;
  */
 class ForwardPasswordPolicyStateRequest extends ExtendedRequest
 {
-    private Dn $dn;
-
     /**
      * @var list<DateTimeImmutable>
      */
@@ -61,21 +58,12 @@ class ForwardPasswordPolicyStateRequest extends ExtendedRequest
      * @param DateTimeImmutable|null $lastSuccess Latest observed successful bind, bounding which failures it clears.
      */
     public function __construct(
-        Dn|string $dn,
-        private string $entryUuid = '',
+        private readonly string $entryUuid,
         array $failureTimes = [],
-        private ?DateTimeImmutable $lastSuccess = null,
+        private readonly ?DateTimeImmutable $lastSuccess = null,
     ) {
-        $this->dn = $dn instanceof Dn
-            ? $dn
-            : new Dn($dn);
         $this->failureTimes = array_values($failureTimes);
         parent::__construct(ExtendedRequest::OID_PPOLICY_STATE_FORWARD);
-    }
-
-    public function getDn(): Dn
-    {
-        return $this->dn;
     }
 
     public function getEntryUuid(): string
@@ -99,7 +87,6 @@ class ForwardPasswordPolicyStateRequest extends ExtendedRequest
     public function toAsn1(): SequenceType
     {
         $sequence = Asn1::sequence(
-            Asn1::octetString($this->dn->toString()),
             Asn1::octetString($this->entryUuid),
             Asn1::setOf(...array_map(
                 static fn(DateTimeImmutable $time): OctetStringType
@@ -134,22 +121,23 @@ class ForwardPasswordPolicyStateRequest extends ExtendedRequest
         $childCount = $request instanceof SequenceType
             ? count($request->getChildren())
             : 0;
-        if (!($request instanceof SequenceType) || $childCount < 3 || $childCount > 4) {
+        if (!($request instanceof SequenceType) || $childCount < 2 || $childCount > 3) {
             throw new ProtocolException('The password policy forward request is malformed.');
         }
 
-        $dn = $request->getChild(0);
-        $entryUuid = $request->getChild(1);
-        $failureTimes = $request->getChild(2);
-        if (!($dn instanceof OctetStringType && $entryUuid instanceof OctetStringType && $failureTimes instanceof SetType)) {
+        $entryUuid = $request->getChild(0);
+        $failureTimes = $request->getChild(1);
+        if (!($entryUuid instanceof OctetStringType && $failureTimes instanceof SetType)) {
             throw new ProtocolException('The password policy forward request is malformed.');
+        }
+        if (!(new UuidSyntaxValidator())->isValid($entryUuid->getValue())) {
+            throw new ProtocolException('The password policy forward request has an invalid entry UUID.');
         }
 
         return new static(
-            $dn->getValue(),
             $entryUuid->getValue(),
             self::parseFailureTimes($failureTimes),
-            self::parseLastSuccess($request->getChild(3)),
+            self::parseLastSuccess($request->getChild(2)),
         );
     }
 

--- a/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandler.php
+++ b/src/FreeDSx/Ldap/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandler.php
@@ -24,9 +24,10 @@ use FreeDSx\Ldap\Operation\Response\ExtendedResponse;
 use FreeDSx\Ldap\Operation\ResultCode;
 use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
 use FreeDSx\Ldap\Server\AccessControl\AccessControlInterface;
 use FreeDSx\Ldap\Server\AccessControl\Rule\AttributeAccess;
-use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Directory\EntryUuidLocator;
 use FreeDSx\Ldap\Server\Backend\Write\Command\ComputeUpdateCommand;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
@@ -53,7 +54,7 @@ readonly class ServerPasswordPolicyForwardHandler implements ServerProtocolHandl
     private const CLOCK_SKEW_TOLERANCE_SECONDS = 30;
 
     public function __construct(
-        private ReadBackendInterface $backend,
+        private EntryUuidLocator $locator,
         private WriteHandlerInterface $writes,
         private PasswordPolicyResolver $policyResolver,
         private PasswordPolicyEngine $engine,
@@ -124,7 +125,8 @@ readonly class ServerPasswordPolicyForwardHandler implements ServerProtocolHandl
         ForwardPasswordPolicyStateRequest $request,
         TokenInterface $token,
     ): void {
-        $target = $this->backend->get($request->getDn());
+        $uuid = $request->getEntryUuid();
+        $target = $this->locator->findByUuid($uuid);
 
         if ($target === null) {
             return;
@@ -139,7 +141,12 @@ readonly class ServerPasswordPolicyForwardHandler implements ServerProtocolHandl
         $this->writes->handle(
             new ComputeUpdateCommand(
                 $target->getDn(),
-                function (Entry $entry) use ($request, $token, $policy): array {
+                function (Entry $entry) use ($request, $token, $policy, $uuid): array {
+                    // The DN could have been re-occupied between the resolve and the lock, so the UUID is re-checked.
+                    if (!$this->isSameEntry($entry, $uuid)) {
+                        return [];
+                    }
+
                     $changes = $this->engine->recordForwardedState(
                         UserPasswordState::fromEntry($entry),
                         $policy,
@@ -161,6 +168,16 @@ readonly class ServerPasswordPolicyForwardHandler implements ServerProtocolHandl
                 new ControlBag(),
             ),
         );
+    }
+
+    private function isSameEntry(
+        Entry $entry,
+        string $uuid,
+    ): bool {
+        $current = $entry->get(AttributeTypeOid::NAME_ENTRY_UUID)
+            ?->firstValue();
+
+        return $current !== null && strtolower($current) === strtolower($uuid);
     }
 
     /**

--- a/src/FreeDSx/Ldap/Server/Backend/Storage/Directory/EntryUuidLocator.php
+++ b/src/FreeDSx/Ldap/Server/Backend/Storage/Directory/EntryUuidLocator.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Backend\Storage\Directory;
+
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
+
+/**
+ * Locates an entry by its entryUUID.
+ *
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+final readonly class EntryUuidLocator
+{
+    public function __construct(
+        private EntryStorageInterface $storage,
+        private FilterEvaluatorInterface $filterEvaluator,
+    ) {}
+
+    /**
+     * The entry carrying $uuid, or null when this storage holds it nowhere.
+     */
+    public function findByUuid(string $uuid): ?Entry
+    {
+        $filter = Filters::equal(
+            AttributeTypeOid::NAME_ENTRY_UUID,
+            $uuid,
+        );
+        $stream = $this->storage->list(new StorageListOptions(
+            baseDn: new Dn(''),
+            subtree: true,
+            filter: $filter,
+        ));
+
+        // A listing guarantees scope only
+        // the filter is evaluated here unless storage already applied it exactly.
+        foreach ($stream->entries() as $entry) {
+            if ($stream->isPreFiltered || $this->filterEvaluator->evaluate($entry, $filter)) {
+                return $entry;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Clock/Sleeper/BackoffSleeper.php
+++ b/src/FreeDSx/Ldap/Server/Clock/Sleeper/BackoffSleeper.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\Clock\Sleeper;
+
+use FreeDSx\Ldap\Server\Config\ReconnectBackoff;
+
+/**
+ * A stateful reconnect backoff: it sleeps the current delay and widens it, resetting to the initial after a success.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class BackoffSleeper
+{
+    private float $delay;
+
+    public function __construct(
+        private readonly ReconnectBackoff $backoff,
+        private readonly SleeperInterface $sleeper,
+    ) {
+        $this->delay = $backoff->initial();
+    }
+
+    /**
+     * Reset to the initial delay after a successful iteration.
+     */
+    public function reset(): void
+    {
+        $this->delay = $this->backoff->initial();
+    }
+
+    /**
+     * Sleep the current delay, then widen it toward the ceiling for the next failure.
+     */
+    public function wait(): void
+    {
+        $this->sleeper->sleep($this->delay);
+        $this->delay = $this->backoff->next($this->delay);
+    }
+
+    /**
+     * The delay the next {@see wait()} will sleep.
+     */
+    public function delay(): float
+    {
+        return $this->delay;
+    }
+}

--- a/src/FreeDSx/Ldap/Server/Config/ReconnectBackoff.php
+++ b/src/FreeDSx/Ldap/Server/Config/ReconnectBackoff.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace FreeDSx\Ldap\Sync\Consumer;
+namespace FreeDSx\Ldap\Server\Config;
 
 use function min;
 

--- a/src/FreeDSx/Ldap/Server/Config/Replication/ConsumerConfig.php
+++ b/src/FreeDSx/Ldap/Server/Config/Replication/ConsumerConfig.php
@@ -20,7 +20,7 @@ use FreeDSx\Ldap\Operation\Request\BindRequest;
 use FreeDSx\Ldap\Search\Filter\FilterInterface;
 use FreeDSx\Ldap\Sync\Consumer\Checkpoint\InMemoryReplicationCheckpoint;
 use FreeDSx\Ldap\Sync\Consumer\Checkpoint\ReplicationCheckpointInterface;
-use FreeDSx\Ldap\Sync\Consumer\ReconnectBackoff;
+use FreeDSx\Ldap\Server\Config\ReconnectBackoff;
 
 /**
  * How a server mirrors an upstream primary over RFC 4533.

--- a/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
+++ b/src/FreeDSx/Ldap/Server/Middleware/OperationAuthorizationMiddleware.php
@@ -22,7 +22,6 @@ use FreeDSx\Ldap\Operation\Request\AddRequest;
 use FreeDSx\Ldap\Operation\Request\CompareRequest;
 use FreeDSx\Ldap\Operation\Request\AbandonRequest;
 use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
-use FreeDSx\Ldap\Operation\Request\ForwardPasswordPolicyStateRequest;
 use FreeDSx\Ldap\Operation\Request\UnbindRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyDnRequest;
 use FreeDSx\Ldap\Operation\Request\ModifyRequest;
@@ -180,8 +179,6 @@ final readonly class OperationAuthorizationMiddleware implements MiddlewareInter
     {
         return match (true) {
             $request instanceof SearchRequest => $request->getBaseDn(),
-            // An extended operation names no entry in general, but this one does, and a rule may name it too.
-            $request instanceof ForwardPasswordPolicyStateRequest => $request->getDn(),
             default => OperationTargetDn::of($request),
         };
     }

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwardWorker.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwardWorker.php
@@ -14,19 +14,14 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward;
 
 use FreeDSx\Ldap\Exception\ForwardStateException;
-use FreeDSx\Ldap\Exception\ForwardStateRejectedException;
-use FreeDSx\Ldap\Operation\Request\ForwardPasswordPolicyStateRequest;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BackoffSleeper;
 use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
 use FreeDSx\Ldap\Server\Logging\ExceptionLogging;
-use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaForwardState;
-use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
 use FreeDSx\Ldap\Server\Process\Signals\ShutdownSignalsInterface;
-use FreeDSx\Ldap\Sync\Consumer\ReconnectBackoff;
 use Psr\Log\LoggerInterface;
 
 /**
- * Drains the replica-local password-policy forward queue on a loop, delivering each pending subject's state to the
- * primary over a reused connection and backing off when the primary is unreachable.
+ * Runs the password-policy forwarder on a loop, sleeping the poll interval and backing off when the primary is down.
  *
  * @internal
  * @author Chad Sikorra <Chad.Sikorra@gmail.com>
@@ -39,19 +34,11 @@ class PasswordPolicyForwardWorker
 
     private bool $stopping = false;
 
-    private int $drain = 0;
-
-    /**
-     * @var array<string, RefusedForward>
-     */
-    private array $refused = [];
-
     public function __construct(
-        private readonly ReplicaPasswordStateStoreInterface $store,
-        private readonly ForwardStateSenderInterface $sender,
+        private readonly PasswordPolicyForwarder $forwarder,
         private readonly SleeperInterface $sleeper,
+        private readonly BackoffSleeper $backoff,
         private readonly float $interval = self::DEFAULT_INTERVAL_SECONDS,
-        private readonly ReconnectBackoff $backoff = new ReconnectBackoff(),
         private readonly ?ShutdownSignalsInterface $signals = null,
         private readonly ?LoggerInterface $logger = null,
     ) {}
@@ -63,20 +50,17 @@ class PasswordPolicyForwardWorker
     {
         $this->signals?->onShutdown($this->stop(...));
 
-        $delay = $this->backoff->initial();
-
         while (!$this->stopping) {
             try {
-                $this->forwardOnce();
-                $delay = $this->backoff->initial();
+                $this->forwarder->forwardOnce();
+                $this->backoff->reset();
                 $this->sleeper->sleep($this->interval);
             } catch (ForwardStateException $e) {
                 $this->logger?->warning(
                     'Password-policy forwarding failed; retrying after backoff.',
-                    ExceptionLogging::makeLogContext($e) + ['backoff_seconds' => $delay],
+                    ExceptionLogging::makeLogContext($e) + ['backoff_seconds' => $this->backoff->delay()],
                 );
-                $this->sleeper->sleep($delay);
-                $delay = $this->backoff->next($delay);
+                $this->backoff->wait();
             }
         }
     }
@@ -87,102 +71,5 @@ class PasswordPolicyForwardWorker
     public function stop(): void
     {
         $this->stopping = true;
-    }
-
-    /**
-     * Forward every pending subject in watermark order, advancing the watermark after each successful delivery; a
-     * delivery failure stops the drain so the remainder stays pending for the next run.
-     *
-     * @return int the number of subjects forwarded
-     * @throws ForwardStateException
-     */
-    public function forwardOnce(): int
-    {
-        $forwarded = 0;
-        $refused = [];
-        ++$this->drain;
-
-        foreach ($this->store->listUnforwarded() as $pending) {
-            $key = self::keyFor($pending);
-            $previous = $this->refusalFor($pending);
-
-            if ($previous !== null && !$previous->isDue($this->drain)) {
-                $refused[$key] = $previous;
-
-                continue;
-            }
-
-            try {
-                $this->sender->send($this->requestFor($pending));
-            } catch (ForwardStateRejectedException $e) {
-                // One subject the primary refuses must not hold back every other subject behind it.
-                $this->reportRefusal($pending, $previous, $e);
-                $refused[$key] = $previous?->again($this->drain)
-                    ?? RefusedForward::after($pending->sequence, $this->drain);
-
-                continue;
-            }
-
-            $this->store->markForwarded(
-                $pending->dn,
-                $pending->sequence,
-            );
-            ++$forwarded;
-        }
-
-        $this->refused = $refused;
-
-        return $forwarded;
-    }
-
-    /**
-     * The standing refusal for this subject, or null when its state has moved on and deserves a fresh attempt.
-     */
-    private function refusalFor(ReplicaForwardState $pending): ?RefusedForward
-    {
-        $refusal = $this->refused[self::keyFor($pending)] ?? null;
-
-        return $refusal?->sequence === $pending->sequence
-            ? $refusal
-            : null;
-    }
-
-    /**
-     * Normalized, so one subject cannot occupy two entries under two spellings of its DN.
-     */
-    private static function keyFor(ReplicaForwardState $pending): string
-    {
-        return $pending->dn
-            ->normalize()
-            ->toString();
-    }
-
-    /**
-     * Reported once per subject state to avoid logging this indefinitely.
-     */
-    private function reportRefusal(
-        ReplicaForwardState $pending,
-        ?RefusedForward $previous,
-        ForwardStateRejectedException $exception,
-    ): void {
-        if ($previous !== null) {
-            return;
-        }
-
-        $this->logger?->warning(
-            'The primary refused a password-policy forward; leaving it pending and continuing.',
-            ExceptionLogging::makeLogContext($exception) + ['dn' => $pending->dn->toString()],
-        );
-    }
-
-    private function requestFor(ReplicaForwardState $pending): ForwardPasswordPolicyStateRequest
-    {
-        $state = $pending->state->toUserPasswordState($pending->dn);
-
-        return new ForwardPasswordPolicyStateRequest(
-            $pending->dn,
-            failureTimes: $state->failureTimes,
-            lastSuccess: $state->lastSuccess,
-        );
     }
 }

--- a/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwarder.php
+++ b/src/FreeDSx/Ldap/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwarder.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward;
+
+use FreeDSx\Ldap\Exception\ForwardStateException;
+use FreeDSx\Ldap\Exception\ForwardStateRejectedException;
+use FreeDSx\Ldap\Operation\Request\ForwardPasswordPolicyStateRequest;
+use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
+use FreeDSx\Ldap\Server\Logging\ExceptionLogging;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaForwardState;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Drains the replica-local password-policy forward queue once, delivering each pending subject by its entryUUID.
+ *
+ * @internal
+ * @author Chad Sikorra <Chad.Sikorra@gmail.com>
+ */
+class PasswordPolicyForwarder
+{
+    private int $drain = 0;
+
+    /**
+     * @var array<string, RefusedForward>
+     */
+    private array $refused = [];
+
+    public function __construct(
+        private readonly ReplicaPasswordStateStoreInterface $store,
+        private readonly ForwardStateSenderInterface $sender,
+        private readonly ReadBackendInterface $backend,
+        private readonly ?LoggerInterface $logger = null,
+    ) {}
+
+    /**
+     * Forward every pending subject in watermark order, advancing the watermark after each delivery.
+     *
+     * @return int the number of subjects forwarded
+     * @throws ForwardStateException
+     */
+    public function forwardOnce(): int
+    {
+        $forwarded = 0;
+        $refused = [];
+        ++$this->drain;
+
+        foreach ($this->store->listUnforwarded() as $pending) {
+            $key = self::keyFor($pending);
+            $previous = $this->refusalFor($pending);
+
+            if ($previous !== null && !$previous->isDue($this->drain)) {
+                $refused[$key] = $previous;
+
+                continue;
+            }
+
+            $uuid = $this->uuidFor($pending);
+            if ($uuid === null) {
+                $this->reportUnaddressable($pending, $previous);
+                $refused[$key] = $this->nextRefusal($pending, $previous);
+
+                continue;
+            }
+
+            try {
+                $this->sender->send($this->requestFor($pending, $uuid));
+            } catch (ForwardStateRejectedException $e) {
+                // One subject the primary refuses must not hold back every other subject behind it.
+                $this->reportRefusal($pending, $previous, $e);
+                $refused[$key] = $this->nextRefusal($pending, $previous);
+
+                continue;
+            }
+
+            $this->store->markForwarded(
+                $pending->dn,
+                $pending->sequence,
+            );
+            ++$forwarded;
+        }
+
+        $this->refused = $refused;
+
+        return $forwarded;
+    }
+
+    /**
+     * The standing refusal for this subject, or null when its state has moved on and deserves a fresh attempt.
+     */
+    private function refusalFor(ReplicaForwardState $pending): ?RefusedForward
+    {
+        $refusal = $this->refused[self::keyFor($pending)] ?? null;
+
+        return $refusal?->sequence === $pending->sequence
+            ? $refusal
+            : null;
+    }
+
+    /**
+     * The refusal to carry forward for a subject left pending, widening the retry gap or opening a fresh one.
+     */
+    private function nextRefusal(
+        ReplicaForwardState $pending,
+        ?RefusedForward $previous,
+    ): RefusedForward {
+        return $previous?->again($this->drain)
+            ?? RefusedForward::after($pending->sequence, $this->drain);
+    }
+
+    /**
+     * Normalized, so one subject cannot occupy two entries under two spellings of its DN.
+     */
+    private static function keyFor(ReplicaForwardState $pending): string
+    {
+        return $pending->dn
+            ->normalize()
+            ->toString();
+    }
+
+    /**
+     * Reported once per subject state to avoid logging this indefinitely.
+     */
+    private function reportRefusal(
+        ReplicaForwardState $pending,
+        ?RefusedForward $previous,
+        ForwardStateRejectedException $exception,
+    ): void {
+        if ($previous !== null) {
+            return;
+        }
+
+        $this->logger?->warning(
+            'The primary refused a password-policy forward; leaving it pending and continuing.',
+            ExceptionLogging::makeLogContext($exception) + ['dn' => $pending->dn->toString()],
+        );
+    }
+
+    private function reportUnaddressable(
+        ReplicaForwardState $pending,
+        ?RefusedForward $previous,
+    ): void {
+        if ($previous !== null) {
+            return;
+        }
+
+        $this->logger?->warning(
+            'A pending password-policy forward has no resolvable entry UUID; leaving it pending and continuing.',
+            ['dn' => $pending->dn->toString()],
+        );
+    }
+
+    private function uuidFor(ReplicaForwardState $pending): ?string
+    {
+        return $this->backend
+            ->get($pending->dn)
+            ?->get(AttributeTypeOid::NAME_ENTRY_UUID)
+            ?->firstValue();
+    }
+
+    private function requestFor(
+        ReplicaForwardState $pending,
+        string $uuid,
+    ): ForwardPasswordPolicyStateRequest {
+        $state = $pending->state->toUserPasswordState($pending->dn);
+
+        return new ForwardPasswordPolicyStateRequest(
+            $uuid,
+            failureTimes: $state->failureTimes,
+            lastSuccess: $state->lastSuccess,
+        );
+    }
+}

--- a/src/FreeDSx/Ldap/Sync/Consumer/LdapReplica.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/LdapReplica.php
@@ -14,16 +14,9 @@ declare(strict_types=1);
 namespace FreeDSx\Ldap\Sync\Consumer;
 
 use FreeDSx\Ldap\Exception\CancelRequestException;
-use FreeDSx\Ldap\Server\Config\Replication\ConsumerConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
-use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
-use FreeDSx\Ldap\Server\Clock\Sleeper\BlockingSleeper;
-use FreeDSx\Ldap\Server\Clock\Sleeper\CoroutineSleeper;
-use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BackoffSleeper;
 use FreeDSx\Ldap\Server\Logging\ExceptionLogging;
-use FreeDSx\Ldap\Server\Process\Signals\PcntlShutdownSignals;
 use FreeDSx\Ldap\Server\Process\Signals\ShutdownSignalsInterface;
-use FreeDSx\Ldap\Server\Process\Signals\SwooleShutdownSignals;
 use FreeDSx\Ldap\Sync\Consumer\Checkpoint\ReplicationCheckpointInterface;
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
 use FreeDSx\Ldap\Sync\Result\SyncIdSetResult;
@@ -54,55 +47,17 @@ final class LdapReplica
      */
     private ?string $pendingCookie = null;
 
+    /**
+     * @param ?ShutdownSignalsInterface $signals null when a host server owns SIGTERM and drives {@see stop()} instead
+     */
     public function __construct(
         private readonly PrimaryConnectionFactory $connectionFactory,
         private readonly ChangeApplierInterface $applier,
         private readonly ReplicationCheckpointInterface $checkpoint,
-        private readonly SleeperInterface $sleeper,
+        private readonly BackoffSleeper $backoff,
         private readonly ?ShutdownSignalsInterface $signals = null,
         private readonly ?LoggerInterface $logger = null,
-        private readonly ReconnectBackoff $backoff = new ReconnectBackoff(),
     ) {}
-
-    public static function forPcntl(
-        ConsumerConfig $config,
-        EntryStorageInterface $storage,
-        ?LoggerInterface $logger = null,
-        ?PrimaryConnectionFactory $connectionFactory = null,
-        ?ReplicaPasswordStateStoreInterface $passwordStateStore = null,
-    ): self {
-        return self::create(
-            $config,
-            $storage,
-            new BlockingSleeper(),
-            new PcntlShutdownSignals(),
-            $logger,
-            $connectionFactory,
-            $passwordStateStore,
-        );
-    }
-
-    /**
-     * @param ?ShutdownSignalsInterface $signals null when a host server owns SIGTERM and drives {@see stop()} instead
-     */
-    public static function forSwoole(
-        ConsumerConfig $config,
-        EntryStorageInterface $storage,
-        ?LoggerInterface $logger = null,
-        ?ShutdownSignalsInterface $signals = new SwooleShutdownSignals(),
-        ?PrimaryConnectionFactory $connectionFactory = null,
-        ?ReplicaPasswordStateStoreInterface $passwordStateStore = null,
-    ): self {
-        return self::create(
-            $config,
-            $storage,
-            new CoroutineSleeper(),
-            $signals,
-            $logger,
-            $connectionFactory,
-            $passwordStateStore,
-        );
-    }
 
     /**
      * Consume from the primary until a shutdown signal, reconnecting with bounded backoff on failure.
@@ -112,12 +67,10 @@ final class LdapReplica
         $this->signals?->onShutdown($this->stop(...));
         $this->logger?->info('Starting replica synchronization.');
 
-        $delay = $this->backoff->initial();
-
         while (!$this->stopping) {
             try {
                 $this->sync();
-                $delay = $this->backoff->initial();
+                $this->backoff->reset();
             } catch (CancelRequestException) {
                 // A shutdown was requested; listen() was cancelled cleanly by the entry handler.
             } catch (Throwable $e) {
@@ -127,10 +80,9 @@ final class LdapReplica
 
                 $this->logger?->warning(
                     'Replica synchronization failed; reconnecting after backoff.',
-                    ExceptionLogging::makeLogContext($e) + ['backoff_seconds' => $delay],
+                    ExceptionLogging::makeLogContext($e) + ['backoff_seconds' => $this->backoff->delay()],
                 );
-                $this->sleeper->sleep($delay);
-                $delay = $this->backoff->next($delay);
+                $this->backoff->wait();
             }
         }
 
@@ -144,34 +96,6 @@ final class LdapReplica
     {
         $this->stopping = true;
         $this->activeSync?->disconnect();
-    }
-
-    private static function create(
-        ConsumerConfig $config,
-        EntryStorageInterface $storage,
-        SleeperInterface $sleeper,
-        ?ShutdownSignalsInterface $signals,
-        ?LoggerInterface $logger,
-        ?PrimaryConnectionFactory $connectionFactory = null,
-        ?ReplicaPasswordStateStoreInterface $passwordStateStore = null,
-    ): self {
-        // listen() must not time out its blocking read, or the persist phase would abort each interval.
-        $config->getPrimary()
-            ->setTimeoutRead(-1);
-
-        $applier = new VerbatimStorageApplier($storage);
-
-        return new self(
-            connectionFactory: $connectionFactory ?? new PrimaryConnectionFactory($config),
-            applier: $passwordStateStore !== null
-                ? new ReconcilingChangeApplier($applier, $passwordStateStore)
-                : $applier,
-            checkpoint: $config->getCheckpoint(),
-            sleeper: $sleeper,
-            signals: $signals,
-            logger: $logger,
-            backoff: $config->getReconnectBackoff(),
-        );
     }
 
     private function sync(): void

--- a/src/FreeDSx/Ldap/Sync/Consumer/VerbatimStorageApplier.php
+++ b/src/FreeDSx/Ldap/Sync/Consumer/VerbatimStorageApplier.php
@@ -16,7 +16,7 @@ namespace FreeDSx\Ldap\Sync\Consumer;
 use FreeDSx\Ldap\Entry\Dn;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Schema\Definition\AttributeTypeOid;
-use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\Backend\Storage\Directory\EntryUuidLocator;
 use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
 use FreeDSx\Ldap\Server\Backend\Storage\StorageListOptions;
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
@@ -45,7 +45,10 @@ final class VerbatimStorageApplier implements ChangeApplierInterface
      */
     private array $presentUuids = [];
 
-    public function __construct(private readonly EntryStorageInterface $storage) {}
+    public function __construct(
+        private readonly EntryStorageInterface $storage,
+        private readonly EntryUuidLocator $locator,
+    ) {}
 
     public function beginRefresh(): void
     {
@@ -181,31 +184,10 @@ final class VerbatimStorageApplier implements ChangeApplierInterface
      */
     private function dnHolding(string $uuid): ?Dn
     {
-        $options = new StorageListOptions(
-            baseDn: new Dn(''),
-            subtree: true,
-            filter: Filters::equal(
-                AttributeTypeOid::NAME_ENTRY_UUID,
-                $uuid,
-            ),
-        );
-
-        $wanted = strtolower($uuid);
-
-        // Storage answers the filter only where it can, so each candidate is checked rather than trusted.
-        foreach ($this->storage->list($options)->entries() as $entry) {
-            $candidate = $entry->get(AttributeTypeOid::NAME_ENTRY_UUID)
-                ?->firstValue();
-
-            if ($candidate === null || strtolower($candidate) !== $wanted) {
-                continue;
-            }
-
-            return $entry->getDn()
-                ->normalize();
-        }
-
-        return null;
+        return $this->locator
+            ->findByUuid($uuid)
+            ?->getDn()
+            ->normalize();
     }
 
     /**

--- a/tests/integration/Sync/SyncReplForwardTestCase.php
+++ b/tests/integration/Sync/SyncReplForwardTestCase.php
@@ -13,11 +13,21 @@ declare(strict_types=1);
 
 namespace Tests\Integration\FreeDSx\Ldap\Sync;
 
+use DateTimeImmutable;
+use DateTimeZone;
+use FreeDSx\Asn1\Asn1;
 use FreeDSx\Ldap\ClientOptions;
 use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\BindException;
+use FreeDSx\Ldap\Exception\OperationException;
 use FreeDSx\Ldap\LdapClient;
+use FreeDSx\Ldap\Operation\Request\ExtendedRequest;
+use FreeDSx\Ldap\Operation\Request\ForwardPasswordPolicyStateRequest;
 use FreeDSx\Ldap\Operation\Request\PasswordModifyRequest;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Operations;
+use FreeDSx\Ldap\Search\Filters;
+use FreeDSx\Ldap\Server\Utility\Uuid;
 use Tests\Integration\FreeDSx\Ldap\ServerTestCase;
 use Tests\Support\FreeDSx\Ldap\LdapServerCommand;
 use Tests\Support\FreeDSx\Ldap\TestWorker;
@@ -80,6 +90,89 @@ abstract class SyncReplForwardTestCase extends ServerTestCase
             $this->pollUntil(fn(): bool => $this->replicaBindSucceeds($dn, 'newpass')),
             'The replica should retire its local lock once the reset replicates.',
         );
+    }
+
+    public function test_a_forward_naming_an_unknown_uuid_applies_nowhere(): void
+    {
+        $before = $this->lockedDnsOnProvider();
+
+        $client = $this->providerClient();
+
+        try {
+            $client->bind(
+                'cn=user,dc=foo,dc=bar',
+                '12345',
+            );
+            $client->sendAndReceive(new ForwardPasswordPolicyStateRequest(
+                Uuid::v4(),
+                [
+                    new DateTimeImmutable('-2 seconds', new DateTimeZone('UTC')),
+                    new DateTimeImmutable('-1 second', new DateTimeZone('UTC')),
+                ],
+            ));
+        } finally {
+            $this->quietUnbind($client);
+        }
+
+        self::assertSame(
+            $before,
+            $this->lockedDnsOnProvider(),
+            'A forward for a UUID the primary does not hold must lock nothing.',
+        );
+    }
+
+    public function test_a_forward_with_a_malformed_uuid_is_refused(): void
+    {
+        $client = $this->providerClient();
+
+        try {
+            $client->bind(
+                'cn=user,dc=foo,dc=bar',
+                '12345',
+            );
+
+            $this->expectException(OperationException::class);
+            $this->expectExceptionCode(ResultCode::PROTOCOL_ERROR);
+
+            $client->sendAndReceive(
+                (new ExtendedRequest(ExtendedRequest::OID_PPOLICY_STATE_FORWARD))
+                    ->setValue(Asn1::sequence(
+                        Asn1::octetString('not-a-uuid'),
+                        Asn1::setOf(),
+                    )),
+            );
+        } finally {
+            $this->quietUnbind($client);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function lockedDnsOnProvider(): array
+    {
+        $manager = $this->providerClient();
+
+        try {
+            $manager->bind(
+                LdapServerCommand::MANAGER_DN,
+                LdapServerCommand::MANAGER_PASSWORD,
+            );
+            $entries = $manager->search(Operations::search(
+                Filters::present(self::PWD_LOCKED_TIME),
+                '1.1',
+            )->base('ou=people,dc=foo,dc=bar'));
+
+            $dns = [];
+            foreach ($entries as $entry) {
+                $dns[] = $entry->getDn()->toString();
+            }
+            sort($dns);
+
+            return $dns;
+        } finally {
+            $this->quietUnbind($manager);
+        }
     }
 
     private function providerHasLock(string $dn): bool

--- a/tests/unit/Operation/Request/ForwardPasswordPolicyStateRequestTest.php
+++ b/tests/unit/Operation/Request/ForwardPasswordPolicyStateRequestTest.php
@@ -25,6 +25,8 @@ use PHPUnit\Framework\TestCase;
 
 final class ForwardPasswordPolicyStateRequestTest extends TestCase
 {
+    private const UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
     private DateTimeImmutable $time;
 
     private DateTimeImmutable $success;
@@ -42,21 +44,16 @@ final class ForwardPasswordPolicyStateRequestTest extends TestCase
             new DateTimeZone('UTC'),
         );
         $this->subject = new ForwardPasswordPolicyStateRequest(
-            'cn=user,dc=foo,dc=bar',
-            'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+            self::UUID,
             [$this->time],
             $this->success,
         );
     }
 
-    public function test_it_exposes_the_dn_uuid_failure_times_and_last_success(): void
+    public function test_it_exposes_the_uuid_failure_times_and_last_success(): void
     {
         self::assertSame(
-            'cn=user,dc=foo,dc=bar',
-            $this->subject->getDn()->toString(),
-        );
-        self::assertSame(
-            'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+            self::UUID,
             $this->subject->getEntryUuid(),
         );
         self::assertEquals(
@@ -72,7 +69,7 @@ final class ForwardPasswordPolicyStateRequestTest extends TestCase
     public function test_last_success_defaults_to_null(): void
     {
         self::assertNull(
-            (new ForwardPasswordPolicyStateRequest('cn=user,dc=foo,dc=bar'))->getLastSuccess(),
+            (new ForwardPasswordPolicyStateRequest(self::UUID))->getLastSuccess(),
         );
     }
 
@@ -92,8 +89,7 @@ final class ForwardPasswordPolicyStateRequestTest extends TestCase
             Asn1::application(23, Asn1::sequence(
                 Asn1::context(0, Asn1::octetString(ExtendedRequest::OID_PPOLICY_STATE_FORWARD)),
                 Asn1::context(1, Asn1::octetString($encoder->encode(Asn1::sequence(
-                    Asn1::octetString('cn=user,dc=foo,dc=bar'),
-                    Asn1::octetString('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'),
+                    Asn1::octetString(self::UUID),
                     Asn1::setOf(Asn1::octetString(GeneralizedTime::formatWithFraction($this->time))),
                     Asn1::context(0, Asn1::octetString(GeneralizedTime::format($this->success))),
                 )))),
@@ -106,8 +102,7 @@ final class ForwardPasswordPolicyStateRequestTest extends TestCase
     {
         $encoder = new LdapEncoder();
         $request = new ForwardPasswordPolicyStateRequest(
-            'cn=user,dc=foo,dc=bar',
-            'uuid',
+            self::UUID,
             [$this->time],
         );
 
@@ -115,8 +110,7 @@ final class ForwardPasswordPolicyStateRequestTest extends TestCase
             Asn1::application(23, Asn1::sequence(
                 Asn1::context(0, Asn1::octetString(ExtendedRequest::OID_PPOLICY_STATE_FORWARD)),
                 Asn1::context(1, Asn1::octetString($encoder->encode(Asn1::sequence(
-                    Asn1::octetString('cn=user,dc=foo,dc=bar'),
-                    Asn1::octetString('uuid'),
+                    Asn1::octetString(self::UUID),
                     Asn1::setOf(Asn1::octetString(GeneralizedTime::formatWithFraction($this->time))),
                 )))),
             )),
@@ -137,8 +131,7 @@ final class ForwardPasswordPolicyStateRequestTest extends TestCase
     public function test_it_round_trips_without_a_last_success(): void
     {
         $request = new ForwardPasswordPolicyStateRequest(
-            'cn=user,dc=foo,dc=bar',
-            'uuid',
+            self::UUID,
             [$this->time],
         );
 
@@ -151,6 +144,20 @@ final class ForwardPasswordPolicyStateRequestTest extends TestCase
         );
     }
 
+    public function test_it_rejects_a_malformed_entry_uuid(): void
+    {
+        $this->expectException(ProtocolException::class);
+
+        ForwardPasswordPolicyStateRequest::fromAsn1(
+            (new ExtendedRequest(ExtendedRequest::OID_PPOLICY_STATE_FORWARD))
+                ->setValue(Asn1::sequence(
+                    Asn1::octetString('not-a-uuid'),
+                    Asn1::setOf(),
+                ))
+                ->toAsn1(),
+        );
+    }
+
     public function test_it_rejects_an_invalid_failure_time(): void
     {
         $this->expectException(ProtocolException::class);
@@ -158,8 +165,7 @@ final class ForwardPasswordPolicyStateRequestTest extends TestCase
         ForwardPasswordPolicyStateRequest::fromAsn1(
             (new ExtendedRequest(ExtendedRequest::OID_PPOLICY_STATE_FORWARD))
                 ->setValue(Asn1::sequence(
-                    Asn1::octetString('cn=user,dc=foo,dc=bar'),
-                    Asn1::octetString('uuid'),
+                    Asn1::octetString(self::UUID),
                     Asn1::setOf(Asn1::octetString('not-a-time')),
                 ))
                 ->toAsn1(),
@@ -173,10 +179,38 @@ final class ForwardPasswordPolicyStateRequestTest extends TestCase
         ForwardPasswordPolicyStateRequest::fromAsn1(
             (new ExtendedRequest(ExtendedRequest::OID_PPOLICY_STATE_FORWARD))
                 ->setValue(Asn1::sequence(
-                    Asn1::octetString('cn=user,dc=foo,dc=bar'),
-                    Asn1::octetString('uuid'),
+                    Asn1::octetString(self::UUID),
                     Asn1::setOf(),
                     Asn1::context(0, Asn1::octetString('not-a-time')),
+                ))
+                ->toAsn1(),
+        );
+    }
+
+    public function test_it_rejects_too_few_children(): void
+    {
+        $this->expectException(ProtocolException::class);
+
+        ForwardPasswordPolicyStateRequest::fromAsn1(
+            (new ExtendedRequest(ExtendedRequest::OID_PPOLICY_STATE_FORWARD))
+                ->setValue(Asn1::sequence(
+                    Asn1::octetString(self::UUID),
+                ))
+                ->toAsn1(),
+        );
+    }
+
+    public function test_it_rejects_too_many_children(): void
+    {
+        $this->expectException(ProtocolException::class);
+
+        ForwardPasswordPolicyStateRequest::fromAsn1(
+            (new ExtendedRequest(ExtendedRequest::OID_PPOLICY_STATE_FORWARD))
+                ->setValue(Asn1::sequence(
+                    Asn1::octetString(self::UUID),
+                    Asn1::setOf(),
+                    Asn1::context(0, Asn1::octetString(GeneralizedTime::format($this->success))),
+                    Asn1::octetString('extra'),
                 ))
                 ->toAsn1(),
         );

--- a/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandlerTest.php
+++ b/tests/unit/Protocol/ServerProtocolHandler/ServerPasswordPolicyForwardHandlerTest.php
@@ -26,6 +26,9 @@ use FreeDSx\Ldap\Protocol\LdapMessageRequest;
 use FreeDSx\Ldap\Protocol\Queue\Response\ResponseStream;
 use FreeDSx\Ldap\Protocol\ServerProtocolHandler\ServerPasswordPolicyForwardHandler;
 use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Directory\EntryUuidLocator;
+use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Backend\Write\Command\ComputeUpdateCommand;
 use FreeDSx\Ldap\Server\Backend\Write\WriteHandlerInterface;
 use FreeDSx\Ldap\Server\Backend\Write\WriteContext;
@@ -40,12 +43,19 @@ use FreeDSx\Ldap\Server\Token\TokenInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Tests\Support\FreeDSx\Ldap\Clock\FrozenClock;
+use Tests\Support\FreeDSx\Ldap\ServerContainerTrait;
 
 final class ServerPasswordPolicyForwardHandlerTest extends TestCase
 {
+    use ServerContainerTrait;
+
     private const NOW = '2026-05-20T12:00:00Z';
 
     private const DN = 'cn=user,dc=foo,dc=bar';
+
+    private const UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+    private InMemoryStorage $storage;
 
     private ReadBackendInterface&MockObject $backend;
 
@@ -59,25 +69,23 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
 
     protected function setUp(): void
     {
+        $this->storage = new InMemoryStorage();
         $this->backend = $this->createMock(ReadBackendInterface::class);
         $this->writes = $this->createMock(WriteHandlerInterface::class);
         $this->accessControl = $this->createMock(AccessControlInterface::class);
         $this->subject = new ServerPasswordPolicyForwardHandler(
-            $this->backend,
+            $this->locator(),
             $this->writes,
-            new PasswordPolicyResolver(
-                $this->backend,
-                null,
-                new PasswordPolicy(lockout: new PasswordLockoutRules(
-                    enabled: true,
-                    maxFailure: 3,
-                )),
-            ),
+            $this->resolverWith(new PasswordPolicy(lockout: new PasswordLockoutRules(
+                enabled: true,
+                maxFailure: 3,
+            ))),
             new PasswordPolicyEngine(
                 FrozenClock::fromString(self::NOW),
                 new PasswordChangeConstraintChain([]),
             ),
             $this->accessControl,
+            FrozenClock::fromString(self::NOW),
         );
     }
 
@@ -87,10 +95,11 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
             '2026-05-20 11:59:00',
             new DateTimeZone('UTC'),
         );
+        $target = $this->storeTarget(['cn' => ['user']]);
 
         $changes = $this->captureComputedChanges(
-            new ForwardPasswordPolicyStateRequest(self::DN, 'uuid', [$time]),
-            Entry::fromArray(self::DN, ['cn' => ['user']]),
+            new ForwardPasswordPolicyStateRequest(self::UUID, [$time]),
+            $target,
         );
 
         self::assertCount(
@@ -113,13 +122,14 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
             '2026-05-20 12:00:00',
             new DateTimeZone('UTC'),
         );
+        $target = $this->storeTarget([
+            'cn' => ['user'],
+            'pwdFailureTime' => ['20260520115000Z'],
+        ]);
 
         $changes = $this->captureComputedChanges(
-            new ForwardPasswordPolicyStateRequest(self::DN, 'uuid', [], $success),
-            Entry::fromArray(self::DN, [
-                'cn' => ['user'],
-                'pwdFailureTime' => ['20260520115000Z'],
-            ]),
+            new ForwardPasswordPolicyStateRequest(self::UUID, [], $success),
+            $target,
         );
 
         self::assertSame(
@@ -134,22 +144,16 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
 
     public function test_it_still_acks_and_does_not_write_when_no_policy_applies(): void
     {
-        $this->backend
-            ->method('get')
-            ->willReturn(Entry::fromArray(self::DN, ['cn' => ['user']]));
+        $this->storeTarget(['cn' => ['user']]);
         $this->writes
             ->expects(self::never())
             ->method('handle');
 
         // A resolver with no source at all, so nothing governs the target.
         $subject = new ServerPasswordPolicyForwardHandler(
-            $this->backend,
+            $this->locator(),
             $this->writes,
-            new PasswordPolicyResolver(
-                $this->backend,
-                null,
-                null,
-            ),
+            $this->resolverWith(null),
             new PasswordPolicyEngine(
                 FrozenClock::fromString(self::NOW),
                 new PasswordChangeConstraintChain([]),
@@ -158,7 +162,7 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
         );
 
         $stream = $subject->handleRequest(
-            $this->messageFor(new ForwardPasswordPolicyStateRequest(self::DN, 'uuid', [
+            $this->messageFor(new ForwardPasswordPolicyStateRequest(self::UUID, [
                 new DateTimeImmutable('2026-05-20 11:59:00', new DateTimeZone('UTC')),
             ])),
             $this->createMock(TokenInterface::class),
@@ -170,17 +174,14 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
         );
     }
 
-    public function test_it_still_acks_and_does_not_write_when_the_target_is_missing(): void
+    public function test_it_still_acks_and_does_not_write_when_no_entry_holds_the_uuid(): void
     {
-        $this->backend
-            ->method('get')
-            ->willReturn(null);
         $this->writes
             ->expects(self::never())
             ->method('handle');
 
         $stream = $this->subject->handleRequest(
-            $this->messageFor(new ForwardPasswordPolicyStateRequest(self::DN, 'uuid', [
+            $this->messageFor(new ForwardPasswordPolicyStateRequest(self::UUID, [
                 new DateTimeImmutable('2026-05-20 11:59:00', new DateTimeZone('UTC')),
             ])),
             $this->createMock(TokenInterface::class),
@@ -189,6 +190,27 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
         self::assertCount(
             1,
             [...$stream->messages],
+        );
+    }
+
+    public function test_it_returns_no_changes_when_the_entry_uuid_no_longer_matches(): void
+    {
+        $this->storeTarget(['cn' => ['user']]);
+
+        // The entry the write lock re-reads carries a different UUID: the DN was re-occupied since the resolve.
+        $changes = $this->captureComputedChanges(
+            new ForwardPasswordPolicyStateRequest(self::UUID, [
+                new DateTimeImmutable('2026-05-20 11:59:00', new DateTimeZone('UTC')),
+            ]),
+            Entry::fromArray(self::DN, [
+                'cn' => ['user'],
+                'entryUUID' => ['bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'],
+            ]),
+        );
+
+        self::assertSame(
+            [],
+            $changes,
         );
     }
 
@@ -208,14 +230,14 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
             ) use (&$seen): void {
                 $seen[] = $dn->toString() . '/' . $attribute . '/' . $access->name;
             });
+        $target = $this->storeTarget(['cn' => ['user']]);
 
         $this->captureComputedChanges(
             new ForwardPasswordPolicyStateRequest(
-                self::DN,
-                'uuid',
+                self::UUID,
                 [new DateTimeImmutable('2026-05-20 11:59:00', new DateTimeZone('UTC'))],
             ),
-            Entry::fromArray(self::DN, ['cn' => ['user']]),
+            $target,
         );
 
         self::assertSame(
@@ -232,11 +254,9 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
                 'Access denied.',
                 ResultCode::INSUFFICIENT_ACCESS_RIGHTS,
             ));
+        $target = $this->storeTarget(['cn' => ['user']]);
 
         $compute = null;
-        $this->backend
-            ->method('get')
-            ->willReturn(Entry::fromArray(self::DN, ['cn' => ['user']]));
         $this->writes
             ->method('handle')
             ->with(self::callback(function (ComputeUpdateCommand $command) use (&$compute): bool {
@@ -247,8 +267,7 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
 
         $this->subject->handleRequest(
             $this->messageFor(new ForwardPasswordPolicyStateRequest(
-                self::DN,
-                'uuid',
+                self::UUID,
                 [new DateTimeImmutable('2026-05-20 11:59:00', new DateTimeZone('UTC'))],
             )),
             $this->createMock(TokenInterface::class),
@@ -258,7 +277,23 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
         $this->expectException(OperationException::class);
         $this->expectExceptionCode(ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
 
-        $compute(Entry::fromArray(self::DN, ['cn' => ['user']]));
+        $compute($target);
+    }
+
+    public function test_it_refuses_a_time_from_the_future(): void
+    {
+        $this->writes
+            ->expects(self::never())
+            ->method('handle');
+        $this->expectException(OperationException::class);
+        $this->expectExceptionCode(ResultCode::CONSTRAINT_VIOLATION);
+
+        $this->subject->handleRequest(
+            $this->messageFor(new ForwardPasswordPolicyStateRequest(self::UUID, [
+                new DateTimeImmutable('2026-05-20 13:00:00', new DateTimeZone('UTC')),
+            ])),
+            $this->createMock(TokenInterface::class),
+        );
     }
 
     public function test_it_rejects_a_request_of_the_wrong_type(): void
@@ -275,9 +310,37 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
         );
     }
 
+    private function locator(): EntryUuidLocator
+    {
+        return new EntryUuidLocator(
+            $this->storage,
+            $this->fromContainer(FilterEvaluatorInterface::class),
+        );
+    }
+
+    private function resolverWith(?PasswordPolicy $policy): PasswordPolicyResolver
+    {
+        return new PasswordPolicyResolver(
+            $this->backend,
+            null,
+            $policy,
+        );
+    }
+
     /**
-     * Drive handleRequest, capture the compute closure passed to atomicUpdate, and return its changes for the given
-     * entry (or an entry with no applicable policy when $entry is null).
+     * @param array<string, list<string>> $attributes
+     */
+    private function storeTarget(array $attributes): Entry
+    {
+        $entry = Entry::fromArray(self::DN, $attributes + ['entryUUID' => [self::UUID]]);
+        $this->storage->store($entry);
+
+        return $entry;
+    }
+
+    /**
+     * Drive handleRequest, capture the compute closure passed to the write command, and return its changes for the
+     * given entry.
      *
      * @return list<Change>
      */
@@ -286,10 +349,6 @@ final class ServerPasswordPolicyForwardHandlerTest extends TestCase
         Entry $entry,
     ): array {
         $captured = [];
-
-        $this->backend
-            ->method('get')
-            ->willReturn($entry);
 
         $this->writes
             ->expects(self::once())

--- a/tests/unit/Server/Backend/Storage/Directory/EntryUuidLocatorTest.php
+++ b/tests/unit/Server/Backend/Storage/Directory/EntryUuidLocatorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Backend\Storage\Directory;
+
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Directory\EntryUuidLocator;
+use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
+use PHPUnit\Framework\TestCase;
+use Tests\Support\FreeDSx\Ldap\ServerContainerTrait;
+
+final class EntryUuidLocatorTest extends TestCase
+{
+    use ServerContainerTrait;
+
+    private const UUID_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+    private const UUID_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+    private InMemoryStorage $storage;
+
+    private EntryUuidLocator $subject;
+
+    protected function setUp(): void
+    {
+        $this->storage = new InMemoryStorage();
+        $this->subject = new EntryUuidLocator(
+            $this->storage,
+            $this->fromContainer(FilterEvaluatorInterface::class),
+        );
+    }
+
+    public function test_it_finds_the_entry_holding_the_uuid(): void
+    {
+        $this->store('cn=alice,dc=example,dc=com', self::UUID_A);
+
+        self::assertSame(
+            'cn=alice,dc=example,dc=com',
+            $this->subject->findByUuid(self::UUID_A)?->getDn()->toString(),
+        );
+    }
+
+    public function test_it_returns_null_when_no_entry_holds_the_uuid(): void
+    {
+        $this->store('cn=alice,dc=example,dc=com', self::UUID_A);
+
+        self::assertNull($this->subject->findByUuid(self::UUID_B));
+    }
+
+    public function test_it_returns_the_matching_entry_when_others_are_in_scope(): void
+    {
+        $this->store('cn=alice,dc=example,dc=com', self::UUID_A);
+        $this->store('cn=bob,dc=example,dc=com', self::UUID_B);
+
+        self::assertSame(
+            'cn=bob,dc=example,dc=com',
+            $this->subject->findByUuid(self::UUID_B)?->getDn()->toString(),
+        );
+    }
+
+    private function store(
+        string $dn,
+        string $uuid,
+    ): void {
+        $this->storage->store(new Entry(
+            $dn,
+            new Attribute('cn', 'x'),
+            new Attribute('entryUUID', $uuid),
+        ));
+    }
+}

--- a/tests/unit/Server/Clock/Sleeper/BackoffSleeperTest.php
+++ b/tests/unit/Server/Clock/Sleeper/BackoffSleeperTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\Clock\Sleeper;
+
+use FreeDSx\Ldap\Server\Clock\Sleeper\BackoffSleeper;
+use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
+use FreeDSx\Ldap\Server\Config\ReconnectBackoff;
+use PHPUnit\Framework\TestCase;
+
+final class BackoffSleeperTest extends TestCase
+{
+    /**
+     * @var list<float>
+     */
+    private array $slept;
+
+    private BackoffSleeper $subject;
+
+    protected function setUp(): void
+    {
+        $this->slept = [];
+        $sleeper = $this->createMock(SleeperInterface::class);
+        $sleeper->method('sleep')
+            ->willReturnCallback(function (float $seconds): void {
+                $this->slept[] = $seconds;
+            });
+
+        $this->subject = new BackoffSleeper(
+            new ReconnectBackoff(
+                baseSeconds: 1.0,
+                maxSeconds: 4.0,
+            ),
+            $sleeper,
+        );
+    }
+
+    public function test_it_starts_at_the_initial_delay(): void
+    {
+        self::assertSame(
+            1.0,
+            $this->subject->delay(),
+        );
+    }
+
+    public function test_wait_sleeps_the_current_delay_then_widens_it(): void
+    {
+        $this->subject->wait();
+
+        self::assertSame(
+            [1.0],
+            $this->slept,
+        );
+        self::assertSame(
+            2.0,
+            $this->subject->delay(),
+        );
+    }
+
+    public function test_repeated_waits_double_up_to_the_ceiling(): void
+    {
+        $this->subject->wait();
+        $this->subject->wait();
+        $this->subject->wait();
+        $this->subject->wait();
+
+        self::assertSame(
+            [1.0, 2.0, 4.0, 4.0],
+            $this->slept,
+        );
+    }
+
+    public function test_reset_returns_to_the_initial_delay(): void
+    {
+        $this->subject->wait();
+        $this->subject->wait();
+        $this->subject->reset();
+
+        self::assertSame(
+            1.0,
+            $this->subject->delay(),
+        );
+    }
+}

--- a/tests/unit/Server/Config/ReconnectBackoffTest.php
+++ b/tests/unit/Server/Config/ReconnectBackoffTest.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Tests\Unit\FreeDSx\Ldap\Sync\Consumer;
+namespace Tests\Unit\FreeDSx\Ldap\Server\Config;
 
-use FreeDSx\Ldap\Sync\Consumer\ReconnectBackoff;
+use FreeDSx\Ldap\Server\Config\ReconnectBackoff;
 use PHPUnit\Framework\TestCase;
 
 final class ReconnectBackoffTest extends TestCase

--- a/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
+++ b/tests/unit/Server/Middleware/OperationAuthorizationMiddlewareTest.php
@@ -467,10 +467,7 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
         self::assertNotNull($this->next->received);
     }
 
-    /**
-     * This extended operation names an entry, so a DN-scoped rule can match instead of falling back to the root.
-     */
-    public function test_a_privileged_control_on_a_forward_is_authorized_against_its_target_dn(): void
+    public function test_a_privileged_control_on_a_forward_is_gated_against_the_root(): void
     {
         $this->routeResolvesTo(HandlerId::PasswordPolicyForward);
 
@@ -487,7 +484,7 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
 
         $message = new LdapMessageRequest(
             1,
-            new ForwardPasswordPolicyStateRequest('cn=locked,ou=people,dc=foo,dc=bar', 'uuid', []),
+            new ForwardPasswordPolicyStateRequest('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', []),
             new Control(Control::OID_RELAX_RULES, criticality: true),
         );
 
@@ -497,7 +494,7 @@ final class OperationAuthorizationMiddlewareTest extends TestCase
         );
 
         self::assertSame(
-            'cn=locked,ou=people,dc=foo,dc=bar',
+            '',
             $authorized,
         );
     }

--- a/tests/unit/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwardWorkerTest.php
+++ b/tests/unit/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwardWorkerTest.php
@@ -13,42 +13,18 @@ declare(strict_types=1);
 
 namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward;
 
-use FreeDSx\Ldap\Entry\Attribute;
-use FreeDSx\Ldap\Entry\Change;
-use FreeDSx\Ldap\Entry\Dn;
-use FreeDSx\Ldap\Entry\Entry;
 use FreeDSx\Ldap\Exception\ForwardStateException;
-use FreeDSx\Ldap\Exception\ForwardStateRejectedException;
-use FreeDSx\Ldap\Operation\ResultCode;
-use FreeDSx\Ldap\Operation\Request\ForwardPasswordPolicyStateRequest;
-use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
-use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BackoffSleeper;
 use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
-use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
-use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\ForwardStateSenderInterface;
+use FreeDSx\Ldap\Server\Config\ReconnectBackoff;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\PasswordPolicyForwarder;
 use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\PasswordPolicyForwardWorker;
-use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
-use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
-use FreeDSx\Ldap\ServerOptions;
-use Tests\Support\FreeDSx\Ldap\Server\Configuration\TestServerOptions;
-use Tests\Support\FreeDSx\Ldap\ServerContainerTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class PasswordPolicyForwardWorkerTest extends TestCase
 {
-    use ServerContainerTrait;
-
-    private const DN = 'cn=foo,dc=example,dc=com';
-
-    private ReplicaPasswordStateStoreInterface $store;
-
-    private ForwardStateSenderInterface&MockObject $sender;
-
-    /**
-     * @var list<ForwardPasswordPolicyStateRequest>
-     */
-    private array $sent;
+    private PasswordPolicyForwarder&MockObject $forwarder;
 
     /**
      * @var list<float>
@@ -59,22 +35,10 @@ final class PasswordPolicyForwardWorkerTest extends TestCase
 
     protected function setUp(): void
     {
-        // Both resolve from the memoised container, so the state store shares the storage holding the subjects.
-        $storage = $this->fromContainer(EntryStorageInterface::class);
-        foreach ([self::DN, 'cn=a,dc=example,dc=com', 'cn=b,dc=example,dc=com'] as $subject) {
-            $dn = new Dn($subject);
-            $storage->store(new Entry(
-                $dn,
-                new Attribute('cn', $dn->getRdn()->getValue()),
-            ));
-        }
-
-        $this->store = $this->fromContainer(ReplicaPasswordStateStoreInterface::class);
-        $this->sent = [];
+        $this->forwarder = $this->createMock(PasswordPolicyForwarder::class);
         $this->slept = [];
-        $this->sender = $this->createMock(ForwardStateSenderInterface::class);
 
-        // Stop after each sleep so run() executes exactly one drain iteration per test.
+        // Stop after each sleep so run() executes exactly one loop iteration per test.
         $sleeper = $this->createMock(SleeperInterface::class);
         $sleeper->method('sleep')
             ->willReturnCallback(function (float $seconds): void {
@@ -83,231 +47,41 @@ final class PasswordPolicyForwardWorkerTest extends TestCase
             });
 
         $this->subject = new PasswordPolicyForwardWorker(
-            $this->store,
-            $this->sender,
+            $this->forwarder,
             $sleeper,
-        );
-    }
-
-    public function test_it_forwards_pending_state_and_advances_the_watermark(): void
-    {
-        $this->recordSends();
-        $this->seedFailure('20260520120000Z');
-
-        $forwarded = $this->subject->forwardOnce();
-
-        self::assertSame(
-            1,
-            $forwarded,
-        );
-        self::assertCount(
-            1,
-            $this->sent,
-        );
-        self::assertSame(
-            self::DN,
-            $this->sent[0]->getDn()->toString(),
-        );
-        self::assertSame(
-            ['20260520120000Z'],
-            array_map(
-                static fn($time): string => GeneralizedTime::format($time),
-                $this->sent[0]->getFailureTimes(),
+            new BackoffSleeper(
+                new ReconnectBackoff(),
+                $sleeper,
             ),
-        );
-        self::assertSame(
-            [],
-            $this->store->listUnforwarded(),
-        );
-    }
-
-    public function test_it_drains_every_pending_subject(): void
-    {
-        $this->recordSends();
-        $this->seedFailure('20260520120000Z', 'cn=a,dc=example,dc=com');
-        $this->seedFailure('20260520120000Z', 'cn=b,dc=example,dc=com');
-
-        self::assertSame(
-            2,
-            $this->subject->forwardOnce(),
-        );
-        self::assertSame(
-            [],
-            $this->store->listUnforwarded(),
-        );
-    }
-
-    public function test_a_send_failure_leaves_the_subject_pending(): void
-    {
-        $this->sender
-            ->method('send')
-            ->willThrowException(new ForwardStateException('primary is unreachable'));
-        $this->seedFailure('20260520120000Z');
-
-        $this->expectException(ForwardStateException::class);
-
-        try {
-            $this->subject->forwardOnce();
-        } finally {
-            self::assertCount(
-                1,
-                $this->store->listUnforwarded(),
-            );
-        }
-    }
-
-    public function test_a_subject_the_primary_refuses_does_not_hold_back_the_others(): void
-    {
-        $this->sender
-            ->method('send')
-            ->willReturnCallback(function (ForwardPasswordPolicyStateRequest $request): void {
-                if ($request->getDn()->toString() === 'cn=a,dc=example,dc=com') {
-                    throw new ForwardStateRejectedException('Access denied.', ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
-                }
-
-                $this->sent[] = $request;
-            });
-        $this->seedFailure('20260520120000Z', 'cn=a,dc=example,dc=com');
-        $this->seedFailure('20260520120000Z', 'cn=b,dc=example,dc=com');
-
-        $forwarded = $this->subject->forwardOnce();
-
-        self::assertSame(
-            1,
-            $forwarded,
-        );
-        self::assertSame(
-            ['cn=b,dc=example,dc=com'],
-            array_map(
-                static fn(ForwardPasswordPolicyStateRequest $request): string => $request->getDn()->toString(),
-                $this->sent,
-            ),
-        );
-        self::assertSame(
-            ['cn=a,dc=example,dc=com'],
-            array_map(
-                static fn($pending): string => $pending->dn->toString(),
-                $this->store->listUnforwarded(),
-            ),
-        );
-    }
-
-    public function test_a_refused_subject_is_retried_on_a_widening_gap_rather_than_every_drain(): void
-    {
-        $attempts = 0;
-        $this->sender
-            ->method('send')
-            ->willReturnCallback(static function () use (&$attempts): void {
-                $attempts++;
-
-                throw new ForwardStateRejectedException('Access denied.', ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
-            });
-        $this->seedFailure('20260520120000Z');
-
-        for ($drain = 1; $drain <= 8; $drain++) {
-            $this->subject->forwardOnce();
-        }
-
-        // Attempted on drains 1, 2, 4 and 8 only.
-        self::assertSame(
-            4,
-            $attempts,
-        );
-        self::assertCount(
-            1,
-            $this->store->listUnforwarded(),
-        );
-    }
-
-    public function test_a_refused_subject_is_attempted_again_as_soon_as_its_state_changes(): void
-    {
-        $attempts = 0;
-        $this->sender
-            ->method('send')
-            ->willReturnCallback(static function () use (&$attempts): void {
-                $attempts++;
-
-                throw new ForwardStateRejectedException('Access denied.', ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
-            });
-        $this->seedFailure('20260520120000Z');
-
-        $this->subject->forwardOnce();
-        $this->subject->forwardOnce();
-        $this->subject->forwardOnce();
-        // A new observation moves the subject on, so the widening gap no longer applies to it.
-        $this->seedFailure('20260520120500Z');
-        $this->subject->forwardOnce();
-
-        self::assertSame(
-            3,
-            $attempts,
         );
     }
 
     public function test_run_drains_then_sleeps_the_poll_interval(): void
     {
-        $this->recordSends();
-        $this->seedFailure('20260520120000Z');
+        $this->forwarder
+            ->expects(self::once())
+            ->method('forwardOnce')
+            ->willReturn(1);
 
         $this->subject->run();
 
-        self::assertCount(
-            1,
-            $this->sent,
-        );
         self::assertSame(
             [PasswordPolicyForwardWorker::DEFAULT_INTERVAL_SECONDS],
             $this->slept,
         );
-        self::assertSame(
-            [],
-            $this->store->listUnforwarded(),
-        );
     }
 
-    public function test_run_backs_off_and_leaves_state_pending_on_a_delivery_failure(): void
+    public function test_run_backs_off_on_a_delivery_failure(): void
     {
-        $this->sender
-            ->method('send')
+        $this->forwarder
+            ->method('forwardOnce')
             ->willThrowException(new ForwardStateException('primary is unreachable'));
-        $this->seedFailure('20260520120000Z');
 
         $this->subject->run();
 
         self::assertSame(
             [1.0],
             $this->slept,
-        );
-        self::assertCount(
-            1,
-            $this->store->listUnforwarded(),
-        );
-    }
-
-    protected function makeServerOptions(): ServerOptions
-    {
-        return TestServerOptions::sqlite();
-    }
-
-    private function recordSends(): void
-    {
-        $this->sender
-            ->method('send')
-            ->willReturnCallback(function (ForwardPasswordPolicyStateRequest $request): void {
-                $this->sent[] = $request;
-            });
-    }
-
-    private function seedFailure(
-        string $time,
-        string $dn = self::DN,
-    ): void {
-        $this->store->atomicMutate(
-            new Dn($dn),
-            static fn(): OperationalChanges => OperationalChanges::of(Change::replace(
-                PasswordPolicyOid::NAME_PWD_FAILURE_TIME,
-                $time,
-            )),
         );
     }
 }

--- a/tests/unit/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwarderTest.php
+++ b/tests/unit/Server/PasswordPolicy/Replica/Forward/PasswordPolicyForwarderTest.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the FreeDSx LDAP package.
+ *
+ * (c) Chad Sikorra <Chad.Sikorra@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit\FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward;
+
+use FreeDSx\Ldap\Entry\Attribute;
+use FreeDSx\Ldap\Entry\Change;
+use FreeDSx\Ldap\Entry\Dn;
+use FreeDSx\Ldap\Entry\Entry;
+use FreeDSx\Ldap\Exception\ForwardStateException;
+use FreeDSx\Ldap\Exception\ForwardStateRejectedException;
+use FreeDSx\Ldap\Operation\ResultCode;
+use FreeDSx\Ldap\Operation\Request\ForwardPasswordPolicyStateRequest;
+use FreeDSx\Ldap\Schema\Definition\GeneralizedTime;
+use FreeDSx\Ldap\Schema\Definition\PasswordPolicyOid;
+use FreeDSx\Ldap\Server\PasswordPolicy\Decision\OperationalChanges;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\ForwardStateSenderInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\Forward\PasswordPolicyForwarder;
+use FreeDSx\Ldap\Server\Backend\ReadBackendInterface;
+use FreeDSx\Ldap\Server\Backend\Storage\EntryStorageInterface;
+use FreeDSx\Ldap\Server\PasswordPolicy\Replica\ReplicaPasswordStateStoreInterface;
+use FreeDSx\Ldap\ServerOptions;
+use Tests\Support\FreeDSx\Ldap\Server\Configuration\TestServerOptions;
+use Tests\Support\FreeDSx\Ldap\ServerContainerTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class PasswordPolicyForwarderTest extends TestCase
+{
+    use ServerContainerTrait;
+
+    private const DN = 'cn=foo,dc=example,dc=com';
+
+    private const UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+    private const UUID_A = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+    private const UUID_B = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+    private ReplicaPasswordStateStoreInterface $store;
+
+    private ForwardStateSenderInterface&MockObject $sender;
+
+    /**
+     * @var list<ForwardPasswordPolicyStateRequest>
+     */
+    private array $sent;
+
+    private PasswordPolicyForwarder $subject;
+
+    protected function setUp(): void
+    {
+        // Both resolve from the memoised container, so the state store shares the storage holding the subjects.
+        $storage = $this->fromContainer(EntryStorageInterface::class);
+        $subjects = [
+            self::DN => self::UUID,
+            'cn=a,dc=example,dc=com' => self::UUID_A,
+            'cn=b,dc=example,dc=com' => self::UUID_B,
+        ];
+        foreach ($subjects as $subject => $uuid) {
+            $dn = new Dn($subject);
+            $storage->store(new Entry(
+                $dn,
+                new Attribute('cn', $dn->getRdn()->getValue()),
+                new Attribute('entryUUID', $uuid),
+            ));
+        }
+
+        $this->store = $this->fromContainer(ReplicaPasswordStateStoreInterface::class);
+        $this->sent = [];
+        $this->sender = $this->createMock(ForwardStateSenderInterface::class);
+
+        $this->subject = new PasswordPolicyForwarder(
+            $this->store,
+            $this->sender,
+            $this->fromContainer(ReadBackendInterface::class),
+        );
+    }
+
+    public function test_it_forwards_pending_state_and_advances_the_watermark(): void
+    {
+        $this->recordSends();
+        $this->seedFailure('20260520120000Z');
+
+        $forwarded = $this->subject->forwardOnce();
+
+        self::assertSame(
+            1,
+            $forwarded,
+        );
+        self::assertCount(
+            1,
+            $this->sent,
+        );
+        self::assertSame(
+            self::UUID,
+            $this->sent[0]->getEntryUuid(),
+        );
+        self::assertSame(
+            ['20260520120000Z'],
+            array_map(
+                static fn($time): string => GeneralizedTime::format($time),
+                $this->sent[0]->getFailureTimes(),
+            ),
+        );
+        self::assertSame(
+            [],
+            $this->store->listUnforwarded(),
+        );
+    }
+
+    public function test_it_drains_every_pending_subject(): void
+    {
+        $this->recordSends();
+        $this->seedFailure('20260520120000Z', 'cn=a,dc=example,dc=com');
+        $this->seedFailure('20260520120000Z', 'cn=b,dc=example,dc=com');
+
+        self::assertSame(
+            2,
+            $this->subject->forwardOnce(),
+        );
+        self::assertSame(
+            [],
+            $this->store->listUnforwarded(),
+        );
+    }
+
+    public function test_a_send_failure_leaves_the_subject_pending(): void
+    {
+        $this->sender
+            ->method('send')
+            ->willThrowException(new ForwardStateException('primary is unreachable'));
+        $this->seedFailure('20260520120000Z');
+
+        $this->expectException(ForwardStateException::class);
+
+        try {
+            $this->subject->forwardOnce();
+        } finally {
+            self::assertCount(
+                1,
+                $this->store->listUnforwarded(),
+            );
+        }
+    }
+
+    public function test_a_subject_the_primary_refuses_does_not_hold_back_the_others(): void
+    {
+        $this->sender
+            ->method('send')
+            ->willReturnCallback(function (ForwardPasswordPolicyStateRequest $request): void {
+                if ($request->getEntryUuid() === self::UUID_A) {
+                    throw new ForwardStateRejectedException('Access denied.', ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+                }
+
+                $this->sent[] = $request;
+            });
+        $this->seedFailure('20260520120000Z', 'cn=a,dc=example,dc=com');
+        $this->seedFailure('20260520120000Z', 'cn=b,dc=example,dc=com');
+
+        $forwarded = $this->subject->forwardOnce();
+
+        self::assertSame(
+            1,
+            $forwarded,
+        );
+        self::assertSame(
+            [self::UUID_B],
+            array_map(
+                static fn(ForwardPasswordPolicyStateRequest $request): string => $request->getEntryUuid(),
+                $this->sent,
+            ),
+        );
+        self::assertSame(
+            ['cn=a,dc=example,dc=com'],
+            array_map(
+                static fn($pending): string => $pending->dn->toString(),
+                $this->store->listUnforwarded(),
+            ),
+        );
+    }
+
+    public function test_a_refused_subject_is_retried_on_a_widening_gap_rather_than_every_drain(): void
+    {
+        $attempts = 0;
+        $this->sender
+            ->method('send')
+            ->willReturnCallback(static function () use (&$attempts): void {
+                $attempts++;
+
+                throw new ForwardStateRejectedException('Access denied.', ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+            });
+        $this->seedFailure('20260520120000Z');
+
+        for ($drain = 1; $drain <= 8; $drain++) {
+            $this->subject->forwardOnce();
+        }
+
+        // Attempted on drains 1, 2, 4 and 8 only.
+        self::assertSame(
+            4,
+            $attempts,
+        );
+        self::assertCount(
+            1,
+            $this->store->listUnforwarded(),
+        );
+    }
+
+    public function test_a_refused_subject_is_attempted_again_as_soon_as_its_state_changes(): void
+    {
+        $attempts = 0;
+        $this->sender
+            ->method('send')
+            ->willReturnCallback(static function () use (&$attempts): void {
+                $attempts++;
+
+                throw new ForwardStateRejectedException('Access denied.', ResultCode::INSUFFICIENT_ACCESS_RIGHTS);
+            });
+        $this->seedFailure('20260520120000Z');
+
+        $this->subject->forwardOnce();
+        $this->subject->forwardOnce();
+        $this->subject->forwardOnce();
+        // A new observation moves the subject on, so the widening gap no longer applies to it.
+        $this->seedFailure('20260520120500Z');
+        $this->subject->forwardOnce();
+
+        self::assertSame(
+            3,
+            $attempts,
+        );
+    }
+
+    public function test_a_subject_without_an_entry_uuid_is_left_pending_and_not_forwarded(): void
+    {
+        $this->recordSends();
+        $dn = 'cn=nouuid,dc=example,dc=com';
+        $this->fromContainer(EntryStorageInterface::class)->store(new Entry(
+            $dn,
+            new Attribute('cn', 'nouuid'),
+        ));
+        $this->seedFailure('20260520120000Z', $dn);
+
+        $forwarded = $this->subject->forwardOnce();
+
+        self::assertSame(
+            0,
+            $forwarded,
+        );
+        self::assertSame(
+            [],
+            $this->sent,
+        );
+        self::assertSame(
+            [$dn],
+            array_map(
+                static fn($pending): string => $pending->dn->toString(),
+                $this->store->listUnforwarded(),
+            ),
+        );
+    }
+
+    protected function makeServerOptions(): ServerOptions
+    {
+        return TestServerOptions::sqlite();
+    }
+
+    private function recordSends(): void
+    {
+        $this->sender
+            ->method('send')
+            ->willReturnCallback(function (ForwardPasswordPolicyStateRequest $request): void {
+                $this->sent[] = $request;
+            });
+    }
+
+    private function seedFailure(
+        string $time,
+        string $dn = self::DN,
+    ): void {
+        $this->store->atomicMutate(
+            new Dn($dn),
+            static fn(): OperationalChanges => OperationalChanges::of(Change::replace(
+                PasswordPolicyOid::NAME_PWD_FAILURE_TIME,
+                $time,
+            )),
+        );
+    }
+}

--- a/tests/unit/Sync/Consumer/LdapReplicaTest.php
+++ b/tests/unit/Sync/Consumer/LdapReplicaTest.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Tests\Unit\FreeDSx\Ldap\Sync\Consumer;
 
 use Closure;
-use FreeDSx\Ldap\ClientOptions;
-use FreeDSx\Ldap\Server\Config\Replication\ConsumerConfig;
-use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Clock\Sleeper\BackoffSleeper;
 use FreeDSx\Ldap\Server\Clock\Sleeper\SleeperInterface;
+use FreeDSx\Ldap\Server\Config\ReconnectBackoff;
 use FreeDSx\Ldap\Server\Process\Signals\ShutdownSignalsInterface;
 use FreeDSx\Ldap\Sync\Consumer\ChangeApplierInterface;
 use FreeDSx\Ldap\Sync\Consumer\Checkpoint\InMemoryReplicationCheckpoint;
@@ -30,12 +29,9 @@ use FreeDSx\Ldap\Sync\SyncRepl;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use Tests\Support\FreeDSx\Ldap\RequiresExtensionsTrait;
 
 final class LdapReplicaTest extends TestCase
 {
-    use RequiresExtensionsTrait;
-
     private ChangeApplierInterface&MockObject $applier;
 
     private InMemoryReplicationCheckpoint $checkpoint;
@@ -109,7 +105,10 @@ final class LdapReplicaTest extends TestCase
             connectionFactory: $connectionFactory,
             applier: $this->applier,
             checkpoint: $this->checkpoint,
-            sleeper: $this->sleeper,
+            backoff: new BackoffSleeper(
+                new ReconnectBackoff(),
+                $this->sleeper,
+            ),
             signals: $this->signals,
         );
     }
@@ -280,29 +279,5 @@ final class LdapReplicaTest extends TestCase
             });
 
         $this->subject->run();
-    }
-
-    public function test_for_pcntl_builds_a_replica(): void
-    {
-        $this->requirePcntl();
-
-        $this->expectNotToPerformAssertions();
-
-        LdapReplica::forPcntl(
-            new ConsumerConfig(new ClientOptions()),
-            new InMemoryStorage(),
-        );
-    }
-
-    public function test_for_swoole_builds_a_replica(): void
-    {
-        $this->requireSwoole();
-
-        $this->expectNotToPerformAssertions();
-
-        LdapReplica::forSwoole(
-            new ConsumerConfig(new ClientOptions()),
-            new InMemoryStorage(),
-        );
     }
 }

--- a/tests/unit/Sync/Consumer/VerbatimStorageApplierTest.php
+++ b/tests/unit/Sync/Consumer/VerbatimStorageApplierTest.php
@@ -22,7 +22,10 @@ use FreeDSx\Ldap\Operation\Response\SyncInfo\SyncIdSet;
 use FreeDSx\Ldap\Protocol\LdapMessageResponse;
 use FreeDSx\Ldap\Search\Result\EntryResult;
 use FreeDSx\Ldap\Server\Backend\Storage\Adapter\InMemoryStorage;
+use FreeDSx\Ldap\Server\Backend\Storage\Directory\EntryUuidLocator;
+use FreeDSx\Ldap\Server\Backend\Storage\Filter\FilterEvaluatorInterface;
 use FreeDSx\Ldap\Server\Utility\Uuid;
+use Tests\Support\FreeDSx\Ldap\ServerContainerTrait;
 use FreeDSx\Ldap\Sync\Consumer\ChangeApplierInterface;
 use FreeDSx\Ldap\Sync\Consumer\VerbatimStorageApplier;
 use FreeDSx\Ldap\Sync\Result\SyncEntryResult;
@@ -32,6 +35,8 @@ use PHPUnit\Framework\TestCase;
 
 final class VerbatimStorageApplierTest extends TestCase
 {
+    use ServerContainerTrait;
+
     private const UUID_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 
     private const UUID_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
@@ -45,7 +50,13 @@ final class VerbatimStorageApplierTest extends TestCase
     protected function setUp(): void
     {
         $this->storage = new InMemoryStorage();
-        $this->subject = new VerbatimStorageApplier($this->storage);
+        $this->subject = new VerbatimStorageApplier(
+            $this->storage,
+            new EntryUuidLocator(
+                $this->storage,
+                $this->fromContainer(FilterEvaluatorInterface::class),
+            ),
+        );
     }
 
     public function test_an_add_stores_the_entry(): void


### PR DESCRIPTION
This updates the password policy forward worker / request to use the entryUUID instead of the DN. This makes the operations immune from moves / renames. Also refactors the worker a bit to extract a forwarder component and a backoff sleeper. Makes things easier to reason about.